### PR TITLE
fix(auth): set verified on SSO-provisioned customers

### DIFF
--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -15,6 +15,8 @@
 # See: features/omniauth.rb (provider registration)
 #
 
+require 'auth/account_statuses'
+
 module Auth::Config::Hooks
   module OmniAuth
     # rubocop:disable Metrics/PerceivedComplexity
@@ -704,6 +706,51 @@ module Auth::Config::Hooks
         custom_domain    = display_domain ? Onetime::CustomDomain.load_by_display_domain(display_domain) : nil
         signup_domain_id = custom_domain&.identifier
 
+        # ────────────────────────────────────────────────────────────────
+        # Verified state for the JIT-provisioned Customer (#3973)
+        # ────────────────────────────────────────────────────────────────
+        #
+        # CreateCustomer defaults to verified: false because that is the
+        # PASSWORD signup shape — Rodauth's after_verify_account flips the flag
+        # when the emailed link is followed. A JIT SSO account never traverses
+        # that flow, so the Customer mirror stayed unverified forever while its
+        # Rodauth account was already open. That is not cosmetic:
+        # has_system_role? (authorization_policies.rb) returns false on
+        # `!cust.verified?` BEFORE it reads the role field, so an
+        # SSO-provisioned colonel could never exercise the role even after CLI
+        # promotion.
+        #
+        # THE GATE — all three must hold, and nothing else is consulted:
+        #
+        #   1. We are inside after_omniauth_create_account. This hook fires
+        #      only on SSO JIT provisioning (the same call that stamps
+        #      provisioning_origin: 'sso_jit'), never on password signup and
+        #      never on login.
+        #   2. Rodauth has ALREADY persisted this account at
+        #      AccountStatuses::VERIFIED. rodauth-omniauth 0.6.2 stamps
+        #      account_open_status_value in _omniauth_new_account and commits it
+        #      in omniauth_save_account, both of which run BEFORE this hook
+        #      (omniauth_create_account), so the read below reports the auth
+        #      store's own decision rather than making a new one. If a
+        #      deployment opens SSO accounts unverified (or skip_status_checks?
+        #      is on) the read is not VERIFIED and the Customer stays
+        #      unverified — exactly the pre-fix behaviour.
+        #   3. The IdP did not EXPLICITLY assert email_verified: false.
+        #
+        # This only mirrors an auth-store fact onto the Customer record; it
+        # grants nothing the accounts row does not already grant. It also
+        # cannot reach a non-SSO account, which is why there is deliberately NO
+        # login-path reconcile: on login a bare status check is worthless
+        # because with verify_account disabled every ordinary password account
+        # is VERIFIED too. Records that already drifted are handled by
+        # `bin/ots customers doctor --repair` (:sso_customer_unverified).
+        account_status = db[:accounts].where(id: account_id).get(:status_id)
+        sso_verified   = account_status == Auth::AccountStatuses::VERIFIED &&
+                         !Auth::Config::Hooks::OmniAuth.idp_asserts_unverified_email?(
+                           info: omniauth_info,
+                           extra: omniauth_extra,
+                         )
+
         # Create Customer record (same as regular signup)
         customer = Onetime::ErrorHandler.safe_execute(
           'create_customer_omniauth',
@@ -716,6 +763,8 @@ module Auth::Config::Hooks
             db: db,
             provisioning_origin: 'sso_jit',
             signup_domain_id: signup_domain_id,
+            verified: sso_verified,
+            verified_by: sso_verified ? 'sso' : nil,
           ).call
         end
 
@@ -827,6 +876,49 @@ module Auth::Config::Hooks
       end
     end
     # rubocop:enable Metrics/PerceivedComplexity
+
+    # Did the IdP EXPLICITLY tell us the address is not verified?
+    #
+    # Only an explicit false is a veto. Absence is NOT: the claim is an OIDC
+    # optional, and several supported providers (Entra ID, plain OAuth2
+    # strategies, GitHub) never emit it at all — treating silence as
+    # "unverified" would leave those deployments in exactly the broken state
+    # the caller is fixing, while treating it as a positive signal would be us
+    # inventing an assertion the IdP never made. So this narrows the
+    # verified stamp and can never widen it.
+    #
+    # Looks in `info` first, then `extra.raw_info` (OIDC UserInfo / the decoded
+    # id_token). Both may be a plain Hash or an OmniAuth::AuthHash, and may be
+    # string- or symbol-keyed, so every read goes through fetch_claim.
+    #
+    # @param info [Hash, OmniAuth::AuthHash, nil] omniauth_info
+    # @param extra [Hash, OmniAuth::AuthHash, nil] omniauth_extra
+    # @return [Boolean] true only on an explicit false-y assertion
+    def self.idp_asserts_unverified_email?(info:, extra:)
+      claim = fetch_claim(info, 'email_verified')
+      claim = fetch_claim(fetch_claim(extra, 'raw_info'), 'email_verified') if claim.nil?
+      return false if claim.nil?
+
+      # Some providers stringify the claim ("false"); false and "false" are the
+      # same assertion. Anything else (true, "true", 1, garbage) is not a veto.
+      claim.to_s.strip.downcase == 'false'
+    end
+
+    # Key-shape-tolerant single-key read. Returns nil for a missing key, an
+    # unindexable source, or any error — never raises into a callback.
+    #
+    # @param source [#[], nil]
+    # @param key [String] string key; the symbol form is tried as a fallback
+    # @return [Object, nil]
+    def self.fetch_claim(source, key)
+      return nil unless source.respond_to?(:[])
+
+      value = source[key]
+      value = source[key.to_sym] if value.nil?
+      value
+    rescue StandardError
+      nil
+    end
 
     # Does the located account have a password the Phase 3 interstitial can
     # challenge? True when a Rodauth password hash exists, OR (coverage) when a

--- a/apps/web/auth/operations/create_customer.rb
+++ b/apps/web/auth/operations/create_customer.rb
@@ -22,12 +22,27 @@ module Auth
       #   Set on newly-created Customer records. Ignored for existing customers to
       #   preserve original signup context (same "don't rewrite history" rule as
       #   provisioning_origin).
