### PR TITLE
feat(cli): add customer reconcile operation to repair role-index drift

### DIFF
--- a/apps/web/auth/operations/customers/reconcile_role_index.rb
+++ b/apps/web/auth/operations/customers/reconcile_role_index.rb
@@ -1,0 +1,278 @@
+# apps/web/auth/operations/customers/reconcile_role_index.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/models/colonel_audit_event'
+require 'onetime/audited_failure'
+
+module Auth
+  module Operations
+    module Customers
+      # Reconcile the customer role index (customer:role_index:*) against the
+      # authoritative `role` field on each customer record (#3974).
+      #
+      # The ONE implementation of the role-index reconcile verb. The
+      # `bin/ots customers role reconcile` command is a thin adapter: it owns
+      # CLI concerns (flags, confirmation, output, exit codes) and delegates
+      # the check + repair to this op.
+      #
+      # ## Why the index drifts (familia 2.12)
+      #
+      # `Customer` declares `multi_index :role, :role_index`. Two mechanisms
+      # let the derived index disagree with the `role` field:
+      #
+      # 1. ADD-ONLY partial writes. In familia 2.12, `save_fields` /
+      #    `multi_field_update` / `commit_fields` route multi_index maintenance
+      #    through `add_to_class_role_index`, which only ever SADDs into the
+      #    NEW value's bucket — stale membership in the previous value's bucket
+      #    is intentionally retained on value change. Only the app's full-save
+      #    override (lib/onetime/models/customer/features/role_index.rb) does
+      #    old-bucket removal, so any role change persisted through a targeted
+      #    writer leaves the customer in two buckets.
+      #
+      # 2. TTL-expired customer hashes. The right-to-be-forgotten feature sets
+      #    `default_expiration = 365.days` on the customer hash
+      #    (lib/onetime/models/features/right_to_be_forgotten.rb). When the
+      #    hash expires, the `customer:role_index:*` set member for it persists
+      #    forever — permanently inflating `colonel_count` and `role list`.
+      #
+      # ## Repair strategy: incremental, never destructive
+      #
+      # `Customer.rebuild_role_index` (familia-generated) is DEL-then-
+      # repopulate: it SCANs and DELs every `customer:role_index:*` key before
+      # re-adding members, so a crash mid-run leaves a PARTIAL index (an empty
+      # or half-filled bucket that under-reports colonels until the next run).
+      # This op instead computes the exact per-bucket diff and applies targeted
+      # SADD/SREM operations. Every individual write is a correct repair on its
+      # own, so an interrupted run leaves the index strictly closer to correct
+      # — never worse than when it started — and a re-run converges.
+      #
+      # ## Audit (epic #20 CONTRACT 4)
+      #
+      # A dry run is a pure diagnostic read and records nothing. An applied run
+      # that changed the index records ONE ColonelAuditEvent summarizing the
+      # additions/removals when an `actor` is supplied. A failed APPLIED run
+      # records a failure event on the same gate (Doctor precedent: never audit
+      # a failed read-only pass).
+      class ReconcileRoleIndex
+        include Onetime::LoggerMethods
+
+        AUDIT_VERB = 'customer.role_index_reconcile'
+
+        # How many identifiers to load per LOAD_MULTI batch while building the
+        # expected membership map (same default as familia's rebuild).
+        BATCH_SIZE = 100
+
+        # @!attribute status [r]
+        #   @return [Symbol] :clean (index matches the role fields),
+        #     :drift (dry run found divergence; nothing written),
+        #     :repaired (applied run wrote the diff)
+        # @!attribute scanned [r]
+        #   @return [Integer] customer identifiers examined from Customer.instances
+        # @!attribute buckets [r]
+        #   @return [Hash{String=>Hash}] per-role bucket report:
+        #     { 'colonel' => { members: 3, stale: 1, missing: 0 }, ... }.
+        #     Includes buckets that exist only in the index (all-stale) and
+        #     roles that exist only on customer records (all-missing).
+        # @!attribute additions [r]
+        #   @return [Array<Hash>] { role:, objid: } members missing from their
+        #     role's bucket (SADDed on an applied run)
+        # @!attribute removals [r]
+        #   @return [Array<Hash>] { role:, objid: } stale members — customer
+        #     gone/expired, or its current role differs (SREMed on apply)
+        # @!attribute dry_run [r]
+        #   @return [Boolean]
+        Result = Data.define(:status, :scanned, :buckets, :additions, :removals, :dry_run)
+
+        # @param apply [Boolean] write the SADD/SREM diff when true; default is
+        #   a report-only dry run (the safe default — this rewrites index sets
+        #   that `role list`, `colonel_count` and `find_first_colonel` read).
+        # @param actor [String, #extid, #email, nil] acting admin's PUBLIC
+        #   identity (colonel extid, or the CLI sentinel). Only consulted on an
+        #   applied run; a dry run records no audit event.
+        def initialize(apply: false, actor: nil)
+          @apply = apply
+          @actor = actor
+        end
+
+        # @return [Result]
+        def call
+          expected, scanned = expected_memberships
+          actual            = indexed_memberships
+
+          additions, removals = diff(expected, actual)
+          buckets             = bucket_report(expected, actual, additions, removals)
+
+          if additions.empty? && removals.empty?
+            return Result.new(
+              status: :clean,
+              scanned: scanned,
+              buckets: buckets,
+              additions: additions,
+              removals: removals,
+              dry_run: !@apply,
+            )
+          end
+
+          unless @apply
+            return Result.new(
+              status: :drift,
+              scanned: scanned,
+              buckets: buckets,
+              additions: additions,
+              removals: removals,
+              dry_run: true,
+            )
+          end
+
+          apply_diff(additions, removals)
+          audit_repair(scanned, additions, removals)
+
+          Result.new(
+            status: :repaired,
+            scanned: scanned,
+            buckets: buckets,
+            additions: additions,
+            removals: removals,
+            dry_run: false,
+          )
+        rescue StandardError => ex
+          # Same gate as Doctor: a failed dry run is a failed READ and must not
+          # write an audit event (CONTRACT 4: viewing never writes). A failed
+          # APPLIED run may have left part of the diff written — each applied
+          # SADD/SREM is individually correct, but the attempt belongs in the
+          # trail.
+          audit_repair_failure(ex) if @apply && !@actor.nil?
+          raise
+        end
+
+        private
+
+        # Authoritative state: role field per live customer, built from the
+        # class instances collection. A customer whose hash TTL-expired (RTBF)
+        # still has its objid in `instances` but loads as nil, so it lands in
+        # NO expected bucket — exactly the shape that makes its lingering index
+        # member a removal.
+        #
+        # @return [Array(Hash{String=>Set}, Integer)] role => Set(objid), and
+        #   the count of identifiers examined
+        def expected_memberships
+          expected = Hash.new { |hash, key| hash[key] = Set.new }
+          scanned  = 0
+
+          Onetime::Customer.instances.members.each_slice(BATCH_SIZE) do |identifiers|
+            scanned += identifiers.size
+
+            Onetime::Customer.load_multi(identifiers).compact.each do |customer|
+              role = customer.role.to_s
+              next if role.strip.empty?
+
+              expected[role] << customer.identifier.to_s
+            end
+          end
+
+          [expected, scanned]
+        end
+
+        # Current index state, straight from the datastore. SCAN pattern
+        # construction mirrors familia's own rebuild_role_index: the namespace
+        # prefix comes from class metadata, so the '*' only matches keys under
+        # customer:role_index:.
+        #
+        # @return [Hash{String=>Set}] role => Set(objid) as currently indexed
+        def indexed_memberships
+          sample  = Onetime::Customer.role_index_for('*')
+          pattern = sample.dbkey
+          prefix  = pattern.delete_suffix('*')
+          client  = Onetime::Customer.dbclient
+
+          actual = {}
+          client.scan_each(match: pattern) do |key|
+            role         = key.delete_prefix(prefix)
+            actual[role] = client.smembers(key).to_set(&:to_s)
+          end
+          actual
+        end
+
+        # @return [Array(Array<Hash>, Array<Hash>)] [additions, removals],
+        #   each entry { role:, objid: }, deterministically ordered so reports
+        #   and audit details are stable across runs
+        def diff(expected, actual)
+          roles = (expected.keys | actual.keys).sort
+
+          additions = []
+          removals  = []
+
+          roles.each do |role|
+            want = expected[role] || Set.new
+            have = actual[role] || Set.new
+
+            (want - have).sort.each { |objid| additions << { role: role, objid: objid } }
+            (have - want).sort.each { |objid| removals << { role: role, objid: objid } }
+          end
+
+          [additions, removals]
+        end
+
+        # @return [Hash{String=>Hash}] see Result#buckets
+        def bucket_report(expected, actual, additions, removals)
+          roles = (expected.keys | actual.keys).sort
+
+          roles.to_h do |role|
+            [role, {
+              members: (actual[role] || Set.new).size,
+              stale: removals.count { |entry| entry[:role] == role },
+              missing: additions.count { |entry| entry[:role] == role },
+            }]
+          end
+        end
+
+        # Incremental repair. Additions first: if the run dies partway, the
+        # worst intermediate state is the union of both (the same over-report
+        # the add-only drift already produces), never a missing colonel.
+        # Removing the last member of a set deletes the key server-side, so
+        # emptied buckets need no separate cleanup.
+        def apply_diff(additions, removals)
+          additions.each do |entry|
+            Onetime::Customer.role_index_for(entry[:role]).add(entry[:objid])
+          end
+
+          removals.each do |entry|
+            Onetime::Customer.role_index_for(entry[:role]).remove_element(entry[:objid])
+          end
+        end
+
+        # One audit event per applied run that changed the index. objid lists
+        # are intentionally NOT embedded — a large drift repair would bloat the
+        # count-capped audit set; the CLI/report output carries the detail.
+        def audit_repair(scanned, additions, removals)
+          return if @actor.nil?
+
+          Onetime::ColonelAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: 'customer:role_index',
+            result: :success,
+            detail: {
+              scanned: scanned,
+              additions: additions.size,
+              removals: removals.size,
+              roles: (additions + removals).map { |entry| entry[:role] }.uniq.sort,
+            },
+          )
+        end
+
+        # Shared failure-record path (drops authorization rejections, never
+        # double-records, best-effort write) — same helper Doctor uses.
+        def audit_repair_failure(error)
+          Onetime::AuditedFailure.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: 'customer:role_index',
+            error: error,
+          )
+        end
+      end
+    end
+  end
+end

