### PR TITLE
Configure Zed tasks and JSON LSP for git worktree setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ pnpm-debug.log*
 .temp/
 .zed/*
 !.zed/settings.json
+!.zed/tasks.json
 .appendonlydir/
 .bundle/
 .rspec

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -21,7 +21,10 @@
     },
     "Ruby": {
       "language_servers": ["ruby-lsp"],
-      "formatter": "language_server"
-    }
-  }
+      "formatter": "language_server",
+    },
+    "JSON": {
+      "language_servers": ["json5-lsp"]
+    },
+  },
 }

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -1,0 +1,26 @@
+// Worktree setup tasks, stored in this project's tasks.json.
+// See https://zed.dev/docs/tasks#hooks for the full Tasks Hooks documentation.
+//
+// Tasks with the `create_worktree` hook run automatically right after Zed
+// creates a new git worktree. Use them to get a fresh worktree ready to work
+// in — for example, installing dependencies or copying files that git doesn't
+// track (like `.env`) from the original repository.
+//
+// Two variables are available to these tasks:
+// * $ZED_WORKTREE_ROOT     — the root directory of the newly created worktree
+// * $ZED_MAIN_GIT_WORKTREE — the original repository's working directory
+//
+// Uncomment the example below and adjust the command to get started.
+// Note: hooked tasks run as soon as a worktree is created, so only enable
+// commands you want to run automatically.
+[
+  {
+    "label": "Set up new worktree",
+    "command": "echo \"From $ZED_WORKTREE_ROOT met love\" && bin/setup --test",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "hooks": ["create_worktree"],
+    "reveal": "always",
+    "show_summary": true,
+    "show_command": true,
+  },
+]


### PR DESCRIPTION
## Summary
- Configures Zed tasks specifically for automatic git worktree setup.
- Unignores `.zed/tasks.json` in `.gitignore` to track tasks configuration.
- Configures the JSON language server (`json5-lsp`) in `.zed/settings.json`.
- Adds a worktree setup task in `.zed/tasks.json` that runs `bin/setup --test` automatically upon creating a new git worktree.

## Review guide
- Verify that `json5-lsp` is configured correctly under `"JSON"` in `.zed/settings.json`.
- Check `.zed/tasks.json` to verify the `create_worktree` hook runs `bin/setup --test` automatically.

## Validation
- Pre-commit, pre-push, and CI checks will validate this change.
