### PR TITLE
Enforce the per-domain signin/signup config axis on full-mode auth routes

### DIFF
--- a/apps/web/auth/config/hooks/restrict_to.rb
+++ b/apps/web/auth/config/hooks/restrict_to.rb
@@ -54,12 +54,21 @@ module Auth::Config::Hooks
     # credential. This hook closes it at the one chokepoint both entry points
     # share.
     #
+    # BOTH AXES hang here, for the same reason they both hang on before_rodauth:
+    # the restrict_to gate answers "may this host offer magic links as a METHOD"
+    # and Auth::SigninGate answers "did this host opt into sign-in at all, and
+    # is email_auth effective for it" (SigninConfig.resolve_email_auth_enabled).
+    # before_rodauth cannot cover this path — it sees route :login and applies
+    # only the plain sign-in axis, so leaving SigninGate off this hook leaves a
+    # host that disabled magic links still sending them.
+    #
     # Registered separately because `before_email_auth_request` only EXISTS as a
     # configuration method when the email_auth feature is loaded — see the call
     # site in config.rb, inside the email_auth_enabled? branch.
     def self.configure_email_auth(auth)
       auth.before_email_auth_request do
         Auth::RestrictTo.enforce_method!(self, 'email_auth', :email_auth_request)
+        Auth::SigninGate.enforce_email_auth!(self)
       end
     end
   end

--- a/apps/web/auth/config/hooks/restrict_to.rb
+++ b/apps/web/auth/config/hooks/restrict_to.rb
@@ -7,6 +7,10 @@
 # (ADR-034#restrict-to-is-an-access-control-not-a-display-preference
 # / #reject-as-not-found-not-forbidden, issue #4139).
 #
+# This file registers BOTH pre-auth gates, because before_rodauth can only be
+# defined once (hooks do not chain): the restrict_to axis (Auth::RestrictTo)
+# and the ADR-024 sign-in/sign-up opt-in axis (Auth::SigninGate, #4163).
+#
 # The POLICY — the route → sign-in-method table, resolution input gathering,
 # and the 404 reject shape — lives in apps/web/auth/restrict_to.rb
 # (Auth::RestrictTo), because it also has non-Rodauth callers that must not be
@@ -21,12 +25,23 @@
 #
 
 require_relative '../../restrict_to'
+require_relative '../../signin_gate'
 
 module Auth::Config::Hooks
   module RestrictTo
     def self.configure(auth)
       auth.before_rodauth do
         Auth::RestrictTo.enforce_route!(self)
+        # SECOND AXIS, same hook (#4163). restrict_to says WHICH sign-in method
+        # a host may offer; Auth::SigninGate says whether the host opted into
+        # sign-in / sign-up at all (ADR-024). Hooks do not chain, so both must
+        # be driven from this one registration.
+        #
+        # ORDER IS LOAD-BEARING ONLY IN ONE DIRECTION: the reject bodies are
+        # byte-identical, so neither order leaks which gate fired, but
+        # restrict_to runs first so the narrower method-level verdict is the one
+        # that stands where both apply.
+        Auth::SigninGate.enforce_route!(self)
       end
     end
 

--- a/apps/web/auth/restrict_to.rb
+++ b/apps/web/auth/restrict_to.rb
@@ -34,14 +34,10 @@
 #   nothing to hide, and "the backend read failed, retry" is both the truth and
 #   the alertable signal.
 #
-# MECHANISM — before_rodauth
-#   Rodauth builds `route_hash` once and FREEZES it in post_configure, and
-#   `route!` is a frozen-hash lookup — returning nil from `login_route` per
-#   request does nothing, and routes cannot be un-mounted per host. The gate is
-#   therefore request-time and *emulates* non-existence. `before_rodauth` fires
-#   inside the matched route, after `@current_route` is set and after CSRF has
-#   been checked (rodauth.rb, `define_method(handle_meth)`), which is exactly
-#   where the route's identity is known and nothing has executed yet.
+# MECHANISM — before_rodauth (ADR-038#gate-at-before-rodauth): Rodauth routes
+#   never pass through Otto and cannot be un-mounted per request or host, so
+#   the gate is request-time and *emulates* non-existence from the one
+#   chokepoint where `@current_route` is known and nothing has executed yet.
 #
 # WHERE THIS LIVES, AND WHY NOT UNDER config/hooks/. This is the POLICY, and it
 # has three callers in two different worlds: the Rodauth hook
@@ -81,9 +77,7 @@ require_relative 'lib/logging'
 module Auth
   module RestrictTo
     # Sign-in method a pre-auth Rodauth route belongs to, keyed by
-    # `@current_route` (the symbol passed to Rodauth's `route(...)`, NOT the
-    # URL — the URLs are configurable and several are renamed in
-    # config/features/).
+    # `@current_route` (ADR-038#classify-by-symbol-not-url).
     #
     # Every route here goes dark when its method is restricted away. Secondary
     # endpoints are included on purpose (A7): a gate that covers POST /login
@@ -148,9 +142,8 @@ module Auth
 
     GATED_ROUTES = PRE_AUTH_ROUTES.freeze
 
-    # Routes this gate deliberately does NOT touch. Named explicitly (rather
-    # than defaulted-open) so the coverage spec can fail when a new Rodauth
-    # route appears and nobody classified it — an unclassified route silently
+    # Routes this gate deliberately does NOT touch
+    # (ADR-038#classify-exhaustively-or-fail): an unclassified route silently
     # defaulting to "allowed" is how surface #1 rots.
     #
     # Three reasons appear here:

--- a/apps/web/auth/signin_gate.rb
+++ b/apps/web/auth/signin_gate.rb
@@ -25,10 +25,11 @@
 # changes; the function does not, so this gate's SIGNUP_ROUTES are unchanged
 # by that feature.
 #
-# ORDER — AFTER RestrictTo.enforce_route!, from the same before_rodauth hook
-# (config/hooks/restrict_to.rb). Both gates reject as the same 404 body, so
-# order cannot leak which one fired; running restrict_to first keeps the
-# narrower, method-level verdict authoritative on a host where both apply.
+# MECHANISM — before_rodauth (ADR-038#gate-at-before-rodauth), AFTER
+# RestrictTo.enforce_route! from the same hook (config/hooks/restrict_to.rb):
+# restrict_to first keeps the narrower, method-level verdict authoritative on
+# a host where both apply, and the shared 404 body keeps the firing gate
+# invisible either way.
 #
 # REJECT SHAPE — 404 (ADR-034#reject-as-not-found-not-forbidden). A host that
 # never opted into sign-in presents no reachable sign-in surface; the body is
@@ -65,8 +66,7 @@ require_relative 'lib/logging'
 module Auth
   module SigninGate
     # Routes that let a visitor OBTAIN or RECOVER a session on the request host.
-    # Keyed by `@current_route` (the symbol passed to Rodauth's `route(...)`,
-    # not the URL — several URLs are renamed in config/features/).
+    # Keyed by `@current_route` (ADR-038#classify-by-symbol-not-url).
     #
     # reset_password* is here rather than under sign-up or ungated: password
     # recovery is a sign-in path. A host that never opted into sign-in must not
@@ -75,6 +75,18 @@ module Auth
     #
     # webauthn_autofill_js serves the conditional-UI challenge; without it the
     # ceremony-start endpoint stays live on a host that offers no sign-in.
+    #
+    # unlock_account* is here for the same reason as reset_password*, and it is
+    # not second-factor or account-scoped despite the name: both routes are
+    # PRE-auth (check_already_logged_in), and Rodauth's lockout defaults are
+    # unlock_account_requires_password? false + unlock_account_autologin? true
+    # (config/features/lockout.rb overrides neither), so unlock_account mints a
+    # full session from an emailed key alone. Ungated, a canonical account
+    # holder — or anyone who can trip five failed logins for that login and
+    # reach the resulting mail — obtains a session on a host that never opted
+    # into sign-in. Lockout POLICY stays install-wide and non-overridable
+    # (ADR-024 scope); what is gated here is only WHERE the session may be
+    # obtained, and the canonical host still serves both routes.
     SIGNIN_ROUTES = [
       :login,
       :email_auth_request,
@@ -83,16 +95,21 @@ module Auth
       :webauthn_autofill_js,
       :reset_password_request,
       :reset_password,
+      :unlock_account_request,
+      :unlock_account,
     ].freeze
 
     # Sign-in routes that ALSO require effective email-auth (magic links) to be
     # enabled for the host — the per-domain override can turn magic links off
     # while leaving password sign-in on (SigninConfig.resolve_email_auth_enabled).
     #