--- a/apps/web/auth/operations/customers/reconcile_role_index.rb
+++ b/apps/web/auth/operations/customers/reconcile_role_index.rb
@@ -47,6 +47,19 @@ module Auth
       # own, so an interrupted run leaves the index strictly closer to correct
       # — never worse than when it started — and a re-run converges.
       #
+      # ## Concurrency posture: revalidate at apply, converge on rerun
+      #
+      # The customer scan and the index scan are separate, non-atomic reads, so
+      # a role change/creation/deletion that lands between snapshot and apply
+      # can make a diff entry stale. An applied run therefore REVALIDATES each
+      # entry immediately before writing it: the customer is freshly reloaded
+      # and the write is skipped (and reported in Result#skipped) when the
+      # entry's premise no longer holds. A single fresh read per entry is
+      # deliberate — no WATCH/MULTI across the whole run; the tiny remaining
+      # window between an entry's revalidation and its SADD/SREM is accepted,
+      # and a rerun (which skipped entries exit non-cleanly into anyway)
+      # converges on it.
+      #
       # ## Audit (epic #20 CONTRACT 4)
       #
       # A dry run is a pure diagnostic read and records nothing. An applied run
@@ -76,13 +89,21 @@ module Auth
         #     roles that exist only on customer records (all-missing).
         # @!attribute additions [r]
         #   @return [Array<Hash>] { role:, objid: } members missing from their
-        #     role's bucket (SADDed on an applied run)
+        #     role's bucket. On a dry run: the full detected set. On an applied
+        #     run: only the entries actually SADDed (stale ones move to skipped).
         # @!attribute removals [r]
         #   @return [Array<Hash>] { role:, objid: } stale members — customer
