### PR TITLE
fix(masthead): resolve neutral alt/site-name from productName directly

### DIFF
--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -154,6 +154,14 @@
   // private-label install (#3571). A brand-neutral value should not be
   // translatable in the first place.
   const getSiteName = () => props.logo?.siteName || productName.value;
+
+  // Sign-in tooltip: genuinely translatable copy, so it stays an i18n message
+  // with the resolver's product name interpolated. Computed in script so the
+  // ref read is an explicit `.value`, consistent with every other resolver
+  // read in this component (the template would otherwise rely on auto-unwrap).
+  const signInLinkTitle = computed(() =>
+    t('web.homepage.log_in_to_onetime_secret', { product_name: productName.value })
+  );
   const getAriaLabel = () => props.logo?.ariaLabel;
   const getIsColonelArea = () => props.logo?.isColonelArea ?? props.colonel;
 
@@ -341,7 +349,7 @@
             <router-link
               v-if="authentication?.signin"
               to="/signin"
-              :title="t('web.homepage.log_in_to_onetime_secret', { product_name: productName })"
+              :title="signInLinkTitle"
               data-testid="header-signin-link"
               class="text-gray-600 transition-colors duration-200
                 hover:text-gray-800 dark:text-gray-300 dark:hover:text-white">

--- a/src/shared/components/layout/MastHead.vue
+++ b/src/shared/components/layout/MastHead.vue
@@ -89,7 +89,7 @@
   const getLogoDarkUrl = () =>
     props.logo?.url ? null : logoDarkSource.value;
   // Alt text: caller > operator BRAND_LOGO_ALT (only while the install logo
-  // is the asset being shown) > i18n string derived from the product name.
+  // is the asset being shown) > the resolver's productName, read directly.
   // When platform identity is suppressed (custom domain / tenant logo), the
   // accessible name must not leak the operator's product name either — use
   // the tenant-facing displayName (brand description or display domain),
@@ -97,9 +97,7 @@
   const getLogoAlt = () =>
     props.logo?.alt ||
     installLogoAlt.value ||
-    (showPlatformIdentity.value
-      ? t('web.homepage.one_time_secret_literal', { product_name: productName.value })
-      : displayName.value);
+    (showPlatformIdentity.value ? productName.value : displayName.value);
   const getLogoHref = () => props.logo?.href || headerConfig.value?.logo?.href || '/';
 
   // Custom install-wide logo: operator set BRAND_LOGO_URL. Distinct from the
@@ -146,7 +144,16 @@
   // The wordmark text is the resolver's productName (brand.product_name or
   // the neutral default) — the deprecated header.branding.site_name is
   // absorbed into brand.product_name by Config#normalize_brand (#3612).
-  const getSiteName = () => props.logo?.siteName || t('web.homepage.one_time_secret_literal', { product_name: productName.value });
+  //
+  // Read from the resolver directly rather than through the
+  // `web.homepage.one_time_secret_literal` i18n key. That key is a bare
+  // `{product_name}` passthrough in every locale today, so this is not a
+  // behavior change — it removes the indirection, and with it the risk that
+  // a future locale edit replaces the placeholder with a literal brand
+  // string and reintroduces the platform-brand leak on a neutral or
+  // private-label install (#3571). A brand-neutral value should not be
+  // translatable in the first place.
+  const getSiteName = () => props.logo?.siteName || productName.value;
   const getAriaLabel = () => props.logo?.ariaLabel;
   const getIsColonelArea = () => props.logo?.isColonelArea ?? props.colonel;
 

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -98,6 +98,17 @@ describe('branding resolver consolidation guardrail', () => {
       expect(raw).toContain('installLogoAlt');
       expect(raw).toContain('logoSource');
     });
+
+    it('does not route the neutral alt/site-name through a translatable brand literal (#3571)', () => {
+      // The neutral alt text and wordmark come from the resolver's
+      // productName directly. web.homepage.one_time_secret_literal is a bare
+      // {product_name} passthrough in every locale today, so routing through
+      // it is currently equivalent — but it makes a brand-neutral value
+      // translatable, and one locale edit swapping the placeholder for a
+      // literal brand string would leak the platform brand onto a
+      // neutral/private-label install. Keep the indirection out.
+      expect(code).not.toContain('one_time_secret_literal');
+    });
   });
 
   describe('identityStore is the one place the raw install-brand fields are read', () => {

--- a/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
+++ b/src/tests/shared/brandingResolverConsolidation.guard.spec.ts
@@ -42,6 +42,12 @@ function stripComments(src: string): string {
     if (src.startsWith('<!--', i)) {
       const end = src.indexOf('-->', i + 4);
       i = end === -1 ? src.length : end + 3;
+    } else if (src.startsWith('-->', i)) {
+      // A bare `-->` only occurs as residue of a nested `<!-- <!-- … --> -->`
+      // (the region scan above ends at the first `-->`); it is never valid
+      // Vue/TS code on its own. Drop it so the stripped output carries no
+      // dangling comment closer a future guard assertion could match.
+      i += 3;
     } else if (src.startsWith('/*', i)) {
       const end = src.indexOf('*/', i + 2);
       i = end === -1 ? src.length : end + 2;
@@ -212,10 +218,11 @@ describe('stripComments (guard helper)', () => {
 
   // Invariant guarded by the comment scanner: however comments nest, no
   // forbidden token and no dangling comment opener may survive.
-  it('removes nested HTML comments, leaving no forbidden token or `<!--` opener', () => {
+  it('removes nested HTML comments, leaving no forbidden token, `<!--` opener, or `-->` closer', () => {
     const out = stripComments('<!--<!-- brand_product_name -->--> keep');
     expect(out).not.toContain('brand_product_name');
     expect(out).not.toContain('<!--');
+    expect(out).not.toContain('-->');
     expect(out).toContain('keep');
   });
 


### PR DESCRIPTION
## Summary

[#3571](https://github.com/onetimesecret/onetimesecret/issues/3571)

Resolve the masthead's neutral logo alt / site-name from `productName.value` directly instead of routing through the translatable key `t('web.homepage.one_time_secret_literal', { product_name })`, and add a guard spec pinning the structure.

Supersedes #3996 — the code change there was correct, but its stated premise was not: every locale's `secret-homepage.json` already carries `"text": "{product_name}"` with matching `source_hash: 7bec5899`, so there is no live brand leak. This is **hardening, not a bug fix** — output is byte-identical in every locale today. What it removes is the re-leak vector: a brand-neutral value should not be translatable, so a future locale edit cannot reintroduce a hardcoded brand string on custom domains.

Differences from #3996 beyond the code:
- New explanatory comment states the true rationale (no false "stale locales" claim)
- Fixed the pre-existing comment above `getLogoAlt` that the change would have made wrong ("i18n string derived from the product name")
- Guard test renamed to drop the false premise
- Does not claim `Closes #3571` — the issue as filed describes a bug that is not reproducible; whether to close it as such is a maintainer call

Original change by @mahdi13830510, credited via `Co-Authored-By`.

## Related Issues

Refs #3571, supersedes #3996

## Test Plan

- `vitest run` on `MastHead.spec.ts`, `MastHead.customDomain.spec.ts`, `brandingResolverConsolidation.guard.spec.ts`: 3 files, 93 tests passed
- `lint:base` / `lint:tests` on changed files: clean
- `pnpm run type-check`: clean. (`type-check:tests` fails with 584 pre-existing errors — verified identical count on clean `origin/main`, none touching these files.)
- No changelog fragment: byte-identical output in all locales; `changelog.d/README.md` excludes internal refactoring

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmGkCYohcumhy9g6GrCwPk