-    # The login route is NOT here even though multi-phase login can dispatch a
-    # magic link from it: that path is closed at its own chokepoint
-    # (before_email_auth_request, config/hooks/restrict_to.rb), which is the
-    # only place both entry points meet.
+    # The login route is NOT here because its magic-link dispatch is not a
+    # property of the ROUTE: with the email_auth feature loaded,
+    # use_multi_phase_login? makes POST /login dispatch a link only for a
+    # passwordless account. Route-level ANDing would 404 password sign-in on a
+    # host that merely turned magic links off. That path is closed instead at
+    # before_email_auth_request (enforce_email_auth!), the one chokepoint both
+    # entry points share — which enforces THIS axis, not just restrict_to.
     EMAIL_AUTH_ROUTES = [
       :email_auth_request,
       :email_auth,
@@ -113,10 +130,10 @@ module Auth
 
     GATED_ROUTES = (SIGNIN_ROUTES + SIGNUP_ROUTES).freeze
 
-    # Routes this axis deliberately does NOT touch. Named explicitly (rather
-    # than defaulted-open) so the coverage spec fails when a new Rodauth route
-    # appears and nobody classified it on this axis — an unclassified route
-    # silently defaulting to "allowed" is the exact defect #4163 fixes.
+    # Routes this axis deliberately does NOT touch. Named explicitly with the
+    # coverage spec behind it (ADR-038#classify-exhaustively-or-fail) — an
+    # unclassified route silently defaulting to "allowed" is the exact defect
+    # #4163 fixes.
     #
     # Two reasons appear here:
     #   - ACCOUNT-SCOPED: reachable only when already authenticated, so keying
@@ -136,8 +153,6 @@ module Auth
       :change_login,
       :verify_login_change,
       :confirm_password,
-      :unlock_account,
-      :unlock_account_request,
       :otp_auth,
       :otp_setup,
       :otp_disable,
@@ -177,6 +192,36 @@ module Auth
 
         env = rodauth.request.env
         return if allowed?(env, axis, route)
+
+        reject!(rodauth, route, axis)
+      end
+
+      # Gate the SECONDARY email_auth surface, which is not its own route.
+      #
+      # With the email_auth feature loaded, use_multi_phase_login? is true, so a
+      # POST to the LOGIN route for a passwordless account reaches
+      # after_login_entered_during_multi_phase_login and dispatches a magic link
+      # without ever entering the email_auth_request route. enforce_route! sees
+      # :login and applies only the plain sign-in axis, so a host with
+      # signin_enabled and email_auth DISABLED would still emit a magic link
+      # from that path. before_email_auth_request is the one chokepoint both
+      # entry points share; the restrict_to gate already hangs there, and this
+      # is the same chokepoint for the ADR-024 opt-in axis
+      # (ADR-034#resolution-is-model-owned — one policy, every entry point).
+      #
+      # @param rodauth [Rodauth::Auth]
+      # @raise [Onetime::SigninPolicyUnavailable] on an unreadable host policy
+      def enforce_email_auth!(rodauth)
+        return if rodauth.send(:internal_request?)
+        return if signin_allowed?(rodauth.request.env, email_auth: true)
+
+        reject!(rodauth, :email_auth_request, :signin)
+      end
+
+      # Log and halt. Single reject shape for both entry points, so the surface
+      # that fired is invisible to the caller.
+      def reject!(rodauth, route, axis)
+        env = rodauth.request.env
 
         Auth::Logging.log_auth_event(
           :signin_gate_route_rejected,

--- a/apps/web/auth/signin_gate.rb
+++ b/apps/web/auth/signin_gate.rb
@@ -1,0 +1,371 @@
+# apps/web/auth/signin_gate.rb
+#
+# frozen_string_literal: true
+
+#
+# Runtime enforcement of the sign-in / sign-up OPT-IN axis on the full-mode
+# Rodauth routes (ADR-024, issue #4163).
+#
+# WHAT THIS CLOSES
+#   Simple mode consults the ADR-024 resolvers at its POST handlers
+#   (Core::Controllers::Base#signin_enabled? / #signup_enabled?). Full mode did
+#   not: its pre-auth routes are served by Rodauth and only the `restrict_to`
+#   axis was gated (Auth::RestrictTo, #4139). So a custom domain with no
+#   enabled SigninConfig — a host whose /signin page offers nothing and whose
+#   masthead hides the link — still ACCEPTED POST /auth/login and authenticated
+#   canonical accounts. Enforcement of an access control must not depend on
+#   which auth mode the install runs.
+#
+# TWO AXES OVER ONE ROUTE TABLE. `restrict_to` answers "WHICH sign-in method
+# may this host offer"; this gate answers "may this host offer sign-in (or
+# sign-up) AT ALL". They are independent, so the classification here is by
+# FUNCTION and does not reuse RestrictTo's method table. One visible
+# consequence: RestrictTo reclassifies the create/verify routes as 'webauthn'
+# when the webauthn_verify_account feature is loaded, because the METHOD
+# changes; the function does not, so this gate's SIGNUP_ROUTES are unchanged
+# by that feature.
+#
+# ORDER — AFTER RestrictTo.enforce_route!, from the same before_rodauth hook
+# (config/hooks/restrict_to.rb). Both gates reject as the same 404 body, so
+# order cannot leak which one fired; running restrict_to first keeps the
+# narrower, method-level verdict authoritative on a host where both apply.
+#
+# REJECT SHAPE — 404 (ADR-034#reject-as-not-found-not-forbidden). A host that
+# never opted into sign-in presents no reachable sign-in surface; the body is
+# the router's shared Auth::ErrorTranslator::NOT_FOUND_BODY so a gated route is
+# byte-identical to an undefined one. The one exception is an unreadable
+# policy → 503 (see below).
+#
+# WHERE THIS LIVES: beside restrict_to.rb, same reason — a plain module with no
+# boot chain, so callers that must not load anything under config/ (unit specs,
+# non-Rodauth surfaces) can require it. config/hooks/restrict_to.rb is the thin
+# Rodauth wiring.
+#
+# THIS IS NOT THE WHOLE GATE on this axis:
+#   1. Rodauth routes — here.
+#   2. Simple mode — Core::Controllers::Base#signin_enabled? / #signup_enabled?.
+#   3. SSO (OmniAuth) — deliberately NOT on this axis: tenant SSO is gated by
+#      SsoConfig, and resolve_signin_enabled_for_custom_domain's SSO carve-out
+#      exists for the DISPLAY surface only. See signin_allowed?.
+#
+# See: docs/adr/adr-024-custom-domain-auth-override-resolution.md,
+#      lib/onetime/models/custom_domain/signin_config.rb and
+#      lib/onetime/models/custom_domain/signup_config.rb (resolution is owned
+#      there and re-derived nowhere — ADR-034#resolution-is-model-owned).
+#
+
+require 'json'
+
+require 'onetime/errors'
+require 'onetime/models/custom_domain/signin_config'
+require 'onetime/models/custom_domain/signup_config'
+require_relative 'error_translator'
+require_relative 'lib/logging'
+
+module Auth
+  module SigninGate
+    # Routes that let a visitor OBTAIN or RECOVER a session on the request host.
+    # Keyed by `@current_route` (the symbol passed to Rodauth's `route(...)`,
+    # not the URL — several URLs are renamed in config/features/).
+    #
+    # reset_password* is here rather than under sign-up or ungated: password
+    # recovery is a sign-in path. A host that never opted into sign-in must not
+    # accept a reset request, or the opt-in becomes advisory — the credential
+    # it mints is usable on the canonical host.
+    #
+    # webauthn_autofill_js serves the conditional-UI challenge; without it the
+    # ceremony-start endpoint stays live on a host that offers no sign-in.
+    SIGNIN_ROUTES = [
+      :login,
+      :email_auth_request,
+      :email_auth,
+      :webauthn_login,
+      :webauthn_autofill_js,
+      :reset_password_request,
+      :reset_password,
+    ].freeze
+
+    # Sign-in routes that ALSO require effective email-auth (magic links) to be
+    # enabled for the host — the per-domain override can turn magic links off
+    # while leaving password sign-in on (SigninConfig.resolve_email_auth_enabled).
+    #
+    # The login route is NOT here even though multi-phase login can dispatch a
+    # magic link from it: that path is closed at its own chokepoint
+    # (before_email_auth_request, config/hooks/restrict_to.rb), which is the
+    # only place both entry points meet.
+    EMAIL_AUTH_ROUTES = [
+      :email_auth_request,
+      :email_auth,
+    ].freeze
+
+    # Routes that CREATE an account on the request host. Classified by
+    # function, so unchanged by Rodauth's webauthn_verify_account feature (it
+    # changes the credential the ceremony mints, not what the ceremony is).
+    #
+    # verify_account and verify_account_resend complete a creation that started
+    # here; leaving them open would let a host that revoked its sign-up opt-in
+    # still finish accounts mid-flight.
+    SIGNUP_ROUTES = [
+      :create_account,
+      :verify_account,
+      :verify_account_resend,
+    ].freeze
+
+    GATED_ROUTES = (SIGNIN_ROUTES + SIGNUP_ROUTES).freeze
+
+    # Routes this axis deliberately does NOT touch. Named explicitly (rather
+    # than defaulted-open) so the coverage spec fails when a new Rodauth route
+    # appears and nobody classified it on this axis — an unclassified route
+    # silently defaulting to "allowed" is the exact defect #4163 fixes.
+    #
+    # Two reasons appear here:
+    #   - ACCOUNT-SCOPED: reachable only when already authenticated, so keying
+    #     them to the REQUEST HOST is the wrong axis. Sign-in opt-in governs
+    #     whether a session may be OBTAINED here, never what an existing
+    #     session may do. Gating them would strand a signed-in user mid-session
+    #     when a domain owner flips the opt-in off.
+    #   - NOT A SIGN-IN OFFER: second-factor ceremonies (the account already
+    #     presented a first factor this host permitted — same reasoning as
+    #     Auth::RestrictTo::SECOND_FACTOR_ROUTES) and logout, which must never
+    #     404.
+    UNGATED_ROUTES = [
+      :logout,
+      :remember,
+      :close_account,
+      :change_password,
+      :change_login,
+      :verify_login_change,
+      :confirm_password,
+      :unlock_account,
+      :unlock_account_request,
+      :otp_auth,
+      :otp_setup,
+      :otp_disable,
+      :otp_unlock,
+      :recovery_auth,
+      :recovery_codes,
+      :two_factor_auth,
+      :two_factor_manage,
+      :two_factor_disable,
+      :webauthn_auth,
+      :webauthn_auth_js,
+      :webauthn_setup,
+      :webauthn_setup_js,
+      :webauthn_remove,
+    ].freeze
+
+    class << self
+      # Gate the currently-matched Rodauth route on the opt-in axis.
+      #
+      # @param rodauth [Rodauth::Auth]
+      # @raise [Onetime::SigninPolicyUnavailable, Onetime::SignupPolicyUnavailable]
+      #   when the host's policy could not be read (→ 503, Auth::ErrorTranslator)
+      def enforce_route!(rodauth)
+        route = rodauth.current_route
+        axis  = axis_for(route)
+        return unless axis
+
+        # Internal requests (Rodauth's internal_request feature) synthesize a
+        # bare env with no Host and no DomainStrategy classification, and are
+        # server-initiated app operations rather than a visitor signing in or up
+        # on a host — e.g. invite signup autologin. Gating them would break app
+        # flows for a policy about REQUEST HOSTS that an internal request does
+        # not have. handle_internal_request calls before_rodauth directly, so
+        # this guard is load-bearing. Same guard, same rationale as
+        # Auth::RestrictTo.enforce_method!.
+        return if rodauth.send(:internal_request?)
+
+        env = rodauth.request.env
+        return if allowed?(env, axis, route)
+
+        Auth::Logging.log_auth_event(
+          :signin_gate_route_rejected,
+          level: :info,
+          route: route,
+          axis: axis,
+          domain_strategy: env['onetime.domain_strategy'],
+          host: env['onetime.display_domain'],
+          path: rodauth.request.path,
+        )
+
+        rodauth.request.halt(not_found_response)
+      end
+
+      # Which axis a route belongs to, or nil when this gate does not touch it.
+      #
+      # @param route [Symbol] Rodauth's `@current_route`
+      # @return [Symbol, nil] :signin, :signup
+      def axis_for(route)
+        return :signup if SIGNUP_ROUTES.include?(route)
+        return :signin if SIGNIN_ROUTES.include?(route)
+
+        nil
+      end
+
+      # @param env [Hash] Rack env
+      # @param axis [Symbol] :signin or :signup
+      # @param route [Symbol]
+      # @return [Boolean]
+      def allowed?(env, axis, route)
+        return signup_allowed?(env) if axis == :signup
+
+        signin_allowed?(env, email_auth: EMAIL_AUTH_ROUTES.include?(route))
+      end
+
+      # Whether this host may accept sign-in submissions.
+      #
+      # domain_id is OMITTED, mirroring Core::Controllers::Base#signin_enabled?
+      # exactly: the tenant-SSO carve-out inside
+      # resolve_signin_enabled_for_custom_domain keeps the /signin PAGE
+      # reachable on a custom domain that has SSO but no SigninConfig. This is
+      # the password/email POST gate, where that carve-out would re-open
+      # precisely the credential submission ADR-024 closes.
+      #
+      # The branch between operator default and tenant default is chosen by
+      # resolve_signin_enabled_for_request — a POSITIVE :canonical/:subdomain
+      # test, never `== :custom`
+      # (ADR-024#operator-defaults-require-positive-classification), so the
+      # :invalid classification a failing domain-index read manufactures for a
+      # real customer domain cannot inherit the operator's global default.
+      #
+      # @param env [Hash] Rack env
+      # @param email_auth [Boolean] AND in effective magic-link availability
+      # @raise [Onetime::SigninPolicyUnavailable] on an unreadable host policy
+      # @return [Boolean]
+      def signin_allowed?(env, email_auth: false)
+        config   = signin_config_for(env)
+        strategy = env['onetime.domain_strategy']
+
+        enabled = Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+          Onetime::CustomDomain::SigninConfig.global_signin_enabled,
+          config,
+          domain_strategy: strategy,
+        )
+        return false unless enabled
+        return true unless email_auth
+
+        Onetime::CustomDomain::SigninConfig.resolve_email_auth_enabled(
+          Onetime.auth_config.email_auth_enabled?,
+          config,
+        )
+      end
+
+      # Whether this host may accept account creation.
+      #
+      # Same polarity and the same positive operator test as signin_allowed?;
+      # sign-up has no SSO carve-out, so there is no domain_id argument to omit.
+      #
+      # @param env [Hash] Rack env
+      # @raise [Onetime::SignupPolicyUnavailable] on an unreadable host policy
+      # @return [Boolean]
+      def signup_allowed?(env)
+        Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(
+          Onetime::CustomDomain::SignupConfig.global_signup_enabled,
+          signup_config_for(env),
+          domain_strategy: env['onetime.domain_strategy'],
+        )
+      end
+
+      # The tenant's SigninConfig for the request host, or nil.
+      #
+      # @raise [Onetime::SigninPolicyUnavailable] on an unreadable non-operator host
+      def signin_config_for(env)
+        domain_id = domain_id_for(env)
+        return nil unless domain_id
+
+        Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id)
+      rescue Redis::BaseError => ex
+        signin_policy_read_failed!(env, ex)
+      end
+
+      # The tenant's SignupConfig for the request host, or nil.
+      #
+      # @raise [Onetime::SignupPolicyUnavailable] on an unreadable non-operator host
+      def signup_config_for(env)
+        domain_id = domain_id_for(env)
+        return nil unless domain_id
+
+        Onetime::CustomDomain::SignupConfig.find_by_domain_id(domain_id)
+      rescue Redis::BaseError => ex
+        log_policy_read_failure(:signup, env, ex)
+        # DECIDED BY THE MODEL, not here: SignupConfig.resolve_lookup_failure
+        # raises on any host not positively an operator host and returns nil —
+        # "no per-domain config", the only answer such a host could ever have
+        # had — on :canonical/:subdomain, whose policy is in-memory config that
+        # cannot have failed. Same rule the simple-mode gate uses
+        # (Onetime::Logic::SignupConfigResolution#signup_policy_read_failed!),
+        # so the two modes cannot drift.
+        Onetime::CustomDomain::SignupConfig.resolve_lookup_failure(
+          domain_strategy: env['onetime.domain_strategy'],
+        )
+      end
+
+      # The per-domain sign-in policy could not be read.
+      #
+      # NOT SigninConfig.resolve_lookup_failure: that helper answers the
+      # restrict_to axis and returns a RestrictToResolution. This axis needs the
+      # CONFIG shape (nil = no per-domain config), which is what the sign-up
+      # sibling's resolve_lookup_failure returns and what
+      # Core::Controllers::Base#signin_policy_read_failed! does for simple mode.
+      # The RULE is shared even though the return shape is not:
+      # SigninConfig.operator_host? is the single owner of "which hosts may
+      # inherit operator auth defaults", and it is a POSITIVE test — :custom,
+      # :invalid and nil all fail closed, because :invalid is exactly what
+      # DomainStrategy answers for a real customer domain when the same blip
+      # broke its own read.
+      #
+      # @raise [Onetime::SigninPolicyUnavailable] on any non-operator host
+      # @return [nil] on an operator host
+      def signin_policy_read_failed!(env, exception)
+        log_policy_read_failure(:signin, env, exception)
+        strategy = env['onetime.domain_strategy']
+        raise Onetime::SigninPolicyUnavailable unless
+          Onetime::CustomDomain::SigninConfig.operator_host?(strategy)
+
+        nil
+      end
+
+      def log_policy_read_failure(axis, env, exception)
+        Auth::Logging.log_auth_event(
+          :signin_gate_policy_lookup_failed,
+          level: :error,
+          axis: axis,
+          host: env['onetime.display_domain'],
+          domain_strategy: env['onetime.domain_strategy'],
+          error: exception.message,
+        )
+      end
+
+      # CustomDomain identifier for the request host, or nil.
+      #
+      # from_display_domain, NOT load_by_display_domain (#4157): the latter
+      # rescues Redis::BaseError internally and returns nil, which would make
+      # the rescues above unreachable for the FIRST of the two policy reads — a
+      # blip would resolve as "host has no tenant config" and, on the :invalid
+      # classification the same blip produces, silently inherit the operator's
+      # global sign-in default.
+      #
+      # @raise [Redis::BaseError] handled by the callers
+      def domain_id_for(env)
+        display_domain = env['onetime.display_domain']
+        return nil if display_domain.to_s.empty?
+
+        Onetime::CustomDomain.from_display_domain(display_domain)&.identifier
+      end
+
+      # The router's shared 404 — a gated route must be indistinguishable from
+      # an undefined one (ADR-034#reject-as-not-found-not-forbidden). Built here
+      # rather than reusing the router's status_handler because request.halt
+      # bypasses Roda's status handlers. Byte-identical to
+      # Auth::RestrictTo.not_found_response, so the reject cannot reveal which
+      # gate fired.
+      def not_found_response
+        [
+          404,
+          { 'content-type' => 'application/json' },
+          [JSON.generate(Auth::ErrorTranslator::NOT_FOUND_BODY)],
+        ]
+      end
+    end
+  end
+end