-        #     gone/expired, or its current role differs (SREMed on apply)
+        #     gone/expired, or its current role differs. On an applied run: only
+        #     the entries actually SREMed (stale ones move to skipped).
+        # @!attribute skipped [r]
+        #   @return [Array<Hash>] { role:, objid:, action:, reason: } diff
+        #     entries whose premise no longer held at apply-time revalidation
+        #     (a concurrent role change/creation/deletion overlapped the run);
+        #     nothing was written for them. Always empty on a dry run. A rerun
+        #     re-evaluates them from fresh snapshots.
         # @!attribute dry_run [r]
         #   @return [Boolean]
-        Result = Data.define(:status, :scanned, :buckets, :additions, :removals, :dry_run)
+        Result = Data.define(:status, :scanned, :buckets, :additions, :removals, :skipped, :dry_run)
 
         # @param apply [Boolean] write the SADD/SREM diff when true; default is
         #   a report-only dry run (the safe default — this rewrites index sets
@@ -110,6 +131,7 @@ module Auth
               buckets: buckets,
               additions: additions,
               removals: removals,
+              skipped: [],
               dry_run: !@apply,
             )
           end
@@ -121,19 +143,25 @@ module Auth
               buckets: buckets,
               additions: additions,
               removals: removals,
+              skipped: [],
               dry_run: true,
             )
           end
 
-          apply_diff(additions, removals)
-          audit_repair(scanned, additions, removals)
+          applied_additions, applied_removals, skipped = apply_diff(additions, removals)
+
+          # Diff fully written: from here on, a raise (e.g. in the audit write)
+          # must not be recorded as a repair failure.
+          repair_written = true
+          audit_repair(scanned, applied_additions, applied_removals, skipped)
 
           Result.new(
             status: :repaired,
             scanned: scanned,
             buckets: buckets,
-            additions: additions,
-            removals: removals,
+            additions: applied_additions,
+            removals: applied_removals,
+            skipped: skipped,
             dry_run: false,
           )
         rescue StandardError => ex
@@ -141,8 +169,12 @@ module Auth
           # write an audit event (CONTRACT 4: viewing never writes). A failed
           # APPLIED run may have left part of the diff written — each applied
           # SADD/SREM is individually correct, but the attempt belongs in the
-          # trail.
-          audit_repair_failure(ex) if @apply && !@actor.nil?
+          # trail. Once the diff is fully written, though, a failure in the
+          # audit write itself must NOT record a failure event — the repair
+          # succeeded, and a `:failure` entry for a run that fixed the index
+          # would poison the trail (the exception still propagates so the CLI
+          # surfaces it).
+          audit_repair_failure(ex) if @apply && !@actor.nil? && !repair_written
           raise
         end
 
@@ -232,20 +264,67 @@ module Auth
         # the add-only drift already produces), never a missing colonel.
         # Removing the last member of a set deletes the key server-side, so
         # emptied buckets need no separate cleanup.
+        #
+        # Each entry is REVALIDATED against a fresh read of its customer
+        # immediately before the write, because the diff was computed from
+        # snapshots that a concurrent role change/creation/deletion may have
+        # invalidated. A write whose premise no longer holds is skipped and
+        # reported instead of applied. A mutation can still land between an
+        # entry's fresh read and its SADD/SREM — that residual per-entry window
+        # is accepted; a rerun converges on it.
+        #
+        # @return [Array(Array<Hash>, Array<Hash>, Array<Hash>)]
+        #   [applied_additions, applied_removals, skipped]
         def apply_diff(additions, removals)
-          additions.each do |entry|
-            Onetime::Customer.role_index_for(entry[:role]).add(entry[:objid])
+          skipped = []
+
+          applied_additions = additions.select do |entry|
+            current = current_role(entry[:objid])
+            if current == entry[:role]
+              Onetime::Customer.role_index_for(entry[:role]).add(entry[:objid])
+              true
+            else
+              skipped << entry.merge(
+                action: :add,
+                reason: "customer role is now #{current.nil? ? '(gone)' : current.inspect}",
+              )
+              false
+            end
           end
 
-          removals.each do |entry|
-            Onetime::Customer.role_index_for(entry[:role]).remove_element(entry[:objid])
+          applied_removals = removals.select do |entry|
+            current = current_role(entry[:objid])
+            if current == entry[:role]
+              skipped << entry.merge(
+                action: :remove,
+                reason: 'customer now holds this role again',
+              )
+              false
+            else
+              Onetime::Customer.role_index_for(entry[:role]).remove_element(entry[:objid])
+              true
+            end
           end
+
+          [applied_additions, applied_removals, skipped]
+        end
+
+        # Fresh, non-batched read of the customer's current role, bypassing the
+        # snapshot the diff was computed from.
+        #
+        # @return [String, nil] the role, or nil when the customer hash is
+        #   gone/expired or the role field is blank (no bucket membership is
+        #   correct for either)
+        def current_role(objid)
+          customer = Onetime::Customer.load(objid)
+          role     = customer&.role.to_s
+          role.strip.empty? ? nil : role
         end
 
         # One audit event per applied run that changed the index. objid lists
         # are intentionally NOT embedded — a large drift repair would bloat the
         # count-capped audit set; the CLI/report output carries the detail.
-        def audit_repair(scanned, additions, removals)
+        def audit_repair(scanned, additions, removals, skipped)
           return if @actor.nil?
 
           Onetime::ColonelAuditEvent.record(
@@ -257,7 +336,8 @@ module Auth
               scanned: scanned,
               additions: additions.size,
               removals: removals.size,
-              roles: (additions + removals).map { |entry| entry[:role] }.uniq.sort,
+              skipped: skipped.size,
+              roles: (additions + removals + skipped).map { |entry| entry[:role] }.uniq.sort,
             },
           )
         end

