### PR TITLE
Add SMTP2GO delivery accounting

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -719,6 +719,14 @@ SMTP2GO_API_KEY=
 # tracking. Default: track
 #CUSTOM_MAIL_SMTP2GO_TRACKING_SUBDOMAIN=track
 
+# Accept SMTP2GO messages asynchronously for faster API responses.
+# When enabled, synchronous rejection details are unavailable; use webhooks
+# for delivery results. Leave disabled for sender-configuration test emails
+# and only enable if you aren't running the background workers and you
+# find that requests the trigger an email send are taking too long to load.
+# Default: false
+#CUSTOM_MAIL_SMTP2GO_FASTACCEPT=false
+
 # --- SendGrid ---
 # Coming soon...
 

--- a/.github/actions/check-ci-metrics/action.yml
+++ b/.github/actions/check-ci-metrics/action.yml
@@ -16,11 +16,11 @@
 #   - Tier 3: Integration Tests (Simple, Full, Disabled auth modes)
 #   - Tier 4: Container Validation
 #
-# Performance Targets (cumulative from workflow start, revised 2025-12):
-#   - Tier 1: <60s   (lint + build complete)
-#   - Tier 2: <120s  (unit tests complete)
-#   - Tier 3: <210s  (integration tests complete)
-#   - Tier 4: <400s  (container validated, full pipeline)
+# Performance Targets (cumulative from workflow start, revised 2026-08):
+#   - Tier 1: <130s  (lint + build complete)
+#   - Tier 2: <540s  (unit tests complete)
+#   - Tier 3: <510s  (integration tests complete)
+#   - Tier 4: <720s  (container validated, full pipeline)
 #
 # Outputs:
 #   - GitHub Step Summary with timing breakdown by tier
@@ -69,19 +69,19 @@ inputs:
   target-tier1:
     description: 'Target seconds for Tier 1 (Lint & Build)'
     required: false
-    default: '60'
+    default: '130'
   target-tier2:
     description: 'Target seconds for Tier 2 (Unit Tests)'
     required: false
-    default: '120'
+    default: '540'
   target-tier3:
     description: 'Target seconds for Tier 3 (Integration Tests)'
     required: false
-    default: '210'
+    default: '510'
   target-tier4:
     description: 'Target seconds for Tier 4 (Container / Full Pipeline)'
     required: false
-    default: '400'
+    default: '720'
 
   # Behavior
   fail-on-violation:
@@ -167,40 +167,23 @@ runs:
           fi
         done
 
