### PR TITLE
docs(release): complete the v0.26.5 operator docs — post-RC delta and the #4196 controls

### DIFF
--- a/docs/operations/upgrading-v0-26-5.md
+++ b/docs/operations/upgrading-v0-26-5.md
@@ -36,6 +36,8 @@ guides first; this one only covers the v0.26.4 → v0.26.5 step.
 | Boolean parsing | `BILLING_ENABLED`, `STRIPE_AUTOMATIC_TAX`, `RABBITMQ_VERIFY_PEER` accept the full `1/true/yes/on/y/t` vocabulary and **raise at boot** on anything unrecognized | **Yes**, if any of the three is set to something other than `true`/`false` |
 | Geo | `GEO_HEADER` is honoured only in `TRUSTED_PROXY_MODE=filter`; depth-mode and direct-connect installs need `GEO_DB_PATH` | Only to keep session country resolving |
 | Passkey flag names | `WEBAUTHN_VERIFY_ACCOUNT` / `WEBAUTHN_AUTOFILL` renamed to `AUTH_WEBAUTHN_*` | Rename when convenient — the old names log a warning and are ignored |
+| Tenant SSO `allowed_domains` | The per-tenant SSO email-domain allowlist is now enforced on the callback. It was never called at runtime before, so every allowlist was inert | **Yes**, if any tenant has one configured — a stale list now locks its users out |
+| Org-scope receipts | `GET /receipt/recent?scope=org` now requires the `audit_logs` entitlement | **Yes** on billing-enabled installs — the shipped catalog grants it in no plan |
 | SSO-provisioned admins | Customers created just-in-time through SSO were written unverified, which blocks their role. New signups are fixed; existing records need a one-time repair | **Yes**, if you use SSO — see After Upgrading |
 | V1 API anonymous TTL | Anonymous secret creation through the V1 API is capped at the configured anonymous ceiling (default 7 days) instead of falling through to the 30-day global one | Only if anonymous V1 clients request longer expiries |
 | Custom-domain `HttpOrigin` | 403s on custom domains are fixed; middleware is assembled from a registry with per-app profiles and `MIDDLEWARE_AUTH_*` toggles | Remove any workaround you added for those 403s |
@@ -114,7 +116,38 @@ open self-service registration keeps a working `create-account` route.
 SSO is deliberately not gated by these flags, so tenant SSO sign-in is
 unaffected.
 