--- a/changelog.d/20260815_120000_claude_3974_role_index_reconcile.rst
+++ b/changelog.d/20260815_120000_claude_3974_role_index_reconcile.rst
@@ -1,0 +1,29 @@
+.. A new scriv changelog fragment.
+
+Added
+-----
+
+- (`#3974 <https://github.com/onetimesecret/onetimesecret/issues/3974>`_)
+  New ``bin/ots customers role reconcile`` command repairs drift between the
+  authoritative ``role`` field and the derived ``customer:role_index:*`` sets
+  that ``role list`` and ``colonel_count`` read. The default run is a dry-run
+  report of per-bucket stale and missing members; ``--apply`` (with ``--force``
+  or an interactive confirmation) writes the repair, and ``--json`` emits a
+  machine-readable report. The repair is an incremental SADD/SREM diff rather
+  than the familia-generated DEL-then-repopulate rebuild, so an interrupted
+  run can never leave the index emptier than it started. Check + repair logic
+  lives in the shared ``Auth::Operations::Customers::ReconcileRoleIndex`` op,
+  which records one audit event per applied run.
+
+  The index drifts through two familia 2.12 mechanisms: targeted writers
+  (``save_fields`` / ``multi_field_update`` / ``commit_fields``) maintain
+  multi-indexes through an add-only path that retains the previous role's
+  bucket member on change, and right-to-be-forgotten TTL expiry deletes the
+  customer hash while its index members persist — permanently inflating
+  ``colonel_count`` until reconciled.
+
+AI Assistance
+-------------
+
+- Claude implemented the reconcile op, CLI action, specs and tryouts,
+  building on the original contribution in PR #3999. (#3974)

--- a/lib/onetime/cli/customers/role_command.rb
+++ b/lib/onetime/cli/customers/role_command.rb
@@ -198,7 +198,8 @@ module Onetime
 
         OT.info "[cli-customers-role-reconcile] status=#{result.status} " \
                 "scanned=#{result.scanned} additions=#{result.additions.size} " \
-                "removals=#{result.removals.size} dry_run=#{result.dry_run}"
+                "removals=#{result.removals.size} skipped=#{result.skipped.size} " \
+                "dry_run=#{result.dry_run}"
 
         json ? reconcile_output_json(result) : reconcile_output_text(result)
 
@@ -255,6 +256,17 @@ module Onetime
         verb = result.dry_run ? 'Would add' : 'Added'
         result.additions.each { |entry| puts "#{verb} #{entry[:objid]} to role_index:#{entry[:role]}" }
 
+        # Entries whose premise no longer held when the applied run revalidated
+        # them (concurrent role change) — nothing was written; rerun to
+        # re-evaluate from fresh snapshots.
+        result.skipped.each do |entry|
+          puts "Skipped #{entry[:action]} of #{entry[:objid]} in role_index:#{entry[:role]} (#{entry[:reason]})"
+        end
+        if result.skipped.any?
+          puts
+          puts "#{result.skipped.size} entr#{result.skipped.size == 1 ? 'y' : 'ies'} skipped after revalidation; rerun reconcile to re-check."
+        end
+
         return unless result.dry_run
 
         puts
@@ -269,6 +281,7 @@ module Onetime
           buckets: result.buckets,
           additions: result.additions,
           removals: result.removals,
+          skipped: result.skipped,
         )
       end
 

--- a/lib/onetime/cli/customers/role_command.rb
+++ b/lib/onetime/cli/customers/role_command.rb
@@ -11,23 +11,30 @@
 #   bin/ots customers role demote user@example.com               # Demote to customer
 #   bin/ots customers role list                                  # List all colonels
 #   bin/ots customers role list --role admin                     # List users with specific role
+#   bin/ots customers role reconcile                             # Report role-index drift (dry run)
+#   bin/ots customers role reconcile --apply                     # Confirm, then repair the index
+#   bin/ots customers role reconcile --apply --force --json      # Repair, machine-readable
 #
 # The actual role mutation + admin audit event is performed by the shared
 # Auth::Operations::Customers::SetRole op (single implementation); this command
-# owns only CLI concerns (arg parsing, confirmation prompt, output). The CLI runs
-# outside the auth app's autoloader, so require the op explicitly.
+# owns only CLI concerns (arg parsing, confirmation prompt, output). The role
+# index check + repair likewise lives in the shared
+# Auth::Operations::Customers::ReconcileRoleIndex op. The CLI runs outside the
+# auth app's autoloader, so require the ops explicitly.
+require 'json'
 require 'auth/operations/customers/set_role'
+require 'auth/operations/customers/reconcile_role_index'
 require 'onetime/cli/customers/shared'
 
 module Onetime
   module CLI
     class CustomersRoleCommand < Command
-      desc 'Manage customer roles (promote, demote, list)'
+      desc 'Manage customer roles (promote, demote, list, reconcile)'
 
       argument :action,
         type: :string,
         required: true,
-        desc: 'Action to perform: promote, demote, or list'
+        desc: 'Action to perform: promote, demote, list, or reconcile'
 
       argument :email,
         type: :string,
@@ -45,11 +52,25 @@ module Onetime
         aliases: ['-f'],
         desc: 'Skip confirmation prompt'
 
+      # reconcile-only options. --apply and --force are ORTHOGONAL on purpose
+      # (the org reconcile precedent): the default run writes nothing so it
+      # needs no confirmation; an applied run always needs --force (or an
+      # interactive 'y').
+      option :apply,
+        type: :boolean,
+        default: false,
+        desc: 'reconcile: write the repair (default: dry-run report)'
+
+      option :json,
+        type: :boolean,
+        default: false,
+        desc: 'reconcile: output as JSON'
+
       # Valid roles in hierarchy order (highest to lowest). Single source of
       # truth lives on the op; the CLI references it rather than forking a copy.
       VALID_ROLES = Auth::Operations::Customers::SetRole::VALID_ROLES
 
-      def call(action:, email: nil, role: 'colonel', force: false, **)
+      def call(action:, email: nil, role: 'colonel', force: false, apply: false, json: false, **)
         boot_application!
 
         case action.downcase
@@ -59,9 +80,11 @@ module Onetime
           demote_customer(email, force)
         when 'list'
           list_customers_by_role(role)