-        # Tier 1: Lint & Build - latest completion of all Tier 1 jobs
+        # Each prefix defines its tier, including the full integration matrix.
+        # This avoids stale explicit job-name lists when matrix labels change.
         TIER1_COMPLETE=$(echo "$JOBS_JSON" | jq -r '
-          [.[] | select(
-              .name == "T1 · Ruby Lint" or
-              .name == "T1 · TypeScript Lint" or
-              .name == "T1 · Build Frontend Assets"
-            )
+          [.[] | select(.name | startswith("T1 · "))
             | select(.completed_at != null) | .completed_at]
           | sort | last // empty
         ')
 
-        # Tier 2: Unit Tests - latest completion of all Tier 2 jobs
         TIER2_COMPLETE=$(echo "$JOBS_JSON" | jq -r '
-          [.[] | select(
-              .name == "T2 · Ruby Unit Tests" or
-              .name == "T2 · TypeScript Unit Tests"
-            )
+          [.[] | select(.name | startswith("T2 · "))
             | select(.completed_at != null) | .completed_at]
           | sort | last // empty
         ')
 
-        # Tier 3: Integration Tests - latest completion of all Tier 3 jobs.
-        # The full-mode rows are matched by prefix because their names carry
-        # the matrix suffix (ci.yml: 'T3 · Ruby Integration (Full, SQLite,
-        # billing: off)' and five siblings). Equality against the pre-matrix
-        # names 'Full Mode - SQLite' / 'Full Mode - PostgreSQL' matched
-        # nothing, so tier3 silently reported Simple+Disabled only.
+        # Tier 3: latest completion of all Tier 3 jobs, including matrix rows.
         TIER3_COMPLETE=$(echo "$JOBS_JSON" | jq -r '
-          [.[] | select(
-              .name == "T3 · Ruby Integration (Simple Mode)" or
-              .name == "T3 · Ruby Integration (API Contract)" or
-              .name == "T3 · Ruby Integration (Disabled Mode)" or
-              (.name | startswith("T3 · Ruby Integration (Full, "))
-            )
+          [.[] | select(.name | startswith("T3 · "))
             | select(.completed_at != null) | .completed_at]
           | sort | last // empty
         ')

--- a/.github/actions/run-test-lane/action.yml
+++ b/.github/actions/run-test-lane/action.yml
@@ -183,8 +183,18 @@ runs:
         fi
         echo "" >> $GITHUB_STEP_SUMMARY
 
-        if [ -n "${RESULTS_FILE}" ] && [ -f "tmp/${RESULTS_FILE}" ]; then
-          echo "### RSpec" >> $GITHUB_STEP_SUMMARY
-          echo "- Total: $(jq '.summary.example_count' "tmp/${RESULTS_FILE}")" >> $GITHUB_STEP_SUMMARY
-          echo "- Failures: $(jq '.summary.failure_count' "tmp/${RESULTS_FILE}")" >> $GITHUB_STEP_SUMMARY
+        if [ -n "${RESULTS_FILE}" ]; then
+          results_base="${RESULTS_FILE%.json}"
+          results_files=("tmp/${RESULTS_FILE}" "tmp/${results_base}"_*.json)
+          existing_results=()
+
+          for results_file in "${results_files[@]}"; do
+            [ -f "$results_file" ] && existing_results+=("$results_file")
+          done
+
+          if [ "${#existing_results[@]}" -gt 0 ]; then
+            echo "### RSpec" >> $GITHUB_STEP_SUMMARY
+            echo "- Total: $(jq -s '[.[].summary.example_count] | add' "${existing_results[@]}")" >> $GITHUB_STEP_SUMMARY
+            echo "- Failures: $(jq -s '[.[].summary.failure_count] | add' "${existing_results[@]}")" >> $GITHUB_STEP_SUMMARY
+          fi
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
           echo "| OCI | ${{ steps.compute.outputs.oci }} |" >> $GITHUB_STEP_SUMMARY
 
   # ============================================================================
-  # TIER 1: LINT & BUILD JOBS (~30-45s)
+  # TIER 1: LINT & BUILD JOBS (~2 min)
   # ============================================================================
 
   ruby-lint:
@@ -358,7 +358,7 @@ jobs:
           if-no-files-found: error
 
   # ============================================================================
-  # TIER 2: UNIT TESTS (~30-45s)
+  # TIER 2: UNIT TESTS (~7-9 min)
   # ============================================================================
 
   ruby-unit:
@@ -506,7 +506,7 @@ jobs:
         run: pnpm type-check:tests
 
   # ============================================================================
-  # TIER 3: INTEGRATION TESTS (~45-90s each, run in parallel)
+  # TIER 3: INTEGRATION TESTS (~4-6 min each, run in parallel)
   # ============================================================================
 
   ruby-integration-simple:
@@ -719,7 +719,7 @@ jobs:
           results-file: 'rspec_disabled_results.json'
 
   # ============================================================================
-  # TIER 4: CONTAINER VALIDATION (~2-3 min)
+  # TIER 4: CONTAINER VALIDATION (~3 min, after Tier 3)
   # ============================================================================
 
   check-oci-image:

--- a/apps/api/domains/logic/sender_config/auto_provisioning.rb
+++ b/apps/api/domains/logic/sender_config/auto_provisioning.rb
@@ -18,7 +18,7 @@ module DomainsAPI
       # - @organization: Organization instance
       # - @domain_id: Domain identifier string
       # - cust: Customer/user performing the action
-      # - log_sender_change_event: Method from ChangeLogger module
+      # - log_sender_config_event: Method from ChangeLogger module
       #
       module AutoProvisioning
         include Onetime::LoggerMethods
@@ -66,7 +66,7 @@ module DomainsAPI
                 provider: provider,
                 record_count: result.dns_records.size
 
-              log_sender_change_event(
+              log_sender_config_event(
                 event: :domain_sender_provisioned,
                 domain: @custom_domain,
                 org: @organization,

--- a/apps/api/domains/logic/sender_config/change_logger.rb
+++ b/apps/api/domains/logic/sender_config/change_logger.rb
@@ -49,7 +49,7 @@ module DomainsAPI
         # @return [void]
         def log_sender_config_event(event:, domain:, org:, actor:, provider: nil, changes: nil, details: nil, timestamp: Time.now.to_i)
           log_config_change_event(
-            tag: 'DOMAIN_SENDER_CHANGE',
+            tag: 'DOMAIN_SENDER_CONFIG',
             event: event,
             domain: domain,
             org: org,

--- a/apps/api/domains/logic/sender_config/change_logger.rb
+++ b/apps/api/domains/logic/sender_config/change_logger.rb
@@ -47,7 +47,7 @@ module DomainsAPI
         #   Pass explicitly to ensure multiple audit events in one request share
         #   the same timestamp.
         # @return [void]
-        def log_sender_change_event(event:, domain:, org:, actor:, provider: nil, changes: nil, details: nil, timestamp: Time.now.to_i)
+        def log_sender_config_event(event:, domain:, org:, actor:, provider: nil, changes: nil, details: nil, timestamp: Time.now.to_i)
           log_config_change_event(
             tag: 'DOMAIN_SENDER_CHANGE',
             event: event,

--- a/apps/api/domains/logic/sender_config/delete_sender_config.rb
+++ b/apps/api/domains/logic/sender_config/delete_sender_config.rb
@@ -58,7 +58,7 @@ module DomainsAPI
           deleted = Onetime::CustomDomain::MailerConfig.delete_for_domain!(@custom_domain.identifier)
 
           if deleted
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_config_deleted,
               domain: @custom_domain,
               org: @organization,

--- a/apps/api/domains/logic/sender_config/patch_sender_config.rb
+++ b/apps/api/domains/logic/sender_config/patch_sender_config.rb
@@ -99,7 +99,7 @@ end
             # Compute changes before updating
             changes = compute_sender_changes(@existing_config, params)
             update_existing_config
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_config_updated,
               domain: @custom_domain,
               org: @organization,
@@ -108,7 +108,7 @@ end
             )
           else
             create_new_config
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_config_created,
               domain: @custom_domain,
               org: @organization,
@@ -226,14 +226,14 @@ end
 
           # Log when sender config is enabled (new config or was disabled)
           if is_enabled && (was_enabled.nil? || was_enabled == false)
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_config_enabled,
               domain: @custom_domain,
               org: @organization,
               actor: cust,
             )
           elsif was_enabled == true && !is_enabled
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_config_disabled,
               domain: @custom_domain,
               org: @organization,

--- a/apps/api/domains/logic/sender_config/provision_sender_config.rb
+++ b/apps/api/domains/logic/sender_config/provision_sender_config.rb
@@ -83,7 +83,7 @@ module DomainsAPI
               provider: provider,
               record_count: result.dns_records.size
 
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_provisioned,
               domain: @custom_domain,
               org: @organization,

--- a/apps/api/domains/logic/sender_config/put_sender_config.rb
+++ b/apps/api/domains/logic/sender_config/put_sender_config.rb
@@ -77,7 +77,7 @@ module DomainsAPI
 
           if @existing_config
             replace_existing_config
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_config_replaced,
               domain: @custom_domain,
               org: @organization,
@@ -85,7 +85,7 @@ module DomainsAPI
             )
           else
             create_new_config
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_config_created,
               domain: @custom_domain,
               org: @organization,
@@ -187,14 +187,14 @@ module DomainsAPI
           # Log when sender config is enabled (new config or was disabled).
           # !was_enabled covers both nil (new config) and false (was disabled).
           if is_enabled && !was_enabled
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_config_enabled,
               domain: @custom_domain,
               org: @organization,
               actor: cust,
             )
           elsif was_enabled == true && !is_enabled
-            log_sender_change_event(
+            log_sender_config_event(
               event: :domain_sender_config_disabled,
               domain: @custom_domain,
               org: @organization,

--- a/apps/api/domains/logic/sender_config/send_test_email.rb
+++ b/apps/api/domains/logic/sender_config/send_test_email.rb
@@ -175,7 +175,8 @@ module DomainsAPI
           api_key  = @mailer_config.api_key.to_s.strip
 
           if api_key.empty?
-            OT.info "[SendTestEmail] No domain api_key for #{@domain_id}, using global backend"
+            OT.info '[SendTestEmail] Using global mail credentials (domain-specific credentials not configured)'
+            OT.info "[SendTestEmail] Sending from validated domain: #{@custom_domain.display_domain}"
             return Onetime::Mail::Mailer.delivery_backend
           end
 
@@ -185,12 +186,14 @@ module DomainsAPI
           when 'sendgrid'
             Onetime::Mail::Delivery::SendGrid.new(api_key: api_key)
           when 'smtp2go'
-            Onetime::Mail::Delivery::Smtp2go.new('api_key' => api_key)
+            # Test emails need real delivery accounting, not fire-and-forget
+            Onetime::Mail::Delivery::Smtp2go.new('api_key' => api_key, 'fastaccept' => false)
           else
             # SES requires IAM credentials (key + secret + region) which
             # can't be reconstructed from a single api_key field — fall back
             # to the global backend which has the full SES config.
-            OT.info "[SendTestEmail] No per-domain backend for provider=#{provider}, using global"
+            OT.info "[SendTestEmail] Provider #{provider} requires multi-field credentials; using global backend"
+            OT.info "[SendTestEmail] Sending from validated domain: #{@custom_domain.display_domain}"
             Onetime::Mail::Mailer.delivery_backend
           end
         end
@@ -321,7 +324,7 @@ module DomainsAPI
         end
 
         def log_test_email_event(result)
-          log_sender_change_event(
+          log_sender_config_event(
             event: :domain_sender_test_email_sent,
             domain: @custom_domain,
             org: @organization,
@@ -331,6 +334,20 @@ module DomainsAPI
               success: result[:success],
               recipient: cust.email,
               from_address: @mailer_config.from_address,
+              error_code: result.dig(:details, :error_code),
+            }.compact,
+          )
+
+          # Persist to audit trail for admin visibility
+          Onetime::ColonelAuditEvent.record(
+            actor: cust,
+            verb: 'domain_sender.test_email_sent',
+            target: @custom_domain.identifier,
+            result: result[:success] ? :success : :failure,
+            detail: {
+              recipient: cust.email,
+              from_address: @mailer_config.from_address,
+              provider: @mailer_config.effective_provider,
               error_code: result.dig(:details, :error_code),
             }.compact,
           )

--- a/apps/api/domains/logic/sender_config/validate_sender_config.rb
+++ b/apps/api/domains/logic/sender_config/validate_sender_config.rb
@@ -158,7 +158,7 @@ module DomainsAPI
             lock&.release(lock_token) if lock_token
           end
 
-          log_sender_change_event(
+          log_sender_config_event(
             event: :domain_sender_validation_requested,
             domain: @custom_domain,
             org: @organization,

--- a/apps/api/domains/spec/logic/sender_config/send_test_email_spec.rb
+++ b/apps/api/domains/spec/logic/sender_config/send_test_email_spec.rb
@@ -9,8 +9,9 @@
 #   - On success: verb 'domain_sender.test_email_sent', result :success
 #   - On failure: result :failure, error_code in detail
 #
-# RUN:
-#   pnpm run test:rspec apps/api/domains/spec/logic/sender_config/send_test_email_spec.rb
+# RUN (lane runner only — a raw rspec/rake invocation inherits the dev
+# shell's env and can reach dev data; see AGENTS.md "Running tests"):
+#   tests/lanes/run api --only apps/api/domains/spec/logic/sender_config/send_test_email_spec.rb
 
 require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
 require_relative '../../../../../../apps/api/domains/application'

--- a/apps/api/domains/spec/logic/sender_config/send_test_email_spec.rb
+++ b/apps/api/domains/spec/logic/sender_config/send_test_email_spec.rb
@@ -1,0 +1,236 @@
+# apps/api/domains/spec/logic/sender_config/send_test_email_spec.rb
+#
+# frozen_string_literal: true
+
+# Unit tests for SenderConfig::SendTestEmail ColonelAuditEvent.record coverage.
+#
+# The send_test_email flow calls ColonelAuditEvent.record to persist test email
+# events to the audit trail. These specs verify:
+#   - On success: verb 'domain_sender.test_email_sent', result :success
+#   - On failure: result :failure, error_code in detail
+#
+# RUN:
+#   pnpm run test:rspec apps/api/domains/spec/logic/sender_config/send_test_email_spec.rb
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require_relative '../../../../../../apps/api/domains/application'
+require 'onetime/models/colonel_audit_event'
+
+RSpec.describe DomainsAPI::Logic::SenderConfig::SendTestEmail do
+  let(:customer) do
+    instance_double(
+      Onetime::Customer,
+      custid: 'cust123',
+      objid: 'cust123',
+      extid: 'ext-cust123',
+      email: 'user@example.com',
+      anonymous?: false,
+      verified?: true,
+    )
+  end
+
+  let(:custom_domain) do
+    instance_double(
+      Onetime::CustomDomain,
+      identifier: 'domain123',
+      extid: 'ext-domain123',
+      display_domain: 'example.com',
+      org_id: 'org123',
+    )
+  end
+
+  let(:organization) do
+    instance_double(
+      Onetime::Organization,
+      objid: 'org123',
+      extid: 'ext-org123',
+      display_name: 'Test Org',
+    )
+  end
+
+  let(:mailer_config) do
+    instance_double(
+      Onetime::CustomDomain::MailerConfig,
+      from_address: 'noreply@example.com',
+      from_name: 'Test Sender',
+      reply_to: 'reply@example.com',
+      effective_provider: 'smtp2go',
+      api_key: 'test-api-key',
+    )
+  end
+
+  let(:session) { { 'authenticated' => true, 'csrf' => 'test-csrf-token' } }
+  let(:strategy_result) do
+    double('StrategyResult', session: session, user: customer, authenticated?: true, metadata: {})
+  end
+
+  let(:params) { { 'extid' => 'ext-domain123' } }
+  let(:logic) { described_class.new(strategy_result, params) }
+
+  # Stub for the delivery backend
+  let(:mock_backend) { double('DeliveryBackend') }
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+
+    # Bypass authorization and set up ivars directly
+    allow(logic).to receive(:authorize_sender_config!) do
+      logic.instance_variable_set(:@custom_domain, custom_domain)
+      logic.instance_variable_set(:@organization, organization)
+    end
+
+    allow(Onetime::CustomDomain::MailerConfig).to receive(:find_by_domain_id)
+      .with('domain123')
+      .and_return(mailer_config)
+
+    # Stub the audit event recording
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  describe '#process (audit trail)' do
+    context 'when test email succeeds' do
+      before do
+        allow(logic).to receive(:build_test_backend).and_return(mock_backend)
+        allow(mock_backend).to receive(:deliver).and_return(true)
+      end
+
+      it 'calls ColonelAuditEvent.record with result: :success' do
+        logic.raise_concerns
+        logic.process
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          actor: customer,
+          verb: 'domain_sender.test_email_sent',
+          target: 'domain123',
+          result: :success,
+          detail: hash_including(
+            recipient: 'user@example.com',
+            from_address: 'noreply@example.com',
+            provider: 'smtp2go',
+          ),
+        )
+      end
+
+      it 'does not include error_code in detail on success' do
+        logic.raise_concerns
+        logic.process
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_excluding(detail: hash_including(:error_code)),
+        )
+      end
+    end
+
+    context 'when test email fails with delivery error' do
+      let(:delivery_error) do
+        error = Onetime::Mail::DeliveryError.new('Connection refused')
+        allow(error).to receive(:transient?).and_return(false)
+        allow(error).to receive(:original_error).and_return(nil)
+        error
+      end
+
+      before do
+        allow(logic).to receive(:build_test_backend).and_return(mock_backend)
+        allow(mock_backend).to receive(:deliver).and_raise(delivery_error)
+      end
+
+      it 'calls ColonelAuditEvent.record with result: :failure' do
+        logic.raise_concerns
+        logic.process
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          actor: customer,
+          verb: 'domain_sender.test_email_sent',
+          target: 'domain123',
+          result: :failure,
+          detail: hash_including(
+            recipient: 'user@example.com',
+            from_address: 'noreply@example.com',
+            provider: 'smtp2go',
+            error_code: 'delivery_failed',
+          ),
+        )
+      end
+    end
+
+    context 'when test email fails with transient error' do
+      let(:transient_error) do
+        error = Onetime::Mail::DeliveryError.new('Temporary failure')
+        allow(error).to receive(:transient?).and_return(true)
+        allow(error).to receive(:original_error).and_return(nil)
+        error
+      end
+
+      before do
+        allow(logic).to receive(:build_test_backend).and_return(mock_backend)
+        allow(mock_backend).to receive(:deliver).and_raise(transient_error)
+      end
+
+      it 'records transient_error as error_code' do
+        logic.raise_concerns
+        logic.process
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            result: :failure,
+            detail: hash_including(error_code: 'transient_error'),
+          ),
+        )
+      end
+    end
+
+    context 'when test email fails with unexpected error' do
+      before do
+        allow(logic).to receive(:build_test_backend).and_return(mock_backend)
+        allow(mock_backend).to receive(:deliver).and_raise(StandardError, 'Something broke')
+      end
+
+      it 'records unexpected_error as error_code' do
+        logic.raise_concerns
+        logic.process
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            result: :failure,
+            detail: hash_including(error_code: 'unexpected_error'),
+          ),
+        )
+      end
+    end
+
+    context 'when domain not provisioned on provider' do
+      let(:domain_not_found_error) do
+        error = Onetime::Mail::DeliveryError.new('Domain not found')
+        allow(error).to receive(:transient?).and_return(false)
+        original = double('OriginalError', status_code: 422, message: 'Domain not found')
+        allow(Lettermint::HttpRequestError).to receive(:===).and_return(false) if defined?(Lettermint::HttpRequestError)
+        allow(error).to receive(:original_error).and_return(original)
+        error
+      end
+
+      before do
+        # Simulate Lettermint 422 error (domain not provisioned)
+        stub_const('Lettermint::HttpRequestError', Class.new(StandardError))
+        allow(logic).to receive(:build_test_backend).and_return(mock_backend)
+        allow(mock_backend).to receive(:deliver).and_raise(domain_not_found_error)
+        allow(domain_not_found_error.original_error).to receive(:is_a?)
+          .with(Lettermint::HttpRequestError).and_return(true)
+      end
+
+      it 'records domain_not_provisioned as error_code' do
+        logic.raise_concerns
+        logic.process
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            result: :failure,
+            detail: hash_including(error_code: 'domain_not_provisioned'),
+          ),
+        )
+      end
+    end
+  end
+end

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -1162,6 +1162,11 @@ email_providers:
     # Published by the customer as a CNAME record for open/click tracking.
     # Override via CUSTOM_MAIL_SMTP2GO_TRACKING_SUBDOMAIN env var
     tracking_subdomain: <%= ENV['CUSTOM_MAIL_SMTP2GO_TRACKING_SUBDOMAIN'] || 'track' %>
+    # Fast-accept mode: true = fire-and-forget (lower latency, no per-recipient
+    # failure detection); false = synchronous delivery accounting (succeeded/
+    # failed keys in response). Default true for backward compatibility.
+    # Override via CUSTOM_MAIL_SMTP2GO_FASTACCEPT env var (true/false)
+    fastaccept: <%= ENV.fetch('CUSTOM_MAIL_SMTP2GO_FASTACCEPT', 'false') == 'true' %>
 
 mail:
   truemail:

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -1162,9 +1162,10 @@ email_providers:
     # Published by the customer as a CNAME record for open/click tracking.
     # Override via CUSTOM_MAIL_SMTP2GO_TRACKING_SUBDOMAIN env var
     tracking_subdomain: <%= ENV['CUSTOM_MAIL_SMTP2GO_TRACKING_SUBDOMAIN'] || 'track' %>
-    # Fast-accept mode: true = fire-and-forget (lower latency, no per-recipient
-    # failure detection); false = synchronous delivery accounting (succeeded/
-    # failed keys in response). Default true for backward compatibility.
+    # Fast-accept mode. Default false = synchronous delivery accounting: the
+    # response carries succeeded/failed/failures, so a failed recipient is
+    # reported instead of silently dropped. Set true only to opt into
+    # fire-and-forget (lower latency, no per-recipient failure detection).
     # Override via CUSTOM_MAIL_SMTP2GO_FASTACCEPT env var (true/false)
     fastaccept: <%= ENV.fetch('CUSTOM_MAIL_SMTP2GO_FASTACCEPT', 'false') == 'true' %>
 

--- a/lib/onetime/mail/delivery/smtp2go.rb
+++ b/lib/onetime/mail/delivery/smtp2go.rb
@@ -30,6 +30,13 @@ module Onetime
         # the vetted corpus; this twin only covers standalone mail-lib loads.
         EMAIL_PATTERN = /\b(?>[\p{L}\p{N}._%+'-]+)@[\p{L}\p{N}.\p{Pd}]+\.\p{L}{2,}\b/
 
+        def initialize(config = {})
+          super
+          # Default to true for backward compatibility (fire-and-forget mode).
+          # Set to false for synchronous delivery accounting.
+          @fastaccept = config.fetch('fastaccept', false)
+        end
+
         def perform_delivery(email)
           data = client.post('/email/send', build_payload(email))
 
@@ -48,6 +55,18 @@ module Onetime
               "SMTP2GO reported #{failed} failed recipient(s): #{failures}",
               status_code: 200,
               error_code: 'E_DeliveryFailures',
+              response_body: redact_emails(data.to_json)[0, 500],
+            )
+          end
+
+          # Fail-closed: if response has neither 'succeeded' key nor a non-empty
+          # 'email_id', treat as unknown response shape rather than silent success.
+          # This guards against fastaccept or API changes omitting accounting keys.
+          unless data.key?('succeeded') || data['email_id'].to_s.strip.length.positive?
+            raise Smtp2goClient::APIError.new(
+              'SMTP2GO response missing delivery accounting',
+              status_code: 200,
+              error_code: 'E_MissingAccounting',
               response_body: redact_emails(data.to_json)[0, 500],
             )
           end
@@ -130,9 +149,14 @@ module Onetime
         #
         # SMTP2GO expects: sender (string), to (array of strings), subject,
         # text_body always, html_body only when present, Reply-To via
-        # custom_headers, and fastaccept: true so the message is accepted
-        # immediately and dispatched in the background (recommended by
-        # SMTP2GO; slated to become the default).
+        # custom_headers, and fastaccept controlling sync vs async mode.
+        #
+        # When fastaccept is true, the message is accepted immediately
+        # and dispatched in the background — lower latency but no per-recipient
+        # failure detection (succeeded/failed keys omitted from response).
+        #
+        # When fastaccept is false, the response includes full delivery accounting
+        # (succeeded, failed, failures, email_id).
         #
         # @param email [Hash] Normalized email parameters
         # @return [Hash] String-keyed request payload
@@ -142,7 +166,7 @@ module Onetime
             'to' => [email[:to]],
             'subject' => email[:subject],
             'text_body' => email[:text_body],
-            'fastaccept' => true,
+            'fastaccept' => @fastaccept,
           }
 
           payload['html_body'] = email[:html_body] if html_content?(email)

--- a/lib/onetime/mail/delivery/smtp2go.rb
+++ b/lib/onetime/mail/delivery/smtp2go.rb
@@ -15,6 +15,8 @@ module Onetime
       #   api_key:  SMTP2GO API key (ENV: SMTP2GO_API_KEY)
       #   base_url: Custom API base URL (ENV: SMTP2GO_BASE_URL)
       #   timeout:  Read timeout in seconds
+      #   fastaccept: Fire-and-forget mode, default false
+      #     (ENV: CUSTOM_MAIL_SMTP2GO_FASTACCEPT)
       #
       # Response semantics: SMTP2GO returns 200 with per-recipient
       # accounting ({succeeded:, failed:, failures: [], email_id:}), so a
@@ -30,11 +32,21 @@ module Onetime
         # the vetted corpus; this twin only covers standalone mail-lib loads.
         EMAIL_PATTERN = /\b(?>[\p{L}\p{N}._%+'-]+)@[\p{L}\p{N}.\p{Pd}]+\.\p{L}{2,}\b/
 
+        # Recognized truthy tokens for standalone mail-lib loads, where the
+        # canonical strict coercion (Onetime::Utils::Strings.strict_bool!) is
+        # not on the load path. Same token set, minus the loud rejection of
+        # unrecognized input — see #coerce_fastaccept.
+        FASTACCEPT_TRUE_TOKENS = %w[1 true yes on y t].freeze
+
         def initialize(config = {})
           super
-          # Default to true for backward compatibility (fire-and-forget mode).
-          # Set to false for synchronous delivery accounting.
-          @fastaccept = config.fetch('fastaccept', false)
+          # Default false: synchronous delivery accounting. SMTP2GO's
+          # fastaccept=true is fire-and-forget — the API returns 200 with no
+          # succeeded/failed/failures keys, so every delivery failure is
+          # invisible. Opt into it only when the latency matters more than
+          # knowing a message bounced. Read from @config (string-keyed by
+          # Base#initialize) so symbol-keyed callers are not silently ignored.
+          @fastaccept = coerce_fastaccept(@config['fastaccept'])
         end
 
         def perform_delivery(email)
@@ -149,6 +161,25 @@ module Onetime
           return address unless parts.length == 2
 
           "***@#{parts[1]}"
+        end
+
+        # Coerce the configured fastaccept value to a real boolean. SMTP2GO
+        # expects a JSON boolean; a string "false" arriving from ENV or a
+        # hand-built config hash would be truthy on their side and silently
+        # switch off the per-recipient accounting this backend depends on.
+        #
+        # Prefers the canonical strict coercion, which raises on an
+        # unrecognized token instead of quietly resolving to the default. The
+        # standalone mail-lib load (no Onetime::Utils) falls back to token
+        # matching, mirroring #email_pattern's twin-constant arrangement.
+        def coerce_fastaccept(raw)
+          return raw if [true, false].include?(raw)
+
+          if defined?(Onetime::Utils::Strings) && Onetime::Utils::Strings.respond_to?(:strict_bool!)
+            return Onetime::Utils::Strings.strict_bool!("smtp2go 'fastaccept'", raw, default: false)
+          end
+
+          FASTACCEPT_TRUE_TOKENS.include?(raw.to_s.strip.downcase)
         end
 
         # The canonical, corpus-pinned pattern when the app is loaded; the

--- a/lib/onetime/mail/delivery/smtp2go.rb
+++ b/lib/onetime/mail/delivery/smtp2go.rb
@@ -128,11 +128,27 @@ module Onetime
 
         private
 
-        # Replace each email address embedded in provider text with its
-        # obscured form (Base#obscure_email), leaving the surrounding
-        # failure-reason wording intact for diagnostics.
+        # Replace each email address embedded in provider text with a
+        # domain-preserving mask. Unlike obscure_email (which masks domains
+        # for log/Sentry privacy), tenant-facing error messages must show
+        # which domain failed verification — the local-part is redacted,
+        # but the domain is kept intact.
+        #
+        # Example: "no-reply@local-secrets.pet" → "***@local-secrets.pet"
         def redact_emails(text)
-          text.to_s.gsub(email_pattern) { |address| obscure_email(address) }
+          text.to_s.gsub(email_pattern) { |address| mask_local_preserve_domain(address) }
+        end
+
+        # Mask the local-part of an email address, preserving the domain.
+        # @param address [String] Email address to mask
+        # @return [String] Masked address with full domain preserved
+        def mask_local_preserve_domain(address)
+          return address if address.to_s.empty?
+
+          parts = address.split('@', 2)
+          return address unless parts.length == 2
+
+          "***@#{parts[1]}"
         end
 
         # The canonical, corpus-pinned pattern when the app is loaded; the

--- a/lib/onetime/mail/mailer.rb
+++ b/lib/onetime/mail/mailer.rb
@@ -2,6 +2,7 @@
 #
 # frozen_string_literal: true
 
+require_relative '../utils/strings' # strict_bool! for boolean provider options
 require_relative 'provider_registry'
 require_relative 'delivery/base'
 require_relative 'delivery/disabled'
@@ -398,7 +399,33 @@ module Onetime
             'returnpath_subdomain' => s2g_conf['returnpath_subdomain'] || ENV.fetch('CUSTOM_MAIL_SMTP2GO_RETURNPATH_SUBDOMAIN', 'bounce'),
             'tracking_subdomain' => s2g_conf['tracking_subdomain'] || ENV.fetch('CUSTOM_MAIL_SMTP2GO_TRACKING_SUBDOMAIN', 'track'),
             'timeout' => conf['smtp2go_timeout'],
+            # Always a real boolean, never nil: .compact must not drop it,
+            # otherwise Delivery::Smtp2go falls back to its own default and
+            # the configured value never reaches the payload.
+            'fastaccept' => smtp2go_fastaccept(s2g_conf),
           }.compact
+        end
+
+        # Resolve the SMTP2GO fastaccept toggle.
+        #
+        # The provider config section wins (config.defaults.yaml already
+        # evaluates CUSTOM_MAIL_SMTP2GO_FASTACCEPT to a boolean there); the
+        # ENV read is the fallback for configs built without that template.
+        # Default false = synchronous per-recipient accounting, so a failed
+        # delivery raises instead of disappearing into fire-and-forget.
+        #
+        # @return [Boolean] never nil — see the .compact note above
+        def smtp2go_fastaccept(s2g_conf)
+          raw = s2g_conf.fetch('fastaccept') { s2g_conf.fetch(:fastaccept, nil) }
+          unless raw.nil?
+            return Onetime::Utils::Strings.strict_bool!(
+              "email_providers.smtp2go 'fastaccept'", raw, default: false
+            )
+          end
+
+          Onetime::Utils::Strings.strict_bool!(
+            'CUSTOM_MAIL_SMTP2GO_FASTACCEPT', ENV.fetch('CUSTOM_MAIL_SMTP2GO_FASTACCEPT', nil), default: false
+          )
         end
 
         def emailer_config

--- a/lib/onetime/mail/provider_registry.rb
+++ b/lib/onetime/mail/provider_registry.rb
@@ -241,7 +241,16 @@ module Onetime
             returnpath_subdomain: %w[CUSTOM_MAIL_SMTP2GO_RETURNPATH_SUBDOMAIN].freeze,
             tracking_subdomain: %w[CUSTOM_MAIL_SMTP2GO_TRACKING_SUBDOMAIN].freeze,
           }.freeze,
-          # fastaccept is a boolean with ENV override, not a passthrough - lives here
+          # fastaccept is not a DNS option, but dns_defaults is the registry's
+          # only shipped-default channel: the parity specs read it as the
+          # expected default for both the rendered YAML and the generated
+          # static config schema, and Mailer#smtp2go_fastaccept resolves the
+          # same false default at runtime. It cannot live in config_env_sources
+          # because that map declares verbatim string passthroughs (the parity
+          # spec sets a marker in the ENV var and expects it to arrive in the
+          # config unchanged), while this key's template coerces to a boolean.
+          # Consequence: CUSTOM_MAIL_SMTP2GO_FASTACCEPT is not covered by the
+          # ENV parity specs — Mailer's own spec covers that wiring instead.
           dns_defaults: {
             api_base_url: 'https://api.smtp2go.com/v3',
             returnpath_subdomain: 'bounce',

--- a/lib/onetime/mail/provider_registry.rb
+++ b/lib/onetime/mail/provider_registry.rb
@@ -241,10 +241,12 @@ module Onetime
             returnpath_subdomain: %w[CUSTOM_MAIL_SMTP2GO_RETURNPATH_SUBDOMAIN].freeze,
             tracking_subdomain: %w[CUSTOM_MAIL_SMTP2GO_TRACKING_SUBDOMAIN].freeze,
           }.freeze,
+          # fastaccept is a boolean with ENV override, not a passthrough - lives here
           dns_defaults: {
             api_base_url: 'https://api.smtp2go.com/v3',
             returnpath_subdomain: 'bounce',
             tracking_subdomain: 'track',
+            fastaccept: false,
           }.freeze,
         ),
         Descriptor.new(

--- a/spec/unit/onetime/mail/delivery/smtp2go_spec.rb
+++ b/spec/unit/onetime/mail/delivery/smtp2go_spec.rb
@@ -74,6 +74,64 @@ RSpec.describe Onetime::Mail::Delivery::Smtp2go do
       end
     end
 
+    # Base#initialize stringifies config keys, so a symbol-keyed caller
+    # (BYOK backends are built with api_key:/fastaccept:) must not silently
+    # fall through to the default.
+    context 'with symbol-keyed fastaccept: true' do
+      let(:backend) { described_class.new(config.merge(fastaccept: true)) }
+
+      before do
+        allow(backend).to receive(:client).and_return(mock_client)
+        allow(backend).to receive(:log_delivery)
+        allow(backend).to receive(:log_error)
+      end
+
+      it 'posts fastaccept: true in payload' do
+        backend.deliver(email)
+
+        expect(mock_client).to have_received(:post).with(
+          '/email/send',
+          hash_including('fastaccept' => true),
+        )
+      end
+    end
+
+    # SMTP2GO's API expects a JSON boolean; the string "false" would be
+    # truthy on their side and silently disable delivery accounting.
+    {
+      'true' => true,
+      'True' => true,
+      ' TRUE ' => true,
+      'false' => false,
+      'no' => false,
+      '' => false,
+      nil => false,
+    }.each do |raw, expected|
+      context "with fastaccept configured as #{raw.inspect}" do
+        let(:backend) { described_class.new(config.merge('fastaccept' => raw)) }
+
+        before do
+          allow(backend).to receive(:client).and_return(mock_client)
+          allow(backend).to receive(:log_delivery)
+          allow(backend).to receive(:log_error)
+        end
+
+        it "coerces to the boolean #{expected}" do
+          backend.deliver(email)
+
+          expect(mock_client).to have_received(:post).with(
+            '/email/send',
+            hash_including('fastaccept' => expected),
+          )
+        end
+      end
+    end
+
+    it 'rejects an unrecognized fastaccept token instead of defaulting' do
+      expect { described_class.new(config.merge('fastaccept' => 'ture')) }
+        .to raise_error(Onetime::ConfigError, /fastaccept/)
+    end
+
     it 'sets Reply-To via custom_headers when present' do
       backend.deliver(email.merge(reply_to: 'reply@example.com'))
 

--- a/spec/unit/onetime/mail/delivery/smtp2go_spec.rb
+++ b/spec/unit/onetime/mail/delivery/smtp2go_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Onetime::Mail::Delivery::Smtp2go do
       expect(backend).to have_received(:log_delivery)
     end
 
-    it 'posts sender, to array, subject, text_body and fastaccept' do
+    it 'defaults fastaccept to false when not specified in config' do
       backend.deliver(email)
 
       expect(mock_client).to have_received(:post).with(
@@ -50,9 +50,28 @@ RSpec.describe Onetime::Mail::Delivery::Smtp2go do
           'to' => ['recipient@example.com'],
           'subject' => 'Test email',
           'text_body' => 'Hello',
-          'fastaccept' => true,
+          'fastaccept' => false,
         ),
       )
