### PR TITLE
Enforce per-domain signin/signup opt-ins in full mode (ADR-024)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -691,7 +691,7 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 RUBY VERSION
-  ruby 3.3.6
+  ruby 3.4.10
 
 BUNDLED WITH
   4.0.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -691,7 +691,7 @@ DEPENDENCIES
   webmock (~> 3.0)
 
 RUBY VERSION
-  ruby 3.4.10
+  ruby 3.3.6
 
 BUNDLED WITH
   4.0.9

--- a/apps/web/auth/config/hooks/restrict_to.rb
+++ b/apps/web/auth/config/hooks/restrict_to.rb
@@ -24,38 +24,48 @@
 # elsewhere (hooks do not chain — see config/hooks.rb).
 #
 
-# WHY THIS FILE OWNS TWO GATES
+# WHY THIS FILE OWNS THREE GATES
 #
 # `before_rodauth` and `before_email_auth_request` are SINGLY OWNED: Rodauth
 # hooks do not chain, so a second `auth.before_rodauth do ... end` anywhere
 # would REPLACE this one rather than run alongside it (config/hooks.rb states
 # the rule; config.rb's hook list is a precedence list for exactly this
-# reason). The per-domain `signin_enabled` availability gate
-# (Auth::SigninEnabled, ADR-024) needs the same two chokepoints, so it is
-# invoked from inside these blocks instead of registering its own. Its POLICY
-# lives in its own sibling module beside apps/web/auth/restrict_to.rb; only the
-# call sites are shared.
+# reason). The per-domain availability gates (Auth::SigninEnabled and
+# Auth::SignupEnabled, ADR-024) need the same chokepoint, so they are invoked
+# from inside these blocks instead of registering their own. Their POLICY
+# lives in their own sibling modules beside apps/web/auth/restrict_to.rb; only
+# the call sites are shared.
 #
-# THE TWO GATES ARE DIFFERENT QUESTIONS AND ARE ANDed, NOT MERGED:
+# THE GATES ARE DIFFERENT QUESTIONS AND ARE ANDed, NOT MERGED:
 #   Auth::SigninEnabled — IS password/email sign-in available on this host at
 #     all? Defaults CLOSED on custom domains (ADR-024 opt-in only).
-#   Auth::RestrictTo    — GIVEN that it is, WHICH methods may be offered?
-#     Defaults OPEN; an absence of restriction gates nothing, by invariant.
-# Collapsing either into the other is the #4139 shape — see the header of
+#   Auth::SignupEnabled — MAY an account be created on this host? A separate
+#     opt-in (SignupConfig#signup_enabled) on separate routes; also defaults
+#     CLOSED on custom domains. Independent of sign-in: an SSO-only tenant can
+#     run open registration with password sign-in off.
+#   Auth::RestrictTo    — GIVEN that sign-in is offered, WHICH methods may be
+#     offered? Defaults OPEN; an absence of restriction gates nothing, by
+#     invariant.
+# Collapsing any into another is the #4139 shape — see the header of
 # apps/web/auth/signin_enabled.rb.
 
 require_relative '../../restrict_to'
+require_relative '../../signin_enabled'
 require_relative '../../signin_gate'
+require_relative '../../signup_enabled'
 
 module Auth::Config::Hooks
   module RestrictTo
     def self.configure(auth)
       auth.before_rodauth do
         # Availability first, then method narrowing: a host that is not
-        # offering password/email sign-in at all has no method question to
-        # answer. Both reject with the same 404 body, so the order is not
+        # offering sign-in (or registration) at all has no method question to
+        # answer. The two availability gates cover DISJOINT route sets (the
+        # subtraction in SigninEnabled::GATED_ROUTES guarantees it), and all
+        # three reject with the same 404 body, so the order is not
         # observable — it is written this way to read in policy order.
         Auth::SigninEnabled.enforce_route!(self)
+        Auth::SignupEnabled.enforce_route!(self)
         Auth::RestrictTo.enforce_route!(self)
         # SECOND AXIS, same hook (#4163). restrict_to says WHICH sign-in method
         # a host may offer; Auth::SigninGate says whether the host opted into

--- a/apps/web/auth/config/hooks/restrict_to.rb
+++ b/apps/web/auth/config/hooks/restrict_to.rb
@@ -24,6 +24,26 @@
 # elsewhere (hooks do not chain — see config/hooks.rb).
 #
 
+# WHY THIS FILE OWNS TWO GATES
+#
+# `before_rodauth` and `before_email_auth_request` are SINGLY OWNED: Rodauth
+# hooks do not chain, so a second `auth.before_rodauth do ... end` anywhere
+# would REPLACE this one rather than run alongside it (config/hooks.rb states
+# the rule; config.rb's hook list is a precedence list for exactly this
+# reason). The per-domain `signin_enabled` availability gate
+# (Auth::SigninEnabled, ADR-024) needs the same two chokepoints, so it is
+# invoked from inside these blocks instead of registering its own. Its POLICY
+# lives in its own sibling module beside apps/web/auth/restrict_to.rb; only the
+# call sites are shared.
+#
+# THE TWO GATES ARE DIFFERENT QUESTIONS AND ARE ANDed, NOT MERGED:
+#   Auth::SigninEnabled — IS password/email sign-in available on this host at
+#     all? Defaults CLOSED on custom domains (ADR-024 opt-in only).
+#   Auth::RestrictTo    — GIVEN that it is, WHICH methods may be offered?
+#     Defaults OPEN; an absence of restriction gates nothing, by invariant.
+# Collapsing either into the other is the #4139 shape — see the header of
+# apps/web/auth/signin_enabled.rb.
+
 require_relative '../../restrict_to'
 require_relative '../../signin_gate'
 
@@ -31,6 +51,11 @@ module Auth::Config::Hooks
   module RestrictTo
     def self.configure(auth)
       auth.before_rodauth do
+        # Availability first, then method narrowing: a host that is not
+        # offering password/email sign-in at all has no method question to
+        # answer. Both reject with the same 404 body, so the order is not
+        # observable — it is written this way to read in policy order.
+        Auth::SigninEnabled.enforce_route!(self)
         Auth::RestrictTo.enforce_route!(self)
         # SECOND AXIS, same hook (#4163). restrict_to says WHICH sign-in method
         # a host may offer; Auth::SigninGate says whether the host opted into
@@ -67,6 +92,11 @@ module Auth::Config::Hooks
     # site in config.rb, inside the email_auth_enabled? branch.
     def self.configure_email_auth(auth)
       auth.before_email_auth_request do
+        # Same pairing as before_rodauth above, and needed for the same reason:
+        # this path emits an email_auth credential from the LOGIN route, so a
+        # host that never opted into sign-in (ADR-024 default-OFF) would
+        # otherwise still get a magic link mailed on its behalf.
+        Auth::SigninEnabled.enforce!(self, :email_auth_request)
         Auth::RestrictTo.enforce_method!(self, 'email_auth', :email_auth_request)
         Auth::SigninGate.enforce_email_auth!(self)
       end

--- a/apps/web/auth/restrict_to.rb
+++ b/apps/web/auth/restrict_to.rb
@@ -62,6 +62,14 @@
 #      config/hooks/omniauth_tenant.rb (omniauth_setup +
 #      before_omniauth_callback_route) and in the app-owned SSO linking routes
 #      (routes/link_sso.rb, routes/sso_link_confirm.rb) via .allows?.
+#   1a. SIBLING GATE, same chokepoint: `restrict_to` answers WHICH methods may
+#      be offered, never WHETHER sign-in is offered at all. The per-domain
+#      `signin_enabled` opt-in (ADR-024, custom domains default OFF) is the
+#      availability half and lives in apps/web/auth/signin_enabled.rb; it is
+#      invoked from the same before_rodauth block (hooks do not chain, so it
+#      cannot register its own). Do NOT fold it in here: this resolver's
+#      invariant is that an absent restriction gates nothing, and teaching it
+#      to manufacture one from an absence takes SSO-only tenants dark — #4139.
 #   3. Simple mode — POST /auth/login is served by Core, not Rodauth
 #      (apps/web/core/routes.txt). Gated in
 #      Core::Controllers::Base#restrict_to_allows?.