-      def initialize(account_id:, account:, db: nil, provisioning_origin: nil, signup_domain_id: nil)
+      # @param verified [Boolean] Initial verification state for a NEWLY-created
+      #   Customer. Defaults to false — the password-signup shape, where
+      #   Rodauth's after_verify_account flips the flag once the emailed link is
+      #   followed. A caller passes true ONLY when the account is already
+      #   verified at creation time and no later hook will do it (the SSO/JIT
+      #   path: Rodauth opens the account at AccountStatuses::VERIFIED and never
+      #   fires after_verify_account). Ignored when the customer already exists —
+      #   same "don't rewrite history" rule as provisioning_origin, and it keeps
+      #   this operation from silently upgrading an existing unverified record.
+      # @param verified_by [String, nil] Provenance tag stored alongside
+      #   `verified` (see Auth::Operations::Customers::Doctor::VALID_VERIFIED_BY).
+      #   Only meaningful when verified: true.
+      def initialize(account_id:, account:, db: nil, provisioning_origin: nil, signup_domain_id: nil,
+                     verified: false, verified_by: nil)
         @account_id          = account_id
         @account             = account
         @db                  = db || Auth::Database.connection
         @provisioning_origin = provisioning_origin
         @signup_domain_id    = signup_domain_id
+        @verified            = verified ? true : false
+        @verified_by         = @verified ? verified_by : nil
       end
 
       # Executes the customer creation/loading operation
@@ -62,12 +77,19 @@ module Auth
           customer = Onetime::Customer.create!(
             email: email,
             role: 'customer',
-            verified: false, # needs to be updated in after_verify_account
+            # Default false: the password-signup shape, flipped later by
+            # after_verify_account. True only when the caller has already
+            # established verification (see the `verified:` param docs).
+            verified: @verified,
+            verified_by: @verified_by,
             provisioning_origin: @provisioning_origin,
             signup_domain_id: @signup_domain_id,
           )
 
-          auth_logger.info "[create-customer] Created new customer: #{customer.custid} (role: customer, origin: #{@provisioning_origin || 'unknown'}, signup_domain_id: #{@signup_domain_id || 'none'})"
+          auth_logger.info "[create-customer] Created new customer: #{customer.custid} (role: customer, " \
+                           "origin: #{@provisioning_origin || 'unknown'}, " \
+                           "signup_domain_id: #{@signup_domain_id || 'none'}, " \
+                           "verified: #{@verified}, verified_by: #{@verified_by || 'none'})"
         end
 
         customer

--- a/apps/web/auth/operations/customers/doctor.rb
+++ b/apps/web/auth/operations/customers/doctor.rb
@@ -4,6 +4,8 @@
 
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'auth/account_statuses'
+require 'auth/operations/set_customer_verification'
 
 module Auth
   module Operations
@@ -28,8 +30,11 @@ module Auth
       # ## Email-drift checks (#3731 PR-C1)
       #
       # Three checks exist specifically to make a half-completed email change
-      # visible: `:auth_email_drift` (the ONLY Redis-vs-SQL comparison here — a
-      # `ChangeEmail` op returning `:partial` is invisible without it),
+      # visible: `:auth_email_drift` (one of the two Redis-vs-SQL comparisons
+      # here — a `ChangeEmail` op returning `:partial` is invisible without it;
+      # the other is `:sso_customer_unverified`, and both share one memoized
+      # `auth_account` read so the sweep still costs one SQL round trip per
+      # customer),
       # `:org_email_index_stale` (the org-scoped index, which Familia never
       # auto-populates) and `:org_contact_email_stale` (default workspaces still
       # contacting a dead address). See each method for its scoping rules.
@@ -51,8 +56,10 @@ module Auth
         # Valid customer roles (historical data-shape check — see NOTE above)
         VALID_ROLES = %w[customer anonymous colonel].freeze
 
-        # Valid verified_by values
-        VALID_VERIFIED_BY = %w[email stripe_payment autoverify].freeze
+        # Valid verified_by values. 'sso' is stamped by the OmniAuth JIT
+        # provisioning path (config/hooks/omniauth.rb) and by this doctor's
+        # :sso_customer_unverified repair.
+        VALID_VERIFIED_BY = %w[email stripe_payment autoverify sso].freeze
 
         # Counter fields to check
         COUNTER_FIELDS = [:secrets_created, :secrets_burned, :secrets_shared, :emails_sent].freeze
@@ -85,6 +92,7 @@ module Auth
           check_org_membership_sync(issues, repaired)
           check_role_validity(issues)
           check_verified_consistency(issues, repaired)
+          check_sso_customer_unverified(issues, repaired)
           check_counter_sanity(issues, repaired)
           check_field_serialization(issues, repaired)
 
@@ -276,8 +284,10 @@ module Auth
 
         # CHECK: the Rodauth accounts row agrees with the Customer record
         #
-        # THE ONLY CROSS-STORE CHECK IN THIS DOCTOR. Every other check compares
-        # Redis against Redis, which means a half-completed cross-store email
+        # ONE OF THE TWO CROSS-STORE CHECKS IN THIS DOCTOR (the other is
+        # check_sso_customer_unverified, which reads the SAME memoized row).
+        # Every other check compares Redis
+        # against Redis, which means a half-completed cross-store email
         # change (Auth::Operations::Customers::ChangeEmail returning `:partial`)
         # was previously UNDETECTABLE: Redis is internally consistent on one
         # address while Postgres holds the other, so the customer signs in with an
@@ -301,11 +311,9 @@ module Auth
           db = auth_db
           return if db.nil?
 
-          extid = @customer.extid.to_s
-          return if extid.empty?
           return if @customer.email.to_s.empty?
 
-          account = db[:accounts].where(external_id: extid).select(:id, :email).first
+          account = auth_account
           return if account.nil?
 
           sql_email = account[:email].to_s
@@ -641,6 +649,98 @@ module Auth
             action: :fields_reserialized,
             fields: bad_fields.map { |f| f[:field] },
           }
