### PR TITLE
Document HttpOrigin middleware Host header requirements

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1377,6 +1377,17 @@ ASSUME_HTTPS=false
 # requests whose Origin header does not match the site's own origin.
 # Requests without an Origin header are allowed through. Default:
 # false. Set to 'true' to enable.
+#
+# WARNING: the "site's own origin" is derived from the Host header
+# (or X-Forwarded-Host) as seen by the application, not from the
+# host resolved by Rack::DetectHost. Enabling this requires the
+# proxy tier to pass the public hostname through in Host or
+# X-Forwarded-Host. If your proxy rewrites Host to the canonical
+# origin and forwards the real host only in Apx-Incoming-Host or
+# X-Original-Host, every state-changing request from a custom
+# domain is rejected with a 403 — most visibly SSO sign-in, which
+# has no authenticity-token fallback. Symptom in logs:
+# "attack prevented by Rack::Protection::HttpOrigin".
 #MIDDLEWARE_HTTP_ORIGIN=false
 
 # IP spoofing detection (site.middleware.ip_spoofing).


### PR DESCRIPTION
## Summary

Add comprehensive documentation to `.env.reference` explaining the requirements and potential pitfalls when enabling the `MIDDLEWARE_HTTP_ORIGIN` setting.

The new warning clarifies that:
- The "site's own origin" is derived from the `Host` header (or `X-Forwarded-Host`), not from `Rack::DetectHost`
- Proxy configurations that rewrite `Host` to a canonical origin while forwarding the real host in alternative headers (e.g., `Apx-Incoming-Host` or `X-Original-Host`) will cause state-changing requests to be rejected with a 403 error
- This is particularly problematic for SSO sign-in flows which lack an authenticity-token fallback
- The error message to look for in logs is "attack prevented by Rack::Protection::HttpOrigin"

## Related Issues

<!-- Add issue number if applicable -->

## Test Plan

N/A - Documentation only

https://claude.ai/code/session_019J5Z4UVv4VeGcwN947bzYC