### PR TITLE
fix(ci): stop passing bake metadata through process env

### DIFF
--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -382,7 +382,7 @@ jobs:
         continue-on-error: true
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          BAKE_METADATA: ${{ steps.bake.outputs.metadata }}
+          BAKE_METADATA_FILE: ${{ runner.temp }}/bake-metadata.json
           DIST_DEST: ./public/web/dist
           IMAGE_DIST_PATH: /app/public/web/dist
           VERSION: ${{ steps.version.outputs.version }}
@@ -392,7 +392,20 @@ jobs:
           PLATFORMS: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
           REGISTRY_MODE: ${{ inputs.registry_target || 'public' }}
           CUSTOM_REGISTRY: ${{ secrets.CUSTOM_REGISTRY_HOST }}
-        run: bash scripts/ci/extract-frontend-dist.sh
+        # docker/bake-action's `metadata` output carries provenance/attestation
+        # data for every target × platform in group `ci` (3 targets x 2
+        # platforms). For multi-platform, multi-target builds that JSON can run
+        # into the multi-MB range. Passing it through `env:` puts it in the
+        # step process's envp, which shares the OS execve() size limit with
+        # argv — a large enough blob makes the runner fail to even start bash
+        # ("Argument list too long"), skipping this step and, transitively,
+        # sourcemap upload. Writing it to a file sidesteps that limit entirely:
+        # file content has no such cap.
+        run: |
+          cat > "$BAKE_METADATA_FILE" <<'BAKE_METADATA_EOF'
+          ${{ steps.bake.outputs.metadata }}
+          BAKE_METADATA_EOF
+          bash scripts/ci/extract-frontend-dist.sh
 
       - name: Create Sentry release and associate commits
         if: github.event_name != 'pull_request'

--- a/scripts/ci/extract-frontend-dist.sh
+++ b/scripts/ci/extract-frontend-dist.sh
@@ -40,9 +40,16 @@
 #   SENTRY_AUTH_TOKEN  presence separates a quiet SKIP from a loud failure
 #   DIST_DEST          where to place the tree (default ./public/web/dist)
 #   IMAGE_DIST_PATH    path inside the image (default /app/public/web/dist)
-#   BAKE_METADATA      docker/bake-action `metadata` output (JSON). When it
-#                      carries a digest the pull is digest-pinned, which is
-#                      immune to a tag being overwritten between push and pull.
+#   BAKE_METADATA_FILE path to docker/bake-action `metadata` output (JSON),
+#                      written to disk by the calling step rather than passed
+#                      as an env var — group `ci` builds 3 targets x 2
+#                      platforms and buildx attaches provenance/attestation
+#                      data by default, so this JSON can run into the
+#                      multi-MB range: large enough to blow the OS execve()
+#                      argv+envp limit if it rode through `env:` instead (see
+#                      docker/build-push-action#1257). When it carries a
+#                      digest the pull is digest-pinned, which is immune to a
+#                      tag being overwritten between push and pull.
 #   BAKE_FILE          bake definition (default docker/bake.hcl)
 #   BAKE_GROUP         bake group to resolve tags from (default ci)
 #   BAKE_TARGET        target within that group to extract from (default main)
@@ -112,9 +119,9 @@ fi
 # Prefer the digest the push actually produced. Tags are mutable; a digest names
 # the exact image whose bundles this release's events will come from.
 digest=""
-if [ -n "${BAKE_METADATA:-}" ]; then
-  digest="$(printf '%s' "$BAKE_METADATA" \
-    | jq -r --arg t "$BAKE_TARGET" '.[$t]["containerimage.digest"] // empty' 2>/dev/null)"
+if [ -n "${BAKE_METADATA_FILE:-}" ] && [ -s "$BAKE_METADATA_FILE" ]; then
+  digest="$(jq -r --arg t "$BAKE_TARGET" '.[$t]["containerimage.digest"] // empty' \
+    "$BAKE_METADATA_FILE" 2>/dev/null)"
 fi
 
 if [ -n "$digest" ]; then


### PR DESCRIPTION
## Summary
- The v0.26.6 GA workflow run ([32439854328](https://github.com/onetimesecret/onetimesecret/actions/runs/32439854328)) failed the "Extract frontend assets from built image" step with `##[error]An error occurred trying to start process '/usr/bin/bash' ... Argument list too long`
- Root cause: group `ci` builds 3 targets × 2 platforms; buildx attaches full provenance/attestation JSON per target/platform to `docker/bake-action`'s `metadata` output. Measured at ~700KB in that run — over Linux's 128KB single-env-var limit — and the workflow passed it through `env: BAKE_METADATA` on that step, so `execve()` failed with `E2BIG` before bash could even start
- That single failed step cascaded: extraction never ran → sourcemap preflight/upload/verify all skipped → both `sourcemaps` and `frontend-assets` reported "did NOT ship"

## Fix
- Write `steps.bake.outputs.metadata` to a file via heredoc instead of a process env var (file content isn't subject to the exec argv/envp size limit)
- `scripts/ci/extract-frontend-dist.sh` now reads the digest from `BAKE_METADATA_FILE` via `jq` instead of a `BAKE_METADATA` env var

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [x] `bash -n scripts/ci/extract-frontend-dist.sh` — script syntax valid
- [ ] Next tagged release / manual `workflow_dispatch` run confirms "Extract frontend assets" step no longer fails and sourcemaps ship