+        end
+
+        # The customer's Rodauth accounts row, or nil (simple mode, unreachable
+        # DB, no extid, no row). Memoized because TWO cross-store checks read
+        # it — :auth_email_drift and :sso_customer_unverified — and the class
+        # docs call the one SQL round trip per customer the dominant cost of an
+        # `--all` sweep. One shared read keeps that cost unchanged.
+        #
+        # A repair inside check_auth_email_drift rewrites the row's email; the
+        # memo is deliberately not invalidated because the only later reader
+        # wants :status_id, which no repair here touches.
+        def auth_account
+          return @auth_account if defined?(@auth_account)
+
+          db    = auth_db
+          extid = @customer.extid.to_s
+
+          @auth_account = if db.nil? || extid.empty?
+                            nil
+                          else
+                            db[:accounts].where(external_id: extid).select(:id, :email, :status_id).first
+                          end
+        rescue StandardError
+          @auth_account = nil
+        end
+
+        # CHECK: an SSO-provisioned Customer left unverified (#3973)
+        #
+        # The JIT SSO path used to hard-code `verified: false` on the Customer
+        # while Rodauth opened the accounts row at VERIFIED, and nothing ever
+        # reconciled the two — after_verify_account only fires in the email
+        # verify flow, which an SSO user never traverses. The visible symptom is
+        # an SSO-provisioned colonel who cannot exercise their role, because
+        # has_system_role? tests verified? BEFORE it reads the role.
+        #
+        # The forward fix (config/hooks/omniauth.rb) stops new records drifting.
+        # This check is the ONLY thing that heals records created before it, and
+        # it is deliberately narrow on BOTH sides of the split:
+        #
+        #   * Redis side — provisioning_origin must literally be 'sso_jit'. This
+        #     is set once at creation and never rewritten, so it is real
+        #     provenance, not an inference from current state.
+        #   * SQL side — the accounts row must already be at
+        #     AccountStatuses::VERIFIED. The repair therefore only copies a fact
+        #     the auth store already holds; it never decides that anyone is
+        #     verified, and never touches SQL (rodauth_already_synced: true).
+        #
+        # An existing verified_by is PRESERVED — a customer who was
+        # email-verified or stripe-verified keeps that provenance, and only a
+        # record with no provenance at all is stamped 'sso'.
+        def check_sso_customer_unverified(issues, repaired)
+          return if @customer.verified?
+          return unless @customer.provisioning_origin.to_s == 'sso_jit'
+
+          account = auth_account
+          return if account.nil?
+          return unless account[:status_id] == Auth::AccountStatuses::VERIFIED
+
+          existing_provenance = @customer.verified_by.to_s
+          provenance          = existing_provenance.empty? ? 'sso' : existing_provenance
+
+          issues << {
+            check: :sso_customer_unverified,
+            severity: :high,
+            message: 'SSO-provisioned customer is unverified while its auth account is Verified ' \
+                     '(system roles are gated on verified?)',
+            repairable: true,
+            repair_action: "Mirror the auth account's verified state onto the Customer " \
+                           "(verified_by: '#{provenance}')",
+          }
+
+          return unless @repair
+
+          Auth::Operations::SetCustomerVerification.new(
+            customer: @customer,
+            verified: true,
+            verified_by: provenance,
+            rodauth_already_synced: true,
+          ).call
+
+          OT.info "[customers doctor] Verified SSO-provisioned customer #{@customer.extid} " \
+                  "(verified_by: #{provenance})"
+          repaired << {
+            customer: @customer.extid,
+            action: :sso_customer_verified,
+            value: provenance,
+          }
+        rescue StandardError => ex
+          # Same rule as the other cross-store check: never abort a sweep over
+          # one unreachable DB or one bad record.
+          OT.le "[customers doctor] sso_customer_unverified check failed for #{@customer.extid}: " \
+                "#{ex.class} #{ex.message}"
         end
 
         # Auth database handle, or nil in simple mode / when unreachable.

--- a/apps/web/auth/operations/customers/doctor.rb
+++ b/apps/web/auth/operations/customers/doctor.rb
@@ -56,10 +56,27 @@ module Auth
         # Valid customer roles (historical data-shape check — see NOTE above)
         VALID_ROLES = %w[customer anonymous colonel].freeze
 
-        # Valid verified_by values. 'sso' is stamped by the OmniAuth JIT
-        # provisioning path (config/hooks/omniauth.rb) and by this doctor's
-        # :sso_customer_unverified repair.
-        VALID_VERIFIED_BY = %w[email stripe_payment autoverify sso].freeze
+        # Every verified_by provenance tag the codebase writes, with the
+        # writer for each:
+        #   email          - secret reveal by owner (apps/api/v2/logic/secrets/
+        #                    {show,reveal}_secret.rb) and Rodauth verify_account
+        #                    (apps/web/auth/config/hooks/account.rb)
+        #   stripe_payment - payment-initiated signup (apps/web/billing/logic/welcome.rb)
+        #   autoverify     - autoverify-mode account creation
+        #                    (apps/api/account/logic/account/create_account.rb)
+        #   sso            - OmniAuth JIT provisioning (apps/web/auth/config/hooks/
+        #                    omniauth.rb) and this doctor's :sso_customer_unverified repair
+        #   invite_token   - invitation acceptance (apps/web/auth/operations/
+        #                    accept_invitation.rb, config/hooks/account.rb)
+        #   cli_provision  - CLI customer/apitoken commands (lib/onetime/cli/)
+        #   colonel_admin  - colonel admin verification (apps/api/colonel/logic/
+        #                    colonel/set_user_verification.rb)
+        #   legacy         - backfilled by this doctor's verified_by repair
+        # Keep this list in sync when adding a new provenance writer.
+        VALID_VERIFIED_BY = %w[
+          email stripe_payment autoverify sso
+          invite_token cli_provision colonel_admin legacy
+        ].freeze
 
         # Counter fields to check
         COUNTER_FIELDS = [:secrets_created, :secrets_burned, :secrets_shared, :emails_sent].freeze

--- a/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
@@ -61,15 +61,17 @@ RSpec.describe 'after_omniauth_create_account operations', type: :integration do
 
   # Helper to create a test account in the database.
   #