-### 5. Normalize the three strict-parsed booleans
+### 5. Only if you use tenant SSO or org-scope receipts: check the two newly enforced controls
+
+Both closed High findings from the 2026-08-14 security review (#4196), and both fail
+closed — an install that was quietly relying on the gap sees the change immediately.
+
+**Tenant SSO `allowed_domains`.** The allowlist existed in the model, the UI, the API
+and the docs, but nothing called it at runtime, so no tenant's list was ever applied.
+It is enforced on the OmniAuth callback now.
+
+> **Caution.** If a tenant's allowlist is stale, incomplete or was configured
+> aspirationally while it was inert, **their users stop being able to sign in on
+> upgrade.** Review each tenant SSO allowlist first.
+
+An empty allowlist remains the documented allow-all state. An unreadable one denies
+rather than degrading to allow-all. Denials surface as
+`auth_error=domain_not_allowed` and emit `:omniauth_tenant_domain_rejected`, distinct
+from the signup-domain denial, so you can tell the two apart in the audit trail.
+
+**Org-scope receipts.** `GET /receipt/recent?scope=org` returns receipts created by
+*other* org members, so it is now gated at the same `audit_logs` entitlement as the
+sibling org-wide audit surface.
+
+| Your install | Result |
+|---|---|
+| Standalone / billing disabled | Unaffected — `STANDALONE_ENTITLEMENTS` already includes `audit_logs` |
+| Billing enabled | **403 for every role, owners included**, until a plan grants `audit_logs` |
+
+On a billing-enabled install, entitlements come from the plan catalog, and the shipped
+example catalog defines `audit_logs` without granting it in any plan. Grant it on the
+plans that should have org-wide visibility.
+
+### 6. Normalize the three strict-parsed booleans
 
 ```bash
 BILLING_ENABLED=true          # was: only the literal 'true' counted
@@ -152,7 +185,7 @@ fix the certificate.
 > the literal `false` and nothing else — so `API_ENABLED=no` leaves the API
 > **on**. Use `true` and `false` everywhere and none of this can bite you.
 
-### 6. Only if you rely on geo: point it at the right source
+### 7. Only if you rely on geo: point it at the right source
 
 | Deployment | Setting |
 |---|---|
@@ -166,7 +199,7 @@ Organization Secret Activity country is **off by default**
 (`SECRET_ACTIVITY_GEO_COUNTRY_ENABLED`), pending the legal review tracked in
 ADR-021. Do not enable it without that review.
 
-### 7. Rename the passkey variables
+### 8. Rename the passkey variables
 
 ```bash
 AUTH_WEBAUTHN_VERIFY_ACCOUNT=true     # was WEBAUTHN_VERIFY_ACCOUNT
@@ -241,7 +274,13 @@ Run these in order — each one isolates a different gate that answers `404`.
    `/signin` and complete one sign-in. A `404` means the domain has not opted in;
    a `503` means the per-domain policy could not be read (a datastore problem,
    not a policy decision).
-5. **Boot log clean.** No `CONFIG DEPRECATION`, no `Invalid CIDR`, no
+5. **Tenant SSO sign-in.** If any tenant has an `allowed_domains` allowlist, sign
+   in once through that tenant's IdP. A denial shows `auth_error=domain_not_allowed`
+   and logs `:omniauth_tenant_domain_rejected` — the allowlist is now enforced where
+   it previously was not.
+6. **Org-scope receipts.** On a billing-enabled install, `GET /receipt/recent?scope=org`
+   as an org owner. A 403 means no plan grants `audit_logs` yet.
+7. **Boot log clean.** No `CONFIG DEPRECATION`, no `Invalid CIDR`, no
    `INACTIVE: no routable hostname` you did not intend.
 
 ## Config Mapping Reference
@@ -287,6 +326,18 @@ whichever gate is active.
 
 The domain has no enabled sign-in opt-in. Enable it in the domain's settings.
 This is the ADR-024 default-OFF rule now reaching full mode.
+
+### Tenant SSO users suddenly cannot sign in
+
+That tenant's `allowed_domains` allowlist is now enforced and does not list the
+domain the IdP asserted. Look for `:omniauth_tenant_domain_rejected` in the audit
+trail. Fix the allowlist, or clear it — an empty allowlist is allow-all.
+
+### `/receipt/recent?scope=org` returns 403
+
+The `audit_logs` entitlement is now required for org-scope receipts and no plan in
+your catalog grants it. Grant it on the plans that should have org-wide visibility.
+Standalone installs do not hit this.
 
 ### Sign-in returns 503
 

--- a/docs/operations/upgrading-v0-26-5.md
+++ b/docs/operations/upgrading-v0-26-5.md
@@ -3,8 +3,9 @@
 v0.26.5 tightens several gates that previously degraded permissively. Nothing in
 this release adds a schema migration or a bulk data transform, so **rollback is a
 tag swap** — but three of the tightened gates produce the *same* symptom (a
-`404`), and one config-parsing change can flip a flag you thought was off. Those
-are the reasons to read this before upgrading rather than after.
+`404`), one config-parsing change starts honouring a flag that was previously
+ignored, and SSO installs need a one-time repair afterwards. Those are the
+reasons to read this before upgrading rather than after.
 
 Coming from a version older than v0.26.0? Work through the earlier upgrade
 guides first; this one only covers the v0.26.4 → v0.26.5 step.
@@ -22,6 +23,7 @@ guides first; this one only covers the v0.26.4 → v0.26.5 step.
      `RABBITMQ_VERIFY_PEER` in your environment, if set.
    - Whether any custom domain in your install serves password or magic-link
      sign-in.
+   - Whether any of your admins or colonels were provisioned through SSO.
 
 ## What Changes
 
@@ -34,6 +36,9 @@ guides first; this one only covers the v0.26.4 → v0.26.5 step.
 | Boolean parsing | `BILLING_ENABLED`, `STRIPE_AUTOMATIC_TAX`, `RABBITMQ_VERIFY_PEER` accept the full `1/true/yes/on/y/t` vocabulary and **raise at boot** on anything unrecognized | **Yes**, if any of the three is set to something other than `true`/`false` |
 | Geo | `GEO_HEADER` is honoured only in `TRUSTED_PROXY_MODE=filter`; depth-mode and direct-connect installs need `GEO_DB_PATH` | Only to keep session country resolving |
 | Passkey flag names | `WEBAUTHN_VERIFY_ACCOUNT` / `WEBAUTHN_AUTOFILL` renamed to `AUTH_WEBAUTHN_*` | Rename when convenient — the old names log a warning and are ignored |