--- a/apps/web/auth/signin_enabled.rb
+++ b/apps/web/auth/signin_enabled.rb
@@ -1,0 +1,282 @@
+# apps/web/auth/signin_enabled.rb
+#
+# frozen_string_literal: true
+
+#
+# Runtime enforcement of the per-domain `signin_enabled` OPT-IN
+# (ADR-024 "custom domains default OFF, opt-in only";
+#  ADR-034#resolution-is-model-owned + #reject-as-not-found-not-forbidden).
+#
+# WHAT THIS CLOSES
+#   ADR-024 promises that password/email sign-in is NOT available on a custom
+#   domain unless the domain owner explicitly opted in with an *enabled*
+#   SigninConfig carrying signin_enabled=true. That promise was implemented in
+#   the model (SigninConfig.resolve_signin_enabled_for_custom_domain /
+#   _for_request) and enforced on three surfaces:
+#
+#     - simple mode  — Core::Controllers::Base#signin_enabled?, because in
+#                      simple mode Core serves POST /auth/login itself;
+#     - display      — the branded masthead's Sign In link
+#                      (DomainSerializer#effective_signin_enabled?) and the
+#                      /signin page availability verdict (ConfigSerializer);
+#     - settings API — DomainsAPI signin_config details (#3814).
+#
+#   In FULL mode nothing consulted it. Rodauth serves POST /auth/login there,
+#   and the only per-domain policy on that path was `restrict_to`. So a custom
+#   domain that had never opted in (no SigninConfig at all — the DEFAULT shape)
+#   or had explicitly opted OUT (enabled config, signin_enabled=false) still
+#   accepted a valid credential at POST /auth/login and authenticated: 200,
+#   real session. The promise held in simple mode and on every display surface
+#   and silently did not hold on the route that matters most.
+#
+#   It looked covered because `restrict_to` DID reject on such hosts whenever a
+#   restriction happened to exist and degrade to :unavailable. That coverage is
+#   incidental and it is not this policy.
+#
+# WHY THIS IS A SIBLING OF Auth::RestrictTo AND NOT PART OF IT
+#   `restrict_to` is a NARROWING FILTER OVER METHODS: given that sign-in is
+#   available here, WHICH methods may be offered. Its resolver's explicit
+#   invariant is that an absence of restriction resolves :unrestricted and
+#   gates NOTHING ("an unrestricted install must not go dark"). Teaching it to
+#   manufacture a restriction out of an absence would fight that invariant and
+#   overload a method filter into an availability check — two different
+#   questions with two different defaults (restrict_to defaults OPEN, per-domain
+#   signin_enabled defaults CLOSED on custom hosts). They are ANDed at the hook,
+#   not merged in the resolver.
+#
+#   FAILURE MODE A FUTURE EDIT WOULD REINTRODUCE: "simplifying" this away by
+#   making resolve_restrict_to return :unavailable when signin_enabled is false.
+#   That takes SSO down with it on every SSO-only tenant, which is #4139
+#   verbatim — see restriction_available_for_custom_domain?'s `when 'sso'`
+#   branch in signin_config.rb.
+#
+# NEVER GATE SSO ON THIS FLAG
+#   `signin_enabled` is the PASSWORD/EMAIL opt-in and has never governed SSO.
+#   An SSO-only tenant sets signin_enabled=false precisely to say "no passwords
+#   on this host"; gating SSO on it would take that tenant's ONLY working
+#   sign-in path dark. SSO availability is SsoConfig's question
+#   (tenant_sso_available_for? / sso_available_for_tenant_host?). Hence
+#   GATED_ROUTES below covers exactly the 'password' and 'email_auth' entries of
+#   Auth::RestrictTo::PRE_AUTH_ROUTES and nothing else — not 'webauthn', not the
+#   middleware-served OmniAuth request phase, not the app-owned SSO linking
+#   routes.
+#
+# SCOPE — pre-auth password/email routes only
+#   The route classification is REUSED from Auth::RestrictTo::PRE_AUTH_ROUTES
+#   rather than re-transcribed, so a route that gets classified for one gate
+#   cannot be missed by the other. Deliberately untouched, for the reasons
+#   documented on those constants: UNGATED_ROUTES (account-scoped credential
+#   management — wrong axis, that is ADR-035/SsoOnlyGating), SECOND_FACTOR_ROUTES
+#   (a second factor is a property of the ACCOUNT, not the request host; gating
+#   it is a lockout), and :logout, which must never 404.
+#
+# REJECT SHAPE — 404, byte-identical to an undefined route
+#   ADR-034#reject-as-not-found-not-forbidden. A host that never opted into
+#   sign-in presents NO reachable password surface; a 403 would leave the
+#   handler mounted and reachable, i.e. "configuration presenting as
+#   availability". Reuses Auth::RestrictTo.not_found_response so the two gates
+#   cannot drift in body shape.
+#
+# UNREADABLE POLICY — 503, NOT a fail-closed 404
+#   Deliberate, and the same answer its sibling gives (see
+#   Auth::RestrictTo.resolution_for and SigninConfig.resolve_lookup_failure).
+#   Two datastore reads feed this gate on the hot path of every request to a
+#   custom host — the CustomDomain identity lookup and the SigninConfig lookup —
+#   so this path is reached by a transient Valkey blip, not only by a real
+#   outage.
+#
+#   404 would be the gate claiming an opt-out it never managed to look up:
+#   mystery not-founds on the sign-in routes of an install whose domains may all
+#   be opted IN, indistinguishable from a routing regression and invisible to
+#   alerting. A 404 exists to hide a policy-gated surface; an unreadable policy
+#   has nothing to hide, and "the backend read failed, retry" is both the truth
+#   and the alertable signal. It is still FAIL-CLOSED — 503 denies the sign-in —
+#   just fail-closed with an honest shape.
+#
+#   The operator/tenant split is the model's rule, not a local one:
+#   SigninConfig.operator_host? is a POSITIVE test, so :custom, :invalid and nil
+#   all take the tenant-safe raising branch, while a positively-classified
+#   :canonical/:subdomain host keeps working from in-memory config that a
+#   datastore failure cost it nothing
+#   (ADR-024#operator-defaults-require-positive-classification).
+#
+# WHERE THIS LIVES — beside restrict_to.rb, for its reasons
+#   A plain module with no boot chain, so any surface can require it without
+#   dragging in Auth::Config (see restrict_to.rb's header). The Rodauth wiring
+#   is the thin config/hooks/signin_enabled.rb, registered from the same
+#   before_rodauth area as the restrict_to hook.
+#
+# THIS IS THE FULL-MODE HALF ONLY. Simple mode's POST /auth/login is served by
+# Core, not Rodauth, and is already gated by
+# Core::Controllers::Base#signin_enabled? — the same model resolver, the same
+# omitted domain_id. Nothing here changes that surface.
+#
+# See: docs/adr/adr-024-custom-domain-auth-override-resolution.md,
+#      lib/onetime/models/custom_domain/signin_config.rb (the resolver; it is
+#      owned there and re-derived nowhere).
+#
+
+require 'onetime/models/custom_domain/signin_config'
+require_relative 'restrict_to'
+require_relative 'lib/logging'
+
+module Auth
+  module SigninEnabled
+    # The sign-in methods this opt-in governs. `signin_enabled` is the
+    # password/email flag; 'webauthn' and 'sso' answer to their own
+    # availability predicates and MUST NOT be listed here (#4139).
+    GOVERNED_METHODS = %w[password email_auth].freeze
+
+    # Pre-auth routes gated by this flag, derived from Auth::RestrictTo's
+    # classification so the two gates cannot disagree about what a route IS.
+    # Derived rather than copied on purpose: a new route added there is
+    # automatically considered here, and the coverage spec that guards
+    # PRE_AUTH_ROUTES therefore guards this set too.
+    GATED_ROUTES = Auth::RestrictTo::PRE_AUTH_ROUTES
+                   .select { |_route, method_name| GOVERNED_METHODS.include?(method_name) }
+                   .keys
+                   .freeze
+
+    class << self
+      # Gate the currently-matched Rodauth route.
+      #
+      # @param rodauth [Rodauth::Auth]
+      def enforce_route!(rodauth)
+        route = rodauth.current_route
+        return unless GATED_ROUTES.include?(route)
+
+        # Same reclassification Auth::RestrictTo applies: with Rodauth's
+        # webauthn_verify_account feature loaded, create_account /
+        # verify_account / verify_account_resend stop being password routes —
+        # the ceremony registers a WebAuthn credential and sets no password. A
+        # password/email opt-in has no say over them, so they fall out of this
+        # gate exactly as they change method for the restrict_to gate.
+        if Auth::RestrictTo::WEBAUTHN_VERIFY_ACCOUNT_ROUTES.include?(route) &&
+           rodauth.features.include?(:webauthn_verify_account)
+          return
+        end
+
+        enforce!(rodauth, route)
+      end
+
+      # Gate the password/email opt-in for the current request.
+      #
+      # @param rodauth [Rodauth::Auth]
+      # @param route [Symbol] for logging only
+      # @raise [Onetime::SigninPolicyUnavailable] on an unreadable host policy
+      def enforce!(rodauth, route)
+        # Internal requests (Rodauth's internal_request feature) synthesize a
+        # bare env with NO Host and no DomainStrategy classification, and are
+        # server-initiated app operations rather than a visitor signing in on a
+        # host — invite-signup autologin is one. This policy is about REQUEST
+        # HOSTS, which an internal request does not have, and
+        # handle_internal_request calls before_rodauth directly, so this guard
+        # is load-bearing: without it those flows break.
+        return if rodauth.send(:internal_request?)
+
+        env = rodauth.request.env
+        return if enabled_for_request?(env)
+
+        Auth::Logging.log_auth_event(
+          :signin_enabled_route_rejected,
+          level: :info,
+          route: route,
+          host: env['onetime.display_domain'],
+          path: rodauth.request.path,
+        )
+
+        rodauth.request.halt(Auth::RestrictTo.not_found_response)
+      end
+
+      # Whether password/email sign-in is available on the host this request
+      # arrived on.
+      #
+      # GATHERS INPUTS ONLY (ADR-034#resolution-is-model-owned). The
+      # custom-domain default-OFF rule, the global kill-switch AND, and the
+      # operator/tenant branch all belong to
+      # SigninConfig.resolve_signin_enabled_for_request and are re-derived
+      # nowhere — the same call Core::Controllers::Base#signin_enabled? makes,
+      # so the simple-mode and full-mode gates cannot drift.
+      #
+      # domain_id IS DELIBERATELY OMITTED. Passing it enables the tenant-SSO
+      # carve-out, which exists for DISPLAY surfaces: an SSO-only tenant has a
+      # working /signin page, so the masthead link and the settings page must
+      # report sign-in as available. This is the password/email POST gate, and
+      # SSO never flows through it, so it must keep the strict-false branch.
+      # The asymmetry is specified in
+      # SigninConfig.resolve_signin_enabled_for_custom_domain (#3415, #3783).
+      # Adding domain_id here would let an SSO-only tenant's password POSTs
+      # through — the gap this gate exists to close.
+      #
+      # @param env [Hash] Rack env
+      # @raise [Onetime::SigninPolicyUnavailable] when a datastore read failed
+      #   on a host that could carry a per-domain opt-in, so its policy is
+      #   unknown (503; see this file's header for why not a 404)
+      # @return [Boolean]
+      def enabled_for_request?(env)
+        signin_config = signin_config_for(env)
+        global        = Onetime::CustomDomain::SigninConfig.global_signin_enabled
+
+        Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+          global,
+          signin_config,
+          domain_strategy: env['onetime.domain_strategy'],
+        )
+      rescue Redis::BaseError => ex
+        log_domain_lookup_failure(env, ex)
+        resolve_lookup_failure(env)
+      end
+
+      # The per-domain opt-in record for the request host, or nil.
+      #
+      # from_display_domain, NOT load_by_display_domain (#4157): the latter
+      # rescues Redis::BaseError internally and returns nil, which would make
+      # the rescue above unreachable for the FIRST of the two reads — a blip
+      # would silently resolve as "host has no tenant config", and on a
+      # :custom-classified host that still means default-OFF, but on any host
+      # whose classification ALSO degraded it would inherit operator defaults.
+      # Letting the error out keeps the failure explicit.
+      #
+      # @raise [Redis::BaseError] handled by enabled_for_request?
+      def signin_config_for(env)
+        display_domain = env['onetime.display_domain']
+        return nil if display_domain.to_s.empty?
+
+        domain_id = Onetime::CustomDomain.from_display_domain(display_domain)&.identifier
+        return nil unless domain_id
+
+        Onetime::CustomDomain::SigninConfig.find_by_domain_id(domain_id)
+      end
+
+      # What an unreadable policy resolves to. Mirrors the rule
+      # SigninConfig.resolve_lookup_failure applies for restrict_to, expressed
+      # for a boolean: raise (→ 503) unless the host is positively one of the
+      # operator's own, whose availability is entirely in-memory config and
+      # therefore still fully known.
+      #
+      # @raise [Onetime::SigninPolicyUnavailable]
+      # @return [Boolean]
+      def resolve_lookup_failure(env)
+        domain_strategy = env['onetime.domain_strategy']
+        unless Onetime::CustomDomain::SigninConfig.operator_host?(domain_strategy)
+          raise Onetime::SigninPolicyUnavailable
+        end
+
+        Onetime::CustomDomain::SigninConfig.resolve_signin_enabled_for_request(
+          Onetime::CustomDomain::SigninConfig.global_signin_enabled,
+          nil,
+          domain_strategy: domain_strategy,
+        )
+      end
+
+      def log_domain_lookup_failure(env, exception)
+        Auth::Logging.log_auth_event(
+          :signin_enabled_domain_lookup_failed,
+          level: :error,
+          host: env['onetime.display_domain'],
+          error: exception.message,
+        )
+      end
+    end
+  end
+end

--- a/apps/web/auth/signin_enabled.rb
+++ b/apps/web/auth/signin_enabled.rb
@@ -56,12 +56,22 @@
 #   on this host"; gating SSO on it would take that tenant's ONLY working
 #   sign-in path dark. SSO availability is SsoConfig's question
 #   (tenant_sso_available_for? / sso_available_for_tenant_host?). Hence