-  # Status is UNVERIFIED, and that is correct for these examples even though
-  # nothing here reads it: CreateCustomer hard-codes `verified: false` (the
-  # account's own status never reaches it — after_verify_account flips the
-  # Customer later), so an account fresh out of signup is the honest subject.
-  def create_test_account(email:)
+  # Status is UNVERIFIED, and that is correct for these examples: CreateCustomer
+  # never reads the account's status — it takes the caller's `verified:`
+  # argument, which defaults to false (the password-signup shape, where
+  # after_verify_account flips the Customer later). An account fresh out of
+  # signup is the honest subject. The SSO caller that passes `verified: true` is
+  # the omniauth hook, driven end-to-end in omniauth_jit_verified_spec.rb.
+  def create_test_account(email:, status_id: AuthTestConstants::STATUS_UNVERIFIED)
     db = Auth::Database.connection
     account_id = db[:accounts].insert(
       email: email,
-      status_id: AuthTestConstants::STATUS_UNVERIFIED,
+      status_id: status_id,
       created_at: Time.now,
       updated_at: Time.now
     )
@@ -233,6 +235,109 @@ RSpec.describe 'after_omniauth_create_account operations', type: :integration do
       created_customers << customer
 
       expect(customer.verified.to_s).to eq('false')
+    end
+
+    # ======================================================================
+    # verified: / verified_by: parameters (#3973)
+    # ======================================================================
+    #
+    # The operation used to hard-code `verified: false` with no way to say
+    # otherwise, which is why the SSO JIT path could never mark its customers
+    # verified. These examples pin the parameter contract the omniauth hook
+    # depends on; the hook's own decision (when it passes true at all) is
+    # driven end-to-end in omniauth_jit_verified_spec.rb.
+    describe 'verified/verified_by parameters' do
+      it 'threads verified: true and verified_by: through to the new Customer' do
+        email = unique_test_email('verified-threaded')
+        account = create_test_account(email: email, status_id: AuthTestConstants::STATUS_VERIFIED)
+
+        customer = Auth::Operations::CreateCustomer.new(
+          account_id: account[:id],
+          account: account,
+          provisioning_origin: 'sso_jit',
+          verified: true,
+          verified_by: 'sso',
+        ).call
+        created_customers << customer
+
+        expect(customer.verified?).to be true
+        expect(customer.verified_by.to_s).to eq('sso')
+
+        # Persisted, not just set on the in-memory instance.
+        reloaded = Onetime::Customer.load(customer.custid)
+        expect(reloaded.verified?).to be true
+        expect(reloaded.verified_by.to_s).to eq('sso')
+      end
+
+      # The NEGATIVE case, and the reason the default matters: a customer that
+      # is not being provisioned by SSO gets the unchanged behaviour. If the
+      # default ever flips, every password signup silently becomes verified.
+      it 'leaves a customer unverified when no verification is asserted' do
+        email = unique_test_email('verified-default')
+        account = create_test_account(email: email)
+
+        customer = Auth::Operations::CreateCustomer.new(
+          account_id: account[:id],
+          account: account,
+          provisioning_origin: 'canonical_signup',
+        ).call
+        created_customers << customer
+
+        expect(customer.verified?).to be false
+        expect(customer.verified_by.to_s).to eq('')
+
+        reloaded = Onetime::Customer.load(customer.custid)
+        expect(reloaded.verified?).to be false
+        expect(reloaded.verified_by.to_s).to eq('')
+      end
+
+      # verified_by is provenance. Recording one without the verified flag it
+      # describes would produce a record no check in the doctor can reason
+      # about, so the operation drops it.
+      it 'ignores verified_by when verified is false' do
+        email = unique_test_email('verified-by-orphan')
+        account = create_test_account(email: email)
+
+        customer = Auth::Operations::CreateCustomer.new(
+          account_id: account[:id],
+          account: account,
+          verified: false,
+          verified_by: 'sso',
+        ).call
+        created_customers << customer
+
+        expect(customer.verified?).to be false
+        expect(customer.verified_by.to_s).to eq('')
+      end
+
+      # Same "don't rewrite history" rule as provisioning_origin and
+      # signup_domain_id: the existing-customer branch is a no-op, so this
+      # operation can never upgrade an already-unverified record.
+      it 'does not verify an existing customer' do
+        email = unique_test_email('verified-existing')
+        account = create_test_account(email: email)
+
+        customer1 = Auth::Operations::CreateCustomer.new(
+          account_id: account[:id],
+          account: account,
+        ).call
+        created_customers << customer1
+        expect(customer1.verified?).to be false
+
+        customer2 = Auth::Operations::CreateCustomer.new(
+          account_id: account[:id],
+          account: account,
+          verified: true,
+          verified_by: 'sso',
+        ).call
+
+        expect(customer2.custid).to eq(customer1.custid)
+        expect(customer2.verified?).to be false
+
+        reloaded = Onetime::Customer.load(customer1.custid)
+        expect(reloaded.verified?).to be false
+        expect(reloaded.verified_by.to_s).to eq('')
+      end
     end
   end
 