+| SSO-provisioned admins | Customers created just-in-time through SSO were written unverified, which blocks their role. New signups are fixed; existing records need a one-time repair | **Yes**, if you use SSO — see After Upgrading |
+| V1 API anonymous TTL | Anonymous secret creation through the V1 API is capped at the configured anonymous ceiling (default 7 days) instead of falling through to the 30-day global one | Only if anonymous V1 clients request longer expiries |
+| Custom-domain `HttpOrigin` | 403s on custom domains are fixed; middleware is assembled from a registry with per-app profiles and `MIDDLEWARE_AUTH_*` toggles | Remove any workaround you added for those 403s |
 | Sessions list | The account "active sessions" list starts showing IP, browser and country | No — it fills in as users re-authenticate |
 
 ## The Upgrade Checklist
@@ -172,6 +177,52 @@ The old names are ignored and log a `CONFIG DEPRECATION` line. They are
 registered as soft deprecations, so they will not fail your boot even under the
 default `DEPRECATED_CONFIG_MODE=strict`. Only the literal `true` enables either
 flag.
+
+## After Upgrading
+
+### Only if you use SSO: repair provisioned admins
+
+Customers provisioned just-in-time through SSO were created unverified and nothing
+ever flipped the flag — the flag is normally set by the emailed verify-account flow,
+which an SSO user never traverses. The visible consequence is that an
+SSO-provisioned colonel or admin **cannot exercise their role**: the system role
+check refuses an unverified customer before it looks at the role at all, even after
+a promotion from the CLI.
+
+New SSO signups are marked verified at creation. Existing records need a one-time
+repair:
+
+```bash
+bin/ots customers doctor --all              # reports :sso_customer_unverified
+bin/ots customers doctor --all --repair     # heals them
+```
+
+The repair is limited to records whose provisioning origin is literally SSO and
+whose Rodauth account is already Verified. It writes only the customer mirror and
+preserves any verification provenance already present. (#3973)
+
+### Optional: reconcile the role index
+
+```bash
+bin/ots customers role reconcile            # dry-run report
+bin/ots customers role reconcile --apply --force
+```
+
+This repairs drift between the authoritative `role` field and the derived
+`customer:role_index:*` sets that `role list` and `colonel_count` read. The drift
+predates this release — targeted field writers retain the previous role's bucket
+member, and TTL expiry deletes the customer hash while its index members persist,
+permanently inflating `colonel_count`. The repair is an incremental SADD/SREM diff
+rather than a delete-and-repopulate rebuild, so an interrupted run cannot leave the
+index emptier than it started. (#3974)
+
+### Expect the active-sessions list to fill in gradually
+
+The account "active sessions" list previously showed no IP address, browser or
+country for anyone — it joined Rodauth's session rows on a value Rodauth never
+stores. Sessions that already exist at deploy time have no join key until their
+next sign-in, so they keep listing without those details. No migration or backfill
+is needed. (#3989)
 
 ## Verify
 

--- a/docs/planning/release-v0.26.5-deployment-notes.md
+++ b/docs/planning/release-v0.26.5-deployment-notes.md
@@ -7,6 +7,15 @@ detail lives in [`docs/operations/upgrading-v0-26-5.md`](../operations/upgrading
 
 ## Deployment Notes
 
+> [!TIP]
+> **Already running `v0.26.5-rc1`?** Everything in the first three boxes below is
+> already live for you — the admin gates, the proxy and geo changes, the boolean
+> reader and the passkey renames all shipped in the RC. What is new since the RC is:
+> the full-mode per-domain sign-in/sign-up enforcement (the third checklist item),
+> the SSO admin repair and the role-index tool under **After upgrading**, the V1
+> anonymous TTL cap, and the `HttpOrigin` fix with the middleware registry. Those are
+> the only items worth re-reading.
+
 > [!IMPORTANT]
 > **Three gates now fail closed, and all three answer the same `404`.** The admin
 > host gate, the admin CIDR gate, and the new per-domain sign-in/sign-up opt-ins
@@ -63,6 +72,40 @@ detail lives in [`docs/operations/upgrading-v0-26-5.md`](../operations/upgrading
   to compensate for the old miscount, restore the real value. (#4024)
 - **Org-trail geolocation is opt-in and stays off.** `SECRET_ACTIVITY_GEO_COUNTRY_ENABLED`
   defaults to `false` pending the legal review in ADR-021. (#3989)
+- **Anonymous secrets created through the V1 API are now capped at the configured
+  anonymous TTL** (default 7 days). They previously fell through to the global
+  ceiling — 30 days — so an anonymous V1 client asking for a longer expiry now gets
+  7 days instead. The V2 path already behaved this way. (#4172)
+- **Custom-domain `HttpOrigin` 403s are fixed.** If you added a proxy rule or a
+  middleware workaround for those, you can remove it. The middleware stack is now
+  assembled from a registry with per-app profiles, and the auth app's members are
+  individually toggleable via `MIDDLEWARE_AUTH_*` (all default on — leave them alone
+  unless you are debugging). (#4170, #4181)
+
+**After upgrading:**
+
+- **Repair SSO-provisioned admins.** Customers created just-in-time through SSO were
+  written unverified and nothing ever flipped the flag, so an SSO-provisioned colonel
+  or admin **cannot exercise their role** — the system role check refuses an
+  unverified customer before it looks at the role. New signups are fixed at creation;
+  existing records need a one-time repair:
+
+  ```bash
+  bin/ots customers doctor --all              # reports :sso_customer_unverified
+  bin/ots customers doctor --all --repair     # heals them
+  ```
+
+  The repair only touches records whose provisioning origin is literally SSO and whose
+  Rodauth account is already Verified. If you have never used SSO, skip this. (#3973)
+- **Optional: reconcile the role index.** `bin/ots customers role reconcile` reports
+  drift between the authoritative `role` field and the derived `customer:role_index:*`
+  sets that `role list` and `colonel_count` read. Drift predates this release (targeted
+  field writers and TTL expiry both leave stale members, permanently inflating
+  `colonel_count`). Dry-run by default; `--apply` writes an incremental diff. (#3974)
+- **Expect the account "active sessions" list to fill in gradually.** It previously
+  showed no IP, browser or country for anyone, because it joined on a value Rodauth
+  never stores. Sessions that already exist at deploy time have no join key until
+  their next sign-in. No migration or backfill. (#3989)
 
 **Background on the admin host gate:** it anchors on the canonical hostname, which
 means it needs a routable one. On an install serving `localhost` or a bare IP, boot

--- a/docs/planning/release-v0.26.5-deployment-notes.md
+++ b/docs/planning/release-v0.26.5-deployment-notes.md
@@ -13,8 +13,9 @@ detail lives in [`docs/operations/upgrading-v0-26-5.md`](../operations/upgrading
 > reader and the passkey renames all shipped in the RC. What is new since the RC is:
 > the full-mode per-domain sign-in/sign-up enforcement (the third checklist item),
 > the SSO admin repair and the role-index tool under **After upgrading**, the V1
-> anonymous TTL cap, and the `HttpOrigin` fix with the middleware registry. Those are
-> the only items worth re-reading.
+> anonymous TTL cap, the `HttpOrigin` fix with the middleware registry, and the two
+> authorization controls from #4196 in the box below. Those are the only items worth
+> re-reading.
 
 > [!IMPORTANT]
 > **Three gates now fail closed, and all three answer the same `404`.** The admin
@@ -43,6 +44,27 @@ detail lives in [`docs/operations/upgrading-v0-26-5.md`](../operations/upgrading
 > Confirm your value is `true` or `false`. If you were unknowingly relying on the
 > old behaviour to reach a node with an untrusted certificate, that connection will
 > now fail — set `RABBITMQ_VERIFY_PEER=false` explicitly and fix the certificate.
+
+> [!WARNING]
+> **Two authorization controls start being enforced (#4196).** Both were closed as
+> High findings from the 2026-08-14 security review, and both fail closed, so the
+> tightening is visible on day one.
+> - **Tenant SSO `allowed_domains` is now actually applied.** The method existed in
+>   the model, the UI, the API and the docs, but nothing called it at runtime — every
+>   tenant allowlist was inert. It is enforced on the OmniAuth callback now. **If any
+>   tenant's allowlist is stale or wrong, their users stop being able to sign in.**
+>   Review each tenant SSO allowlist before upgrading. An empty allowlist is still the
+>   documented allow-all state; an unreadable one denies rather than degrading to
+>   allow-all. Rejections carry `auth_error=domain_not_allowed` and the distinct audit
+>   event `:omniauth_tenant_domain_rejected`.
+> - **Organization-scope receipts now require `audit_logs`.** `GET /receipt/recent?scope=org`
+>   returns other members' receipts, so it is gated at the same entitlement as the
+>   sibling org-wide audit surface. Standalone and billing-disabled installs are
+>   unaffected — `STANDALONE_ENTITLEMENTS` already includes `audit_logs`. **On
+>   billing-enabled installs it is an operator action:** entitlements come from the
+>   plan catalog, and the shipped example catalog defines `audit_logs` without granting
+>   it in any plan, so `scope=org` returns 403 for every role — owners included — until
+>   you grant it on the plans that should have org-wide visibility.
 
 > [!NOTE]
 > **`BILLING_ENABLED=1` now does what it says.** Billing remains **disabled by

--- a/docs/planning/release-v0.26.5-readiness.md
+++ b/docs/planning/release-v0.26.5-readiness.md
@@ -6,6 +6,10 @@
 `v0.26.5-rc1` is three days behind the commit this assessment covers. Everything
 below describes `58df007ee`, not the RC.
 
+**Updated 2026-08-18.** `main` has since moved to `03277fa36`, which carries #4196 —
+the three High authorization findings are now closed. The risk register below
+reflects that; the volume figures still describe the `58df007ee` window.
+
 **`v0.26.5-rc1` has been running in production for several days.** That is the
 most valuable single input to this assessment, and it moves the picture — but it
 covers the RC's tree, not this one. The section below draws the line.
@@ -30,10 +34,12 @@ tests rather than tested afterward. The heaviest single change in the release �
 otto 2.8.0 under the proxy and host-detection rewrite — now has days of
 production behind it.
 
-Two conditions remain. The three unfixed High authorization findings carried from
-the 2026-08-14 review (tracked separately, and note that production is currently
-exposed to them). And the rc1 → HEAD delta, which is where the remaining unknown
-now sits.
+One condition remains. The three High authorization findings carried from the
+2026-08-14 review are **closed** — #4196 landed H-1, H-2 and H-3, and each was
+verified in the merged code. What remains is the rc1 → HEAD delta, which is where
+the unknown now sits. Note that two of the three fixes fail closed in ways an
+operator will notice on day one; they are covered in the upgrade guide and the
+deployment notes rather than left to be discovered.
 
 ## What production has soaked, and what it hasn't
 
@@ -86,7 +92,7 @@ builds that automation.
 
 | Risk | Severity | Why it matters for this release |
 |---|---|---|
-| Three unfixed High authorization findings ship (H-1 org-member secret bearer-token harvest, H-2 non-owner reaches the org's Stripe portal, H-3 tenant SSO `allowed_domains` never enforced) | **High** | Verified still present at `58df007ee`: `customer_portal_redirect` is routed `auth=sessionauth` with no ownership check, and `SsoConfig#valid_email_domain?` has no runtime caller outside specs. H-3 is the worst kind — a control that exists in the UI, the API and the docs but not at runtime, so operators believe they have domain restriction and do not. Being fixed on a separate branch; the tag should wait for them or the release notes must say the controls are not in force. |
+| ~~Three unfixed High authorization findings ship~~ **Closed by #4196** | ~~High~~ **Low** | H-1, H-2 and H-3 all landed in `main` after this assessment was first written, and each was verified in the merged code: `ListReceipts` gates `scope=org` on the `audit_logs` entitlement and redacts non-owned capability tokens; `customer_portal_redirect` gates on ownership (with the reasoning that `default_org_id` is not proof of ownership — `JoinDomainOrganization` repoints it for plain members); and `enforce_tenant_email_domain!` now actually calls `valid_email_domain?` on the OmniAuth callback. **Two of the three carry operator impact and are documented in the upgrade guide (step 5) and the deployment notes:** an enforced tenant SSO allowlist can lock out users of a tenant whose list is stale, and org-scope receipts return 403 on billing-enabled installs until a plan grants `audit_logs`. |
 | ~~otto 2.6.0 → 2.8.0 under a trusted-proxy / host-detection rewrite~~ **Retired** | ~~High~~ **Low** | Both the bump and the proxy rewrite are in `v0.26.5-rc1`, which has run in production for several days behind a real proxy. The soak this row asked for has happened. Retained struck through so a reader of the earlier version knows the assessment changed rather than wondering if they misremembered. |
 | Middleware registry rewrite is unsoaked | **High** | 515 lines across the application-boot and middleware layers of every app, landed after the RC. It changes how the middleware stack is assembled and how security middleware is selected per app profile — the request path itself, on the one part of the release production has *not* exercised. Remedy: this is the change to put in front of real traffic before tagging, or the reason to cut the tag at rc1's tree instead. |
 | New full-mode auth gates are unsoaked | **High** | 1,307 lines of new fail-closed gating on live sign-in, sign-up and account-creation routes, all after the RC. The failure mode is a paying customer who cannot sign in, it is config-dependent, and a synthetic check against the canonical host will not surface it — operator hosts are exactly the case the gates leave alone. Remedy: sign in once on each custom domain that serves passwords, per the upgrade guide's Verify step 4. |
@@ -118,9 +124,9 @@ builds that automation.
 
 ## Recommended before tagging
 
-1. Land or explicitly accept H-1, H-2 and H-3. If accepted, the release notes
-   should say the tenant SSO domain allowlist is not enforced — operators
-   currently believe it is.
+1. ~~Land or explicitly accept H-1, H-2 and H-3.~~ **Done** — #4196. Both
+   operator-visible consequences (an enforced tenant SSO allowlist, and
+   `audit_logs` now required for org-scope receipts) are documented.
 2. Decide what to do about the unsoaked delta. Either put the middleware registry
    rewrite and the new full-mode auth gates in front of real traffic, or cut the
    stable tag at rc1's tree and ship the delta as v0.26.6. Production has soaked


### PR DESCRIPTION
## Summary

Follow-up to #4197. Two things are missing from the v0.26.5 release documents in `main`.

**1. #4197 merged without its last commit.** The branch was auto-deleted at merge and a late push recreated it, so `b120ad33` never landed. That commit is re-applied here, cut fresh from current `main` (delano's admin-host-allowlist clarification is preserved). It adds the post-rc1 items the notes had no entry for:

- **The SSO admin repair.** Customers provisioned just-in-time through SSO were written unverified and nothing ever flipped the flag, so an SSO-provisioned colonel or admin cannot exercise their role — the role check refuses an unverified customer before it looks at the role. New signups are fixed at creation; existing records need `bin/ots customers doctor --all --repair`. This is a *post-upgrade* action and neither document had anywhere to say so, hence a new **After upgrading** section in both. (#3973)
- V1 anonymous TTL cap — anonymous V1 secret creation drops from the 30-day global ceiling to the 7-day anonymous one. (#4172)
- Custom-domain `HttpOrigin` fix and the `MIDDLEWARE_AUTH_*` toggles. (#4170, #4181)
- The role-index reconcile tool. (#3974)
- An "already running rc1?" tip so an rc1 operator can skip the ~three-quarters of the block already live for them.

**2. #4196 landed after the assessment was written, and two of its three fixes fail closed in ways an operator sees on day one.** Neither had any coverage:

- **Tenant SSO `allowed_domains` is now applied.** The method existed in the model, the UI, the API and the docs, but nothing called it at runtime — every tenant allowlist was inert. A tenant whose list is stale, or that was configured aspirationally while it did nothing, **locks its users out on upgrade.** Now a checklist step with a caution, a verify step, and a symptom-first troubleshooting entry.
- **Org-scope receipts now require `audit_logs`.** Standalone and billing-disabled installs are unaffected (`STANDALONE_ENTITLEMENTS` already includes it), but on billing-enabled installs entitlements come from the plan catalog and the shipped example catalog grants `audit_logs` in no plan — so `scope=org` returns 403 for every role, owners included, until a plan grants it. The code comment in `list_receipts.rb` flags this as an operator action; it now appears where operators will read it.

The readiness register's High row for H-1/H-2/H-3 is struck through and restated rather than deleted, since the earlier version has already been read.

Docs only — no runtime changes.

## Related Issues

Refs #4197, #4196, #3973, #3974, #4170, #4172, #4181

(Deliberately `Refs` rather than `Fixes`: the underlying issues were closed by the PRs that implemented them. This PR only documents them.)

## Test Plan

Not applicable — documentation only. Every claim was verified against the merged code rather than the changelog:

- `apps/api/v2/logic/secrets/list_receipts.rb` — `require_entitlement!('audit_logs') if scope == :org`, and the operator-action note about the shipped catalog.
- `apps/web/auth/config/hooks/omniauth_tenant.rb:466` — `valid_email_domain?` is now called on the callback path; empty allowlist remains allow-all, corrupt allowlist denies.
- `apps/web/billing/controllers/plans.rb` — ownership gate on `customer_portal_redirect`.
- `lib/onetime/cli/customers/doctor_command.rb` — `--all --repair` invocation as documented.
- `apps/api/v1/logic/secrets/base_secret_action.rb` — the anonymous TTL clamp and the 30-day fall-through it replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1tuXS9rvC6Qy2hW2Ym8nm

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1tuXS9rvC6Qy2hW2Ym8nm)_