### PR TITLE
Revise ADR guidance, plus a new policy on issue and PR referencing in code

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,7 +12,8 @@ Documents that capture important architectural decisions along with their contex
 
 - **Be courteous**: ADRs should be readable in 2-3 minutes, so focus on why. The decision itself is less important than the reasoning.
 - **Avoid formulaic sections**: Don't force content into rigid templates. If your core argument is complete in Context and Decision, stop there. Skip sections that merely reorganize the same points.
-- **Combine related content**: Merge rationale directly into the Decision section. Trade-offs are optional—only include them when they add genuine insight.
+- **Combine related content**: Merge rationale directly into the Decision section. Trade-offs are optional—include them only when they add genuine insight about the decision's actual exchange.
+- **Make trade-offs complete**: Be terse elsewhere, but name the real costs, lost flexibility, and conditional risks in Trade-offs. Future readers need these details to judge whether the decision still holds or should be superseded.
 - **Immutable**: Once accepted, don't edit the decision; that's like re-writing history. Use Implementation Notes or create another ADR to supersede.
 - **Numbered sequentially**: Makes referencing easy (`ADR-001`, `ADR-002`, etc.)
 - **One decision per ADR**: Don't bundle multiple choices together
@@ -29,6 +30,14 @@ This expands the "One decision per ADR" key above: when two choices show up toge
 **What mature ADR sets do:** sequentially numbered, immutable, short, single-topic records with a consistent template and a *liberal* "Related / References" section that cross-links siblings (Kubernetes KEPs, Arachne, AWS Prescriptive Guidance all do this). Cross-linking is how you get the "these belong together" benefit without a monolith. Keep the status lifecycle explicit (Proposed → Accepted → Superseded) and date every amendment.
 
 **Don't over-split, either.** If a decision is a single sentence with no trade-offs, a code comment at the call site suffices — it doesn't need a record. A choice earns its own ADR when it has real trade-offs, a regulatory or cross-cutting dimension, or a test/contract obligation attached to it.
+
+### Trade-offs Section
+
+Use Trade-offs for the inherent exchange in a decision: what the project gives
+up to obtain a benefit, plus the risks that make the exchange conditional. Do
+not use it to restate the decision, list routine implementation obligations, or
+organize generic positives and negatives. Omit it when Context and Decision
+already contain the complete argument.
 
 ### Implementation Notes Section
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -8,6 +8,8 @@ Documents that capture important architectural decisions along with their contex
 - Deprecated: No longer relevant but kept for history
 - Superseded: Replaced by a newer ADR (reference the new one)
 
+The `status` in an ADR's frontmatter and its `Status` section must agree.
+
 ### Keys to Success
 
 - **Be courteous**: ADRs should be readable in 2-3 minutes, so focus on why. The decision itself is less important than the reasoning.
@@ -36,8 +38,14 @@ This expands the "One decision per ADR" key above: when two choices show up toge
 Use Trade-offs for the inherent exchange in a decision: what the project gives
 up to obtain a benefit, plus the risks that make the exchange conditional. Do
 not use it to restate the decision, list routine implementation obligations, or
-organize generic positives and negatives. Omit it when Context and Decision
-already contain the complete argument.
+organize generic positives and negatives. Include it only when it adds insight
+that does not belong in Context or Decision.
+
+### Related Section
+
+Use Related to cross-link ADRs and other durable documents that help a reader
+understand this decision. Omit it when there are no useful links; do not use it
+for transient implementation discussions or change-tracking metadata.
 
 ### Implementation Notes Section
 

--- a/docs/adr/adr-000.md
+++ b/docs/adr/adr-000.md
@@ -26,14 +26,15 @@ Why this approach? Include the core rationale here—don't save it for later sec
 <!-- Optional sections below — include only when they add value -->
 
 ## Trade-offs
-- **We lose**: What capability or benefit are we giving up?
-- **We gain**: What do we get in return?
-- **Performance/Cost/Risk**: Any notable impacts?
+Describe the decision's inherent exchange. Include this section only when it
+adds insight that does not belong in Context or Decision. Be complete about the
+costs: this is the section a future reader needs when considering whether to
+supersede the decision.
 