--- a/apps/web/auth/spec/integration/full/omniauth_jit_verified_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_jit_verified_spec.rb
@@ -1,0 +1,266 @@
+# apps/web/auth/spec/integration/full/omniauth_jit_verified_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration (full mode)
+# =============================================================================
+#
+# Issue: #3973 — SSO/OmniAuth JIT-provisioned customers were left unverified.
+#
+# THE BUG
+# -------
+# Auth::Operations::CreateCustomer hard-coded `verified: false` with the
+# comment "needs to be updated in after_verify_account". after_verify_account
+# fires only in Rodauth's EMAIL verify_account flow, which a JIT SSO user never
+# traverses — so the Customer stayed unverified forever while its Rodauth
+# accounts row sat at status Verified. That is not cosmetic:
+# Onetime::Application::AuthorizationPolicies#has_system_role? does
+# `return false unless cust.verified?` BEFORE it looks at the role, so an
+# SSO-provisioned colonel/admin could never exercise their role.
+#
+# WHAT THIS FILE LOCKS IN
+# -----------------------
+# The HEADLINE change, driven through the REAL Rodauth omniauth callback rather
+# than by re-implementing the hook's decision:
+#
+#   1. POSITIVE — a brand-new platform SSO sign-in (JIT provisioning) yields a
+#      Customer with verified? == true and verified_by == 'sso', and an
+#      accounts row at STATUS_VERIFIED. If the hook stops passing the new
+#      CreateCustomer parameters, this fails.
+#   2. NEGATIVE — a customer NOT provisioned via SSO (the plain CreateCustomer
+#      call every password signup makes) is NOT verified. This is the guard
+#      against the rejected first attempt at this fix, which verified almost
+#      anyone by checking status_id on the shared login path.
+#   3. NEGATIVE — an IdP that EXPLICITLY asserts email_verified: false does not
+#      get the verified stamp, even though Rodauth opened its account.
+#
+# Layer note: apps/web/auth/spec/integration/full/omniauth_account_creation_spec.rb
+# pins the CreateCustomer PARAMETER contract in isolation. This file pins the
+# WIRING — that the production hook actually passes them, and on what gate.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2163: pnpm run test:database:start
+# - AUTHENTICATION_MODE=full, AUTH_DATABASE_URL (SQLite in-memory; rake sets it)
+#
+# RUN:
+#   tests/lanes/run full \
+#     --only apps/web/auth/spec/integration/full/omniauth_jit_verified_spec.rb
+# =============================================================================
+
+require_relative '../../spec_helper'
+
+RSpec.describe 'OmniAuth JIT provisioning sets verified (#3973)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    # Same boot as omniauth_trusted_link_spec.rb: force a clean reboot so
+    # provider registration runs against this suite's WebMock stubs + ENV, and
+    # assert the auth app actually mounted (a silent empty registry would turn
+    # every callback into a 404 -> skip).
+    require 'onetime'
+    require 'onetime/application/registry'
+    require 'onetime/auth_config'
+
+    Onetime.auth_config.reload! if Onetime.respond_to?(:auth_config) && Onetime.auth_config.respond_to?(:reload!)
+    Onetime::Application::Registry.reset! if Onetime::Application::Registry.respond_to?(:reset!)
+
+    Onetime.boot!(:test, force: true)
+
+    Onetime::Application::Registry.prepare_application_registry
+
+    mounts = Onetime::Application::Registry.mount_mappings.keys
+    raise "Auth app not mounted post-boot: #{mounts.inspect}" unless mounts.any? { |m| m.include?('/auth') }
+  end
+
+  let(:accounts) { auth_db[:accounts] }
+
+  # Customers created by the callback are found by email afterwards; track them
+  # so the shared in-memory DB / Valkey do not accumulate across examples.
+  let(:created_customers) { [] }
+
+  after do
+    created_customers.each do |customer|
+      customer.destroy! if customer&.exists?
+    rescue StandardError
+      nil # non-fatal cleanup
+    end
+  end
+
+  def jit_email(prefix)
+    "#{prefix}-#{SecureRandom.hex(6)}@jit-verified-test.example.com"
+  end
+
+  # The Customer the callback JIT-provisioned, or nil.
+  def customer_for(email)
+    normalized = OT::Utils.normalize_email(email)
+    return nil unless Onetime::Customer.email_exists?(normalized)
+
+    customer = Onetime::Customer.find_by_email(normalized)
+    created_customers << customer
+    customer
+  end
+
+  # ==========================================================================
+  # 1. POSITIVE — JIT SSO sign-in produces a VERIFIED customer
+  # ==========================================================================
+
+  describe 'a new platform SSO sign-in' do
+    before { enable_platform_fallback }
+
+    it 'provisions a verified customer stamped verified_by=sso' do
+      email = jit_email('jit-verified')
+      uid   = "sub-#{SecureRandom.hex(8)}"
+
+      setup_mock_auth(email: email, uid: uid)
+      begin
+        post '/auth/sso/oidc/callback'
+
+        if last_response.status == 404
+          skip 'OmniAuth route not registered (OIDC discovery not available at boot)'
+        end
+        expect(last_response.status).to eq(302),
+          "Expected a post-login redirect, got #{last_response.status}: #{last_response.body}"
+
+        # Rodauth JIT-created the account, and (rodauth-omniauth 0.6.2
+        # _omniauth_new_account) opened it at Verified. This is the fact the
+        # hook mirrors — assert it so a failure below is unambiguous about
+        # which side moved.
+        account = accounts.where(email: OT::Utils.normalize_email(email)).first
+        expect(account).not_to be_nil, 'Expected the callback to JIT-create an accounts row'
+        expect(account[:status_id]).to eq(AuthTestConstants::STATUS_VERIFIED)
+
+        customer = customer_for(email)
+        expect(customer).not_to be_nil, 'Expected the callback to JIT-create a Customer'
+        expect(customer.provisioning_origin.to_s).to eq('sso_jit')
+
+        # THE HEADLINE ASSERTION.
+        expect(customer.verified?).to be(true),
+          'SSO JIT-provisioned customer must be verified — has_system_role? gates on it'
+        expect(customer.verified_by.to_s).to eq('sso')
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # 2. NEGATIVE — a non-SSO customer is NOT verified
+  # ==========================================================================
+  #
+  # The rejected first attempt at this fix reconciled on the LOGIN path guarded
+  # only on status_id == Verified. With verify_account disabled that is true for
+  # ordinary password accounts too, so it verified almost everyone. The fix is
+  # scoped to the SSO JIT provisioning hook, which means the ordinary
+  # CreateCustomer call — the one every password signup makes — must still
+  # produce an unverified customer even when its accounts row is Verified.
+
+  describe 'a customer not provisioned via SSO' do
+    it 'is not verified, even with a Verified accounts row' do
+      email      = jit_email('non-sso')
+      normalized = OT::Utils.normalize_email(email)
+      account_id = accounts.insert(
+        email: normalized,
+        status_id: AuthTestConstants::STATUS_VERIFIED,
+      )
+
+      begin
+        customer = Auth::Operations::CreateCustomer.new(
+          account_id: account_id,
+          account: { id: account_id, email: normalized },
+          provisioning_origin: 'canonical_signup',
+        ).call
+        created_customers << customer
+
+        expect(customer.provisioning_origin.to_s).to eq('canonical_signup')
+        expect(customer.verified?).to be(false),
+          'A non-SSO signup must not inherit verification from its accounts row'
+        expect(customer.verified_by.to_s).to eq('')
+      ensure
+        accounts.where(id: account_id).delete
+      end
+    end
+  end
+
+  # ==========================================================================
+  # 3. NEGATIVE — an explicit email_verified: false vetoes the stamp
+  # ==========================================================================
+  #
+  # Absence of the claim is NOT a veto (most enterprise IdPs never emit it), but
+  # an IdP that actively says the address is unverified is taken at its word.
+
+  describe 'an IdP asserting email_verified: false' do
+    before { enable_platform_fallback }
+
+    it 'provisions the customer unverified' do
+      email = jit_email('jit-unverified-claim')
+      uid   = "sub-#{SecureRandom.hex(8)}"
+
+      OmniAuth.config.test_mode = true
+      OmniAuth.config.allowed_request_methods = %i[get post]
+      OmniAuth.config.mock_auth[:oidc] = OmniAuth::AuthHash.new({
+        provider: 'oidc',
+        uid: uid,
+        info: { email: email, name: 'Unverified Claim', email_verified: false },
+        extra: { raw_info: { sub: uid, email: email, email_verified: false } },
+      })
+
+      begin
+        post '/auth/sso/oidc/callback'
+
+        if last_response.status == 404
+          skip 'OmniAuth route not registered (OIDC discovery not available at boot)'
+        end
+
+        customer = customer_for(email)
+        skip 'Callback did not JIT-provision a customer' if customer.nil?
+
+        expect(customer.verified?).to be(false),
+          'An explicit email_verified: false assertion must veto the verified stamp'
+        expect(customer.verified_by.to_s).to eq('')
+      ensure
+        teardown_mock_auth
+      end
+    end
+  end
+
+  # ==========================================================================
+  # The claim reader, at its own boundary
+  # ==========================================================================
+  #
+  # Cheap and exhaustive on the shapes the callback specs cannot vary quickly:
+  # string vs symbol keys, info vs extra.raw_info, stringified booleans, and the
+  # absence that must NOT read as a veto.
+
+  # Named rather than passed as a constant: the auth app (and therefore
+  # Auth::Config) is only loaded by the before(:all) boot above, well after
+  # RSpec evaluates this file's describe arguments.
+  describe 'Auth::Config::Hooks::OmniAuth.idp_asserts_unverified_email?' do
+    subject(:veto?) { Auth::Config::Hooks::OmniAuth.method(:idp_asserts_unverified_email?) }
+
+    it 'vetoes on an explicit false in info' do
+      expect(veto?.call(info: { 'email_verified' => false }, extra: nil)).to be true
+      expect(veto?.call(info: { email_verified: false }, extra: nil)).to be true
+      expect(veto?.call(info: { 'email_verified' => 'false' }, extra: nil)).to be true
+    end
+
+    it 'vetoes on an explicit false in extra.raw_info' do
+      expect(veto?.call(info: {}, extra: { 'raw_info' => { 'email_verified' => false } })).to be true
+      expect(veto?.call(info: nil, extra: { raw_info: { email_verified: false } })).to be true
+    end
+
+    it 'does not veto when the claim is absent, nil, or true' do
+      expect(veto?.call(info: nil, extra: nil)).to be false
+      expect(veto?.call(info: {}, extra: {})).to be false
+      expect(veto?.call(info: { 'name' => 'No Claim' }, extra: { 'raw_info' => { 'sub' => 'x' } })).to be false
+      expect(veto?.call(info: { 'email_verified' => true }, extra: nil)).to be false
+      expect(veto?.call(info: { 'email_verified' => 'true' }, extra: nil)).to be false
+    end
+
+    it 'prefers info over extra.raw_info' do
+      expect(
+        veto?.call(info: { 'email_verified' => true }, extra: { 'raw_info' => { 'email_verified' => false } }),
+      ).to be false
+    end
+  end
+end