--- a/apps/web/auth/spec/integration/full/restrict_to_enforcement_spec.rb
+++ b/apps/web/auth/spec/integration/full/restrict_to_enforcement_spec.rb
@@ -252,6 +252,24 @@ RSpec.describe 'restrict_to enforcement — full mode (ADR-034#restrict-to-is-an
   end
 
   describe 'the :unrestricted state' do
+    # THE CUSTOM-DOMAIN FEATURE GOES BACK OFF for this block (#4163). These two
+    # examples assert that NO gate fires on the operator's own host, and since
+    # the opt-in axis (Auth::SigninGate) joined this hook they are no longer
+    # only about restrict_to. This lane's canonical host is an IP:port, which is
+    # not a classifiable domain: with the feature ON, DomainStrategy answers
+    # :invalid for it and the opt-in gate correctly takes the tenant-safe
+    # default-OFF branch
+    # (ADR-024#operator-defaults-require-positive-classification), 404ing
+    # /auth/login for reasons that have nothing to do with restrict_to. Turning
+    # the feature off restores the classification a default install gives its
+    # own host (:canonical) so this block keeps testing what it claims to.
+    around do |example|
+      saved                     = Onetime::Runtime.features
+      Onetime::Runtime.features = saved.with(domains_enabled: false)
+      example.run
+      Onetime::Runtime.features = saved
+    end
+
     let(:canonical_host) do
       Onetime::Middleware::DomainStrategy.canonical_domain || 'localhost:3000'
     end

--- a/apps/web/auth/spec/integration/full/signin_gate_enforcement_spec.rb
+++ b/apps/web/auth/spec/integration/full/signin_gate_enforcement_spec.rb
@@ -181,6 +181,19 @@ RSpec.describe 'sign-in/sign-up opt-in enforcement — full mode (ADR-024, #4163
       )
     end
 
+    # Pre-auth despite the name, and Rodauth's defaults make unlock_account
+    # mint a session with no password (unlock_account_requires_password? false,
+    # unlock_account_autologin? true). Left open, a canonical account holder
+    # gets a session on a host that never opted into sign-in.
+    it '404s POST /auth/unlock-account-request' do
+      skip 'lockout feature not enabled in this lane' unless route_mounted?('/unlock-account-request')
+
+      expect_not_found(
+        post_as(host, '/auth/unlock-account-request', login: "nobody-#{run_id}@example.com"),
+        '/auth/unlock-account-request',
+      )
+    end
+
     it '404s POST /auth/email-auth-request' do
       skip 'email_auth feature not enabled in this lane' unless route_mounted?('/email-auth-request')
 

