### PR TITLE
Apply anonymous TTL ceiling to V1 API (#4172)

### DIFF
--- a/apps/api/v1/logic/secrets/base_secret_action.rb
+++ b/apps/api/v1/logic/secrets/base_secret_action.rb
@@ -167,13 +167,21 @@ module V1::Logic
         # Convert to integer, now that we know it has a value
         @ttl = ttl.to_i
 
+        # Anonymous TTL ceiling (#4172): apply the configured anonymous
+        # ceiling when the caller is unauthenticated, mirroring V2's
+        # anonymous_max_ttl. Without this, anonymous callers land on the
+        # bare V1_MAX_TTL (30 days) instead of the configured 7-day default.
+        anon_max = if cust.nil? || cust.anonymous?
+                     anonymous_max_ttl(max_ttl)
+                   end
+
         # V1 TTL clamping [#2621]: silently clamp to V1 bounds.
         # v0.23.4 silently clamped rather than rejecting, so V1 preserves
         # that behavior for backward compatibility. Clamping happens BEFORE
         # the entitlement gate so that e.g. ttl=9999999 gets clamped to
         # 30 days rather than rejected for missing entitlements.
         # plan_max may be lower than max_ttl, so use the stricter ceiling.
-        effective_max_ttl = [max_ttl, plan_max].min
+        effective_max_ttl = [max_ttl, plan_max, anon_max].compact.min
         @ttl              = ttl.clamp(min_ttl, effective_max_ttl)
 
         # Entitlement gate: requests beyond free tier TTL require extended_default_expiration.
@@ -434,6 +442,37 @@ module V1::Logic
       rescue StandardError => ex
         OT.ld "[BaseSecretAction] TTL limit resolution failed: #{ex.message}"
         config_max
+      end
+
+      # Anonymous TTL ceiling (#4172), mirroring V2's anonymous_max_ttl.
+      #
+      # Lowest of up to three ceilings:
+      #   1. configured_anonymous_max_ttl (default 7 days, env TTL_MAX_ANONYMOUS)
+      #   2. config_max (V1_MAX_TTL, so a global cap still wins)
+      #   3. free-tier secret_lifetime limit (only when billing is enabled)
+      #
+      # @param config_max [Integer] V1_MAX_TTL fallback
+      # @return [Integer] Maximum TTL in seconds for anonymous callers
+      def anonymous_max_ttl(config_max)
+        ceilings = [
+          Onetime::Models::Features::WithEntitlements.configured_anonymous_max_ttl,
+          config_max,
+        ]
+
+        billing_enabled = begin
+          Onetime::BillingConfig.instance.enabled?
+        rescue StandardError => ex
+          OT.ld "[anonymous_max_ttl] BillingConfig unavailable (#{ex.class}: #{ex.message}); " \
+                "anonymous TTL ceiling falls back to #{ceilings.min}"
+          false
+        end
+
+        if billing_enabled
+          free_tier_max = Onetime::Organization.free_tier_limits['secret_lifetime.max'].to_i
+          ceilings << free_tier_max if free_tier_max.positive?
+        end
+
+        ceilings.min
       end
 
       # Creates the receipt/secret pair using the modern Metadata.spawn_pair API.

--- a/apps/api/v1/logic/secrets/base_secret_action.rb
+++ b/apps/api/v1/logic/secrets/base_secret_action.rb
@@ -150,16 +150,23 @@ module V1::Logic
         min_ttl = V1_MIN_TTL
         max_ttl = V1_MAX_TTL
 
-        # Plan-aware TTL cap: resolve the customer's org for plan limits.
-        # Falls back to V1_MAX_TTL when billing is disabled (self-hosted).
-        # V1::Logic::Base does not include OrganizationContext (no @strategy_result),
-        # so auth_org is unavailable — guard with respond_to? before calling.
-        plan_max = if respond_to?(:auth_org) && auth_org.respond_to?(:limit_for)
-                     org_limit = auth_org.limit_for('secret_lifetime')
-                     org_limit.positive? ? org_limit : max_ttl
-                   else
-                     resolve_ttl_limit(max_ttl)
-                   end
+        # TTL ceiling dispatch — mirrors V2's three-way structure (#4172).
+        #
+        # 1. auth_org present (V1 specs that inject one): plan limit
+        # 2. anonymous caller: configured anonymous ceiling (default 7 days)
+        # 3. authenticated without OrganizationContext: resolve via billing/org lookup
+        #
+        # Before #4172 the anonymous case fell through to resolve_ttl_limit,
+        # which returned the bare V1_MAX_TTL (30 days) when billing was
+        # disabled — 4× wider than the configured anonymous ceiling.
+        caller_max = if respond_to?(:auth_org) && auth_org.respond_to?(:limit_for)
+                       org_limit = auth_org.limit_for('secret_lifetime')
+                       org_limit.positive? ? org_limit : max_ttl
+                     elsif cust.nil? || cust.anonymous?
+                       anonymous_max_ttl(max_ttl)
+                     else
+                       resolve_ttl_limit(max_ttl)
+                     end
 
         # Apply default if nil
         @ttl = default_ttl || 7.days if ttl.nil?
@@ -167,21 +174,13 @@ module V1::Logic
         # Convert to integer, now that we know it has a value
         @ttl = ttl.to_i
 
-        # Anonymous TTL ceiling (#4172): apply the configured anonymous
-        # ceiling when the caller is unauthenticated, mirroring V2's
-        # anonymous_max_ttl. Without this, anonymous callers land on the
-        # bare V1_MAX_TTL (30 days) instead of the configured 7-day default.
-        anon_max = if cust.nil? || cust.anonymous?
-                     anonymous_max_ttl(max_ttl)
-                   end
-
         # V1 TTL clamping [#2621]: silently clamp to V1 bounds.
         # v0.23.4 silently clamped rather than rejecting, so V1 preserves
         # that behavior for backward compatibility. Clamping happens BEFORE
         # the entitlement gate so that e.g. ttl=9999999 gets clamped to
         # 30 days rather than rejected for missing entitlements.
-        # plan_max may be lower than max_ttl, so use the stricter ceiling.
-        effective_max_ttl = [max_ttl, plan_max, anon_max].compact.min
+        # caller_max may be lower than max_ttl, so use the stricter ceiling.
+        effective_max_ttl = [max_ttl, caller_max].min
         @ttl              = ttl.clamp(min_ttl, effective_max_ttl)
 
         # Entitlement gate: requests beyond free tier TTL require extended_default_expiration.
@@ -389,11 +388,13 @@ module V1::Logic
 
       private
 
-      # Resolve max TTL when OrganizationContext is not available (V1).
+      # Resolve max TTL for an authenticated caller without OrganizationContext.
+      #
+      # Only reached for authenticated users — anonymous callers are dispatched
+      # to anonymous_max_ttl by the three-way split in process_ttl (#4172).
       #
       # Looks up the customer's organization to check plan-based limits.
       # Billing-disabled (self-hosted) deployments get config_max (30 days).
-      # Billing-enabled free/anonymous users get the free tier limit (14 days).
       #
       # Codeflow for organization_instances (Familia participates_in):
       #   1. Customer.participates_in :Organization, :members (customer.rb:116)
@@ -422,12 +423,6 @@ module V1::Logic
 
         # Billing disabled (self-hosted): fail-open at config max
         return config_max unless billing_enabled
-
-        # Anonymous users: free tier limit
-        if cust.nil? || cust.anonymous?
-          free_max = Onetime::Organization.free_tier_limits['secret_lifetime.max']
-          return free_max.positive? ? free_max : config_max
-        end
 
         # Authenticated: look up customer's org for plan-based limit
         resolved_org = cust.organization_instances.to_a.first

--- a/changelog.d/20260815_010000_claude_4172_v1_anonymous_ttl_ceiling.rst
+++ b/changelog.d/20260815_010000_claude_4172_v1_anonymous_ttl_ceiling.rst
@@ -1,0 +1,8 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- (`#4172 <https://github.com/onetimesecret/onetimesecret/issues/4172>`_)
+  V1 API secret-creation endpoints now enforce the configured anonymous TTL
+  ceiling (default 7 days), matching the V2 path.

--- a/spec/api/v1/secret_ttl_entitlement_spec.rb
+++ b/spec/api/v1/secret_ttl_entitlement_spec.rb
@@ -169,11 +169,65 @@ RSpec.describe 'API V1 Secret TTL Entitlement Gate', type: :integration, billing
     end
   end
 
+  # Anonymous TTL ceiling tests (#4172)
+  #
+  # V1 now applies the configured anonymous ceiling (default 7 days) to
+  # unauthenticated callers, matching V2's anonymous_max_ttl behavior.
+  # Previously V1 allowed anonymous users the full V1_MAX_TTL (30 days).
+  shared_examples 'V1 anonymous TTL ceiling' do |logic_class_proc|
+    let(:logic_class) { logic_class_proc.call }
+    let(:anonymous_ceiling) { Onetime::Models::Features::WithEntitlements.configured_anonymous_max_ttl }
+
+    def conceal_params(ttl)
+      { 'secret' => 'test value', 'ttl' => ttl.to_s }
+    end
+
+    context 'anonymous caller requesting TTL above the ceiling' do
+      it 'clamps to the configured anonymous ceiling' do
+        logic = create_logic(logic_class, params: conceal_params(2_592_000), org: nil)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(anonymous_ceiling)
+      end
+    end
+
+    context 'anonymous caller requesting TTL at the ceiling' do
+      it 'preserves the exact ceiling value' do
+        logic = create_logic(logic_class, params: conceal_params(anonymous_ceiling), org: nil)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(anonymous_ceiling)
+      end
+    end
+
+    context 'anonymous caller requesting TTL below the ceiling' do
+      it 'preserves the lower requested value' do
+        one_hour = 3600
+        logic = create_logic(logic_class, params: conceal_params(one_hour), org: nil)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(one_hour)
+      end
+    end
+
+    context 'authenticated caller' do
+      it 'is not affected by the anonymous ceiling' do
+        org = mock_organization(
+          planid: 'identity_plus_v1',
+          entitlements: %w[create_secrets api_access extended_default_expiration],
+          secret_lifetime: 2_592_000,
+        )
+        logic = create_logic(logic_class, params: conceal_params(2_592_000), org: org)
+        expect { logic.process_params }.not_to raise_error
+        expect(logic.ttl).to eq(2_592_000)
+      end
+    end
+  end
+
   describe 'V1::Logic::Secrets::ConcealSecret' do
     include_examples 'V1 extended_default_expiration TTL gate', -> { V1::Logic::Secrets::ConcealSecret }
+    include_examples 'V1 anonymous TTL ceiling', -> { V1::Logic::Secrets::ConcealSecret }
   end
 
   describe 'V1::Logic::Secrets::GenerateSecret' do
     include_examples 'V1 extended_default_expiration TTL gate', -> { V1::Logic::Secrets::GenerateSecret }
+    include_examples 'V1 anonymous TTL ceiling', -> { V1::Logic::Secrets::GenerateSecret }
   end
 end


### PR DESCRIPTION
## Summary

#4172

Implements a three-way TTL ceiling dispatch in V1's `process_ttl` method to match V2's behavior and prevent anonymous callers from bypassing the configured anonymous TTL limit.

**Before:** Anonymous callers could request TTLs up to `V1_MAX_TTL` (30 days) because the code fell through to `resolve_ttl_limit`, which returned the bare config max when billing was disabled.

**After:** Anonymous callers are now explicitly clamped to the configured anonymous ceiling (default 7 days, configurable via `TTL_MAX_ANONYMOUS`), with a three-way dispatch:
1. `auth_org` present (V1 specs that inject one) → plan limit
2. Anonymous caller → configured anonymous ceiling
3. Authenticated without OrganizationContext → resolve via billing/org lookup

The `resolve_ttl_limit` method no longer handles the anonymous case—that logic is now isolated in the new `anonymous_max_ttl` helper, which mirrors V2's implementation and respects free-tier limits when billing is enabled.

## Related Issues

Fixes #4172

## Test Plan

Added comprehensive shared examples `'V1 anonymous TTL ceiling'` covering:
- Anonymous caller requesting TTL above the ceiling (clamps correctly)
- Anonymous caller requesting TTL at the ceiling (preserves exact value)
- Anonymous caller requesting TTL below the ceiling (preserves lower value)
- Authenticated caller (not affected by anonymous ceiling)

Tests applied to both `ConcealSecret` and `GenerateSecret` logic classes. Existing entitlement gate tests continue to pass.

https://claude.ai/code/session_01FfozCrMoP6B41ChTxgwGBw