--- a/apps/web/auth/spec/operations/customers/doctor_email_drift_spec.rb
+++ b/apps/web/auth/spec/operations/customers/doctor_email_drift_spec.rb
@@ -5,8 +5,8 @@
 # Unit tests for the three email-drift checks added to
 # Auth::Operations::Customers::Doctor by #3731 PR-C1:
 #
-#   :auth_email_drift       — the ONLY Redis-vs-SQL comparison in the doctor.
-#                             Without it a ChangeEmail run that returned
+#   :auth_email_drift       — one of the two Redis-vs-SQL comparisons in the
+#                             doctor. Without it a ChangeEmail run that returned
 #                             :partial is undetectable, because every other
 #                             check compares Redis against Redis.
 #   :org_email_index_stale  — the org-scoped index Familia never auto-populates.
@@ -60,7 +60,9 @@ RSpec.describe Auth::Operations::Customers::Doctor do
       allow(db).to receive(:transaction) { |&blk| blk.call }
       allow(accounts).to receive(:where).with(external_id: 'ur_c').and_return(by_external_id)
       allow(accounts).to receive(:where).with(id: 42).and_return(by_id)
-      allow(by_external_id).to receive(:select).with(:id, :email).and_return(by_external_id)
+      # The doctor reads the accounts row ONCE (memoized `auth_account`) and
+      # shares it with :sso_customer_unverified, hence :status_id in the select.
+      allow(by_external_id).to receive(:select).with(:id, :email, :status_id).and_return(by_external_id)
     end
 
     def run(repair: false)