-#   GATED_ROUTES below covers exactly the 'password' and 'email_auth' entries of
+#   GATED_ROUTES below covers the 'password' and 'email_auth' entries of
 #   Auth::RestrictTo::PRE_AUTH_ROUTES and nothing else — not 'webauthn', not the
 #   middleware-served OmniAuth request phase, not the app-owned SSO linking
 #   routes.
 #
-# SCOPE — pre-auth password/email routes only
+# NEVER GATE ACCOUNT CREATION ON THIS FLAG EITHER
+#   The account-creation ceremony (create_account / verify_account /
+#   verify_account_resend) is classified 'password' in PRE_AUTH_ROUTES, but
+#   registration availability answers to the SIGN-UP opt-in
+#   (SignupConfig#signup_enabled), not this one. A tenant may run SSO-only
+#   sign-in with open self-service registration (signin_enabled=false,
+#   signup_enabled=true); gating those routes here 404s a working registration
+#   flow on a policy its owner never applied to it. They are subtracted from
+#   GATED_ROUTES and owned by the sibling Auth::SignupEnabled.
+#
+# SCOPE — pre-auth password/email SIGN-IN routes only
 #   The route classification is REUSED from Auth::RestrictTo::PRE_AUTH_ROUTES
 #   rather than re-transcribed, so a route that gets classified for one gate
 #   cannot be missed by the other. Deliberately untouched, for the reasons
@@ -118,6 +128,7 @@
 
 require 'onetime/models/custom_domain/signin_config'
 require_relative 'restrict_to'
+require_relative 'signup_enabled'
 require_relative 'lib/logging'
 
 module Auth
@@ -132,10 +143,22 @@ module Auth
     # Derived rather than copied on purpose: a new route added there is
     # automatically considered here, and the coverage spec that guards
     # PRE_AUTH_ROUTES therefore guards this set too.
-    GATED_ROUTES = Auth::RestrictTo::PRE_AUTH_ROUTES
-                   .select { |_route, method_name| GOVERNED_METHODS.include?(method_name) }
-                   .keys
-                   .freeze
+    #
+    # The account-creation ceremony is SUBTRACTED, not because those routes
+    # are ungated but because they answer to a DIFFERENT opt-in:
+    # `signup_enabled` on SignupConfig, enforced by the sibling
+    # Auth::SignupEnabled. PRE_AUTH_ROUTES classifies create_account as a
+    # 'password' route — true for the method question restrict_to asks —
+    # but registration availability is the signup axis, and gating it here
+    # took an SSO-only tenant's open self-service registration
+    # (signin_enabled=false, signup_enabled=true) to 404. Subtracting the
+    # sibling's own constant means a route is claimed by exactly one
+    # availability gate, never both and never neither.
+    GATED_ROUTES = (
+      Auth::RestrictTo::PRE_AUTH_ROUTES
+        .select { |_route, method_name| GOVERNED_METHODS.include?(method_name) }
+        .keys - Auth::SignupEnabled::GATED_ROUTES
+    ).freeze
 
     class << self
       # Gate the currently-matched Rodauth route.
@@ -144,17 +167,6 @@ module Auth
       def enforce_route!(rodauth)
         route = rodauth.current_route
         return unless GATED_ROUTES.include?(route)
-
-        # Same reclassification Auth::RestrictTo applies: with Rodauth's
-        # webauthn_verify_account feature loaded, create_account /
-        # verify_account / verify_account_resend stop being password routes —
-        # the ceremony registers a WebAuthn credential and sets no password. A
-        # password/email opt-in has no say over them, so they fall out of this
-        # gate exactly as they change method for the restrict_to gate.
-        if Auth::RestrictTo::WEBAUTHN_VERIFY_ACCOUNT_ROUTES.include?(route) &&
-           rodauth.features.include?(:webauthn_verify_account)
-          return
-        end
 
         enforce!(rodauth, route)
       end

--- a/apps/web/auth/signup_enabled.rb
+++ b/apps/web/auth/signup_enabled.rb
@@ -1,0 +1,204 @@
+# apps/web/auth/signup_enabled.rb
+#
+# frozen_string_literal: true
+
+#
+# Runtime enforcement of the per-domain `signup_enabled` OPT-IN on the
+# full-mode account-creation routes (ADR-024 "custom domains default OFF,
+# opt-in only"; ADR-034#resolution-is-model-owned +
+# #reject-as-not-found-not-forbidden).
+#
+# WHY THIS IS ITS OWN GATE AND NOT PART OF Auth::SigninEnabled
+#   `signin_enabled` and `signup_enabled` are DIFFERENT OPT-INS answering
+#   different tenant questions, stored on different models (SigninConfig /
+#   SignupConfig) and resolved by different model-owned resolvers. An SSO-only
+#   tenant with open self-service registration is a REAL shape: SigninConfig
+#   signin_enabled=false ("no password sign-in here") alongside SignupConfig
+#   signup_enabled=true ("anyone may register"). Gating create_account on the
+#   SIGN-IN opt-in — which is what falls out of inheriting PRE_AUTH_ROUTES'
+#   'password' classification wholesale — takes that tenant's working
+#   registration flow to 404 on a policy its owner never applied to
+#   registration. Auth::SigninEnabled therefore excludes these routes, and this
+#   gate owns them against SignupConfig.
+#
+#   In simple mode this split already exists: Core gates the sign-in POST with
+#   Core::Controllers::Base#signin_enabled? and the signup POST with
+#   #signup_enabled?, each against its own resolver. This file is the full-mode
+#   half of the SIGNUP side, exactly as signin_enabled.rb is of the sign-in
+#   side.
+#
+# SCOPE — the account-creation ceremony, all credential types
+#   create_account, verify_account, verify_account_resend. Unlike its two
+#   siblings this gate is NOT method-scoped and takes no webauthn_verify_account
+#   carve-out: `signup_enabled` governs whether an account may be CREATED on
+#   this host at all, regardless of which credential the ceremony registers.
+#   With webauthn_verify_account loaded these routes stop being *password*
+#   routes (which is why the method-scoped gates release them) but they do not
+#   stop being *signup* routes.
+#
+#   verify_account / verify_account_resend are gated alongside create_account
+#   deliberately: a host that does not offer registration presents no part of
+#   the registration ceremony, and leaving verification reachable would let a
+#   signup started elsewhere complete on a host whose owner opted out. The cost
+#   is that flipping signup_enabled off strands a tenant's own in-flight
+#   verifications until it is flipped back — the fail-closed direction, and the
+#   owner's own switch.
+#
+# REJECT SHAPE — 404, byte-identical to an undefined route
+#   ADR-034#reject-as-not-found-not-forbidden, reusing
+#   Auth::RestrictTo.not_found_response so the three gates cannot drift in
+#   body shape.
+#
+# UNREADABLE POLICY — 503, NOT a fail-closed 404
+#   Same rule and same reasoning as its siblings (see signin_enabled.rb's
+#   header at length). The decision is the MODEL's:
+#   SignupConfig.resolve_lookup_failure raises Onetime::SignupPolicyUnavailable
+#   unless the host is positively an operator host, in which case nil ("no
+#   per-domain config" — the only answer such a host could ever have had) is
+#   returned and resolution proceeds from in-memory global config. This is the
+#   same rule Core's simple-mode signup gate already applies via
+#   Onetime::Logic::SignupConfigResolution (#4157).
+#
+# See: docs/adr/adr-024-custom-domain-auth-override-resolution.md,
+#      lib/onetime/models/custom_domain/signup_config.rb (the resolver; it is
+#      owned there and re-derived nowhere).
+#
+
+require 'onetime/models/custom_domain/signup_config'
+require_relative 'restrict_to'
+require_relative 'lib/logging'
+
+module Auth
+  module SignupEnabled
+    # The account-creation ceremony. Auth::SigninEnabled derives its own set
+    # by SUBTRACTING this one from the password/email pre-auth routes, so a
+    # route listed here is claimed by this gate and automatically released by
+    # that one — the two cannot both gate or both miss a route.
+    GATED_ROUTES = %i[
+      create_account
+      verify_account
+      verify_account_resend
+    ].freeze
+
+    class << self
+      # Gate the currently-matched Rodauth route.
+      #
+      # @param rodauth [Rodauth::Auth]
+      def enforce_route!(rodauth)
+        route = rodauth.current_route
+        return unless GATED_ROUTES.include?(route)
+
+        enforce!(rodauth, route)
+      end
+
+      # Gate the sign-up opt-in for the current request.
+      #
+      # @param rodauth [Rodauth::Auth]
+      # @param route [Symbol] for logging only
+      # @raise [Onetime::SignupPolicyUnavailable] on an unreadable host policy
+      def enforce!(rodauth, route)
+        # Internal requests synthesize a bare env with no Host and no
+        # DomainStrategy classification, and are server-initiated app
+        # operations rather than a visitor registering on a host —
+        # invite-signup account creation is one, and it MUST NOT be gated by a
+        # per-host opt-in the request does not have a host for. Same
+        # load-bearing guard as both sibling gates.
+        return if rodauth.send(:internal_request?)
+
+        env = rodauth.request.env
+        return if enabled_for_request?(env)
+
+        Auth::Logging.log_auth_event(
+          :signup_enabled_route_rejected,
+          level: :info,
+          route: route,
+          host: env['onetime.display_domain'],
+          path: rodauth.request.path,
+        )
+
+        rodauth.request.halt(Auth::RestrictTo.not_found_response)
+      end
+
+      # Whether account creation is available on the host this request
+      # arrived on.
+      #
+      # GATHERS INPUTS ONLY (ADR-034#resolution-is-model-owned). The
+      # custom-domain default-OFF rule, the global kill-switch AND, and the
+      # operator/tenant branch all belong to
+      # SignupConfig.resolve_signup_enabled_for_request and are re-derived
+      # nowhere — the same call Core::Controllers::Base#signup_enabled? makes,
+      # so the simple-mode and full-mode gates cannot drift. There is no
+      # domain_id / display carve-out on the signup side at all: unlike
+      # sign-in, sign-up has no SSO path that works without an enabled config
+      # (the resolver documents this).
+      #
+      # @param env [Hash] Rack env
+      # @raise [Onetime::SignupPolicyUnavailable] when a datastore read failed
+      #   on a host that could carry a per-domain opt-in, so its policy is
+      #   unknown (503; see signin_enabled.rb's header for why not a 404)
+      # @return [Boolean]
+      def enabled_for_request?(env)
+        signup_config = signup_config_for(env)
+        global        = Onetime::CustomDomain::SignupConfig.global_signup_enabled
+
+        Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(
+          global,
+          signup_config,
+          domain_strategy: env['onetime.domain_strategy'],
+        )
+      rescue Redis::BaseError => ex
+        log_domain_lookup_failure(env, ex)
+        resolve_lookup_failure(env)
+      end
+
+      # The per-domain opt-in record for the request host, or nil.
+      #
+      # from_display_domain, NOT load_by_display_domain, for the reason
+      # documented on Auth::SigninEnabled.signin_config_for (#4157): the
+      # failure must reach the rescue above explicitly, not dissolve into
+      # "host has no tenant config".
+      #
+      # @raise [Redis::BaseError] handled by enabled_for_request?
+      def signup_config_for(env)
+        display_domain = env['onetime.display_domain']
+        return nil if display_domain.to_s.empty?
+
+        domain_id = Onetime::CustomDomain.from_display_domain(display_domain)&.identifier
+        return nil unless domain_id
+
+        Onetime::CustomDomain::SignupConfig.find_by_domain_id(domain_id)
+      end
+
+      # What an unreadable policy resolves to. The rule is the model's
+      # (SignupConfig.resolve_lookup_failure): raise (→ 503) unless the host
+      # is positively an operator host, whose availability is entirely
+      # in-memory config and therefore still fully known — the read could only
+      # ever have produced nil there, which is what the model returns for us
+      # to resolve with.
+      #
+      # @raise [Onetime::SignupPolicyUnavailable]
+      # @return [Boolean]
+      def resolve_lookup_failure(env)
+        domain_strategy = env['onetime.domain_strategy']
+        config          = Onetime::CustomDomain::SignupConfig.resolve_lookup_failure(
+          domain_strategy: domain_strategy,
+        )
+
+        Onetime::CustomDomain::SignupConfig.resolve_signup_enabled_for_request(
+          Onetime::CustomDomain::SignupConfig.global_signup_enabled,
+          config,
+          domain_strategy: domain_strategy,
+        )
+      end
+
+      def log_domain_lookup_failure(env, exception)
+        Auth::Logging.log_auth_event(
+          :signup_enabled_domain_lookup_failed,
+          level: :error,
+          host: env['onetime.display_domain'],
+          error: exception.message,
+        )
+      end
+    end
+  end
+end