+        when 'reconcile'
+          reconcile_role_index(apply: apply, force: force, json: json)
         else
           puts "Unknown action: #{action}"
-          puts 'Valid actions: promote, demote, list'
+          puts 'Valid actions: promote, demote, list, reconcile'
           exit 1
         end
       end
@@ -148,6 +171,105 @@ module Onetime
 
         puts '-' * 40
         puts "Total: #{customers.size}"
+      end
+
+      # Reconcile customer:role_index:* against the authoritative `role` field
+      # (#3974). The index drifts through two familia-2.12 mechanisms — the
+      # ADD-ONLY multi_index maintenance on targeted writers (save_fields et
+      # al. never clear the previous value's bucket) and customer hashes whose
+      # right-to-be-forgotten TTL expired while their index members persist.
+      # See the ReconcileRoleIndex op for the full mechanism; this method owns
+      # only confirmation, output and exit codes.
+      #
+      # Default is a report-only dry run. Applying requires --apply plus
+      # either --force or an interactive 'y'; a scripted --json apply without
+      # --force is refused outright (never mutate from a script that did not
+      # say so — the org reconcile rule).
+      def reconcile_role_index(apply:, force:, json:)
+        return unless confirm_reconcile!(apply: apply, force: force, json: json)
+
+        result = Auth::Operations::Customers::ReconcileRoleIndex.new(
+          apply: apply,
+          # Never fabricate a Customer for the shell (ADR-023) — the audit
+          # trail records the shared CLI sentinel. Only attributed when the
+          # run can actually mutate.
+          actor: apply ? Customers::Shared::CLI_ACTOR : nil,
+        ).call
+
+        OT.info "[cli-customers-role-reconcile] status=#{result.status} " \
+                "scanned=#{result.scanned} additions=#{result.additions.size} " \
+                "removals=#{result.removals.size} dry_run=#{result.dry_run}"
+
+        json ? reconcile_output_json(result) : reconcile_output_text(result)
+
+        # A dry run that FOUND drift exits non-zero so scripts and monitoring
+        # can detect it (customers doctor precedent); a clean or repaired run
+        # exits zero.
+        exit 1 if result.status == :drift
+      rescue StandardError => ex
+        OT.le "[cli-customers-role-reconcile] failed: #{ex.class}: #{ex.message}"
+        if json
+          puts JSON.pretty_generate(error: "#{ex.class}: #{ex.message}")
+        else
+          puts "Error: reconcile failed: #{ex.message}"
+        end
+        exit 1
+      end
+
+      # @return [Boolean] true to proceed
+      def confirm_reconcile!(apply:, force:, json:)
+        return true unless apply
+        return true if force
+
+        if json
+          puts JSON.pretty_generate(error: 'Refusing to apply without --force in --json mode')
+          exit 1
+        end
+
+        print 'Apply role-index repairs? [y/N] '
+        response = $stdin.gets&.strip&.downcase
+        return true if response == 'y'
+
+        puts 'Aborted.'
+        false
+      end
+
+      def reconcile_output_text(result)
+        puts 'DRY RUN — nothing was written' if result.dry_run
+        puts "Customers scanned: #{result.scanned}"
+        puts "Status:            #{result.status}"
+
+        if result.buckets.any?
+          puts
+          puts format('%-20s %8s %8s %8s', 'Bucket', 'Members', 'Stale', 'Missing')
+          result.buckets.each do |role, stats|
+            puts format('%-20s %8d %8d %8d', role, stats[:members], stats[:stale], stats[:missing])
+          end
+        end
+
+        return if result.status == :clean
+
+        puts
+        verb = result.dry_run ? 'Would remove' : 'Removed'
+        result.removals.each { |entry| puts "#{verb} #{entry[:objid]} from role_index:#{entry[:role]}" }
+        verb = result.dry_run ? 'Would add' : 'Added'
+        result.additions.each { |entry| puts "#{verb} #{entry[:objid]} to role_index:#{entry[:role]}" }
+
+        return unless result.dry_run
+
+        puts
+        puts 'To apply these repairs, run with --apply'
+      end
+
+      def reconcile_output_json(result)
+        puts JSON.pretty_generate(
+          status: result.status,
+          dry_run: result.dry_run,
+          scanned: result.scanned,
+          buckets: result.buckets,
+          additions: result.additions,
+          removals: result.removals,
+        )
       end
 
       def validate_email_provided!(email, action)

--- a/spec/cli/customers_role_reconcile_command_spec.rb
+++ b/spec/cli/customers_role_reconcile_command_spec.rb
@@ -221,6 +221,68 @@ RSpec.describe 'Customers Role Reconcile Command' do
         expect(customer_bucket.member?(drifted.objid)).to be(true)
       end
 