+    end
+
+    context 'with fastaccept: false configured' do
+      let(:backend) { described_class.new(config.merge('fastaccept' => false)) }
+
+      before do
+        allow(backend).to receive(:client).and_return(mock_client)
+        allow(backend).to receive(:log_delivery)
+        allow(backend).to receive(:log_error)
+      end
+
+      it 'posts fastaccept: false in payload' do
+        backend.deliver(email)
+
+        expect(mock_client).to have_received(:post).with(
+          '/email/send',
+          hash_including('fastaccept' => false),
+        )
+      end
     end
 
     it 'sets Reply-To via custom_headers when present' do
@@ -92,6 +111,59 @@ RSpec.describe Onetime::Mail::Delivery::Smtp2go do
 
       expect(payload).not_to have_key('html_body')
       expect(payload['text_body']).to eq('Hello')
+    end
+
+    it 'accepts fastaccept response with email_id only (no succeeded key)' do
+      # When fastaccept: true, SMTP2GO may omit succeeded/failed keys
+      fastaccept_data = { 'email_id' => '1er8bV-6Sw0i9-6ci1pC' }
+      allow(mock_client).to receive(:post).and_return(fastaccept_data)
+
+      result = backend.deliver(email)
+      expect(result).to eq(fastaccept_data)
+      expect(backend).to have_received(:log_delivery)
+    end
+  end
+
+  describe '#deliver with missing accounting (fail-closed)' do
+    it 'raises E_MissingAccounting when response lacks both succeeded and email_id' do
+      # Empty response or malformed data without accounting keys
+      allow(mock_client).to receive(:post).and_return({})
+
+      expect { backend.deliver(email) }
+        .to raise_error(Onetime::Mail::DeliveryError) do |err|
+          expect(err.transient?).to be false
+          expect(err.original_error).to be_a(Onetime::Mail::Smtp2goClient::APIError)
+          expect(err.original_error.status_code).to eq(200)
+          expect(err.original_error.error_code).to eq('E_MissingAccounting')
+          expect(err.message).to include('missing delivery accounting')
+        end
+    end
+
+    it 'raises E_MissingAccounting when email_id is nil and succeeded is absent' do
+      allow(mock_client).to receive(:post).and_return({ 'email_id' => nil })
+
+      expect { backend.deliver(email) }
+        .to raise_error(Onetime::Mail::DeliveryError) do |err|
+          expect(err.original_error.error_code).to eq('E_MissingAccounting')
+        end
+    end
+
+    it 'raises E_MissingAccounting when email_id is empty string and succeeded is absent' do
+      allow(mock_client).to receive(:post).and_return({ 'email_id' => '' })
+
+      expect { backend.deliver(email) }
+        .to raise_error(Onetime::Mail::DeliveryError) do |err|
+          expect(err.original_error.error_code).to eq('E_MissingAccounting')
+        end
+    end
+
+    it 'does NOT raise when succeeded key is present (even if zero)' do
+      # succeeded: 0, failed: 0 is valid (empty batch, edge case)
+      data = { 'succeeded' => 0, 'failed' => 0, 'failures' => [] }
+      allow(mock_client).to receive(:post).and_return(data)
+
+      result = backend.deliver(email)
+      expect(result).to eq(data)
     end
   end
 