--- a/apps/web/auth/spec/integration/full/restrict_to_enforcement_spec.rb
+++ b/apps/web/auth/spec/integration/full/restrict_to_enforcement_spec.rb
@@ -64,11 +64,44 @@ RSpec.describe 'restrict_to enforcement — full mode (ADR-034#restrict-to-is-an
     # middleware resolves the Host header it was given, and restore after.
     @original_features        = Onetime::Runtime.features
     Onetime::Runtime.features = @original_features.with(domains_enabled: true)
+
+    # AND give the lane a PARSEABLE canonical host (added with the
+    # signin_enabled availability gate, ADR-024).
+    #
+    # The test config's site.host is an IP with a port (127.0.0.1:3000), which
+    # PublicSuffix cannot parse, so with domains_enabled flipped on above the
+    # canonical SET is empty and Chooserator classifies every non-custom host
+    # :invalid — the "unrestricted host" examples below included. :invalid is
+    # NOT an operator host
+    # (ADR-024#operator-defaults-require-positive-classification): it takes the
+    # tenant-safe branch, where password/email sign-in defaults OFF, so those
+    # examples were asserting against a host the policy layer considers
+    # unknown. That was invisible while restrict_to was the only per-domain
+    # gate (an unrestricted resolution rejects nothing regardless of
+    # classification) and became visible the moment the availability gate
+    # started reading the same classification.
+    #
+    # Overriding OT.conf and not just the class state is load-bearing:
+    # DomainStrategy#initialize re-derives from OT.conf, and the Rack app is
+    # built lazily on the first request, i.e. after this hook.
+    @original_domains_config       = OT.conf.dig('features', 'domains') || {}
+    OT.conf['features']['domains'] = @original_domains_config.merge(
+      'enabled' => true,
+      'default' => CANONICAL_HOST,
+    )
+    Onetime::Middleware::DomainStrategy.initialize_from_config(OT.conf['features']['domains'])
   end
 
   after(:all) do
     Onetime::Runtime.features = @original_features if @original_features
+    if @original_domains_config
+      OT.conf['features']['domains'] = @original_domains_config
+      Onetime::Middleware::DomainStrategy.initialize_from_config(@original_domains_config)
+    end
   end
+
+  # An operator host the classifier can actually parse. See before(:all).
+  CANONICAL_HOST = 'operator-restrict-to.example.com'
 
   let(:run_id) { SecureRandom.hex(6) }
 

--- a/apps/web/auth/spec/integration/full/signin_enabled_enforcement_spec.rb
+++ b/apps/web/auth/spec/integration/full/signin_enabled_enforcement_spec.rb
@@ -256,7 +256,10 @@ RSpec.describe 'per-domain signin_enabled enforcement — full mode (ADR-024 cus
     end
 
     it '404s the secondary password endpoints' do
-      %w[/auth/create-account /auth/reset-password-request /auth/reset-password].each do |path|
+      # /auth/create-account is NOT in this list: registration answers to the
+      # SIGN-UP opt-in (Auth::SignupEnabled, SignupConfig#signup_enabled), not
+      # this gate — see signup_enabled_enforcement_spec.rb.
+      %w[/auth/reset-password-request /auth/reset-password].each do |path|
         expect_not_found(post_as(host, path, login: "nobody-#{run_id}@example.com", password: password), path)
       end
     end
@@ -281,7 +284,7 @@ RSpec.describe 'per-domain signin_enabled enforcement — full mode (ADR-024 cus
     end
 
     it '404s the secondary password endpoints' do
-      %w[/auth/create-account /auth/reset-password-request /auth/reset-password].each do |path|
+      %w[/auth/reset-password-request /auth/reset-password].each do |path|
         expect_not_found(post_as(host, path, login: "nobody-#{run_id}@example.com", password: password), path)
       end
     end
@@ -413,16 +416,35 @@ RSpec.describe 'per-domain signin_enabled enforcement — full mode (ADR-024 cus
       post_as(build_domain(:no_domain_id), '/auth/login', login: "nobody-#{run_id}@example.com", password: password)
     end
 
-    it 'gates exactly the password and email_auth pre-auth routes' do
+    it 'gates the password and email_auth pre-auth routes, minus the account-creation ceremony' do
       # Reuses Auth::RestrictTo's classification rather than a second copy of
       # it, so a newly-classified route cannot be covered by one gate and
-      # missed by the other.
-      expect(Auth::SigninEnabled::GATED_ROUTES.to_a)
-        .to match_array(Auth::RestrictTo::PRE_AUTH_ROUTES.select { |_, m| %w[password email_auth].include?(m) }.keys)
+      # missed by the other. The account-creation routes answer to the SIGN-UP
+      # opt-in and are owned by Auth::SignupEnabled instead — gating them here
+      # 404'd an SSO-only tenant's open registration (signin_enabled=false,
+      # signup_enabled=true).
+      expected = Auth::RestrictTo::PRE_AUTH_ROUTES
+                 .select { |_, m| %w[password email_auth].include?(m) }
+                 .keys - Auth::SignupEnabled::GATED_ROUTES
+
+      expect(Auth::SigninEnabled::GATED_ROUTES.to_a).to match_array(expected)
 
       expect(Auth::SigninEnabled::GATED_ROUTES).not_to include(:logout)
       expect(Auth::SigninEnabled::GATED_ROUTES).not_to include(*Auth::RestrictTo::SECOND_FACTOR_ROUTES.keys)
       expect(Auth::SigninEnabled::GATED_ROUTES).not_to include(:webauthn_login)
+    end
+
+    it 'partitions the password/email pre-auth routes with Auth::SignupEnabled — disjoint, jointly exhaustive' do
+      # Every password/email pre-auth route is claimed by exactly ONE
+      # availability gate. A route in both would let the sign-in opt-in veto
+      # registration again; a route in neither is the original full-mode gap.
+      password_email = Auth::RestrictTo::PRE_AUTH_ROUTES
+                       .select { |_, m| %w[password email_auth].include?(m) }
+                       .keys
+
+      expect(Auth::SigninEnabled::GATED_ROUTES & Auth::SignupEnabled::GATED_ROUTES).to be_empty
+      expect(Auth::SigninEnabled::GATED_ROUTES.to_a + Auth::SignupEnabled::GATED_ROUTES.to_a)
+        .to match_array(password_email)
     end
   end
 end