-## Consequences
-### Positive
-### Negative
-### Neutral
+- **We lose**: The actual capability, benefit, or flexibility given up.
+- **We gain**: The concrete benefit received in return.
+- **Risk**: Conditional or situational downsides, including process, tooling,
+  cost, or operational implications.
 
 ## Implementation Notes
 [Clarifications, rollout timelines, and implementation details that don't change the core decision. Each note should be dated.]

--- a/docs/adr/adr-000.md
+++ b/docs/adr/adr-000.md
@@ -1,15 +1,17 @@
 ---
 id: 000
-status: accepted
+status: proposed
 title: ADR-000: [Short Title]
 ---
 
 <!-- Filename: adr-NNN-kebab-slug.md (slug derived from title) -->
+<!-- Before writing, confirm this decision warrants an ADR: docs/adr/README.md -->
+<!-- Keep the frontmatter status and Status section in sync. -->
 
 <!-- Required sections: Status, Date, Context, Decision -->
 
 ## Status
-[Proposed | Accepted | Deprecated | Superseded]
+Proposed
 
 ## Date
 YYYY-MM-DD
@@ -35,6 +37,9 @@ supersede the decision.
 - **We gain**: The concrete benefit received in return.
 - **Risk**: Conditional or situational downsides, including process, tooling,
   cost, or operational implications.
+
+## Related
+[Related ADRs and durable documents that provide useful context.]
 
 ## Implementation Notes
 [Clarifications, rollout timelines, and implementation details that don't change the core decision. Each note should be dated.]

--- a/docs/adr/adr-039-issue-and-pull-request-references-in-change-metadata.md
+++ b/docs/adr/adr-039-issue-and-pull-request-references-in-change-metadata.md
@@ -1,0 +1,57 @@
+---
+id: 039
+status: proposed
+decided: 2026-08-15
+title: "ADR-039: Issue and Pull Request References in Change Metadata"
+---
+
+## Context
+
+Issue and pull request references provide useful traceability, but their
+placement determines whether they remain useful as code evolves. Bare ticket
+numbers in source comments require access to the tracker, can become detached
+from the code they originally described, and do not explain the local reason
+for a non-obvious behavior.
+
+Conversely, commit messages and pull request descriptions are durable,
+searchable change metadata. They can carry the full root cause, alternatives,
+and links to related work without making source comments depend on external
+context.
+
+## Decision
+
+Record issue and pull request references in commit messages and pull request
+descriptions. Use `Fixes #N`, `Closes #N`, or `Refs #N` where the repository's
+workflow supports those trailers. Branch names may include an issue number for
+additional traceability.
+
+Source comments must explain the local, enduring reason for code that is not
+self-evident. They must be understandable without access to an issue tracker.
+A comment may add an issue or pull request reference only when it points to
+necessary deeper context, such as a temporary upstream workaround, and only
+after stating the reason directly. Do not use bare references such as `#4231`
+or comments that merely say a change was made by a pull request.
+
+Use an ADR or other maintained documentation for long-lived architectural
+decisions rather than encoding them in either change metadata or inline
+comments.
+
+This keeps repository history as the source of change traceability while
+keeping source code self-explanatory at the point of use.
+
+## Consequences
+
+### Positive
+
+- `git log --grep` and repository tooling can find changes associated with an
+  issue without searching source comments.
+- Commit and pull request metadata can retain detailed rationale without
+  bloating code.
+- Comments remain useful to readers who cannot access the issue tracker.
+
+### Negative
+
+- Authors must provide meaningful issue references when writing commits and
+  pull requests rather than relying on a later code comment.
+- Temporary workarounds require a self-contained comment and, when applicable,
+  a tracked follow-up reference.

--- a/docs/adr/adr-039-issue-and-pull-request-references-in-change-metadata.md
+++ b/docs/adr/adr-039-issue-and-pull-request-references-in-change-metadata.md
@@ -1,9 +1,16 @@
 ---
 id: 039
 status: proposed
-decided: 2026-08-15
 title: "ADR-039: Issue and Pull Request References in Change Metadata"
 ---
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-15
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Centralize middleware component definitions in a registry and resolve declared per-application profiles while preserving the universal security stack.
- Apply the authenticated web profile to the auth app in every environment, with independent configuration toggles and display-domain-aware HttpOrigin handling so custom-domain requests behind Host-rewriting proxies are accepted.
- Add coverage for middleware manifests, profile resolution, registry behavior, and origin handling; refine ADR authoring guidance and add ADR-039 for keeping issue and PR references in change metadata rather than source comments.

## Review guide
- Start with `lib/onetime/middleware/registry.rb` and `lib/onetime/application/middleware_profile.rb` to review component declarations, profile lookup, ordering, and inherited class middleware.
- Review `apps/web/auth/application.rb`, `etc/defaults/config.defaults.yaml`, and `.env.reference` for the auth stack's environment-independent defaults and operational controls.
- Check `lib/onetime/middleware/http_origin_options.rb` and its specs for the display-domain allowlist behavior, and `docs/adr/adr-039-issue-and-pull-request-references-in-change-metadata.md` for the new documentation policy.

## Validation
- Pre-commit, pre-push, and CI checks will validate this change.

Closes #4170