--- a/spec/unit/onetime/mail/delivery/smtp2go_spec.rb
+++ b/spec/unit/onetime/mail/delivery/smtp2go_spec.rb
@@ -193,10 +193,11 @@ RSpec.describe Onetime::Mail::Delivery::Smtp2go do
         .to raise_error(Onetime::Mail::DeliveryError) do |err|
           original = err.original_error
           # The raw address never reaches the wrapped message, the APIError
-          # message, or its response_body — but the obscured form and the
-          # failure reason text survive for diagnostics.
+          # message, or its response_body — but the domain-preserving masked
+          # form and the failure reason text survive for diagnostics.
+          # Domain is preserved so tenants know which domain failed.
           expect(err.message).not_to include('recipient@example.com')
-          expect(err.message).to include('re***@')
+          expect(err.message).to include('***@example.com')
           expect(err.message).to include('unable to verify sender')
           expect(original.message).not_to include('recipient@example.com')
           expect(original.response_body).not_to include('recipient@example.com')
@@ -364,6 +365,32 @@ RSpec.describe Onetime::Mail::Delivery::Smtp2go do
       ).and_return(mock_client)
 
       fresh_backend.send(:client)
+    end
+  end
+
+  describe '#redact_emails (domain-preserving)' do
+    # Error messages shown to tenants configuring domains must preserve
+    # the domain so they know which domain failed verification.
+    it 'masks local-part and preserves domain' do
+      text = 'Unrouteable address <no-reply@local-secrets.pet>'
+      result = backend.send(:redact_emails, text)
+      expect(result).to eq('Unrouteable address <***@local-secrets.pet>')
+    end
+
+    it 'handles multiple email addresses' do
+      text = 'user@example.com failed and admin@sub.example.org also failed'
+      result = backend.send(:redact_emails, text)
+      expect(result).to eq('***@example.com failed and ***@sub.example.org also failed')
+    end
+
+    it 'preserves non-email text' do
+      text = 'domain verify fail'
+      result = backend.send(:redact_emails, text)
+      expect(result).to eq('domain verify fail')
+    end
+
+    it 'handles empty string' do
+      expect(backend.send(:redact_emails, '')).to eq('')
     end
   end
 end