--- a/apps/web/auth/spec/integration/full/signin_gate_enforcement_spec.rb
+++ b/apps/web/auth/spec/integration/full/signin_gate_enforcement_spec.rb
@@ -1,0 +1,341 @@
+# apps/web/auth/spec/integration/full/signin_gate_enforcement_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — the sign-in / sign-up OPT-IN axis as an ACCESS
+# CONTROL in full mode (ADR-024, ADR-034#reject-as-not-found-not-forbidden,
+# #4163)
+# =============================================================================
+#
+# THE DEFECT. Simple mode consults the ADR-024 resolvers at its POST handlers;
+# full mode did not. A custom domain with no enabled SigninConfig — a host
+# whose /signin page offers nothing and whose masthead hides the link — still
+# ACCEPTED POST /auth/login and authenticated canonical accounts, because
+# Rodauth serves that route and only the `restrict_to` axis was gated
+# (restrict_to_enforcement_spec.rb, its sibling in this directory). These
+# examples are the crafted POSTs.
+#
+# THE TWO AXES ARE SEPARATED ON PURPOSE HERE. Both reject as the same 404, so
+# an example that merely asserts 404 on a host with no configuration at all
+# would pass whichever gate fired. The isolating cases are the ones in the
+# middle: a host with an enabled SigninConfig (which makes the restrict_to
+# resolution :unrestricted, so that gate cannot be the one rejecting) and NO
+# SignupConfig, where the 404 on /auth/create-account can only be this gate —
+# and its mirror image.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2163: pnpm run test:database:start
+# - AUTH_DATABASE_URL set (SQLite or PostgreSQL)
+# - AUTHENTICATION_MODE=full
+#
+# RUN:
+#   tests/lanes/run full-sqlite
+#   # or directly:
+#   RACK_ENV=test AUTHENTICATION_MODE=full AUTH_DATABASE_URL='sqlite::memory:' \
+#     ORGS_SSO_ENABLED=true bundle exec rspec \
+#     apps/web/auth/spec/integration/full/signin_gate_enforcement_spec.rb
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require 'rack/test'
+
+RSpec.describe 'sign-in/sign-up opt-in enforcement — full mode (ADR-024, #4163)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    boot_onetime_app
+
+    # The custom-domain feature ships OFF in the test config (DOMAINS_ENABLED),
+    # and with it off Onetime::Middleware::DomainStrategy short-circuits: every
+    # request is classified :canonical and env['onetime.display_domain'] is the
+    # canonical host, so a per-domain config can never be reached and every
+    # example here would pass vacuously against the operator default. Flip the
+    # runtime flag (not the env var — the lane env is shared) and restore after.
+    @original_features        = Onetime::Runtime.features
+    Onetime::Runtime.features = @original_features.with(domains_enabled: true)
+  end
+
+  after(:all) do
+    Onetime::Runtime.features = @original_features if @original_features
+  end
+
+  let(:run_id) { SecureRandom.hex(6) }
+
+  # A host DomainStrategy will classify as :custom, with whichever per-domain
+  # opt-in records the example needs and nothing else.
+  #
+  # tr('_', '-'): an underscore is not legal in a hostname label, and
+  # DomainStrategy silently falls back to the canonical host for one
+  # (basically_valid? fails), which would make the example pass vacuously.
+  def build_domain(label, signin: nil, signup: nil)
+    owner = Onetime::Customer.new(email: "owner-#{run_id}@test.local")
+    owner.save
+    org  = Onetime::Organization.create!("SigninGate Org #{run_id}", owner, 'contact@test.local')
+    host = "optin-#{label.tr('_', '-')}-#{run_id}.example.com"
+
+    domain = Onetime::CustomDomain.new(display_domain: host, org_id: org.org_id)
+    domain.save
+    Onetime::CustomDomain.display_domain_index.put(host, domain.domainid)
+
+    # restrict_to is left unset on purpose: this file is about the OTHER axis,
+    # and an enabled SigninConfig with no restriction resolves :unrestricted, so
+    # Auth::RestrictTo cannot be the gate producing any 404 below.
+    unless signin.nil?
+      Onetime::CustomDomain::SigninConfig.create!(
+        domain_id: domain.identifier,
+        enabled: true,
+        signin_enabled: signin,
+        sso_enabled: false,
+      )
+    end
+
+    unless signup.nil?
+      Onetime::CustomDomain::SignupConfig.create!(
+        domain_id: domain.identifier,
+        enabled: true,
+        signup_enabled: signup,
+      )
+    end
+
+    @fixtures << [org, domain, owner, host]
+    host
+  end
+
+  before { @fixtures = [] }
+
+  after do
+    Array(@fixtures).each do |org, domain, owner, host|
+      Onetime::CustomDomain::SigninConfig.delete_for_domain!(domain.identifier)
+      Onetime::CustomDomain::SignupConfig.delete_for_domain!(domain.identifier)
+      Onetime::CustomDomain.display_domain_index.remove(host)
+      domain.destroy!
+      org.destroy!
+      owner.destroy!
+    rescue StandardError => ex
+      warn "[signin_gate spec] cleanup failed for #{host}: #{ex.message}"
+    end
+  end
+
+  # POST with the CSRF token AND an explicit Host, so DomainStrategy classifies
+  # the request as the tenant under test. CSRF matters: check_csrf runs BEFORE
+  # before_rodauth, so a token-less POST would be rejected upstream of the gate
+  # and the example would pass for the wrong reason.
+  def post_as(host, path, params = {})
+    header 'Host', host
+    csrf_json_post(path, params)
+  end
+
+  def login_params
+    { login: "nobody-#{run_id}@example.com", password: 'x' * 20 }
+  end
+
+  def signup_params
+    { login: "newbie-#{run_id}@example.com", password: 'x' * 20, 'password-confirm': 'x' * 20 }
+  end
+
+  # A gated route must be byte-identical to an undefined one
+  # (ADR-034#reject-as-not-found-not-forbidden): same status AND the router's
+  # shared ADR-013 body, not a bespoke shape.
+  def expect_not_found(response, path)
+    expect(response.status).to eq(404),
+      "#{path} returned #{response.status}, expected 404 (the host never opted in). " \
+      "Body: #{response.body[0, 300]}"
+    expect(JSON.parse(response.body)['error_type']).to eq('NotFound'),
+      "#{path} 404'd with a non-router body: #{response.body[0, 300]}"
+  end
+
+  # The route RAN. 401 (no such account) is the healthy answer for a crafted
+  # login; what matters is that the gate did not stand in front of it.
+  def expect_route_executed(response, path)
+    expect(response.status).not_to eq(404),
+      "#{path} was rejected on a host that opted in (got 404)"
+  end
+
+  def route_mounted?(path)
+    Auth::Config.route_hash.key?(path)
+  end
+
+  # ==========================================================================
+  # 1. The defect: a custom host that opted into nothing
+  # ==========================================================================
+
+  describe 'a custom host with NO per-domain opt-in' do
+    let(:host) { build_domain('none') }
+
+    it '404s POST /auth/login — this is the #4163 defect' do
+      expect_not_found(post_as(host, '/auth/login', login_params), '/auth/login')
+    end
+
+    it '404s POST /auth/create-account' do
+      expect_not_found(post_as(host, '/auth/create-account', signup_params), '/auth/create-account')
+    end
+
+    # Password recovery is a sign-in path: the credential it mints is usable on
+    # the canonical host, so leaving it open would make the opt-in advisory.
+    it '404s POST /auth/reset-password-request' do
+      expect_not_found(
+        post_as(host, '/auth/reset-password-request', login: "nobody-#{run_id}@example.com"),
+        '/auth/reset-password-request',
+      )
+    end
+
+    it '404s POST /auth/email-auth-request' do
+      skip 'email_auth feature not enabled in this lane' unless route_mounted?('/email-auth-request')
+
+      expect_not_found(
+        post_as(host, '/auth/email-auth-request', login: "nobody-#{run_id}@example.com"),
+        '/auth/email-auth-request',
+      )
+    end
+
+    # Exempt: gating logout would strand a signed-in user the moment a domain
+    # owner flipped the opt-in off.
+    it 'leaves logout reachable' do
+      expect_route_executed(post_as(host, '/auth/logout'), '/auth/logout')
+    end
+  end
+
+  # ==========================================================================
+  # 2. The isolating cases — proof that THIS gate is the one firing
+  # ==========================================================================
+  #
+  # Both gates reject as the same 404, so section 1 alone cannot tell them
+  # apart. Here each host carries an enabled SigninConfig with no restrict_to,
+  # which resolves :unrestricted — Auth::RestrictTo allows everything, and every
+  # 404 below is necessarily the opt-in axis.
+  #
+  describe 'a custom host that opted into SIGN-IN only' do
+    let(:host) { build_domain('signin-only', signin: true) }
+
+    it 'executes POST /auth/login — the lookup ran and said yes' do
+      expect_route_executed(post_as(host, '/auth/login', login_params), '/auth/login')
+    end
+
+    it 'still 404s POST /auth/create-account — sign-in does not imply sign-up' do
+      expect_not_found(post_as(host, '/auth/create-account', signup_params), '/auth/create-account')
+    end
+
+    it 'executes POST /auth/reset-password-request' do
+      expect_route_executed(
+        post_as(host, '/auth/reset-password-request', login: "nobody-#{run_id}@example.com"),
+        '/auth/reset-password-request',
+      )
+    end
+  end
+
+  describe 'a custom host that opted into SIGN-UP only' do
+    # signin: false is an EXPLICIT opt-out on an enabled record, which is what
+    # keeps the restrict_to axis unrestricted while this axis closes sign-in.
+    let(:host) { build_domain('signup-only', signin: false, signup: true) }
+
+    it 'executes POST /auth/create-account' do
+      expect_route_executed(post_as(host, '/auth/create-account', signup_params), '/auth/create-account')
+    end
+
+    it '404s POST /auth/login — sign-up does not imply sign-in' do
+      expect_not_found(post_as(host, '/auth/login', login_params), '/auth/login')
+    end
+  end
+
+  describe 'a custom host whose enabled records opted OUT of both' do
+    let(:host) { build_domain('opted-out', signin: false, signup: false) }
+
+    it '404s both POSTs' do
+      expect_not_found(post_as(host, '/auth/login', login_params), '/auth/login')
+      expect_not_found(post_as(host, '/auth/create-account', signup_params), '/auth/create-account')
+    end
+  end
+
+  # ==========================================================================
+  # 3. The operator's own host is untouched
+  # ==========================================================================
+
+  describe 'the canonical host' do
+    # THE CUSTOM-DOMAIN FEATURE GOES BACK OFF for this section, which is a
+    # default install and the operator-host shape these examples are about:
+    # DomainStrategy short-circuits and classifies every request :canonical.
+    #
+    # It has to be turned off explicitly, and that is not a test convenience.
+    # This lane's canonical host is an IP:port, which is not a classifiable
+    # domain — with the feature ON, DomainStrategy answers :invalid for it and
+    # the gate takes the tenant-safe default-OFF branch, exactly as
+    # ADR-024#operator-defaults-require-positive-classification requires. Correct
+    # behavior, wrong subject: it would exercise the fail-closed branch again
+    # rather than the operator default. Simple mode answers :invalid identically
+    # (Core::Controllers::Base#signin_enabled? asks the same resolver), so this
+    # is a property of the host, not a mode difference.
+    around do |example|
+      saved                     = Onetime::Runtime.features
+      Onetime::Runtime.features = saved.with(domains_enabled: false)
+      example.run
+      Onetime::Runtime.features = saved
+    end
+
+    let(:canonical_host) do
+      Onetime::Middleware::DomainStrategy.canonical_domain || 'localhost:3000'
+    end
+
+    it 'executes POST /auth/login' do
+      skip 'sign-in disabled globally in this lane' unless
+        Onetime::CustomDomain::SigninConfig.global_signin_enabled
+
+      expect_route_executed(post_as(canonical_host, '/auth/login', login_params), '/auth/login')
+    end
+
+    it 'executes POST /auth/create-account' do
+      skip 'sign-up disabled globally in this lane' unless
+        Onetime::CustomDomain::SignupConfig.global_signup_enabled
+
+      expect_route_executed(post_as(canonical_host, '/auth/create-account', signup_params),
+        '/auth/create-account')
+    end
+
+    it 'leaves logout reachable' do
+      expect_route_executed(post_as(canonical_host, '/auth/logout'), '/auth/logout')
+    end
+  end
+
+  # ==========================================================================
+  # 4. Route coverage — the guard against a new route slipping past the gate
+  # ==========================================================================
+  #
+  # Rodauth freezes route_hash in post_configure, so this reads the LIVE mounted
+  # set rather than a transcription of it. A new auth route either lands on this
+  # axis (SIGNIN_ROUTES / SIGNUP_ROUTES) or gets an explicit exemption;
+  # defaulting to "allowed" silently is the defect #4163 exists to close.
+  #
+  describe 'route coverage on the opt-in axis' do
+    let(:gate) { Auth::SigninGate }
+
+    def mounted_route_names
+      Auth::Config.route_hash.values.map { |meth| meth.to_s.delete_prefix('handle_').to_sym }
+    end
+
+    it 'classifies every mounted Rodauth route as gated or explicitly exempt' do
+      classified   = gate::GATED_ROUTES + gate::UNGATED_ROUTES
+      unclassified = mounted_route_names - classified
+
+      expect(unclassified).to be_empty,
+        "Rodauth routes with no sign-in/sign-up opt-in classification: #{unclassified.inspect}\n" \
+        'Add each to SIGNIN_ROUTES / SIGNUP_ROUTES or UNGATED_ROUTES (with a reason) ' \
+        'in apps/web/auth/signin_gate.rb. See ADR-024.'
+    end
+
+    it 'reads a non-trivial route set (guards against a vacuous pass)' do
+      expect(mounted_route_names).to include(:login, :logout)
+      expect(mounted_route_names.size).to be >= 8
+    end
+
+    it 'never gates logout' do
+      expect(gate::GATED_ROUTES).not_to include(:logout)
+    end
+
+    # The two axes must stay reject-identical, or the shape leaks which policy
+    # closed the route.
+    it 'rejects with the same body as the restrict_to gate' do
+      expect(gate.not_found_response).to eq(Auth::RestrictTo.not_found_response)
+    end
+  end
+end

--- a/apps/web/auth/spec/unit/signin_gate_spec.rb
+++ b/apps/web/auth/spec/unit/signin_gate_spec.rb
@@ -213,6 +213,16 @@ RSpec.describe Auth::SigninGate do
       expect(described_class.axis_for(:reset_password_request)).to eq(:signin)
       expect(described_class.axis_for(:reset_password)).to eq(:signin)
     end
+
+    # Both unlock routes are PRE-auth, and Rodauth's lockout defaults
+    # (unlock_account_requires_password? false, unlock_account_autologin? true —
+    # config/features/lockout.rb overrides neither) make unlock_account mint a
+    # full session from an emailed key. Exempting them as "account-scoped" would
+    # hand a canonical account holder a session on a host that never opted in.
+    it 'classifies account unlock as sign-in — it mints a session with no password' do
+      expect(described_class.axis_for(:unlock_account_request)).to eq(:signin)
+      expect(described_class.axis_for(:unlock_account)).to eq(:signin)
+    end
   end
 
   # ==========================================================================
@@ -339,12 +349,69 @@ RSpec.describe Auth::SigninGate do
       end
     end
 
-    # Multi-phase login can dispatch a magic link from the LOGIN route. That
-    # path is closed at before_email_auth_request (config/hooks/restrict_to.rb),
-    # the one chokepoint both entry points share — so :login is deliberately not
-    # in EMAIL_AUTH_ROUTES and must not start consulting the magic-link flag.
+    # Multi-phase login can dispatch a magic link from the LOGIN route, but only
+    # for a passwordless account — ANDing the flag into the route itself would
+    # 404 password sign-in on a host that merely turned magic links off. The
+    # route stays on the plain axis and the dispatch is closed at
+    # before_email_auth_request instead (enforce_email_auth!, below).
     it 'does not AND the email-auth flag into the login route' do
       expect(described_class::EMAIL_AUTH_ROUTES).not_to include(:login)
+      expect(described_class::SIGNIN_ROUTES).to include(:login)
+    end
+  end
+
+  # The before_email_auth_request chokepoint: the multi-phase-login dispatch
+  # never enters the email_auth_request ROUTE, so enforce_route! cannot see it.
+  describe '.enforce_email_auth! — the multi-phase login dispatch' do
+    def gate_email_auth(strategy: :custom, internal: false)
+      instance = rodauth_double(:login, strategy: strategy, internal: internal)
+      catch(:halted) do
+        described_class.enforce_email_auth!(instance)
+        nil
+      end
+    end
+
+    context 'on a host that opted into sign-in but DISABLED magic links' do
+      let(:signin_config) { signin_config_double(signin_enabled: true, email_auth_enabled: false) }
+
+      it 'allows POST /login itself (password sign-in is still on)' do
+        expect_allowed(:login)
+      end
+
+      it '404s the magic-link dispatch reached from that same route' do
+        halted = gate_email_auth
+
+        expect(halted&.first).to eq(404),
+          'a host that turned magic links off still dispatched one via multi-phase login'
+        expect(JSON.parse(halted[2].first)['error_type']).to eq('NotFound')
+      end
+    end
+
+    context 'on a host with no SigninConfig at all' do
+      it '404s — no opt-in, no magic link' do
+        expect(gate_email_auth&.first).to eq(404)
+      end
+    end
+
+    context 'on a host that opted into sign-in with magic links ON' do
+      let(:signin_config) { signin_config_double(signin_enabled: true, email_auth_enabled: true) }
+
+      it 'allows the dispatch' do
+        expect(gate_email_auth).to be_nil
+      end
+    end
+
+    context 'when magic links are disabled INSTALL-wide' do
+      let(:email_auth_global) { false }
+      let(:signin_config)     { signin_config_double(signin_enabled: true, email_auth_enabled: true) }
+
+      it '404s' do
+        expect(gate_email_auth&.first).to eq(404)
+      end
+    end
+
+    it 'exempts internal requests, same as enforce_route!' do
+      expect(gate_email_auth(internal: true)).to be_nil
     end
   end
 