--- a/apps/web/auth/spec/integration/full/signin_enabled_enforcement_spec.rb
+++ b/apps/web/auth/spec/integration/full/signin_enabled_enforcement_spec.rb
@@ -1,0 +1,428 @@
+# apps/web/auth/spec/integration/full/signin_enabled_enforcement_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — per-domain `signin_enabled` as an AVAILABILITY GATE
+# (ADR-024 "custom domains default OFF, opt-in only";
+#  ADR-034#reject-as-not-found-not-forbidden for the reject shape)
+# =============================================================================
+#
+# THE GAP THESE EXAMPLES CLOSE
+#
+# ADR-024's promise is that a custom domain does NOT get password/email sign-in
+# unless its owner explicitly opted in (an *enabled* SigninConfig with
+# signin_enabled=true). That promise was enforced in three places and missing
+# from a fourth:
+#
+#   - simple mode — Core::Controllers::Base#signin_enabled? gates POST
+#     /auth/login, because in simple mode Core serves that route;
+#   - display — the branded masthead's Sign In link and the /signin page
+#     availability verdict;
+#   - full mode — NOWHERE, except incidentally when a `restrict_to`
+#     restriction happened to exist and narrow to :unavailable.
+#
+# So in FULL mode a custom domain that had never opted in (no SigninConfig at
+# all) or had explicitly opted OUT (enabled config, signin_enabled=false) still
+# ACCEPTED valid credentials at POST /auth/login and authenticated: 200, real
+# session. `Auth::RestrictTo` cannot cover this — it is a NARROWING filter over
+# sign-in METHODS and resolves :unrestricted when no restriction exists, which
+# by its own explicit invariant must gate nothing ("an unrestricted install must
+# not go dark"). The availability half needed its own sibling gate, which is
+# Auth::SigninEnabled.
+#
+# The two regression cases are `D` and `E` in the describes below, and they are
+# the reason this file exists. Both were 200 + authenticated before the gate.
+#
+# WHAT MUST NOT REGRESS IN THE OTHER DIRECTION — the gate NARROWS, it does not
+# close. A domain that DID opt in still signs in; canonical/operator hosts are
+# untouched; logout, the second-factor ceremony, and SSO stay reachable.
+# Gating SSO on this flag in particular would re-create the #4139 regression
+# documented at length in signin_config.rb — `signin_enabled` is the
+# password/email opt-in and has never governed SSO.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2163: pnpm run test:database:start
+# - AUTH_DATABASE_URL set (SQLite or PostgreSQL)
+# - AUTHENTICATION_MODE=full
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=full AUTH_DATABASE_URL='sqlite::memory:' \
+#     ORGS_SSO_ENABLED=true bundle exec rspec \
+#     apps/web/auth/spec/integration/full/signin_enabled_enforcement_spec.rb
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require 'rack/test'
+require 'argon2'
+
+RSpec.describe 'per-domain signin_enabled enforcement — full mode (ADR-024 custom domains default OFF)',
+  type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    boot_onetime_app
+
+    # Same reason as restrict_to_enforcement_spec.rb: with DOMAINS_ENABLED off
+    # (the test-config default) Onetime::Middleware::DomainStrategy
+    # short-circuits and classifies EVERY request :canonical, which routes this
+    # gate down its operator branch and makes every example here pass
+    # vacuously. Flip the runtime flag rather than the env var (the lane env is
+    # shared) and restore afterwards.
+    @original_features        = Onetime::Runtime.features
+    Onetime::Runtime.features = @original_features.with(domains_enabled: true)
+
+    # AND give the lane a PARSEABLE canonical host.
+    #
+    # The test config sets site.host to an IP with a port (127.0.0.1:3000),
+    # which PublicSuffix cannot parse, so the canonical SET comes out empty and
+    # Chooserator classifies EVERY non-custom host :invalid — including the
+    # canonical one. That is correct behaviour for a nonsense configuration
+    # (and harmless in real installs, where an IP site.host only ever ships
+    # with domains_enabled OFF, under which DomainStrategy short-circuits to
+    # :canonical), but it makes the operator-branch examples below untestable:
+    # :invalid takes the tenant-safe default-OFF branch by design
+    # (ADR-024#operator-defaults-require-positive-classification), so the
+    # canonical host would 404 for a reason that has nothing to do with what
+    # those examples assert.
+    #
+    # This edits OT.conf and NOT just the class state, which is load-bearing:
+    # DomainStrategy#initialize re-runs initialize_from_config from OT.conf,
+    # and the Rack app is built lazily on the first request — i.e. AFTER this
+    # hook — so a class-state-only override is silently overwritten before the
+    # first example runs. (That overwrite is also what pins the lane at
+    # :invalid: the instance-level domains_enabled? reads Runtime.features,
+    # which we just flipped to true, while the canonical SET was re-derived
+    # with enabled=false and an unparseable site.host, leaving it empty.)
+    # Both are restored in after(:all).
+    @original_domains_config       = OT.conf.dig('features', 'domains') || {}
+    OT.conf['features']['domains'] = @original_domains_config.merge(
+      'enabled' => true,
+      'default' => CANONICAL_HOST,
+    )
+    Onetime::Middleware::DomainStrategy.initialize_from_config(OT.conf['features']['domains'])
+  end
+
+  after(:all) do
+    Onetime::Runtime.features = @original_features if @original_features
+    if @original_domains_config
+      OT.conf['features']['domains'] = @original_domains_config
+      Onetime::Middleware::DomainStrategy.initialize_from_config(@original_domains_config)
+    end
+  end
+
+  # An operator host the classifier can actually parse. See before(:all).
+  CANONICAL_HOST = 'operator-signin-gate.example.com'
+
+  let(:run_id)   { SecureRandom.hex(6) }
+  let(:password) { 'TestPassword123!' }
+
+  # A REAL, verified account in the BOOTED APP's OWN database.
+  #
+  # Auth::Database.connection, not create_test_database: the latter is a
+  # DIFFERENT database that the running app never reads, so the login would
+  # fail with "no matching login" (401) and every example below would pass for
+  # the wrong reason — a false green that hides exactly the gap this file
+  # exists to prove.
+  def create_account(email:)
+    db = Auth::Database.connection
+    id = db[:accounts].insert(
+      email: email,
+      status_id: AuthTestConstants::STATUS_VERIFIED,
+      external_id: SecureRandom.uuid,
+      created_at: Time.now,
+      updated_at: Time.now,
+    )
+    # Cost params match config/features/argon2.rb's test config.
+    hasher = Argon2::Password.new(t_cost: 1, m_cost: 5, p_cost: 1)
+    db[:account_password_hashes].insert(id: id, password_hash: hasher.create(password))
+    email
+  end
+
+  # A host DomainStrategy will classify as :custom, in one of the SigninConfig
+  # shapes under test.
+  #
+  # signin_config: nil          => NO SigninConfig row at all (case E — the
+  #                                "never opted in" default, the common shape)
+  #                a Hash       => attributes for a SigninConfig row
+  # sso:           true         => also stand up tenant SSO credentials
+  def build_domain(label, signin_config: nil, sso: false)
+    owner = Onetime::Customer.new(email: "owner-#{label}-#{run_id}@test.local")
+    owner.save
+    org = Onetime::Organization.create!("SigninEnabled Org #{label} #{run_id}", owner, 'contact@test.local')
+
+    # tr('_', '-'): an underscore is not a legal hostname label character and
+    # DomainStrategy silently falls back to the canonical host for one, which
+    # would make the example pass vacuously on the operator branch.
+    host   = "signin-#{label.to_s.tr('_', '-')}-#{run_id}.example.com"
+    domain = Onetime::CustomDomain.new(display_domain: host, org_id: org.org_id)
+    domain.save
+    Onetime::CustomDomain.display_domain_index.put(host, domain.domainid)
+
+    if signin_config
+      Onetime::CustomDomain::SigninConfig.create!(
+        **{ domain_id: domain.identifier }.merge(signin_config),
+      )
+    end
+
+    if sso
+      Onetime::CustomDomain::SsoConfig.create!(
+        domain_id: domain.identifier,
+        provider_type: 'oidc',
+        display_name: 'Tenant SSO',
+        issuer: 'https://idp.example.com',
+        client_id: "client-#{run_id}",
+        client_secret: "secret-#{run_id}",
+        enabled: true,
+      )
+    end
+
+    @fixtures << [org, domain, owner, host]
+    host
+  end
+
+  before { @fixtures = [] }
+
+  after do
+    Array(@fixtures).each do |org, domain, owner, host|
+      Onetime::CustomDomain::SigninConfig.delete_for_domain!(domain.identifier)
+      Onetime::CustomDomain::SsoConfig.delete_for_domain!(domain.identifier)
+      Onetime::CustomDomain.display_domain_index.remove(host)
+      domain.destroy!
+      org.destroy!
+      owner.destroy!
+    rescue StandardError => ex
+      warn "[signin_enabled spec] cleanup failed for #{host}: #{ex.message}"
+    end
+  end
+
+  # POST with the CSRF token AND an explicit Host so DomainStrategy classifies
+  # the request as the tenant under test. CSRF matters: check_csrf runs BEFORE
+  # before_rodauth, so a token-less POST is rejected upstream of the gate and
+  # the example would pass for the wrong reason.
+  def post_as(host, path, params = {})
+    header 'Host', host
+    csrf_json_post(path, params)
+  end
+
+  # A gated route must be byte-identical to an undefined one
+  # (ADR-034#reject-as-not-found-not-forbidden): same status AND the router's
+  # shared ADR-013 body, not a bespoke shape.
+  def expect_not_found(response, path)
+    expect(response.status).to eq(404),
+      "#{path} returned #{response.status}, expected 404. Body: #{response.body[0, 300]}"
+    body = JSON.parse(response.body)
+    expect(body['error_type']).to eq('NotFound'),
+      "#{path} 404'd with a non-router body: #{response.body[0, 300]}"
+  end
+
+  def route_mounted?(path)
+    Auth::Config.route_hash.key?(path)
+  end
+
+  # ==========================================================================
+  # 1. THE REGRESSION CASES — a custom domain that never opted in
+  # ==========================================================================
+  #
+  # Both used a VALID credential for a REAL verified account and returned 200 +
+  # authenticated before Auth::SigninEnabled existed. Asserting with a valid
+  # credential is the whole point: a nonexistent account 401s either way, which
+  # proves only that the route is live, not that it is gated.
+  #
+  describe 'case D: an ENABLED SigninConfig with signin_enabled=false (explicit opt-OUT)' do
+    let(:host) do
+      build_domain(:opted_out, signin_config: {
+        enabled: true,
+        signin_enabled: false,
+        sso_enabled: false,
+      })
+    end
+
+    it '404s POST /auth/login for a VALID credential' do
+      email = create_account(email: "user-d-#{run_id}@example.com")
+
+      expect_not_found(post_as(host, '/auth/login', login: email, password: password), '/auth/login')
+    end
+
+    it '404s POST /auth/login for a nonexistent account too (no enumeration side channel)' do
+      # The gate must fire BEFORE credential processing, so the two answers are
+      # indistinguishable. A 401 here would leak that the route is live and
+      # would also mean the gate is running too late to be an availability gate.
+      expect_not_found(
+        post_as(host, '/auth/login', login: "nobody-#{run_id}@example.com", password: password),
+        '/auth/login',
+      )
+    end
+
+    it '404s the secondary password endpoints' do
+      %w[/auth/create-account /auth/reset-password-request /auth/reset-password].each do |path|
+        expect_not_found(post_as(host, path, login: "nobody-#{run_id}@example.com", password: password), path)
+      end
+    end
+
+    it '404s POST /auth/email-auth-request (email_auth is the other half of the opt-in)' do
+      skip 'email_auth feature not enabled in this lane' unless route_mounted?('/email-auth-request')
+
+      expect_not_found(
+        post_as(host, '/auth/email-auth-request', login: "nobody-#{run_id}@example.com"),
+        '/auth/email-auth-request',
+      )
+    end
+  end
+
+  describe 'case E: NO SigninConfig at all (the "custom domains default OFF" case)' do
+    let(:host) { build_domain(:no_config) }
+
+    it '404s POST /auth/login for a VALID credential' do
+      email = create_account(email: "user-e-#{run_id}@example.com")
+
+      expect_not_found(post_as(host, '/auth/login', login: email, password: password), '/auth/login')
+    end
+
+    it '404s the secondary password endpoints' do
+      %w[/auth/create-account /auth/reset-password-request /auth/reset-password].each do |path|
+        expect_not_found(post_as(host, path, login: "nobody-#{run_id}@example.com", password: password), path)
+      end
+    end
+  end
+
+  # ==========================================================================
+  # 2. THE GATE NARROWS, IT DOES NOT CLOSE
+  # ==========================================================================
+
+  describe 'a domain that HAS opted in (enabled=true, signin_enabled=true)' do
+    let(:host) do
+      build_domain(:opted_in, signin_config: {
+        enabled: true,
+        signin_enabled: true,
+        sso_enabled: false,
+      })
+    end
+
+    it 'authenticates a valid credential at POST /auth/login' do
+      email    = create_account(email: "user-in-#{run_id}@example.com")
+      response = post_as(host, '/auth/login', login: email, password: password)
+
+      expect(response.status).to eq(200),
+        "an opted-in domain must still sign in (got #{response.status}: #{response.body[0, 300]})"
+    end
+
+    it 'leaves the secondary password endpoints reachable' do
+      response = post_as(host, '/auth/reset-password-request', login: "nobody-#{run_id}@example.com")
+
+      expect(response.status).not_to eq(404)
+    end
+  end
+
+  describe 'canonical / operator hosts' do
+    let(:canonical_host) { CANONICAL_HOST }
+
+    it 'classifies as :canonical (guards against a vacuous pass on :invalid)' do
+      seen = nil
+      allow(Auth::SigninEnabled).to receive(:enabled_for_request?).and_wrap_original do |orig, env|
+        seen = env['onetime.domain_strategy']
+        orig.call(env)
+      end
+
+      post_as(canonical_host, '/auth/login', login: "nobody-#{run_id}@example.com", password: password)
+      expect(seen).to eq(:canonical)
+    end
+
+    it 'authenticates normally — operator defaults are untouched' do
+      email    = create_account(email: "user-canon-#{run_id}@example.com")
+      response = post_as(canonical_host, '/auth/login', login: email, password: password)
+
+      expect(response.status).to eq(200),
+        "the canonical host must follow the operator default (got #{response.status}: #{response.body[0, 300]})"
+    end
+
+    it 'leaves logout reachable' do
+      expect(post_as(canonical_host, '/auth/logout').status).not_to eq(404)
+    end
+  end
+
+  # ==========================================================================
+  # 3. ROUTES THIS GATE MUST NOT TOUCH
+  # ==========================================================================
+
+  describe 'routes outside the password/email opt-in' do
+    let(:host) do
+      build_domain(:not_gated, signin_config: {
+        enabled: true,
+        signin_enabled: false,
+        sso_enabled: true,
+      }, sso: true)
+    end
+
+    it 'never gates logout — logout must never 404' do
+      expect(post_as(host, '/auth/logout').status).not_to eq(404)
+    end
+
+    it 'never gates the SSO request phase on signin_enabled (#4139)' do
+      skip 'SSO routes not registered in this lane' unless Onetime.auth_config.orgs_sso_enabled?
+
+      # signin_enabled is the PASSWORD/EMAIL opt-in. An SSO-only tenant sets
+      # signin_enabled=false precisely to say "no passwords here" — gating SSO
+      # on it takes that tenant's only working sign-in path dark, which is the
+      # #4139 regression verbatim.
+      response = post_as(host, '/auth/sso/oidc')
+      expect(response.status).not_to eq(404),
+        'SSO must not be gated by signin_enabled (#4139)'
+    end
+
+    it 'never gates the second-factor ceremony routes' do
+      # Second factors are a property of the ACCOUNT, not of the request host
+      # (ADR-034#reject-as-not-found-not-forbidden "Scope"). Gating them on a
+      # host flag is a lockout, not an access control.
+      skip 'webauthn feature not enabled in this lane' unless route_mounted?('/webauthn-auth')
+
+      expect(post_as(host, '/auth/webauthn-auth').status).not_to eq(404)
+    end
+  end
+
+  # ==========================================================================
+  # 4. POLICY-SOURCE CONTRACT
+  # ==========================================================================
+  #
+  # These lock the two decisions that are easy to "simplify" away in a later
+  # edit and would silently re-open the gap.
+  #
+  describe 'policy source (ADR-034#resolution-is-model-owned)' do
+    it 'asks the model resolver rather than re-deriving availability locally' do
+      expect(Onetime::CustomDomain::SigninConfig)
+        .to receive(:resolve_signin_enabled_for_request)
+        .at_least(:once)
+        .and_return(true)
+
+      post_as(build_domain(:probe), '/auth/login', login: "nobody-#{run_id}@example.com", password: password)
+    end
+
+    it 'omits domain_id, keeping the strict-false branch for the POST gate' do
+      # Passing domain_id would enable the tenant-SSO DISPLAY carve-out
+      # (signin_config.rb, resolve_signin_enabled_for_custom_domain), which
+      # would let an SSO-only tenant's password POST through. SSO never flows
+      # through this route, so the asymmetry is deliberate (#3415, #3783).
+      allow(Onetime::CustomDomain::SigninConfig)
+        .to receive(:resolve_signin_enabled_for_request)
+        .and_wrap_original do |orig, *args, **kwargs|
+          expect(kwargs).not_to have_key(:domain_id)
+          orig.call(*args, **kwargs)
+        end
+
+      post_as(build_domain(:no_domain_id), '/auth/login', login: "nobody-#{run_id}@example.com", password: password)
+    end
+
+    it 'gates exactly the password and email_auth pre-auth routes' do
+      # Reuses Auth::RestrictTo's classification rather than a second copy of
+      # it, so a newly-classified route cannot be covered by one gate and
+      # missed by the other.
+      expect(Auth::SigninEnabled::GATED_ROUTES.to_a)
+        .to match_array(Auth::RestrictTo::PRE_AUTH_ROUTES.select { |_, m| %w[password email_auth].include?(m) }.keys)
+
+      expect(Auth::SigninEnabled::GATED_ROUTES).not_to include(:logout)
+      expect(Auth::SigninEnabled::GATED_ROUTES).not_to include(*Auth::RestrictTo::SECOND_FACTOR_ROUTES.keys)
+      expect(Auth::SigninEnabled::GATED_ROUTES).not_to include(:webauthn_login)
+    end
+  end
+end