--- a/spec/unit/onetime/mail/mailer_spec.rb
+++ b/spec/unit/onetime/mail/mailer_spec.rb
@@ -319,5 +319,79 @@ RSpec.describe Onetime::Mail::Mailer do
         expect(result).to eq({})
       end
     end
+
+    # fastaccept controls whether SMTP2GO returns per-recipient accounting,
+    # so it has to survive the trip from config/ENV into the hash that
+    # constructs Delivery::Smtp2go — including the .compact at the end of
+    # smtp2go_provider_config, which would drop a nil.
+    context 'with SMTP2GO fastaccept' do
+      subject(:credentials) { described_class.provider_credentials('smtp2go') }
+
+      let(:config) { { 'smtp2go_api_key' => 'api-key-123' } }
+      let(:provider_section) { {} }
+
+      around do |example|
+        saved = ENV.fetch('CUSTOM_MAIL_SMTP2GO_FASTACCEPT', nil)
+        ENV.delete('CUSTOM_MAIL_SMTP2GO_FASTACCEPT')
+        example.run
+      ensure
+        saved.nil? ? ENV.delete('CUSTOM_MAIL_SMTP2GO_FASTACCEPT') : (ENV['CUSTOM_MAIL_SMTP2GO_FASTACCEPT'] = saved)
+      end
+
+      before do
+        allow(described_class).to receive(:provider_config).with('smtp2go').and_return(provider_section)
+      end
+
+      it 'defaults to false when neither config nor ENV is set' do
+        expect(credentials).to include('fastaccept' => false)
+      end
+
+      context 'when the provider config section sets it' do
+        let(:provider_section) { { 'fastaccept' => true } }
+
+        it 'wins over the ENV fallback' do
+          ENV['CUSTOM_MAIL_SMTP2GO_FASTACCEPT'] = 'false'
+
+          expect(credentials).to include('fastaccept' => true)
+        end
+      end
+
+      context 'when the provider config section sets it to false' do
+        let(:provider_section) { { 'fastaccept' => false } }
+
+        it 'keeps the explicit false through .compact' do
+          expect(credentials).to have_key('fastaccept')
+          expect(credentials['fastaccept']).to be(false)
+        end
+      end
+
+      context 'when the provider config section carries a string' do
+        let(:provider_section) { { 'fastaccept' => 'true' } }
+
+        it 'coerces to a real boolean' do
+          expect(credentials['fastaccept']).to be(true)
+        end
+      end
+
+      context 'when only ENV is set' do
+        it 'falls back to the ENV value' do
+          ENV['CUSTOM_MAIL_SMTP2GO_FASTACCEPT'] = 'true'
+
+          expect(credentials['fastaccept']).to be(true)
+        end
+
+        it 'coerces a falsey token to a real boolean' do
+          ENV['CUSTOM_MAIL_SMTP2GO_FASTACCEPT'] = 'false'
+
+          expect(credentials['fastaccept']).to be(false)
+        end
+
+        it 'raises on an unrecognized token rather than silently defaulting' do
+          ENV['CUSTOM_MAIL_SMTP2GO_FASTACCEPT'] = 'ture'
+
+          expect { credentials }.to raise_error(Onetime::ConfigError, /CUSTOM_MAIL_SMTP2GO_FASTACCEPT/)
+        end
+      end
+    end
   end
 end