--- a/apps/web/auth/spec/unit/signin_gate_spec.rb
+++ b/apps/web/auth/spec/unit/signin_gate_spec.rb
@@ -1,0 +1,596 @@
+# apps/web/auth/spec/unit/signin_gate_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for the sign-in / sign-up OPT-IN route gate
+# (ADR-024#operator-defaults-require-positive-classification,
+# ADR-034#reject-as-not-found-not-forbidden, #4163).
+#
+# WHAT IS UNDER TEST. Two things, and only two:
+#
+#   1. THE CLASSIFICATION. Every Rodauth route symbol is on exactly one side of
+#      this axis — SIGNIN_ROUTES, SIGNUP_ROUTES, or an explicit exemption. A
+#      route nobody classified defaults to "allowed", which is the exact defect
+#      #4163 closes, so an unclassified route must RED this file rather than
+#      quietly pass.
+#   2. THE DECISION AND THE HALT. Which resolver the gate asks, with which
+#      inputs, and what it does with the answer.
+#
+# RESOLUTION ITSELF IS NOT UNDER TEST — it is the model's
+# (SigninConfig.resolve_signin_enabled_for_request /
+# SignupConfig.resolve_signup_enabled_for_request,
+# ADR-034#resolution-is-model-owned) and is tested there and in the parity
+# spec. So the DATASTORE reads are stubbed and the resolvers run for real: a
+# gate that agreed with a stubbed resolver would prove nothing about the host
+# it guards.
+#
+# WHY THIS EXISTS ALONGSIDE THE INTEGRATION SPEC, same reason as its restrict_to
+# sibling: the full-mode lane boots with email_auth and webauthn disabled, so
+# those endpoints are absent and any example that POSTs to them skips. Here the
+# routing decision is exercised directly against @current_route, so every gated
+# route symbol is covered whatever features a lane happens to load.
+#
+# Run:
+#   bundle exec rspec apps/web/auth/spec/unit/signin_gate_spec.rb
+
+require_relative '../spec_helper'
+
+# The POLICY module only — deliberately NOT config/hooks/restrict_to.rb, which
+# is namespaced into Auth::Config and would drag the whole boot chain in. That
+# separation is why apps/web/auth/signin_gate.rb exists beside restrict_to.rb;
+# this require is also the assertion that it holds.
+require_relative '../../signin_gate'
+
+# The OTHER axis over the same route table. Required for the coverage assertion
+# below, which compares the two classifications against each other rather than
+# against a transcription — a route added to one and forgotten in the other is
+# precisely the drift that leaves a gate looking closed.
+require_relative '../../restrict_to'
+
+RSpec.describe Auth::SigninGate do
+  let(:display_domain) { 'tenant.example.com' }
+  let(:domain_id)      { 'domain_4163' }
+
+  let(:custom_domain) { instance_double(Onetime::CustomDomain, identifier: domain_id) }
+
+  # Install-level: sign-in, sign-up and magic links all ON, so every rejection
+  # below is the HOST's answer and not a global kill switch.
+  let(:auth_settings)     { { 'enabled' => true, 'signin' => true, 'signup' => true } }
+  let(:email_auth_global) { true }
+
+  let(:signin_config) { nil }
+  let(:signup_config) { nil }
+
+  let(:mock_auth_config) do
+    instance_double(Onetime::AuthConfig, email_auth_enabled?: email_auth_global)
+  end
+
+  before do
+    allow(Onetime).to receive(:auth_config).and_return(mock_auth_config)
+    allow(OT).to receive(:conf).and_return({ 'site' => { 'authentication' => auth_settings } })
+    allow(Auth::Logging).to receive(:log_auth_event)
+
+    # from_display_domain, not load_by_display_domain: the gate reads through
+    # the NON-swallowing finder on purpose (#4157), and stubbing the wrong one
+    # would leave it reading a real (empty) datastore — every example would then
+    # pass vacuously against "no tenant config".
+    allow(Onetime::CustomDomain).to receive(:from_display_domain)
+      .with(display_domain).and_return(custom_domain)
+    allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
+      .with(domain_id).and_return(signin_config)
+    allow(Onetime::CustomDomain::SignupConfig).to receive(:find_by_domain_id)
+      .with(domain_id).and_return(signup_config)
+  end
+
+  def signin_config_double(signin_enabled: true, email_auth_enabled: true, enabled: true)
+    instance_double(
+      Onetime::CustomDomain::SigninConfig,
+      domain_id: domain_id,
+      enabled?: enabled,
+      signin_enabled?: signin_enabled,
+      email_auth_enabled?: email_auth_enabled,
+    )
+  end
+
+  def signup_config_double(signup_enabled: true, enabled: true)
+    instance_double(
+      Onetime::CustomDomain::SignupConfig,
+      domain_id: domain_id,
+      enabled?: enabled,
+      signup_enabled?: signup_enabled,
+    )
+  end
+
+  # Minimal stand-in for the Rodauth instance the before_rodauth block runs
+  # against: current_route, request.env, request.path and the halt.
+  # `internal_request?` is private on the real object, which is why the gate
+  # reaches it with send — the double mirrors that.
+  def rodauth_double(route, strategy: :custom, internal: false)
+    request = double(
+      'request',
+      env: {
+        'onetime.display_domain' => display_domain,
+        'onetime.domain_strategy' => strategy,
+      },
+      path: "/#{route}",
+    )
+    allow(request).to receive(:halt) { |response| throw :halted, response }
+
+    instance = double('rodauth', current_route: route, request: request)
+    allow(instance).to receive(:send).with(:internal_request?).and_return(internal)
+    instance
+  end
+
+  # Runs the gate and returns the halt response, or nil when it allowed through.
+  def gate(route, strategy: :custom, internal: false)
+    catch(:halted) do
+      described_class.enforce_route!(rodauth_double(route, strategy: strategy, internal: internal))
+      nil
+    end
+  end
+
+  def expect_rejected(route, **)
+    halted = gate(route, **)
+
+    expect(halted&.first).to eq(404), "#{route} was ALLOWED where the host never opted in"
+    expect(JSON.parse(halted[2].first)['error_type']).to eq('NotFound')
+  end
+
+  def expect_allowed(route, **)
+    expect(gate(route, **)).to be_nil, "#{route} was rejected where the host opted in"
+  end
+
+  # ==========================================================================
+  # 1. Classification coverage — the guard against a route slipping past
+  # ==========================================================================
+  #
+  # The gate can only be as complete as its tables. The integration spec checks
+  # them against the LIVE route_hash, which covers only what a lane mounts;
+  # here they are checked against the other axis's tables, which enumerate the
+  # same Rodauth route universe and are maintained by the same reviewers.
+  #
+  describe 'route classification' do
+    let(:signin_routes) { described_class::SIGNIN_ROUTES }
+    let(:signup_routes) { described_class::SIGNUP_ROUTES }
+    let(:exempt)        { described_class::UNGATED_ROUTES }
+
+    it 'classifies every route the restrict_to axis knows about' do
+      known        = Auth::RestrictTo::PRE_AUTH_ROUTES.keys + Auth::RestrictTo::UNGATED_ROUTES
+      classified   = signin_routes + signup_routes + exempt
+      unclassified = known - classified
+
+      expect(unclassified).to be_empty,
+        "Rodauth routes with no sign-in/sign-up axis classification: #{unclassified.inspect}\n" \
+        'Add each to SIGNIN_ROUTES / SIGNUP_ROUTES (with its function) or UNGATED_ROUTES ' \
+        "(with a reason) in apps/web/auth/signin_gate.rb. See ADR-024.\n" \
+        'Defaulting to "allowed" is the #4163 defect.'
+    end
+
+    it 'invents no route the restrict_to axis has never heard of' do
+      known  = Auth::RestrictTo::PRE_AUTH_ROUTES.keys + Auth::RestrictTo::UNGATED_ROUTES
+      unique = (signin_routes + signup_routes + exempt) - known
+
+      expect(unique).to be_empty,
+        "classified here but unknown to Auth::RestrictTo: #{unique.inspect} — one of the two tables is stale"
+    end
+
+    it 'puts every route on exactly ONE side (no double classification)' do
+      all = described_class::SIGNIN_ROUTES + described_class::SIGNUP_ROUTES + exempt
+
+      expect(all.tally.select { |_route, count| count > 1 }).to be_empty
+    end
+
+    it 'derives axis_for from the two gated tables and nothing else' do
+      signin_routes.each { |route| expect(described_class.axis_for(route)).to eq(:signin) }
+      signup_routes.each { |route| expect(described_class.axis_for(route)).to eq(:signup) }
+      exempt.each        { |route| expect(described_class.axis_for(route)).to be_nil }
+    end
+
+    it 'reads a non-trivial table (guards against a vacuous pass)' do
+      expect(described_class::GATED_ROUTES).to include(:login, :create_account)
+      expect(described_class::GATED_ROUTES.size).to be >= 10
+    end
+
+    # Not an incidental omission: gating logout would strand a signed-in user
+    # on a host whose owner flipped the opt-in off.
+    it 'never gates logout' do
+      expect(described_class::GATED_ROUTES).not_to include(:logout)
+    end
+
+    # The classification is by FUNCTION, so — unlike RestrictTo, which
+    # reclassifies these three as 'webauthn' when webauthn_verify_account is
+    # loaded — nothing about the credential the ceremony mints moves them.
+    it 'classifies the create/verify trio as sign-up regardless of the signup ceremony' do
+      expect(described_class.axis_for(:create_account)).to eq(:signup)
+      expect(described_class.axis_for(:verify_account)).to eq(:signup)
+      expect(described_class.axis_for(:verify_account_resend)).to eq(:signup)
+    end
+
+    # Password recovery is a sign-in path: the credential it mints is usable on
+    # the canonical host, so a host that never opted into sign-in must not mint
+    # one, or the opt-in is advisory.
+    it 'classifies password recovery as sign-in, not sign-up and not exempt' do
+      expect(described_class.axis_for(:reset_password_request)).to eq(:signin)
+      expect(described_class.axis_for(:reset_password)).to eq(:signin)
+    end
+  end
+
+  # ==========================================================================
+  # 2. The sign-in axis
+  # ==========================================================================
+
+  describe 'sign-in routes on a CUSTOM host' do
+    context 'with no SigninConfig at all — the #4163 defect' do
+      # Before this gate, POST /auth/login on exactly this host authenticated
+      # canonical accounts in full mode while simple mode rejected it.
+      described_class::SIGNIN_ROUTES.each do |route|
+        it "404s #{route}" do
+          expect_rejected(route)
+        end
+      end
+    end
+
+    context 'with a SigninConfig whose master switch is OFF' do
+      let(:signin_config) { signin_config_double(enabled: false) }
+
+      it 'still 404s — a disabled record is not an opt-in' do
+        expect_rejected(:login)
+      end
+    end
+
+    context 'with an enabled SigninConfig that opted IN' do
+      let(:signin_config) { signin_config_double(signin_enabled: true) }
+
+      described_class::SIGNIN_ROUTES.each do |route|
+        it "allows #{route}" do
+          expect_allowed(route)
+        end
+      end
+    end
+
+    context 'with an enabled SigninConfig that opted OUT' do
+      let(:signin_config) { signin_config_double(signin_enabled: false) }
+
+      it '404s login' do
+        expect_rejected(:login)
+      end
+    end
+
+    # The SSO carve-out inside resolve_signin_enabled_for_custom_domain keeps
+    # the /signin PAGE reachable for an SSO-only tenant. It applies to DISPLAY
+    # surfaces only, and this gate omits domain_id so it can never fire here:
+    # SSO does not flow through POST /auth/login, so honoring the carve-out
+    # would re-open the very credential submission ADR-024 closes.
+    it 'does not inherit the display SSO carve-out' do
+      allow(Onetime::CustomDomain::SsoConfig).to receive(:tenant_sso_available_for?).and_return(true)
+
+      expect_rejected(:login)
+      expect(Onetime::CustomDomain::SsoConfig).not_to have_received(:tenant_sso_available_for?)
+    end
+  end
+
+  describe 'sign-in routes on an OPERATOR host' do
+    %i[canonical subdomain].each do |strategy|
+      context "on #{strategy.inspect}" do
+        it 'follows the global default when sign-in is enabled' do
+          expect_allowed(:login, strategy: strategy)
+        end
+
+        context 'with AUTH_SIGNIN off' do
+          let(:auth_settings) { { 'enabled' => true, 'signin' => false, 'signup' => true } }
+
+          it '404s — the global kill switch reaches the operator host too' do
+            expect_rejected(:login, strategy: strategy)
+          end
+        end
+
+        context 'with the AUTH_ENABLED master switch off' do
+          let(:auth_settings) { { 'enabled' => false, 'signin' => true, 'signup' => true } }
+
+          it '404s' do
+            expect_rejected(:login, strategy: strategy)
+          end
+        end
+      end
+    end
+
+    # The branch is chosen by a POSITIVE operator test
+    # (ADR-024#operator-defaults-require-positive-classification), so the
+    # :invalid a failing domain-index read manufactures for a REAL customer
+    # domain cannot inherit the operator's global sign-in default.
+    [:invalid, nil].each do |strategy|
+      it "404s login on #{strategy.inspect} — an unplaceable host is not the operator's" do
+        expect_rejected(:login, strategy: strategy)
+      end
+    end
+  end
+
+  describe 'the email-auth AND' do
+    let(:signin_config) { signin_config_double(signin_enabled: true, email_auth_enabled: tenant_email_auth) }
+    let(:tenant_email_auth) { true }
+
+    context 'when the tenant turned magic links off but kept password sign-in' do
+      let(:tenant_email_auth) { false }
+
+      described_class::EMAIL_AUTH_ROUTES.each do |route|
+        it "404s #{route}" do
+          expect_rejected(route)
+        end
+      end
+
+      it 'leaves the password sign-in routes reachable — the AND is per route, not per host' do
+        expect_allowed(:login)
+        expect_allowed(:reset_password_request)
+      end
+    end
+
+    context 'when magic links are disabled INSTALL-wide' do
+      let(:email_auth_global) { false }
+
+      it '404s email_auth_request even though the host opted into sign-in' do
+        expect_rejected(:email_auth_request)
+      end
+    end
+
+    context 'when both are on' do
+      it 'allows the magic-link routes' do
+        expect_allowed(:email_auth_request)
+        expect_allowed(:email_auth)
+      end
+    end
+
+    # Multi-phase login can dispatch a magic link from the LOGIN route. That
+    # path is closed at before_email_auth_request (config/hooks/restrict_to.rb),
+    # the one chokepoint both entry points share — so :login is deliberately not
+    # in EMAIL_AUTH_ROUTES and must not start consulting the magic-link flag.
+    it 'does not AND the email-auth flag into the login route' do
+      expect(described_class::EMAIL_AUTH_ROUTES).not_to include(:login)
+    end
+  end
+
+  # ==========================================================================
+  # 3. The sign-up axis
+  # ==========================================================================
+
+  describe 'sign-up routes on a CUSTOM host' do
+    context 'with no SignupConfig' do
+      described_class::SIGNUP_ROUTES.each do |route|
+        it "404s #{route}" do
+          expect_rejected(route)
+        end
+      end
+    end
+
+    context 'with an enabled SignupConfig that opted IN' do
+      let(:signup_config) { signup_config_double(signup_enabled: true) }
+
+      described_class::SIGNUP_ROUTES.each do |route|
+        it "allows #{route}" do
+          expect_allowed(route)
+        end
+      end
+
+      # The two axes are independent: a host may accept account creation while
+      # its sign-in opt-in is absent (and vice versa). Reading the wrong config
+      # for an axis would show up here.
+      it 'does not let the sign-up opt-in open the sign-in routes' do
+        expect_rejected(:login)
+      end
+    end
+
+    context 'with an enabled SignupConfig that opted OUT' do
+      let(:signup_config) { signup_config_double(signup_enabled: false) }
+
+      it '404s create_account' do
+        expect_rejected(:create_account)
+      end
+    end
+
+    context 'with a sign-in opt-in but NO sign-up opt-in' do
+      let(:signin_config) { signin_config_double(signin_enabled: true) }
+
+      it 'still 404s create_account — sign-in does not imply sign-up' do
+        expect_rejected(:create_account)
+        expect_allowed(:login)
+      end
+    end
+  end
+
+  describe 'sign-up routes on an OPERATOR host' do
+    it 'follows the global default' do
+      expect_allowed(:create_account, strategy: :canonical)
+    end
+
+    context 'with AUTH_SIGNUP off' do
+      let(:auth_settings) { { 'enabled' => true, 'signin' => true, 'signup' => false } }
+
+      it '404s create_account but leaves sign-in alone — the flags are separate' do
+        expect_rejected(:create_account, strategy: :canonical)
+        expect_allowed(:login, strategy: :canonical)
+      end
+    end
+  end
+
+  # ==========================================================================
+  # 4. Exemptions
+  # ==========================================================================
+
+  describe 'routes outside this axis' do
+    it 'never touches an exempt route, even on a host that opted into nothing' do
+      described_class::UNGATED_ROUTES.each do |route|
+        expect(gate(route)).to be_nil,
+          "#{route} is documented as exempt (account-scoped / second factor / logout) but was rejected"
+      end
+    end
+
+    # Second-factor ceremonies are a property of the ACCOUNT (#4138), not of the
+    # request host. Gating them would lock out a user who already presented a
+    # first factor this host permitted.
+    it 'leaves the second-factor ceremonies reachable' do
+      expect(gate(:otp_auth)).to be_nil
+      expect(gate(:webauthn_auth)).to be_nil
+      expect(gate(:recovery_auth)).to be_nil
+    end
+  end
+
+  describe 'internal requests' do
+    # Rodauth's internal_request feature synthesizes a bare env with no Host and
+    # no DomainStrategy classification, and handle_internal_request calls
+    # before_rodauth directly — so this guard is load-bearing, not defensive.
+    # Invite signup autologin is the flow that breaks without it.
+    it 'is skipped for an internal sign-in request' do
+      expect(gate(:login, internal: true)).to be_nil
+    end
+
+    it 'is skipped for an internal sign-up request' do
+      expect(gate(:create_account, internal: true)).to be_nil
+    end
+
+    it 'is skipped even when the policy read would have raised' do
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
+        .with(display_domain).and_raise(Redis::BaseError, 'lookup unavailable')
+
+      expect(gate(:login, internal: true)).to be_nil
+    end
+  end
+
+  # ==========================================================================
+  # 5. Reject shape and logging
+  # ==========================================================================
+
+  describe 'the reject' do
+    it 'is byte-identical to the restrict_to gate — the shape cannot leak which fired' do
+      expect(described_class.not_found_response).to eq(Auth::RestrictTo.not_found_response)
+    end
+
+    it 'carries the router shared body, so a gated route reads as an undefined one' do
+      _status, headers, body = gate(:login)
+
+      expect(headers).to eq('content-type' => 'application/json')
+      expect(JSON.parse(body.first)).to eq(JSON.parse(JSON.generate(Auth::ErrorTranslator::NOT_FOUND_BODY)))
+    end
+
+    it 'logs the rejection with the route and the host classification' do
+      gate(:create_account)
+
+      expect(Auth::Logging).to have_received(:log_auth_event).with(
+        :signin_gate_route_rejected,
+        hash_including(level: :info, route: :create_account, axis: :signup, domain_strategy: :custom),
+      )
+    end
+
+    it 'logs nothing when it allows through' do
+      gate(:login, strategy: :canonical)
+
+      expect(Auth::Logging).not_to have_received(:log_auth_event)
+    end
+  end
+
+  # ==========================================================================
+  # 6. Unreadable policy — 503, never a guess
+  # ==========================================================================
+  #
+  # Two datastore reads back each verdict on a custom host (the CustomDomain
+  # identity, then the per-domain config), so this path is reached by a
+  # transient blip and not only by a real outage. A 404 here would be the gate
+  # claiming an opt-in it never managed to look up; the global default would be
+  # the widening #4157 closed, since the SAME blip is what makes DomainStrategy
+  # answer :invalid for a real customer domain.
+  #
+  describe 'lookup failures' do
+    shared_examples 'fails closed with 503' do |route, error|
+      it "raises #{error} for #{route}" do
+        expect { gate(route) }.to raise_error(error)
+      end
+    end
+
+    context 'when the CustomDomain identity read raises' do
+      before do
+        allow(Onetime::CustomDomain).to receive(:from_display_domain)
+          .with(display_domain).and_raise(Redis::BaseError, 'lookup unavailable')
+      end
+
+      include_examples 'fails closed with 503', :login, Onetime::SigninPolicyUnavailable
+      include_examples 'fails closed with 503', :create_account, Onetime::SignupPolicyUnavailable
+
+      it 'logs the failure at error — an auth surface is down and it must alert' do
+        expect { gate(:login) }.to raise_error(Onetime::SigninPolicyUnavailable)
+
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:signin_gate_policy_lookup_failed, hash_including(level: :error, axis: :signin))
+      end
+
+      it 'carries a retry_after so the edge can hint a back-off' do
+        expect { gate(:login) }.to raise_error(Onetime::SigninPolicyUnavailable) { |ex|
+          expect(ex.to_h[:error_type]).to eq('SigninPolicyUnavailable')
+          expect(ex.to_h[:retry_after]).to be_a(Integer)
+        }
+      end
+    end
+
+    context 'when the per-domain config read raises' do
+      before do
+        allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
+          .with(domain_id).and_raise(Redis::BaseError, 'config unavailable')
+        allow(Onetime::CustomDomain::SignupConfig).to receive(:find_by_domain_id)
+          .with(domain_id).and_raise(Redis::BaseError, 'config unavailable')
+      end
+
+      include_examples 'fails closed with 503', :login, Onetime::SigninPolicyUnavailable
+      include_examples 'fails closed with 503', :create_account, Onetime::SignupPolicyUnavailable
+    end
+
+    # The POSITIVE operator test, stated as the property rather than a table
+    # cell: :invalid is exactly what DomainStrategy answers for a real customer
+    # domain when the same blip broke its own read, so it must fail closed with
+    # the custom hosts and NOT inherit the operator's global default.
+    context 'on a host that could not be classified' do
+      before do
+        allow(Onetime::CustomDomain).to receive(:from_display_domain)
+          .with(display_domain).and_raise(Redis::BaseError, 'lookup unavailable')
+      end
+
+      [:invalid, nil].each do |strategy|
+        it "raises rather than inheriting the operator default on #{strategy.inspect}" do
+          expect { gate(:login, strategy: strategy) }
+            .to raise_error(Onetime::SigninPolicyUnavailable)
+          expect { gate(:create_account, strategy: strategy) }
+            .to raise_error(Onetime::SignupPolicyUnavailable)
+        end
+      end
+    end
+
+    # An operator host's policy is in-memory config, so the failed read cost it
+    # nothing: nil is the only answer it could ever have had, and resolution
+    # proceeds against the global setting exactly as it always would.
+    context 'on an operator host' do
+      before do
+        allow(Onetime::CustomDomain).to receive(:from_display_domain)
+          .with(display_domain).and_raise(Redis::BaseError, 'lookup unavailable')
+      end
+
+      %i[canonical subdomain].each do |strategy|
+        it "resolves from the in-memory global on #{strategy.inspect}" do
+          expect_allowed(:login, strategy: strategy)
+          expect_allowed(:create_account, strategy: strategy)
+        end
+      end
+
+      context 'with AUTH_SIGNIN off' do
+        let(:auth_settings) { { 'enabled' => true, 'signin' => false, 'signup' => true } }
+
+        it 'still enforces the global — the carve-out is not an allow' do
+          expect_rejected(:login, strategy: :canonical)
+        end
+      end
+    end
+
+    it 'does not reach the datastore at all for an exempt route' do
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
+        .with(display_domain).and_raise(Redis::BaseError, 'lookup unavailable')
+
+      expect(gate(:logout)).to be_nil
+      expect(gate(:otp_auth)).to be_nil
+    end
+  end
+end