+      it 'skips and reports a stale addition when the role changed between snapshot and apply' do
+        # Simulate the race deterministically: the SNAPSHOT (stubbed) claims
+        # the customer is a colonel, but by apply time the datastore says
+        # 'customer' — as if a concurrent demote landed mid-run. Apply-time
+        # revalidation must refuse the SADD instead of writing a membership
+        # the customer no longer holds.
+        raced = create_customer("race_add_#{suffix}@onetimesecret.com", role: 'customer')
+
+        op       = Auth::Operations::Customers::ReconcileRoleIndex.new(apply: true)
+        expected = Hash.new { |hash, key| hash[key] = Set.new }
+        expected['colonel'] << raced.objid
+        allow(op).to receive(:expected_memberships).and_return([expected, 1])
+
+        result = op.call
+
+        expect(result.status).to eq(:repaired)
+        expect(result.additions).to be_empty
+        expect(result.skipped).to include(
+          hash_including(role: 'colonel', objid: raced.objid, action: :add),
+        )
+        expect(colonel_bucket.member?(raced.objid)).to be(false)
+      end
+
+      it 'skips and reports a stale removal when the customer regained the role before apply' do
+        # Inverse race: the snapshot says this colonel-bucket member is stale,
+        # but by apply time the customer legitimately holds 'colonel' again
+        # (concurrent promote). Revalidation must refuse the SREM so the live
+        # colonel keeps its membership.
+        raced = create_customer("race_rem_#{suffix}@onetimesecret.com", role: 'colonel')
+        expect(colonel_bucket.member?(raced.objid)).to be(true)
+
+        op       = Auth::Operations::Customers::ReconcileRoleIndex.new(apply: true)
+        expected = Hash.new { |hash, key| hash[key] = Set.new }
+        allow(op).to receive(:expected_memberships).and_return([expected, 1])
+
+        result = op.call
+
+        expect(result.removals).not_to include(hash_including(objid: raced.objid))
+        expect(result.skipped).to include(
+          hash_including(role: 'colonel', objid: raced.objid, action: :remove),
+        )
+        expect(colonel_bucket.member?(raced.objid)).to be(true)
+      end
+
+      it 'surfaces skipped entries in the CLI text output' do
+        raced = create_customer("race_cli_#{suffix}@onetimesecret.com", role: 'customer')
+
+        op       = Auth::Operations::Customers::ReconcileRoleIndex.new(apply: true)
+        expected = Hash.new { |hash, key| hash[key] = Set.new }
+        expected['colonel'] << raced.objid
+        allow(op).to receive(:expected_memberships).and_return([expected, 1])
+        allow(Auth::Operations::Customers::ReconcileRoleIndex).to receive(:new).and_return(op)
+
+        outcome = run_reconcile(apply: true, force: true)
+
+        expect(outcome[:exit_code]).to eq(0)
+        expect(outcome[:stdout])
+          .to include("Skipped add of #{raced.objid} in role_index:colonel")
+        expect(outcome[:stdout]).to include('skipped after revalidation; rerun reconcile')
+        expect(colonel_bucket.member?(raced.objid)).to be(false)
+      end
+
       it 'applied run returns :repaired and converges to :clean' do
         drifted      = create_customer("op_apply_#{suffix}@onetimesecret.com", role: 'customer')
         drifted.role = 'colonel'