--- a/apps/web/auth/spec/integration/full/signup_enabled_enforcement_spec.rb
+++ b/apps/web/auth/spec/integration/full/signup_enabled_enforcement_spec.rb
@@ -1,0 +1,296 @@
+# apps/web/auth/spec/integration/full/signup_enabled_enforcement_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — per-domain `signup_enabled` as an AVAILABILITY GATE
+# on the full-mode account-creation routes
+# (ADR-024 "custom domains default OFF, opt-in only";
+#  ADR-034#reject-as-not-found-not-forbidden for the reject shape)
+# =============================================================================
+#
+# TWO GAPS, ONE FILE
+#
+# 1. THE OVER-GATE (the headline regression case below). An early draft of the
+#    full-mode availability gate inherited PRE_AUTH_ROUTES' 'password'
+#    classification wholesale, so create_account / verify_account /
+#    verify_account_resend were gated on the SIGN-IN opt-in
+#    (SigninConfig#signin_enabled). On an SSO-only tenant with open
+#    registration — SigninConfig signin_enabled=false, SignupConfig
+#    signup_enabled=true, a real and reasonable shape — POST
+#    /auth/create-account went from 200 "Your account has been created" to
+#    404, killed by a policy the domain owner never applied to registration.
+#    Verified by execution before the fix.
+#
+# 2. THE UNDER-GATE. Symmetrically, nothing in full mode consulted the
+#    per-domain SIGN-UP opt-in at all. ADR-024's default-OFF promise for
+#    custom domains was enforced for signup in simple mode
+#    (Core::Controllers::Base#signup_enabled?) and nowhere on the Rodauth
+#    routes, so a custom domain that never opted into registration still
+#    created accounts at POST /auth/create-account.
+#
+# Both close the same way: the account-creation ceremony is owned by
+# Auth::SignupEnabled (against SignupConfig's model resolver) and subtracted
+# from Auth::SigninEnabled's route set — each route claimed by exactly one
+# availability gate.
+#
+# REQUIREMENTS / RUN: same as signin_enabled_enforcement_spec.rb —
+#   RACK_ENV=test AUTHENTICATION_MODE=full AUTH_DATABASE_URL='sqlite::memory:' \
+#     ORGS_SSO_ENABLED=true bundle exec rspec \
+#     apps/web/auth/spec/integration/full/signup_enabled_enforcement_spec.rb
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require 'rack/test'
+
+RSpec.describe 'per-domain signup_enabled enforcement — full mode (ADR-024 custom domains default OFF)',
+  type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    boot_onetime_app
+
+    # Same lane surgery as signin_enabled_enforcement_spec.rb, for the same
+    # reasons documented there at length: DOMAINS_ENABLED must be on or every
+    # request classifies :canonical (vacuous pass), and site.host must be
+    # replaced by a PublicSuffix-parseable canonical host or every non-custom
+    # host classifies :invalid (operator examples untestable).
+    @original_features        = Onetime::Runtime.features
+    Onetime::Runtime.features = @original_features.with(domains_enabled: true)
+
+    @original_domains_config       = OT.conf.dig('features', 'domains') || {}
+    OT.conf['features']['domains'] = @original_domains_config.merge(
+      'enabled' => true,
+      'default' => CANONICAL_HOST,
+    )
+    Onetime::Middleware::DomainStrategy.initialize_from_config(OT.conf['features']['domains'])
+  end
+
+  after(:all) do
+    Onetime::Runtime.features = @original_features if @original_features
+    if @original_domains_config
+      OT.conf['features']['domains'] = @original_domains_config
+      Onetime::Middleware::DomainStrategy.initialize_from_config(@original_domains_config)
+    end
+  end
+
+  CANONICAL_HOST = 'operator-signup-gate.example.com'
+
+  let(:run_id)   { SecureRandom.hex(6) }
+  let(:password) { 'TestPassword123!' }
+
+  # A host DomainStrategy will classify as :custom, in one of the config
+  # shapes under test. Either config hash may be nil (no row at all — the
+  # default shape for both models).
+  def build_domain(label, signin_config: nil, signup_config: nil)
+    owner = Onetime::Customer.new(email: "owner-#{label}-#{run_id}@test.local")
+    owner.save
+    org = Onetime::Organization.create!("SignupEnabled Org #{label} #{run_id}", owner, 'contact@test.local')
+
+    host   = "signup-#{label.to_s.tr('_', '-')}-#{run_id}.example.com"
+    domain = Onetime::CustomDomain.new(display_domain: host, org_id: org.org_id)
+    domain.save
+    Onetime::CustomDomain.display_domain_index.put(host, domain.domainid)
+
+    if signin_config
+      Onetime::CustomDomain::SigninConfig.create!(
+        **{ domain_id: domain.identifier }.merge(signin_config),
+      )
+    end
+
+    if signup_config
+      Onetime::CustomDomain::SignupConfig.create!(
+        **{ domain_id: domain.identifier }.merge(signup_config),
+      )
+    end
+
+    @fixtures << [org, domain, owner, host]
+    host
+  end
+
+  before { @fixtures = [] }
+
+  after do
+    Array(@fixtures).each do |org, domain, owner, host|
+      Onetime::CustomDomain::SigninConfig.delete_for_domain!(domain.identifier)
+      Onetime::CustomDomain::SignupConfig.delete_for_domain!(domain.identifier)
+      Onetime::CustomDomain.display_domain_index.remove(host)
+      domain.destroy!
+      org.destroy!
+      owner.destroy!
+    rescue StandardError => ex
+      warn "[signup_enabled spec] cleanup failed for #{host}: #{ex.message}"
+    end
+  end
+
+  def post_as(host, path, params = {})
+    header 'Host', host
+    csrf_json_post(path, params)
+  end
+
+  # A WELL-FORMED create-account body. login-confirm matters: without it
+  # Rodauth answers 422 "logins do not match" and a would-be 200 is
+  # indistinguishable from a gate — the false negative that nearly hid the
+  # over-gate regression when it was first probed.
+  def signup_params(email)
+    {
+      login: email,
+      'login-confirm': email,
+      password: password,
+      'password-confirm': password,
+    }
+  end
+
+  def expect_not_found(response, path)
+    expect(response.status).to eq(404),
+      "#{path} returned #{response.status}, expected 404. Body: #{response.body[0, 300]}"
+    body = JSON.parse(response.body)
+    expect(body['error_type']).to eq('NotFound'),
+      "#{path} 404'd with a non-router body: #{response.body[0, 300]}"
+  end
+
+  # ==========================================================================
+  # 1. THE OVER-GATE REGRESSION — sign-in opt-out must not veto registration
+  # ==========================================================================
+
+  describe 'SSO-only sign-in with OPEN registration (signin_enabled=false, signup_enabled=true)' do
+    let(:host) do
+      build_domain(:sso_open_reg,
+        signin_config: { enabled: true, signin_enabled: false, sso_enabled: true },
+        signup_config: { enabled: true, signup_enabled: true },)
+    end
+
+    it 'creates an account at POST /auth/create-account (200, not 404)' do
+      response = post_as(host, '/auth/create-account', signup_params("newuser-#{run_id}@example.com"))
+
+      expect(response.status).to eq(200),
+        "an opted-in registration must succeed regardless of the SIGN-IN opt-out " \
+        "(got #{response.status}: #{response.body[0, 300]})"
+      expect(JSON.parse(response.body)['success']).to match(/created/i)
+    end
+
+    it 'still 404s POST /auth/login — the sign-in opt-out keeps its own routes' do
+      expect_not_found(
+        post_as(host, '/auth/login', login: "nobody-#{run_id}@example.com", password: password),
+        '/auth/login',
+      )
+    end
+  end
+
+  # ==========================================================================
+  # 2. THE UNDER-GATE — custom domains default OFF for registration too
+  # ==========================================================================
+  #
+  # All three closed shapes assert with a WELL-FORMED body for the same reason
+  # the sign-in spec uses a valid credential: a malformed request fails either
+  # way and proves only that the route is live.
+  #
+  describe 'NO SignupConfig at all (the "never opted in" default shape)' do
+    let(:host) { build_domain(:no_config) }
+
+    it '404s POST /auth/create-account' do
+      expect_not_found(
+        post_as(host, '/auth/create-account', signup_params("nobody-#{run_id}@example.com")),
+        '/auth/create-account',
+      )
+    end
+
+    it '404s the verification ceremony routes' do
+      %w[/auth/verify-account /auth/verify-account-resend].each do |path|
+        expect_not_found(post_as(host, path, login: "nobody-#{run_id}@example.com"), path)
+      end
+    end
+  end
+
+  describe 'an ENABLED SignupConfig with signup_enabled=false (explicit opt-OUT)' do
+    let(:host) do
+      build_domain(:opted_out, signup_config: { enabled: true, signup_enabled: false })
+    end
+
+    it '404s POST /auth/create-account' do
+      expect_not_found(
+        post_as(host, '/auth/create-account', signup_params("nobody-#{run_id}@example.com")),
+        '/auth/create-account',
+      )
+    end
+  end
+
+  describe 'a SignupConfig whose master switch is OFF (enabled=false, signup_enabled=true)' do
+    let(:host) do
+      # A disabled config expresses no opinion, and custom domains default
+      # OFF — same rule as the sign-in side (resolve_*_for_custom_domain).
+      build_domain(:master_off, signup_config: { enabled: false, signup_enabled: true })
+    end
+
+    it '404s POST /auth/create-account' do
+      expect_not_found(
+        post_as(host, '/auth/create-account', signup_params("nobody-#{run_id}@example.com")),
+        '/auth/create-account',
+      )
+    end
+  end
+
+  # ==========================================================================
+  # 3. THE GATE NARROWS, IT DOES NOT CLOSE
+  # ==========================================================================
+
+  describe 'canonical / operator hosts' do
+    it 'classifies as :canonical (guards against a vacuous pass on :invalid)' do
+      seen = nil
+      allow(Auth::SignupEnabled).to receive(:enabled_for_request?).and_wrap_original do |orig, env|
+        seen = env['onetime.domain_strategy']
+        orig.call(env)
+      end
+
+      post_as(CANONICAL_HOST, '/auth/create-account', signup_params("probe-#{run_id}@example.com"))
+      expect(seen).to eq(:canonical)
+    end
+
+    it 'creates accounts per the operator default — untouched by the per-domain gate' do
+      response = post_as(CANONICAL_HOST, '/auth/create-account', signup_params("canon-#{run_id}@example.com"))
+
+      expect(response.status).to eq(200),
+        "the canonical host must follow the operator default (got #{response.status}: #{response.body[0, 300]})"
+    end
+  end
+
+  describe 'routes outside the signup opt-in' do
+    let(:host) do
+      build_domain(:not_gated, signup_config: { enabled: true, signup_enabled: false })
+    end
+
+    it 'never gates logout' do
+      expect(post_as(host, '/auth/logout').status).not_to eq(404)
+    end
+
+    it 'does not gate the sign-in routes — signup opt-out is not a sign-in opt-out' do
+      # No SigninConfig on this domain, so sign-in 404s here too — but by the
+      # SIGN-IN gate. Prove the axis by asserting the SIGNUP gate never ran
+      # for the login route.
+      expect(Auth::SignupEnabled).not_to receive(:enforce!)
+
+      post_as(host, '/auth/login', login: "nobody-#{run_id}@example.com", password: password)
+    end
+  end
+
+  # ==========================================================================
+  # 4. POLICY-SOURCE CONTRACT
+  # ==========================================================================
+
+  describe 'policy source (ADR-034#resolution-is-model-owned)' do
+    it 'asks the model resolver rather than re-deriving availability locally' do
+      expect(Onetime::CustomDomain::SignupConfig)
+        .to receive(:resolve_signup_enabled_for_request)
+        .at_least(:once)
+        .and_return(true)
+
+      post_as(build_domain(:probe), '/auth/create-account', signup_params("probe2-#{run_id}@example.com"))
+    end
+
+    it 'gates exactly the account-creation ceremony' do
+      expect(Auth::SignupEnabled::GATED_ROUTES.to_a)
+        .to match_array(%i[create_account verify_account verify_account_resend])
+    end
+  end
+end