--- a/apps/web/core/spec/views/serializers/signin_gate_parity_spec.rb
+++ b/apps/web/core/spec/views/serializers/signin_gate_parity_spec.rb
@@ -1,0 +1,396 @@
+# apps/web/core/spec/views/serializers/signin_gate_parity_spec.rb
+#
+# frozen_string_literal: true
+
+# FULL-MODE GATE <-> SIMPLE-MODE GATE PARITY for the sign-in / sign-up OPT-IN
+# axis (ADR-024#display-runtime-parity,
+# ADR-024#operator-defaults-require-positive-classification,
+# ADR-034#resolution-is-model-owned, #4163).
+#
+# THE DEFECT THIS PINS. Simple mode consults the ADR-024 resolvers at its POST
+# handlers (Core::Controllers::Base#signin_enabled? / #signup_enabled?); full
+# mode did not — its pre-auth routes are Rodauth's and only the `restrict_to`
+# axis was gated. A custom domain with no enabled SigninConfig therefore
+# REJECTED POST /signin on a simple-mode install and ACCEPTED POST /auth/login
+# on a full-mode one, authenticating canonical accounts. An access control that
+# changes with the deployment shape is not an access control.
+#
+# THE ASSERTION IS THE AGREEMENT ITSELF — the two verdicts are compared to each
+# other, not to a table of expected values (the values themselves are pinned by
+# signin_signup_classification_parity_spec.rb, which owns the required matrix).
+# An edit to either gate that "fixes" one without the other reds this file even
+# when it looks locally correct. Both sides reach the same model resolvers, so
+# what is actually asserted is that neither side gathers a different INPUT:
+# a different `global`, a different config, a different classification, or —
+# the one that started this — a domain_id that re-opens the display SSO
+# carve-out on a credential POST.
+#
+# The restrict_to axis has its own parity file next door
+# (restrict_to_parity_spec.rb). Same shape, different axis: that one answers
+# WHICH method a host may offer, this one whether it may offer sign-in at all.
+#
+# No datastore and no HTTP: the domain/config lookups are stubbed, because what
+# is under test is which inputs each gate gathers and that the two agree.
+#
+# Run:
+#   bundle exec rspec apps/web/core/spec/views/serializers/signin_gate_parity_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../../views/serializers'
+
+# The POLICY module only (not config/hooks/restrict_to.rb, which is namespaced
+# into Auth::Config and drags the boot chain in) — the same require the auth
+# unit spec uses.
+require_relative File.join(Onetime::HOME, 'apps', 'web', 'auth', 'signin_gate')
+
+RSpec.describe 'sign-in/sign-up opt-in: full-mode gate vs simple-mode gate parity' do
+  # Every value env['onetime.domain_strategy'] can carry at a consumer. :invalid
+  # and nil are here because they are what a failing domain-index read
+  # manufactures for a REAL customer domain, and they are where a `== :custom`
+  # branch widens.
+  GATE_PARITY_CLASSIFICATIONS = [:canonical, :subdomain, :custom, :invalid, nil].freeze
+
+  let(:display_domain) { 'secrets.tenant.example.com' }
+  let(:domain_id)      { 'domain_4163_parity' }
+
+  let(:custom_domain) { instance_double(Onetime::CustomDomain, identifier: domain_id) }
+
+  let(:auth_settings) { { 'enabled' => true, 'signin' => true, 'signup' => true } }
+
+  let(:signin_config) { nil }
+  let(:signup_config) { nil }
+
+  # SSO OFF: the display carve-out has its own section, and leaving it on here
+  # would mask the password/email default the whole file is about.
+  let(:mock_auth_config) do
+    instance_double(
+      Onetime::AuthConfig,
+      sso_enabled?: false,
+      sso_providers: [],
+      allow_platform_fallback_for_tenants?: false,
+      email_auth_enabled?: true,
+      restrict_to: nil,
+      restrict_to_available?: true
+    )
+  end
+
+  before do
+    allow(Onetime).to receive(:auth_config).and_return(mock_auth_config)
+    allow(OT).to receive(:conf).and_return({ 'site' => { 'authentication' => auth_settings } })
+
+    # BOTH identity reads. The two gates resolve the host through the
+    # non-swallowing .from_display_domain (#4157); ConfigSerializer, used in the
+    # email-auth section below, still resolves through the fail-open
+    # .load_by_display_domain. They are distinct class methods with no alias
+    # between them, so stubbing only one leaves the other reading a real (empty)
+    # datastore and answering "no tenant config" for every case — which turns
+    # the assertions below into assertions about the unconfigured default.
+    allow(Onetime::CustomDomain).to receive(:from_display_domain)
+      .with(display_domain).and_return(custom_domain)
+    allow(Onetime::CustomDomain).to receive(:load_by_display_domain)
+      .with(display_domain).and_return(custom_domain)
+    allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
+      .with(domain_id).and_return(signin_config)
+    allow(Onetime::CustomDomain::SignupConfig).to receive(:find_by_domain_id)
+      .with(domain_id).and_return(signup_config)
+    allow(Onetime::CustomDomain::SsoConfig).to receive(:find_by_domain_id)
+      .with(domain_id).and_return(nil)
+  end
+
+  # ---------------------------------------------------------------- surfaces
+
+  # SIMPLE MODE: the Core POST handlers, reached exactly as a request reaches
+  # them — through req.env['onetime.domain_strategy'].
+  let(:controller_class) do
+    Class.new do
+      include Core::Controllers::Base
+
+      def initialize(env)
+        @req = Struct.new(:env).new(env)
+      end
+    end
+  end
+
+  def env_for(strategy)
+    {
+      'onetime.domain_strategy' => strategy,
+      'onetime.display_domain' => display_domain,
+    }
+  end
+
+  def simple_signin(strategy)
+    controller_class.new(env_for(strategy)).send(:signin_enabled?)
+  end
+
+  def simple_signup(strategy)
+    controller_class.new(env_for(strategy)).send(:signup_enabled?)
+  end
+
+  # FULL MODE: the before_rodauth gate's decision, minus the halt.
+  def full_signin(strategy)
+    Auth::SigninGate.signin_allowed?(env_for(strategy))
+  end
+
+  def full_signup(strategy)
+    Auth::SigninGate.signup_allowed?(env_for(strategy))
+  end
+
+  # THE assertion. Everything below sets up a scenario and calls this.
+  def expect_parity(strategy)
+    expect(full_signin(strategy)).to be(simple_signin(strategy)),
+      "sign-in verdicts diverge on #{strategy.inspect}: " \
+      "full=#{full_signin(strategy)} simple=#{simple_signin(strategy)}"
+    expect(full_signup(strategy)).to be(simple_signup(strategy)),
+      "sign-up verdicts diverge on #{strategy.inspect}: " \
+      "full=#{full_signup(strategy)} simple=#{simple_signup(strategy)}"
+  end
+
+  # ------------------------------------------------------------- the matrix
+
+  describe 'host classification x tenant config' do
+    def signin_config_double(enabled:, opt_in:)
+      instance_double(
+        Onetime::CustomDomain::SigninConfig,
+        domain_id: domain_id,
+        enabled?: enabled,
+        signin_enabled?: opt_in,
+        email_auth_enabled?: true,
+        sso_enabled?: false,
+        restrict_to: nil
+      )
+    end
+
+    def signup_config_double(enabled:, opt_in:)
+      instance_double(
+        Onetime::CustomDomain::SignupConfig,
+        domain_id: domain_id,
+        enabled?: enabled,
+        signup_enabled?: opt_in
+      )
+    end
+
+    # The four states a per-domain policy can be in. The interesting one is the
+    # first: it is the shape #4163 was filed for, and the two modes disagreed
+    # on it in exactly one direction.
+    {
+      'no per-domain config' => { signin: nil, signup: nil },
+      'a disabled record (not an opt-in)' => { signin: [false, true], signup: [false, true] },
+      'an enabled record that opted IN' => { signin: [true, true], signup: [true, true] },
+      'an enabled record that opted OUT' => { signin: [true, false], signup: [true, false] },
+    }.each do |label, state|
+      context "with #{label}" do
+        let(:signin_config) do
+          state[:signin] && signin_config_double(enabled: state[:signin][0], opt_in: state[:signin][1])
+        end
+        let(:signup_config) do
+          state[:signup] && signup_config_double(enabled: state[:signup][0], opt_in: state[:signup][1])
+        end
+
+        GATE_PARITY_CLASSIFICATIONS.each do |strategy|
+          it "agrees on #{strategy.inspect}" do
+            expect_parity(strategy)
+          end
+        end
+      end
+    end
+  end
+
+  # The property, stated once rather than left implicit in the matrix.
+  describe 'the #4163 defect itself' do
+    it 'a custom domain with no opt-in rejects sign-in in BOTH modes' do
+      expect(simple_signin(:custom)).to be(false)
+      expect(full_signin(:custom)).to be(false)
+    end
+
+    it 'and rejects sign-up in both' do
+      expect(simple_signup(:custom)).to be(false)
+      expect(full_signup(:custom)).to be(false)
+    end
+
+    it 'while the operator host is untouched in both' do
+      expect(simple_signin(:canonical)).to be(true)
+      expect(full_signin(:canonical)).to be(true)
+      expect(simple_signup(:canonical)).to be(true)
+      expect(full_signup(:canonical)).to be(true)
+    end
+  end
+
+  # ------------------------------------------------------- the display carve-out
+
+  # resolve_signin_enabled_for_custom_domain has two modes and the full-mode
+  # gate must pick the same one simple mode picks. An SSO-only tenant reports
+  # sign-in AVAILABLE to DISPLAY surfaces (its /signin page works through the
+  # omniauth routes), and strictly DISABLED to the credential POST gates. A
+  # full-mode gate that passed domain_id would re-open precisely the password
+  # submission ADR-024 closes — and would do it on a host where simple mode
+  # rejects.
+  describe 'the SSO carve-out reaches neither gate' do
+    before do
+      allow(Onetime::CustomDomain::SsoConfig)
+        .to receive(:tenant_sso_available_for?).and_return(true)
+    end
+
+    [:custom, :invalid, nil].each do |strategy|
+      it "stays closed on #{strategy.inspect} in both modes" do
+        expect_parity(strategy)
+        expect(full_signin(strategy)).to be(false)
+      end
+    end
+
+    it 'never consults the tenant SSO predicate from the full-mode gate' do
+      full_signin(:custom)
+
+      expect(Onetime::CustomDomain::SsoConfig).not_to have_received(:tenant_sso_available_for?)
+    end
+  end
+
+  # ------------------------------------------------------------ kill switches
+
+  describe 'global kill switches' do
+    {
+      'AUTH_ENABLED off' => { 'enabled' => false, 'signin' => true, 'signup' => true },
+      'AUTH_SIGNIN off' => { 'enabled' => true, 'signin' => false, 'signup' => true },
+      'AUTH_SIGNUP off' => { 'enabled' => true, 'signin' => true, 'signup' => false },
+    }.each do |label, settings|
+      context "with #{label}" do
+        let(:auth_settings) { settings }
+
+        GATE_PARITY_CLASSIFICATIONS.each do |strategy|
+          it "agrees on #{strategy.inspect}" do
+            expect_parity(strategy)
+          end
+        end
+      end
+    end
+
+    # The gate reads the global itself (global_signin_enabled with no argument)
+    # while the controller passes site.authentication in. Same source, two call
+    # shapes — this is the assertion that they stay the same VALUE.
+    it 'reads the same global input on both sides' do
+      expect(Onetime::CustomDomain::SigninConfig.global_signin_enabled)
+        .to be(Onetime::CustomDomain::SigninConfig.global_signin_enabled(auth_settings))
+      expect(Onetime::CustomDomain::SignupConfig.global_signup_enabled)
+        .to be(Onetime::CustomDomain::SignupConfig.global_signup_enabled(auth_settings))
+    end
+  end
+
+  # --------------------------------------------------------- unreadable policy
+
+  # A blip on the hot path must produce the SAME answer in both modes: 503 on
+  # any host not positively the operator's, and the still-known in-memory
+  # global everywhere else. The mode-dependent version of this is what #4157
+  # closed for simple mode; #4163 is the other half.
+  describe 'lookup failures' do
+    before do
+      allow(Onetime::CustomDomain).to receive(:from_display_domain)
+        .with(display_domain).and_raise(Redis::BaseError, 'lookup unavailable')
+      allow(Auth::Logging).to receive(:log_auth_event)
+    end
+
+    [:custom, :invalid, nil].each do |strategy|
+      it "both modes raise SigninPolicyUnavailable on #{strategy.inspect}" do
+        expect { simple_signin(strategy) }.to raise_error(Onetime::SigninPolicyUnavailable)
+        expect { full_signin(strategy) }.to raise_error(Onetime::SigninPolicyUnavailable)
+      end
+
+      it "both modes raise SignupPolicyUnavailable on #{strategy.inspect}" do
+        expect { simple_signup(strategy) }.to raise_error(Onetime::SignupPolicyUnavailable)
+        expect { full_signup(strategy) }.to raise_error(Onetime::SignupPolicyUnavailable)
+      end
+    end
+
+    %i[canonical subdomain].each do |strategy|
+      it "both modes resolve from the in-memory global on #{strategy.inspect}" do
+        expect_parity(strategy)
+        expect(full_signin(strategy)).to be(true)
+      end
+
+      context 'with AUTH_SIGNIN off' do
+        let(:auth_settings) { { 'enabled' => true, 'signin' => false, 'signup' => true } }
+
+        it "both modes still enforce the global on #{strategy.inspect}" do
+          expect_parity(strategy)
+          expect(full_signin(strategy)).to be(false)
+        end
+      end
+    end
+  end
+
+  # ------------------------------------------------------------- email auth
+
+  # The magic-link routes carry a second AND: the per-domain override can turn
+  # magic links off while leaving password sign-in on. Its display consumer is
+  # ConfigSerializer#resolve_email_auth (the button), so the claim here is the
+  # same one the rest of the file makes — the route and the button read one
+  # resolver with one set of inputs.
+  describe 'the email-auth AND on the magic-link routes' do
+    let(:tenant_email_auth) { true }
+    let(:signin_config) do
+      instance_double(
+        Onetime::CustomDomain::SigninConfig,
+        domain_id: domain_id,
+        enabled?: true,
+        signin_enabled?: true,
+        email_auth_enabled?: tenant_email_auth,
+        sso_enabled?: false,
+        restrict_to: nil
+      )
+    end
+
+    def view_vars_for(strategy)
+      {
+        'site' => { 'authentication' => auth_settings },
+        'domain_strategy' => strategy,
+        'display_domain' => display_domain,
+      }
+    end
+
+    def gate_email_auth(strategy)
+      Auth::SigninGate.allowed?(env_for(strategy), :signin, :email_auth_request)
+    end
+
+    def display_email_auth(strategy)
+      Core::Views::ConfigSerializer.resolve_email_auth(view_vars_for(strategy))
+    end
+
+    GATE_PARITY_CLASSIFICATIONS.each do |strategy|
+      it "agrees with signin AND the display magic-link answer on #{strategy.inspect}" do
+        expect(gate_email_auth(strategy))
+          .to be(simple_signin(strategy) && display_email_auth(strategy))
+      end
+    end
+
+    context 'when the tenant turned magic links off' do
+      let(:tenant_email_auth) { false }
+
+      it 'closes the magic-link route while password sign-in stays open' do
+        expect(gate_email_auth(:custom)).to be(false)
+        expect(full_signin(:custom)).to be(true)
+        expect(simple_signin(:custom)).to be(true)
+      end
+    end
+
+    context 'when magic links are disabled install-wide' do
+      before { allow(mock_auth_config).to receive(:email_auth_enabled?).and_return(false) }
+
+      it 'closes the magic-link route on the operator host too' do
+        expect(gate_email_auth(:canonical)).to be(false)
+        expect(display_email_auth(:canonical)).to be(false)
+      end
+    end
+  end
+
+  # ------------------------------------------------------ String classifications
+
+  # StrategyResult metadata is not always a Symbol; operator_host? normalizes
+  # with to_sym, and a gate that compared raw values would disagree with one
+  # that normalized.
+  describe 'String classifications' do
+    %w[canonical subdomain custom invalid].each do |strategy|
+      it "agrees on #{strategy.inspect}" do
+        expect_parity(strategy)
+        expect(full_signin(strategy)).to be(full_signin(strategy.to_sym))
+      end
+    end
+  end
+end