--- a/apps/web/auth/spec/operations/customers/doctor_sso_verified_spec.rb
+++ b/apps/web/auth/spec/operations/customers/doctor_sso_verified_spec.rb
@@ -1,0 +1,191 @@
+# apps/web/auth/spec/operations/customers/doctor_sso_verified_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for the :sso_customer_unverified check added to
+# Auth::Operations::Customers::Doctor by #3973.
+#
+# The forward fix (config/hooks/omniauth.rb) stops NEW SSO signups drifting;
+# this check is the only thing that heals the records created before it. Its
+# whole value is in how narrow the gate is, so that is what these examples pin:
+#
+#   * Redis side — provisioning_origin must literally be 'sso_jit'. Any other
+#     origin (or none) is left alone, because a bare "unverified customer with
+#     a Verified account" describes ordinary password signups too.
+#   * SQL side  — the accounts row must already be at AccountStatuses::VERIFIED.
+#     The repair copies a fact the auth store holds; it never decides one.
+#   * The repair writes REDIS ONLY (rodauth_already_synced: true) and PRESERVES
+#     an existing verified_by rather than relabelling it 'sso'.
+#
+# Follows doctor_email_drift_spec.rb: the check is private and is exercised
+# directly, so a failure names this check rather than dragging in the nine
+# unrelated per-customer checks.
+#
+# Run: bundle exec rspec apps/web/auth/spec/operations/customers/doctor_sso_verified_spec.rb
+
+require 'spec_helper'
+require 'auth/database'
+require 'auth/operations/customers/doctor'
+
+RSpec.describe Auth::Operations::Customers::Doctor do
+  let(:issues)   { [] }
+  let(:repaired) { [] }
+
+  let(:verified)            { false }
+  let(:verified_by)         { nil }
+  let(:provisioning_origin) { 'sso_jit' }
+  let(:account_status)      { Auth::AccountStatuses::VERIFIED }
+  let(:account_row)         { { id: 42, email: 'sso@example.com', status_id: account_status } }
+
+  let(:customer) do
+    double(
+      'Customer',
+      email: 'sso@example.com',
+      objid: 'obj_c',
+      extid: 'ur_c',
+      obscure_email: 'ss***@e***.com',
+      organization_instances: [],
+      verified?: verified,
+      verified_by: verified_by,
+      provisioning_origin: provisioning_origin,
+    )
+  end
+
+  let(:by_external_id) { double('by_external_id') }
+  let(:accounts)       { double('accounts') }
+  let(:db)             { double('db') }
+
+  # Captures the SetCustomerVerification construction so the examples can assert
+  # the contract arguments (verified_by preservation, rodauth_already_synced)
+  # without touching Redis or SQL.
+  let(:verification_calls) { [] }
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:le)
+
+    allow(Auth::Database).to receive(:connection).and_return(db)
+    allow(db).to receive(:[]).with(:accounts).and_return(accounts)
+    allow(accounts).to receive(:where).with(external_id: 'ur_c').and_return(by_external_id)
+    allow(by_external_id).to receive(:select).with(:id, :email, :status_id).and_return(by_external_id)
+    allow(by_external_id).to receive(:first).and_return(account_row)
+
+    allow(Auth::Operations::SetCustomerVerification).to receive(:new) do |**kwargs|
+      verification_calls << kwargs
+      double('SetCustomerVerification', call: :success)
+    end
+  end
+
+  def run(repair: false)
+    described_class.new(customer: customer, repair: repair, actor: 'cli')
+      .send(:check_sso_customer_unverified, issues, repaired)
+  end
+
+  describe 'detection' do
+    it 'reports a high, repairable issue for an unverified sso_jit customer' do
+      run
+
+      expect(issues.size).to eq(1)
+      expect(issues.first[:check]).to eq(:sso_customer_unverified)
+      expect(issues.first[:severity]).to eq(:high)
+      expect(issues.first[:repairable]).to be true
+    end
+
+    context 'when the customer is already verified' do
+      let(:verified) { true }
+
+      it 'reports nothing' do
+        run
+        expect(issues).to be_empty
+      end
+    end
+
+    # The single most important negative: an ordinary password signup also has
+    # an unverified Customer and (with verify_account disabled) a Verified
+    # accounts row. Only real SSO provenance may be repaired.
+    context 'when the customer was not provisioned via SSO' do
+      let(:provisioning_origin) { 'canonical_signup' }
+
+      it 'reports nothing' do
+        run
+        expect(issues).to be_empty
+      end
+    end
+
+    context 'when provisioning_origin is absent' do
+      let(:provisioning_origin) { nil }
+
+      it 'reports nothing' do
+        run
+        expect(issues).to be_empty
+      end
+    end
+
+    context 'when the Rodauth account is not Verified' do
+      let(:account_status) { Auth::AccountStatuses::UNVERIFIED }
+
+      it 'reports nothing — the auth store has not verified them either' do
+        run
+        expect(issues).to be_empty
+      end
+    end
+
+    context 'when there is no Rodauth account row' do
+      let(:account_row) { nil }
+
+      it 'reports nothing' do
+        run
+        expect(issues).to be_empty
+      end
+    end
+  end
+
+  describe 'repair' do
+    it 'routes the write through SetCustomerVerification without touching SQL' do
+      run(repair: true)
+
+      expect(verification_calls.size).to eq(1)
+      expect(verification_calls.first).to include(
+        customer: customer,
+        verified: true,
+        verified_by: 'sso',
+        rodauth_already_synced: true,
+      )
+      expect(repaired).to eq([{ customer: 'ur_c', action: :sso_customer_verified, value: 'sso' }])
+    end
+
+    it 'does not write on a diagnostic (non-repair) run' do
+      run
+
+      expect(verification_calls).to be_empty
+      expect(repaired).to be_empty
+    end
+
+    # Provenance is not ours to overwrite: a record that already says it was
+    # email- or stripe-verified keeps saying so.
+    context 'when the record already carries a verified_by' do
+      let(:verified_by) { 'stripe_payment' }
+
+      it 'preserves it instead of relabelling the record sso' do
+        run(repair: true)
+
+        expect(verification_calls.first[:verified_by]).to eq('stripe_payment')
+        expect(repaired.first[:value]).to eq('stripe_payment')
+        expect(issues.first[:repair_action]).to include('stripe_payment')
+      end
+    end
+
+    it 'never aborts the sweep when the write raises' do
+      allow(Auth::Operations::SetCustomerVerification).to receive(:new).and_raise(StandardError, 'boom')
+
+      expect { run(repair: true) }.not_to raise_error
+      expect(repaired).to be_empty
+    end
+  end
+
+  describe 'registered provenance' do
+    it "lists 'sso' as a valid verified_by value" do
+      expect(described_class::VALID_VERIFIED_BY).to include('sso')
+    end
+  end
+end