--- a/apps/web/core/spec/views/serializers/restrict_to_parity_spec.rb
+++ b/apps/web/core/spec/views/serializers/restrict_to_parity_spec.rb
@@ -384,6 +384,63 @@ RSpec.describe 'restrict_to display/gate parity' do
     end
   end
 
+  # AN ENABLED CONFIG WITHOUT AN OPINION DOES NOT ERASE THE PIN (#4167).
+  # restrict_to unset + signin_enabled=false is a config that is technically
+  # present but expresses no restriction and opts the non-SSO methods off.
+  # Both pin sites used to skip the 'sso' host pin on `enabled?` alone, so with
+  # the platform-SSO fallback keeping /signin alive, resolution widened to
+  # :unrestricted for a host whose only working method is SSO — the direction
+  # ADR-034#resolution-intersects-never-widens exists to prevent.
+  describe 'enabled SigninConfig with no opinion (#4167)' do
+    def no_opinion_config(signin_enabled:, sso_enabled: true)
+      instance_double(
+        Onetime::CustomDomain::SigninConfig,
+        domain_id: domain_id,
+        enabled?: true,
+        signin_enabled?: signin_enabled,
+        email_auth_enabled?: false,
+        sso_enabled?: sso_enabled,
+        restrict_to: nil,
+      )
+    end
+
+    before do
+      allow(mock_auth_config).to receive(:allow_platform_fallback_for_tenants?).and_return(true)
+    end
+
+    context 'with signin_enabled=false and SSO reachable via platform fallback' do
+      before do
+        allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
+          .with(domain_id).and_return(no_opinion_config(signin_enabled: false))
+      end
+
+      it 'agrees' do
+        expect_parity
+      end
+
+      it "still pins 'sso' — the host's effective capability set is SSO-only" do
+        expect(gate_resolution).to be_restricted
+        expect(gate_resolution.restrict_to).to eq('sso')
+        expect(gate_resolution.allows?('password')).to be(false)
+        expect(gate_resolution.allows?('email_auth')).to be(false)
+        expect(display_resolution.restrict_to).to eq('sso')
+      end
+    end
+
+    context 'with signin_enabled=true (the config DOES speak: password/email opted in)' do
+      before do
+        allow(Onetime::CustomDomain::SigninConfig).to receive(:find_by_domain_id)
+          .with(domain_id).and_return(no_opinion_config(signin_enabled: true))
+      end
+
+      it 'agrees, and no pin narrows away the methods the owner enabled' do
+        expect_parity
+        expect(gate_resolution).to be_unrestricted
+        expect(display_resolution).to be_unrestricted
+      end
+    end
+  end
+
   # CLOSED (#4140). The display serializer and the route gate both pin 'sso' as
   # the inherited restriction for a custom host with no enabled SigninConfig
   # that is reachable only via SSO. The settings API did not — it handed the