--- a/docs/adr/adr-038-rodauth-route-gating-by-symbol-classification.md
+++ b/docs/adr/adr-038-rodauth-route-gating-by-symbol-classification.md
@@ -1,0 +1,79 @@
+---
+id: 038
+status: accepted
+decided: 2026-08-13
+title: "ADR-038: Rodauth Route Gating via Exhaustive Symbol Classification"
+---
+
+## Context
+
+Full-mode authentication routes are served by Rodauth inside the Roda auth
+app. Request-time policy gates apply to them — `restrict_to`
+([ADR-034](adr-034-restrict-to-enforcement.md#restrict-to-is-an-access-control-not-a-display-preference))
+first, the signin/signup opt-in axis (#4163) second — and each new axis has
+to answer the same three questions: where does the gate hook in, what is a
+route keyed by, and what happens to a route nobody classified. The first
+gate answered them in file-local comments (`apps/web/auth/restrict_to.rb`);
+with a second gate reusing the answers verbatim, they are shared mechanism,
+recorded once here.
+
+The recurring counter-proposal this ADR exists to answer: the rest of the
+app declares per-route properties in Otto's `routes.txt`, so why not there?
+
+Section headings declare their own citation anchors
+(ADR-036#anchors-are-declared) — cite `ADR-038#slug`, not positions. <!-- adr-lint:ignore -->
+
+## Decision
+
+### Gate at before_rodauth, not in the routing table {#gate-at-before-rodauth}
+
+Rodauth routes never pass through Otto: Rodauth builds `route_hash` once,
+freezes it in `post_configure`, and dispatches internally. There is no
+`routes.txt` row to carry a property, and routes cannot be un-mounted per
+request or per host. Per-route policy therefore hooks `before_rodauth` — the
+one chokepoint that fires inside the matched route, after `@current_route`
+is set and CSRF is checked, before anything executes — and *emulates*
+non-existence with the reject shape of
+ADR-034#reject-as-not-found-not-forbidden.
+
+Otto-dispatched auth surfaces (simple mode's Core controllers) gate in the
+controller instead, through the same model-owned resolvers
+(ADR-034#resolution-is-model-owned), so both modes share resolution rather
+than each mode carrying its own annotation system.
+
+Gates on the same routes compose in a fixed order, broadest-precedence
+first, so a rejected request cannot distinguish which gate fired.
+
+### Classify by route symbol, not URL {#classify-by-symbol-not-url}
+
+Classification keys are the symbols Rodauth's `route(...)` declares (what
+`@current_route` reports), never URL paths. Two reasons, both live:
+
+- URLs are operator-configurable and several are renamed in
+  `config/features/`; a path-keyed table silently stops matching.
+- Loaded features can change what a route *means* without renaming it —
+  `webauthn_verify_account` turns the `create_account`/`verify_account`
+  ceremony into a WebAuthn one. A gate whose axis is sensitive to that
+  re-meaning reclassifies by feature presence (see
+  `Auth::RestrictTo::WEBAUTHN_VERIFY_ACCOUNT_ROUTES`); one whose axis is
+  not (function-keyed axes like signin/signup) states that it is not.
+
+### Classify exhaustively, or fail the build {#classify-exhaustively-or-fail}
+
+Every Rodauth route appears in exactly one bucket per gate axis: gated, or
+exempt with a stated reason (account-scoped, install-wide posture, not a
+sign-in method, second-factor ceremony). A coverage spec enumerates the
+mounted routes and fails when a route appears in no bucket — a new feature
+route is a red test, never a silent default-open. Default-open is how a
+gate rots while looking closed, which is worse than no gate: it invites
+documenting an access control the server does not provide.
+
+## Consequences
+
+- Adding a Rodauth feature forces a classification decision per gate axis,
+  at spec-failure time rather than in an audit.
+- Gate modules stay thin: symbol tables plus input-gathering, with
+  resolution owned by the models (ADR-034#resolution-is-model-owned).
+- The cost is one Ruby constant per axis instead of declarative routing
+  metadata — accepted, because the metadata cannot live where these routes
+  are dispatched.


### PR DESCRIPTION
Closes #4163.

## What

Full mode's Rodauth-served pre-auth routes enforced only the `restrict_to` axis (#4139 / ADR-034). The ADR-024 signin/signup opt-in axis — custom-domain default-OFF — was consulted by the display serializers and the simple-mode Core gates, but not by these routes, so enforcement of that axis was mode-dependent. This PR adds `Auth::SigninGate`, wired from the same `before_rodauth` chokepoint after `Auth::RestrictTo.enforce_route!`, resolving through the same model-owned resolvers as simple mode (`SigninConfig.resolve_signin_enabled_for_request` / `SignupConfig.resolve_signup_enabled_for_request`).

- **Signin axis** (`login`, `email_auth*`, `webauthn_login`/`autofill_js`, `reset_password*`, `unlock_account*`): host must have opted into sign-in; email-auth routes additionally require effective `email_auth_enabled`. `unlock_account*` is classified signin because Rodauth's lockout defaults mint a passwordless autologin session from the emailed key.
- **Signup axis** (`create_account`, `verify_account*`): host must have opted into sign-up. Function-keyed — unchanged by `webauthn_verify_account`.
- **Multi-phase login**: `before_email_auth_request` now enforces this axis too, closing the magic-link dispatch that flows through the LOGIN route.
- Reject shape 404 with the shared `NOT_FOUND_BODY` (ADR-034#reject-as-not-found-not-forbidden); unreadable policy fails closed per host class (`SigninPolicyUnavailable`/`SignupPolicyUnavailable` → 503), operator hosts resolve from in-memory global config (ADR-024#operator-defaults-require-positive-classification). `internal_request?` exempt (invite autologin).

## ADR-038

The gating mechanism is now shared by two axes, so it's promoted from file-local comments to `docs/adr/adr-038-rodauth-route-gating-by-symbol-classification.md` with three declared anchors (gate-at-before-rodauth, classify-by-symbol-not-url, classify-exhaustively-or-fail); both gate files cite the anchors instead of restating the prose.

## Tests

- `signin_gate_spec.rb` (unit, 70+): both-direction classification coverage against RestrictTo's route universe — an unclassified new Rodauth route is a red test — plus the full decision table, lookup-failure per host class, internal-request exemption, reject-shape byte-equality.
- `signin_gate_parity_spec.rb`: simple-mode Core gates vs full-mode SigninGate compared to each other across host classifications × config states × kill switches, so the two modes cannot drift.
- `signin_gate_enforcement_spec.rb` (full-sqlite integration): no-opt-in custom host 404s login/create-account/reset/unlock; signin-only and signup-only hosts isolate each axis; canonical host unaffected.

Whole unit, simple, and full-sqlite lanes green (1719/0/26 full-sqlite; details in the lane runs). Follow-ups: #4164 (display-side signup parity in ConfigSerializer); the gate re-reads the CustomDomain/SigninConfig the restrict_to gate just read — memoizing the reads in the Rack env is a small perf follow-up.