--- a/changelog.d/20260815_101500_claude_3973_sso_verified.rst
+++ b/changelog.d/20260815_101500_claude_3973_sso_verified.rst
@@ -1,0 +1,40 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- (`#3973 <https://github.com/onetimesecret/onetimesecret/issues/3973>`_)
+  Customers provisioned just-in-time through SSO/OmniAuth are now marked
+  verified at creation, with the provenance ``verified_by = 'sso'``.
+  Previously every SSO signup created its customer record unverified and
+  nothing ever flipped it: the flag is normally set by Rodauth's
+  ``after_verify_account``, which only runs in the emailed verify-account flow
+  that an SSO user never traverses. The most visible consequence was that an
+  SSO-provisioned colonel or admin could not exercise their role — the system
+  role check refuses an unverified customer before it looks at the role at all
+  — even after being promoted from the CLI.
+
+  The verified stamp is applied only on the SSO just-in-time provisioning path,
+  and only when the account's own Rodauth record was already opened as Verified
+  and the identity provider did not explicitly assert ``email_verified: false``.
+  It mirrors a fact the authentication store already holds and grants nothing
+  that record did not already grant. Ordinary password signups are unchanged
+  and are still verified by email; there is deliberately no reconciliation on
+  the login path, where an account's status cannot distinguish an SSO user from
+  anyone else.
+
+- (`#3973 <https://github.com/onetimesecret/onetimesecret/issues/3973>`_)
+  ``bin/ots customers doctor`` reports a new ``sso_customer_unverified`` issue
+  for customers provisioned via SSO before the fix above, and ``--repair``
+  heals them. The repair is limited to records whose provisioning origin is
+  literally SSO and whose Rodauth account is already Verified; it writes only
+  the customer mirror, and preserves any verification provenance the record
+  already carries.
+
+AI Assistance
+-------------
+
+- Claude added the verification parameters to the SSO customer-provisioning
+  operation, gated the OmniAuth hook on the account's persisted status plus the
+  identity provider's own claim, added the doctor check and repair, and wrote
+  the regression coverage. Supersedes PR #4001. (#3973)

--- a/lib/onetime/models/customer/features/status.rb
+++ b/lib/onetime/models/customer/features/status.rb
@@ -23,7 +23,10 @@ module Onetime::Customer::Features
       base.field :role
       base.field :joined
       base.boolean_field :verified
-      base.field :verified_by  # 'email', 'stripe_payment', 'autoverify', 'sso', nil
+      # Provenance tag for how the account became verified; nil when
+      # unverified. See Auth::Operations::Customers::Doctor::VALID_VERIFIED_BY
+      # for the full list of in-use values and where each is written.
+      base.field :verified_by
 
       # Reversible trust & safety pause (NOT a role, NOT destructive).
       # A suspended customer keeps all of their data but cannot authenticate:

--- a/lib/onetime/models/customer/features/status.rb
+++ b/lib/onetime/models/customer/features/status.rb
@@ -23,7 +23,7 @@ module Onetime::Customer::Features
       base.field :role
       base.field :joined
       base.boolean_field :verified
-      base.field :verified_by  # 'email', 'stripe_payment', 'autoverify', nil
+      base.field :verified_by  # 'email', 'stripe_payment', 'autoverify', 'sso', nil
 
       # Reversible trust & safety pause (NOT a role, NOT destructive).
       # A suspended customer keeps all of their data but cannot authenticate:


### PR DESCRIPTION
## Summary

[#3973](https://github.com/onetimesecret/onetimesecret/issues/3973)

JIT SSO-provisioned customers were created `verified: false` and nothing ever flipped it: `after_verify_account` only fires in the email verify flow, which SSO users never traverse. Since `has_system_role?` tests `verified?` **before** reading the role, an SSO-provisioned colonel could never exercise their role even after CLI promotion. Supersedes #4001.

**Forward fix** — `CreateCustomer` gains `verified:`/`verified_by:` params defaulting to current behavior (no existing caller changes semantics; ignored for existing customers, so it can't silently upgrade a drifted record). The omniauth hook passes `verified: true, verified_by: 'sso'` only when all three hold:
1. We're inside `after_omniauth_create_account` (fires only on JIT provisioning — never password signup, never login)
2. Rodauth has **already persisted** the accounts row at `AccountStatuses::VERIFIED` (read from the row, not assumed; ordering verified against rodauth-omniauth 0.6.2 source and empirically by the integration spec)
3. The IdP did not explicitly assert `email_verified: false` (absence is not a veto — Entra/GitHub/plain OAuth2 never emit the claim; only an explicit false narrows)

The stamp mirrors a fact the auth store already committed; it grants nothing the accounts row doesn't. Deployments that open SSO accounts unverified keep the pre-fix behavior.

**Deliberately no login-path reconcile** (the defect that sank #4001): with `verify_account` disabled, ordinary password accounts also sit at VERIFIED, so a bare status check on login would verify nearly everyone.

**Drifted records** — new `:sso_customer_unverified` check in `customers doctor`, gated on both `provisioning_origin == 'sso_jit'` (real provenance, written once at creation) **and** the accounts row at VERIFIED. Repair routes through `SetCustomerVerification` with `rodauth_already_synced: true` (Redis-only, no SQL write) and **preserves any existing `verified_by`** — only records with no provenance are stamped `'sso'`. Runs only under operator-invoked `--repair`. Shares one memoized accounts-row read with `:auth_email_drift`, so an `--all` sweep still costs one SQL round trip per customer. One known asymmetry, disclosed: the doctor cannot consult the IdP's `email_verified` claim (no auth hash exists at doctor time) — it mirrors the auth store's committed decision, which the forward path treats as authoritative anyway.

Also: `'sso'` registered in `VALID_VERIFIED_BY` and the `status.rb` field comment (note: that constant currently has no enforcing consumers).

Original diagnosis by @mahdi13830510, credited via `Co-Authored-By`.

## Related Issues

Refs #3973, supersedes #4001

## Test Plan

All via `tests/lanes/run` (local redis on the lane port; no Docker in the sandbox, so `full-pg` was not run — only `full-sqlite` covers the integration specs):
- New `omniauth_jit_verified_spec.rb` (full-sqlite): 7 examples, 0 failures — drives the real Rodauth callback; production logs show `verified: true, verified_by: sso` for JIT SSO, `verified: false` for the explicit `email_verified: false` veto, and `verified: false` for the non-SSO negative
- `omniauth_account_creation_spec.rb`: 16 examples, 0 failures
- New `doctor_sso_verified_spec.rb` + updated `doctor_email_drift_spec.rb`: 34 examples, 0 failures
- Full unit lane: exit 0 (all suites, 0 failures). Full-sqlite lane: 5 failures, all in `puma_rabbitmq_fork_spec.rb` — verified identical on clean `origin/main` (missing RabbitMQ broker, unrelated)
- rubocop on the 4 in-scope production files: no offenses

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KmGkCYohcumhy9g6GrCwPk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmGkCYohcumhy9g6GrCwPk)_