--- a/spec/unit/onetime/mail/provider_registry_spec.rb
+++ b/spec/unit/onetime/mail/provider_registry_spec.rb
@@ -246,6 +246,7 @@ RSpec.describe Onetime::Mail::ProviderRegistry do
           api_base_url: 'https://api.smtp2go.com/v3',
           returnpath_subdomain: 'bounce',
           tracking_subdomain: 'track',
+          fastaccept: false,
         },
       )
     end

--- a/src/schemas/contracts/config/section/mail.ts
+++ b/src/schemas/contracts/config/section/mail.ts
@@ -66,6 +66,7 @@ const smtp2goEmailProviderSchema = z.strictObject({
   api_base_url: z.string().optional(),
   returnpath_subdomain: z.string().optional(),
   tracking_subdomain: z.string().optional(),
+  fastaccept: z.boolean().optional(),
 });
 
 const emailProvidersSchema = z.strictObject({

--- a/src/schemas/shapes/config/section/mail.ts
+++ b/src/schemas/shapes/config/section/mail.ts
@@ -75,6 +75,7 @@ const emailProvidersShape = augment(emailProvidersSchema, {
     api_base_url: (s) => s.default('https://api.smtp2go.com/v3'),
     returnpath_subdomain: (s) => s.default('bounce'),
     tracking_subdomain: (s) => s.default('track'),
+    fastaccept: (b) => b.default(false),
   },
 });
 


### PR DESCRIPTION
## Summary
- Add the SMTP2GO fastaccept configuration option, defaulting to synchronous delivery accounting so test emails can report recipient-level failures.
- Fail closed when SMTP2GO responses contain neither delivery accounting nor an email ID, and preserve domains while redacting recipient local-parts in tenant-facing errors.
- Record sender test-email outcomes in the Colonel audit trail and rename sender-config audit tags for the broader configuration lifecycle.

## Review guide
- Start with lib/onetime/mail/delivery/smtp2go.rb to review request mode selection, response validation, and tenant-safe error redaction.
- Review apps/api/domains/logic/sender_config/send_test_email.rb for the forced synchronous path and audit event payload; accompanying specs cover successful and failed deliveries.
- CUSTOM_MAIL_SMTP2GO_FASTACCEPT remains available for asynchronous operation, but setting it to true trades per-recipient failure detection for lower latency.

## Validation
- Pre-commit, pre-push, and CI checks will validate this change.

Resolves #4190