--- a/spec/cli/customers_role_reconcile_command_spec.rb
+++ b/spec/cli/customers_role_reconcile_command_spec.rb
@@ -1,0 +1,238 @@
+# spec/cli/customers_role_reconcile_command_spec.rb
+#
+# frozen_string_literal: true
+
+# Covers `bin/ots customers role reconcile` (#3974): the dry-run default
+# reports role-index drift without writing, and an applied run repairs the
+# index with targeted SADD/SREM (never rebuild's DEL-then-repopulate).
+#
+# Drift fixtures reproduce the REAL familia-2.12 mechanisms:
+#   * stale-bucket drift — a role change persisted through a targeted writer
+#     (save_fields routes multi_index maintenance through the ADD-ONLY
+#     add_to_class_role_index, retaining the previous value's bucket member)
+#   * expired-hash drift — the customer hash TTL-expired (right_to_be_forgotten
+#     sets default_expiration = 365.days) while its role_index member persists
+#   * missing-member drift — the index simply lacks a live customer's entry
+#
+# Lives in its own file with a REAL datastore (same rationale as
+# spec/cli/org_doctor_command_spec.rb): the reconcile walks Customer.instances
+# and SCANs customer:role_index:*, which the mocked `type: :cli` lane satisfies
+# vacuously. The examples drive the command's private reconcile_role_index
+# (via #send) instead of the full CLI `call` — the reconcile semantics are the
+# unit under test; argument parsing and boot are covered elsewhere.
+#
+# Run: bundle exec rspec spec/cli/customers_role_reconcile_command_spec.rb
+
+require_relative 'cli_spec_helper'
+require 'stringio'
+
+RSpec.describe 'Customers Role Reconcile Command' do
+  describe 'real datastore', :datastore do
+    let(:suffix) { "#{Familia.now.to_i}_#{SecureRandom.hex(4)}" }
+    let(:command) { Onetime::CLI::CustomersRoleCommand.new }
+
+    def colonel_bucket
+      Onetime::Customer.role_index_for('colonel')
+    end
+
+    def customer_bucket
+      Onetime::Customer.role_index_for('customer')
+    end
+
+    before do
+      @customers = []
+      # Converge to a clean baseline first, so residue from other spec files
+      # (customers created without index entries, expired fixtures) cannot
+      # bleed drift into these examples' expectations.
+      Auth::Operations::Customers::ReconcileRoleIndex.new(apply: true).call
+    end
+
+    after do
+      @customers.each do |cust|
+        cust.destroy! if cust.exists?
+      rescue StandardError => ex
+        warn "[role reconcile spec] customer cleanup failed: #{ex.class}: #{ex.message}"
+      end
+      # Drop any index members the examples seeded for customers that no
+      # longer exist (destroy! only clears the CURRENT role's bucket).
+      # Rescued because the failure-handling example's stub on the op class is
+      # still active while after-hooks run.
+      begin
+        Auth::Operations::Customers::ReconcileRoleIndex.new(apply: true).call
+      rescue StandardError => ex
+        warn "[role reconcile spec] index cleanup skipped: #{ex.class}: #{ex.message}"
+      end
+    end
+
+    def create_customer(email, role: 'customer')
+      cust      = Onetime::Customer.create!(email: email)
+      cust.role = role
+      cust.save
+      @customers << cust
+      cust
+    end
+
+    # Runs the command's private reconcile with stdout captured, converting a
+    # SystemExit into its status so exit-code expectations read directly.
+    # @return [Hash] { stdout:, exit_code: } (exit_code 0 when no exit raised)
+    def run_reconcile(apply: false, force: false, json: false)
+      original = $stdout
+      $stdout  = StringIO.new
+      code     = 0
+      begin
+        command.send(:reconcile_role_index, apply: apply, force: force, json: json)
+      rescue SystemExit => ex
+        code = ex.status
+      ensure
+        captured = $stdout.string
+        $stdout  = original
+      end
+      { stdout: captured, exit_code: code }
+    end
+
+    describe 'dry run (default)' do
+      it 'exits 0 and reports clean when the index matches the role fields' do
+        create_customer("clean_#{suffix}@onetimesecret.com", role: 'colonel')
+
+        outcome = run_reconcile
+
+        expect(outcome[:exit_code]).to eq(0)
+        expect(outcome[:stdout]).to include('DRY RUN')
+        expect(outcome[:stdout]).to include('Status:            clean')
+      end
+
+      it 'reports stale-bucket drift from a targeted-writer role change WITHOUT writing' do
+        # Reproduce mechanism 1: save_fields persists the new role but the
+        # multi_index maintenance is add-only, so the customer now occupies
+        # BOTH buckets.
+        drifted      = create_customer("drift_#{suffix}@onetimesecret.com", role: 'customer')
+        drifted.role = 'colonel'
+        drifted.save_fields(:role)
+
+        expect(colonel_bucket.member?(drifted.objid)).to be(true)
+        expect(customer_bucket.member?(drifted.objid)).to be(true) # the stale bucket
+
+        outcome = run_reconcile
+
+        # Drift found on a dry run is a non-zero exit (doctor precedent).
+        expect(outcome[:exit_code]).to eq(1)
+        expect(outcome[:stdout]).to include('DRY RUN')
+        expect(outcome[:stdout]).to include("Would remove #{drifted.objid} from role_index:customer")
+
+        # Nothing was written: the stale member is still there.
+        expect(customer_bucket.member?(drifted.objid)).to be(true)
+      end
+
+      it 'reports an expired-hash member and a missing member without writing' do
+        # Mechanism 2: the customer hash expired (RTBF TTL) but the index
+        # member persists. Simulated by deleting the hash while leaving the
+        # instances entry and index member in place, exactly what EXPIRE does.
+        expired = create_customer("expired_#{suffix}@onetimesecret.com", role: 'colonel')
+        Familia.dbclient.del(expired.dbkey)
+
+        # Missing member: a live colonel the index lost.
+        lost = create_customer("lost_#{suffix}@onetimesecret.com", role: 'colonel')
+        colonel_bucket.remove_element(lost.objid)
+
+        outcome = run_reconcile
+
+        expect(outcome[:exit_code]).to eq(1)
+        expect(outcome[:stdout]).to include("Would remove #{expired.objid} from role_index:colonel")
+        expect(outcome[:stdout]).to include("Would add #{lost.objid} to role_index:colonel")
+
+        expect(colonel_bucket.member?(expired.objid)).to be(true)
+        expect(colonel_bucket.member?(lost.objid)).to be(false)
+      end
+    end
+
+    describe 'applied run' do
+      it 'repairs stale and missing members incrementally and exits 0' do
+        drifted      = create_customer("apply_drift_#{suffix}@onetimesecret.com", role: 'customer')
+        drifted.role = 'colonel'
+        drifted.save_fields(:role)
+
+        lost = create_customer("apply_lost_#{suffix}@onetimesecret.com", role: 'colonel')
+        colonel_bucket.remove_element(lost.objid)
+
+        # Untouched bystander proves the repair is targeted SREM/SADD, not a
+        # DEL-then-repopulate of the whole bucket.
+        steady = create_customer("apply_steady_#{suffix}@onetimesecret.com", role: 'colonel')
+
+        outcome = run_reconcile(apply: true, force: true)
+
+        expect(outcome[:exit_code]).to eq(0)
+        expect(outcome[:stdout]).to include('repaired')
+        expect(outcome[:stdout]).not_to include('DRY RUN')
+
+        expect(customer_bucket.member?(drifted.objid)).to be(false)
+        expect(colonel_bucket.member?(drifted.objid)).to be(true)
+        expect(colonel_bucket.member?(lost.objid)).to be(true)
+        expect(colonel_bucket.member?(steady.objid)).to be(true)
+
+        # Idempotent: a follow-up dry run is clean.
+        expect(run_reconcile[:exit_code]).to eq(0)
+      end
+
+      it 'refuses a scripted --json apply without --force' do
+        outcome = run_reconcile(apply: true, force: false, json: true)
+
+        expect(outcome[:exit_code]).to eq(1)
+        expect(outcome[:stdout]).to include('Refusing to apply without --force in --json mode')
+      end
+
+      it 'emits machine-readable JSON with --json' do
+        lost = create_customer("json_lost_#{suffix}@onetimesecret.com", role: 'colonel')
+        colonel_bucket.remove_element(lost.objid)
+
+        outcome = run_reconcile(apply: true, force: true, json: true)
+        payload = JSON.parse(outcome[:stdout])
+
+        expect(outcome[:exit_code]).to eq(0)
+        expect(payload['status']).to eq('repaired')
+        expect(payload['dry_run']).to be(false)
+        expect(payload['additions']).to include('role' => 'colonel', 'objid' => lost.objid)
+      end
+    end
+
+    describe 'failure handling' do
+      it 'exits 1 when the reconcile op raises' do
+        allow(Auth::Operations::Customers::ReconcileRoleIndex)
+          .to receive(:new).and_raise(RuntimeError, 'datastore unavailable')
+
+        outcome = run_reconcile
+
+        expect(outcome[:exit_code]).to eq(1)
+        expect(outcome[:stdout]).to include('reconcile failed')
+      end
+    end
+
+    describe 'op-level behavior' do
+      it 'dry run returns :drift with per-bucket counts and writes nothing' do
+        drifted      = create_customer("op_drift_#{suffix}@onetimesecret.com", role: 'customer')
+        drifted.role = 'colonel'
+        drifted.save_fields(:role)
+
+        result = Auth::Operations::Customers::ReconcileRoleIndex.new.call
+
+        expect(result.status).to eq(:drift)
+        expect(result.dry_run).to be(true)
+        expect(result.removals).to include(role: 'customer', objid: drifted.objid)
+        expect(result.buckets['customer'][:stale]).to be >= 1
+        expect(customer_bucket.member?(drifted.objid)).to be(true)
+      end
+
+      it 'applied run returns :repaired and converges to :clean' do
+        drifted      = create_customer("op_apply_#{suffix}@onetimesecret.com", role: 'customer')
+        drifted.role = 'colonel'
+        drifted.save_fields(:role)
+
+        applied = Auth::Operations::Customers::ReconcileRoleIndex.new(apply: true).call
+        expect(applied.status).to eq(:repaired)
+        expect(customer_bucket.member?(drifted.objid)).to be(false)
+
+        second = Auth::Operations::Customers::ReconcileRoleIndex.new(apply: true).call
+        expect(second.status).to eq(:clean)
+      end
+    end
+  end
+end