--- a/changelog.d/20260815_000000_claude_4167_restrict_to_no_opinion.rst
+++ b/changelog.d/20260815_000000_claude_4167_restrict_to_no_opinion.rst
@@ -1,0 +1,28 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- (`#4167 <https://github.com/onetimesecret/onetimesecret/issues/4167>`_)
+  An enabled per-domain ``SigninConfig`` that expresses no sign-in opinion —
+  ``restrict_to`` unset and ``signin_enabled=false`` — no longer suppresses
+  the SSO host pin. The display serializer and the route gate pin ``sso`` as
+  the inherited restriction for a custom host reachable only via SSO, and
+  both previously skipped that pin whenever any *enabled* config existed for
+  the host. Combined with the operator platform-SSO fallback, such a
+  no-opinion config resolved ``:unrestricted`` for a host whose only working
+  method is SSO, leaving password/email endpoints accepting crafted POSTs on
+  that host — the widen direction ADR-034 fail-closed degradation exists to
+  prevent. Both pin sites now skip on the new model-owned predicate
+  ``SigninConfig.speaks_for_restrict_to?``: a config speaks when it names a
+  restriction or opts the password/email methods in; enabled-but-silent
+  configs fall through to the pin exactly like the no-config case. A config
+  with ``signin_enabled=true`` and no ``restrict_to`` still resolves
+  unrestricted — the owner explicitly opted the non-SSO methods in.
+
+AI Assistance
+-------------
+
+- Claude added ``SigninConfig.speaks_for_restrict_to?`` and repointed both
+  SSO host-pin sites at it, with unit and display/gate parity coverage.
+  (#4167)

--- a/changelog.d/20260815_050000_claude_full_mode_signin_enabled_gate.rst
+++ b/changelog.d/20260815_050000_claude_full_mode_signin_enabled_gate.rst
@@ -32,11 +32,28 @@ Fixed
   is still denied, but an unreadable policy is reported as an outage instead
   of being disguised as a route that does not exist.
 
+- Full mode now also enforces the per-domain **sign-up** opt-in
+  (``SignupConfig#signup_enabled``) on the account-creation routes
+  (``create-account``, ``verify-account``, ``verify-account-resend``), via a
+  sibling gate (``Auth::SignupEnabled``) using the same model-owned resolver
+  simple mode already uses
+  (``SignupConfig.resolve_signup_enabled_for_request``). Registration and
+  sign-in are gated at parity, each on its own opt-in: the account-creation
+  routes answer to the sign-up flag alone, and the sign-in routes to the
+  sign-in flag alone. This partition also fixes an over-gate present in an
+  earlier draft of the sign-in gate, where an SSO-only tenant with open
+  self-service registration (``signin_enabled=false``,
+  ``signup_enabled=true``) had its working ``create-account`` route taken to
+  ``404`` by the sign-in opt-out. Reject and degradation shapes match the
+  sign-in gate (``404`` identical to an undefined route; ``503`` when the
+  policy cannot be read).
+
 AI Assistance
 -------------
 
-- Claude added the full-mode availability gate (``Auth::SigninEnabled``) as a
-  sibling of ``Auth::RestrictTo``, wired it into the existing
-  ``before_rodauth`` / ``before_email_auth_request`` hooks, and added
-  integration coverage for the opted-out and never-configured custom-domain
-  cases along with the narrowing and non-gated surfaces.
+- Claude added the full-mode availability gates (``Auth::SigninEnabled`` and
+  ``Auth::SignupEnabled``) as siblings of ``Auth::RestrictTo``, wired them
+  into the existing ``before_rodauth`` / ``before_email_auth_request`` hooks,
+  and added integration coverage for the opted-out, never-configured and
+  SSO-only-with-open-registration custom-domain cases along with the
+  narrowing and non-gated surfaces.

--- a/changelog.d/20260815_050000_claude_full_mode_signin_enabled_gate.rst
+++ b/changelog.d/20260815_050000_claude_full_mode_signin_enabled_gate.rst
@@ -1,0 +1,42 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- Full mode now enforces a custom domain's per-domain sign-in opt-in on the
+  password and email (magic-link) authentication routes. ADR-024 specifies
+  that custom domains are default-OFF for password/email sign-in and become
+  available only when the domain owner explicitly opts in with an enabled
+  ``SigninConfig``. That rule was enforced in simple mode (where Core serves
+  the sign-in POST), on the display surfaces (the branded masthead link and
+  the ``/signin`` page availability verdict) and in the settings API — but in
+  full mode, where Rodauth serves those routes, nothing consulted it. A custom
+  domain that had never opted in, or that had explicitly opted out, could
+  still complete a password sign-in. The opt-in is now applied on the same
+  ``before_rodauth`` chokepoint as ``restrict_to``, using the same
+  model-owned resolver (``SigninConfig.resolve_signin_enabled_for_request``)
+  the other surfaces already use, so display and runtime cannot disagree.
+
+  This narrows, it does not close: a domain that has opted in signs in
+  exactly as before, operator (canonical/subdomain) hosts follow the install's
+  global settings unchanged, and logout, the second-factor ceremony and
+  account-scoped routes are untouched. SSO is deliberately not gated by this
+  flag — it is the password/email opt-in, and an SSO-only tenant sets it off
+  precisely to disable passwords — so tenant SSO sign-in is unaffected.
+
+  A rejected route answers ``404`` with the router's shared not-found body,
+  identical to an undefined route, per
+  ADR-034#reject-as-not-found-not-forbidden. If the per-domain policy itself
+  cannot be read (a datastore failure), the answer is ``503`` rather than a
+  fail-closed ``404``, matching the existing ``restrict_to`` gate: the request
+  is still denied, but an unreadable policy is reported as an outage instead
+  of being disguised as a route that does not exist.
+
+AI Assistance
+-------------
+
+- Claude added the full-mode availability gate (``Auth::SigninEnabled``) as a
+  sibling of ``Auth::RestrictTo``, wired it into the existing
+  ``before_rodauth`` / ``before_email_auth_request`` hooks, and added
+  integration coverage for the opted-out and never-configured custom-domain
+  cases along with the narrowing and non-gated surfaces.

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -744,7 +744,7 @@ module Onetime
         # @param custom_host [Boolean] whether the host is a custom domain
         # @return [InheritedRestriction] value plus metadata for availability check (#4165)
         def inherited_restrict_to(config, domain_id: nil, custom_host: false)
-          if config&.enabled?
+          if speaks_for_restrict_to?(config)
             return InheritedRestriction.new(value: Onetime.auth_config.restrict_to, pin_established: false)
           end
 

--- a/lib/onetime/models/custom_domain/signin_config.rb
+++ b/lib/onetime/models/custom_domain/signin_config.rb
@@ -311,6 +311,46 @@ module Onetime
           config.sso_enabled?
         end
 
+        # Whether an enabled per-domain config actually EXPRESSES a sign-in
+        # policy the restrict_to inheritance should defer to (#4167).
+        #
+        # The display serializer and the route gate pin 'sso' as the inherited
+        # (`global`) restriction for a custom host that is reachable only via
+        # SSO, and they must skip that pin when a per-domain config speaks —
+        # under intersection semantics
+        # (ADR-034#resolution-intersects-never-widens) an unconditional pin
+        # would CONFLICT with the tenant's own restrict_to and lock the host
+        # out. Both consumers used to skip on `enabled?` alone, but a config
+        # can be enabled WITHOUT having an opinion: restrict_to unset and
+        # signin_enabled=false (password/email opted off). Such a config
+        # contributes an empty domain half to the resolver, so skipping the
+        # pin for it resolved :unrestricted on a host whose only working
+        # method is SSO (e.g. via the operator platform-SSO fallback) — the
+        # widen direction ADR-034#degradation-is-fail-closed exists to
+        # prevent.
+        #
+        # A config speaks when it names a restriction, or when it opts the
+        # password/email methods IN (signin_enabled) — in that second case the
+        # host genuinely offers more than SSO, so pinning 'sso' would wrongly
+        # narrow away methods the owner explicitly enabled. sso_enabled is
+        # deliberately not consulted: it feeds the SSO availability ladder
+        # (sso_permitted_for?) that decides whether the pin's predicate fires
+        # at all.
+        #
+        # Class-level like the resolvers it serves, so both pin sites
+        # (Core::Views::ConfigSerializer#effective_global_restrict_to,
+        # Auth::RestrictTo.global_restrict_to) ask it identically
+        # (ADR-034#resolution-is-model-owned) and nil configs are handled here.
+        #
+        # @param config [SigninConfig, nil] the per-domain config, if any
+        # @return [Boolean]
+        def speaks_for_restrict_to?(config)
+          return false unless config&.enabled?
+          return true unless config.restrict_to.to_s.strip.empty?
+
+          config.signin_enabled?
+        end
+
         # Resolve effective sign-in availability, combining the install-level
         # (global) capability with an optional per-domain override.
         #

--- a/spec/unit/onetime/models/custom_domain/signin_config_restrict_to_spec.rb
+++ b/spec/unit/onetime/models/custom_domain/signin_config_restrict_to_spec.rb
@@ -119,6 +119,65 @@ RSpec.describe Onetime::CustomDomain::SigninConfig do
     end
   end
 
+  # Whether the display/gate 'sso' host pin must defer to the per-domain
+  # config (#4167). Skipping the pin on `enabled?` alone let a config that is
+  # enabled WITHOUT an opinion (restrict_to unset, signin_enabled=false)
+  # resolve :unrestricted on a host whose only working method is SSO.
+  describe '.speaks_for_restrict_to?' do
+    subject(:speaks) { described_class.speaks_for_restrict_to?(config) }
+
+    context 'with no config at all' do
+      let(:config) { nil }
+
+      it { is_expected.to be(false) }
+    end
+
+    context 'with the master switch off' do
+      let(:config) do
+        described_class.new(domain_id: 'domain-4167', enabled: false, restrict_to: 'password')
+      end
+
+      it 'does not speak, whatever the fields say' do
+        expect(speaks).to be(false)
+      end
+    end
+
+    context 'enabled and naming a restriction' do
+      let(:config) do
+        described_class.new(
+          domain_id: 'domain-4167', enabled: true, signin_enabled: false, restrict_to: 'password'
+        )
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'enabled with restrict_to unset but password/email opted IN' do
+      let(:config) do
+        described_class.new(
+          domain_id: 'domain-4167', enabled: true, signin_enabled: true, restrict_to: nil
+        )
+      end
+
+      it 'speaks — the host genuinely offers more than SSO, so no pin' do
+        expect(speaks).to be(true)
+      end
+    end
+
+    context 'enabled without an opinion (restrict_to unset, signin_enabled off)' do
+      let(:config) do
+        described_class.new(
+          domain_id: 'domain-4167', enabled: true, signin_enabled: false,
+          sso_enabled: true, restrict_to: nil
+        )
+      end
+
+      it 'does not speak — the SSO host pin still applies (#4167)' do
+        expect(speaks).to be(false)
+      end
+    end
+  end
+
   # The `available:` INPUT the three gates hand to the resolver (#4139). It
   # lives on the model precisely so no consumer can gather it differently; the
   # parity spec asserts the display serializer and the route gate agree, and


### PR DESCRIPTION
## Summary

Fixes #4167

Implements runtime enforcement of per-domain `signin_enabled` and `signup_enabled` opt-ins on full-mode Rodauth routes. ADR-024 specifies that custom domains default to OFF for password/email sign-in and account creation, becoming available only when domain owners explicitly opt in. This enforcement existed in simple mode (Core controllers) and on display surfaces, but was missing from full mode's Rodauth routes.

### Changes

**New modules:**
- `Auth::SigninEnabled` — Gates password/email sign-in routes (`/auth/login`, `/auth/reset-password-request`, `/auth/reset-password`, `/auth/email-auth-request`) on `SigninConfig#signin_enabled`. Reuses the model-owned resolver already used by simple mode and display surfaces, ensuring consistency across all surfaces.
- `Auth::SignupEnabled` — Gates account-creation routes (`/auth/create-account`, `/auth/verify-account`, `/auth/verify-account-resend`) on `SignupConfig#signup_enabled`. Separate from sign-in because registration availability is independent (e.g., SSO-only sign-in with open self-service registration is a valid configuration).

**Integration points:**
- Both gates are invoked from `config/hooks/restrict_to.rb` on the shared `before_rodauth` chokepoint, alongside the existing `restrict_to` gate. They are ANDed, not merged — `restrict_to` answers "which methods," while these answer "is this available at all."
- Rejected routes return 404 with the router's shared not-found body (ADR-034#reject-as-not-found-not-forbidden), identical to undefined routes.
- Unreadable policies (datastore failures) return 503, not 404, following the same fail-closed-with-honest-shape rule as `restrict_to`.

**Model improvements:**
- `SigninConfig#speaks_for_restrict_to?` — Prevents suppressing the SSO host pin when an enabled config expresses no opinion (restrict_to unset, signin_enabled=false). Fixes #4167.

**Scope:**
- This narrows, it does not close: opted-in domains sign in exactly as before, operator hosts follow global settings unchanged, logout/second-factor/account-scoped routes are untouched.
- SSO is deliberately not gated by `signin_enabled` — it is the password/email opt-in, and SSO-only tenants set it off precisely to disable passwords.

## Related Issues

Fixes #4167

## Test Plan

Added comprehensive integration tests:
- `signin_enabled_enforcement_spec.rb` — 450 lines covering regression cases (opted-out and never-opted-in domains rejecting valid credentials), gate narrowing (opted-in domains still authenticate), and non-regression (logout, second-factor, SSO remain reachable).
- `signup_enabled_enforcement_spec.rb` — 296 lines covering the over-gate regression (SSO-only with open registration), under-gate (never opted in), and gate narrowing (opted-in registration succeeds).

Both specs boot the full app against a real database and verify 404 responses are byte-identical to undefined routes. Existing unit tests for `SigninConfig#speaks_for_restrict_to?` and display serializer parity also added.

https://claude.ai/code/session_01Tu2e87gHZv7y3tZMgMmeTu