--- a/try/unit/cli/customers/role_command_try.rb
+++ b/try/unit/cli/customers/role_command_try.rb
@@ -369,6 +369,53 @@ demote_customer(@colonel_email)
 reset_role(@colonel_email, 'colonel')
 #=> "colonel"
 
+# -------------------------------------------------------------------
+# Reconcile: repairs drift between the role field and the index (#3974).
+# In familia 2.12, targeted writers (save_fields, multi_field_update,
+# commit_fields) route multi_index maintenance through the ADD-ONLY
+# add_to_class_role_index -- the previous value's bucket member is
+# retained on a value change, so a role change persisted this way leaves
+# the customer in TWO buckets until reconciled. (The other drift source,
+# TTL-expired customer hashes, is exercised in
+# spec/cli/customers_role_reconcile_command_spec.rb.)
+# -------------------------------------------------------------------
+
+## A role change persisted via a targeted writer (save_fields) lands in the
+## new role's bucket...
+@drifted_email = "drifted_#{@test_suffix}@test.example.com"
+@drifted = Onetime::Customer.create!(email: @drifted_email)
+@drifted.role = 'customer'
+@drifted.save
+@drifted.role = 'colonel'
+@drifted.save_fields(:role)
+Onetime::Customer.role_index_for('colonel').member?(@drifted.objid)
+#=> true
+
+## ...while the previous bucket's member is retained (the add-only path)
+Onetime::Customer.role_index_for('customer').member?(@drifted.objid)
+#=> true
+
+## A dry-run reconcile reports the stale member as a removal
+@dry = Auth::Operations::Customers::ReconcileRoleIndex.new.call
+[@dry.status, @dry.removals.include?({ role: 'customer', objid: @drifted.objid })]
+#=> [:drift, true]
+
+## The dry run wrote nothing: the stale member is still indexed
+Onetime::Customer.role_index_for('customer').member?(@drifted.objid)
+#=> true
+
+## An applied reconcile drops the stale member and keeps the correct one
+@applied = Auth::Operations::Customers::ReconcileRoleIndex.new(apply: true).call
+[@applied.status,
+ Onetime::Customer.role_index_for('customer').member?(@drifted.objid),
+ Onetime::Customer.role_index_for('colonel').member?(@drifted.objid)]
+#=> [:repaired, false, true]
+
+## Clean up the drifted customer
+@drifted.destroy!
+Onetime::Customer.email_exists?(@drifted_email)
+#=> false
+
 # TEARDOWN
 
 [@regular_email, @colonel_email, @admin_email, @staff_email].each do |email|


### PR DESCRIPTION
## Summary

[#3974](https://github.com/onetimesecret/onetimesecret/issues/3974)

Adds `bin/ots customers role reconcile` to detect and repair `customer:role_index:*` drift. Supersedes #3999 with a corrected mechanism analysis and the repo's standard repair-command shape.

**The drift is real on current main with familia 2.12** — verified against the 2.12.0 gem source and reproduced empirically against a live Redis. The review objection on #3999 (that 2.12 routing `save_fields` through `add_to_class_*` fixed the drift) holds for `unique_index` but not `multi_index`: `add_to_class_role_index` is add-only by design ("prior buckets are intentionally retained on a value change", familia `persistence.rb`), so any role change persisted through `save_fields`/`multi_field_update`/`commit_fields` leaves the customer in **both** buckets. A second, previously unidentified drift source: right-to-be-forgotten sets a 365-day TTL on the customer hash while its index member never expires, permanently inflating `colonel_count`. The maintenance `index_rebuild_job` covers only three hash-based unique indexes, not `role_index`.

Design, addressing each #3999 review point:
- **Shared op** `Auth::Operations::Customers::ReconcileRoleIndex` (next to `SetRole`/`Doctor`); the CLI is a thin adapter owning flags/confirmation/output/exit codes
- **Default is dry-run**: reports per-bucket adds/removes by diffing SCAN contents against `Customer.instances`, writing nothing; drift found on a dry run exits 1 (doctor precedent)
- **`--apply` + `--force`/interactive confirm, `--json`**; a scripted `--json --apply` without `--force` is refused (org-reconcile rule)
- **Incremental SADD/SREM, never `rebuild_role_index`'s DEL-then-repopulate** — additions applied first, so the worst mid-crash state is the same over-report the drift already produces, never a missing colonel
- One `ColonelAuditEvent` per applied run that changed the index; failure events only on applied runs
- `OT.info "[cli-customers-role-reconcile]"` audit line; failures rescued to exit 1
- Comments describe the true 2.12 mechanism, not the 2.11.2-era `save_fields`-bypass story
- `changelog.d/` fragment (Added + AI Assistance)

Original concept by @mahdi13830510, credited via `Co-Authored-By`.

## Related Issues

Refs #3974, supersedes #3999

## Test Plan

- `rspec spec/cli/customers_role_reconcile_command_spec.rb`: 9 examples, 0 failures (dry-run writes nothing for both drift mechanisms; applied repair with an untouched bystander bucket proving no DEL; JSON; json-without-force refusal; op raise → exit 1; converge-on-rerun)
- Full `rspec spec/cli`: 427 examples, 0 failures
- `try try/unit/cli/customers/role_command_try.rb`: 49 passed — including a new tryout section encoding the 2.12 semantics (customer lands in both buckets after `save_fields`, the opposite of #3999's 2.11.2-pinned assertion)
- rubocop: op and command files clean; the new spec carries the same non-correctable RSpec style cop categories `spec/cli/org_doctor_command_spec.rb` already does

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmGkCYohcumhy9g6GrCwPk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmGkCYohcumhy9g6GrCwPk)_