### PR TITLE
Name Colonel proxy-diagnostic constants by role; scope the Caddy snippet to the diagnostic path

### DIFF
--- a/apps/api/colonel/auth_strategies.rb
+++ b/apps/api/colonel/auth_strategies.rb
@@ -16,7 +16,8 @@ module ColonelAPI
       PROXY_DEBUG_HEADERS_PATH = '/system/proxy-headers'
 
       # `X-OTS-Proxy-Debug-*`: what the reverse proxy saw, injected by Caddy's
-      # `(onetime-proxy-debug)` snippet on PROXY_DEBUG_HEADERS_PATH only.
+      # `(onetime-proxy-debug)` snippet (a path-matched `route` of
+      # `request_header` directives) on PROXY_DEBUG_HEADERS_PATH only.
       PROXY_DEBUG_HEADERS = %w[
         HTTP_X_OTS_PROXY_DEBUG_PEER
         HTTP_X_OTS_PROXY_DEBUG_CLIENT_IP

--- a/apps/api/colonel/auth_strategies.rb
+++ b/apps/api/colonel/auth_strategies.rb
@@ -11,21 +11,33 @@ module ColonelAPI
     class SessionAuthStrategy < Onetime::Application::AuthStrategies::SessionAuthStrategy
       @auth_method_name = 'sessionauth'
 
-      PROXY_HEADERS_DEBUG_PATH = '/system/proxy-headers'
+      # Colonel diagnostic endpoint. The only route where build_metadata attaches
+      # proxy headers (see: docs/operations/proxy-header-diagnostic.md).
+      PROXY_DEBUG_HEADERS_PATH = '/system/proxy-headers'
 
-      CADDY_SNAPSHOT_HEADERS = %w[
+      # `X-OTS-Proxy-Debug-*`: what the reverse proxy saw, injected by Caddy's
+      # `(onetime-proxy-debug)` snippet on PROXY_DEBUG_HEADERS_PATH only.
+      PROXY_DEBUG_HEADERS = %w[
         HTTP_X_OTS_PROXY_DEBUG_PEER
+        HTTP_X_OTS_PROXY_DEBUG_CLIENT_IP
         HTTP_X_OTS_PROXY_DEBUG_HOST
         HTTP_X_OTS_PROXY_DEBUG_RECEIVED_X_FORWARDED_FOR
+        HTTP_X_OTS_PROXY_DEBUG_RECEIVED_X_FORWARDED_HOST
+        HTTP_X_OTS_PROXY_DEBUG_RECEIVED_X_REAL_IP
+        HTTP_X_OTS_PROXY_DEBUG_RECEIVED_X_CLIENT_IP
         HTTP_X_OTS_PROXY_DEBUG_RECEIVED_FORWARDED
         HTTP_X_OTS_PROXY_DEBUG_RECEIVED_APX_INCOMING_HOST
       ].freeze
 
-      REQUEST_HEADERS = %w[
+      # Forwarding headers as Rack received them, for comparison against
+      # PROXY_DEBUG_HEADERS and the resolved env values.
+      FORWARDING_HEADERS = %w[
         HTTP_HOST
         HTTP_X_FORWARDED_FOR
         HTTP_X_FORWARDED_HOST
         HTTP_X_FORWARDED_PROTO
+        HTTP_X_REAL_IP
+        HTTP_X_CLIENT_IP
         HTTP_FORWARDED
         HTTP_APX_INCOMING_HOST
       ].freeze
@@ -37,18 +49,18 @@ module ColonelAPI
       # no request headers are added to ordinary Colonel strategy metadata.
       def build_metadata(env, additional = {})
         metadata = super
-        return metadata unless Otto::Utils.normalize_path(env['PATH_INFO']) == PROXY_HEADERS_DEBUG_PATH
+        return metadata unless Otto::Utils.normalize_path(env['PATH_INFO']) == PROXY_DEBUG_HEADERS_PATH
 
         metadata.merge(
           proxy_header_debug: {
-            caddy_received: header_values(env, CADDY_SNAPSHOT_HEADERS),
+            caddy_received: header_values(env, PROXY_DEBUG_HEADERS),
             rack: {
               remote_addr: env['REMOTE_ADDR'],
               client_ip: env['otto.client_ip'],
               via_trusted_proxy: env['otto.via_trusted_proxy'],
               detected_host: env[Rack::DetectHost.result_field_name],
             },
-            request_headers: header_values(env, REQUEST_HEADERS),
+            request_headers: header_values(env, FORWARDING_HEADERS),
           },
         )
       end

--- a/apps/api/colonel/spec/auth_strategies_spec.rb
+++ b/apps/api/colonel/spec/auth_strategies_spec.rb
@@ -29,8 +29,12 @@ RSpec.describe ColonelAPI::AuthStrategies::SessionAuthStrategy do
       expect(metadata[:proxy_header_debug]).to eq(
         caddy_received: {
           'x-ots-proxy-debug-peer' => '198.51.100.10',
+          'x-ots-proxy-debug-client-ip' => nil,
           'x-ots-proxy-debug-host' => nil,
           'x-ots-proxy-debug-received-x-forwarded-for' => nil,
+          'x-ots-proxy-debug-received-x-forwarded-host' => nil,
+          'x-ots-proxy-debug-received-x-real-ip' => nil,
+          'x-ots-proxy-debug-received-x-client-ip' => nil,
           'x-ots-proxy-debug-received-forwarded' => nil,
           'x-ots-proxy-debug-received-apx-incoming-host' => nil,
         },
@@ -45,6 +49,8 @@ RSpec.describe ColonelAPI::AuthStrategies::SessionAuthStrategy do
           'x-forwarded-for' => '203.0.113.9',
           'x-forwarded-host' => nil,
           'x-forwarded-proto' => nil,
+          'x-real-ip' => nil,
+          'x-client-ip' => nil,
           'forwarded' => nil,
           'apx-incoming-host' => 'tenant.example.test',
         },

--- a/docs/operations/proxy-header-diagnostic.md
+++ b/docs/operations/proxy-header-diagnostic.md
@@ -41,7 +41,8 @@ replaces each diagnostic field supplied by the client with Caddy's own
 observations.
 
 ```caddyfile
-# Caddy-side snapshot for GET /api/colonel/system/proxy-headers.
+# Caddy-side capture of the forwarding headers as received, for GET
+# /api/colonel/system/proxy-headers.
 #
 # Import at the SITE level, next to the reverse_proxy snippet:
 #
@@ -127,9 +128,9 @@ refused the request.
    request through the load balancer with a unique marker, for example
    `X-Forwarded-For: 203.0.113.77`.
 2. Compare `caddy_received` with `request_headers`:
-   - If Caddy's received snapshot contains the marker, the load balancer passed
+   - If `caddy_received` contains the marker, the load balancer passed
      the client header to Caddy.
-   - If the request header received by Rack differs from the snapshot, Caddy
+   - If the request header received by Rack differs from `caddy_received`, Caddy
      changed it while proxying.
 3. Compare `caddy_received.x-ots-proxy-debug-peer` with
    `rack.remote_addr`. They may differ because the Rack IP-privacy middleware

--- a/docs/operations/proxy-header-diagnostic.md
+++ b/docs/operations/proxy-header-diagnostic.md
@@ -41,12 +41,11 @@ replaces each diagnostic field supplied by the client with Caddy's own
 observations.
 
 ```caddyfile
-# Caddy-side capture of the forwarding headers as received, for GET
-# /api/colonel/system/proxy-headers.
+# Caddy snippet for GET /api/colonel/system/proxy-headers.
 #
 # Import at the SITE level, next to the reverse_proxy snippet:
 #
-#   uk.onetimesecret.com {
+#   secrets.example.com {
 #     import onetime-proxy-debug
 #     import onetime-proxy
 #   }

--- a/docs/operations/proxy-header-diagnostic.md
+++ b/docs/operations/proxy-header-diagnostic.md
@@ -41,22 +41,40 @@ with Caddy's own observations.
 
 ```caddyfile
 @proxy_header_debug path /api/colonel/system/proxy-headers
-handle @proxy_header_debug {
-    # A caller must not be able to forge Caddy's snapshots.
-    header_up -X-Ots-Proxy-Debug-Peer
-    header_up -X-Ots-Proxy-Debug-Host
-    header_up -X-Ots-Proxy-Debug-Received-X-Forwarded-For
-    header_up -X-Ots-Proxy-Debug-Received-Forwarded
-    header_up -X-Ots-Proxy-Debug-Received-Apx-Incoming-Host
+# Caddy-side snapshot for GET /api/colonel/system/proxy-headers.
+#
+# Imported INSIDE onetime-proxy's reverse_proxy on purpose. A separate handle
+# with its own reverse_proxy carries none of the header_up rules below, so the
+# endpoint's "did Caddy change this?" comparison would describe a handler no
+# production request passes through.
+#
+# NO explicit deletes. Caddy applies Add -> Set -> Delete regardless of source
+# order, so a `header_up -X` next to a `header_up X {val}` deletes the value it
+# just set and the endpoint reports nothing. Two-arg header_up is Set, which
+# already replaces a client-supplied value; an absent source resolves to "",
+# not to the forged value. Verified on caddy v2.10.2.
+#
+# Sent on every upstream request. Exposure is gated by the endpoint
+# (auth=sessionauth role=colonel + network=admin), not by Caddy.
+(onetime-proxy-debug) {
+  # These are the values Caddy recieves and makes available to the
+  # application. Peer is the TCP peer after PROXY protocol unwrapping;
+  # client_ip is Caddy's trusted_proxies verdict. They diverge exactly
+  # when the trusted_proxies list has drifted.
+  # TODO: Need to rewrite for multiple scenarios (with/without edge
+  # proxy, with/without PROXY, with/without an LB).
+  header_up X-Ots-Proxy-Debug-Peer      {remote_host}
+  header_up X-Ots-Proxy-Debug-Client-IP {client_ip}
+  header_up X-Ots-Proxy-Debug-Host      {http.request.host}
 
-    # Values Caddy observed before it proxies the request.
-    header_up X-Ots-Proxy-Debug-Peer {remote_host}
-    header_up X-Ots-Proxy-Debug-Host {http.request.host}
-    header_up X-Ots-Proxy-Debug-Received-X-Forwarded-For {http.request.header.X-Forwarded-For}
-    header_up X-Ots-Proxy-Debug-Received-Forwarded {http.request.header.Forwarded}
-    header_up X-Ots-Proxy-Debug-Received-Apx-Incoming-Host {http.request.header.Apx-Incoming-Host}
-
-    reverse_proxy 127.0.0.1:7143
+  # These are the values that caddy recieved and removed before
+  # the request reaches the application.
+  header_up X-Ots-Proxy-Debug-Received-X-Forwarded-For   {http.request.header.X-Forwarded-For}
+  header_up X-Ots-Proxy-Debug-Received-X-Forwarded-Host  {http.request.header.X-Forwarded-Host}
+  header_up X-Ots-Proxy-Debug-Received-X-Real-IP         {http.request.header.X-Real-IP}
+  header_up X-Ots-Proxy-Debug-Received-X-Client-IP       {http.request.header.X-Client-IP}
+  header_up X-Ots-Proxy-Debug-Received-Forwarded         {http.request.header.Forwarded}
+  header_up X-Ots-Proxy-Debug-Received-Apx-Incoming-Host {http.request.header.Apx-Incoming-Host}
 }
 ```
 
@@ -70,7 +88,7 @@ Invoke it with curl using a live session cookie — no CSRF token is needed for
 the GET:
 
 ```bash
-curl -s https://admin.example.com/api/colonel/system/proxy-headers \
+curl -s https://uk.onetimesecret.com/api/colonel/system/proxy-headers \
   -H 'Cookie: sess=<session-id>' | jq
 ```
 

--- a/docs/operations/proxy-header-diagnostic.md
+++ b/docs/operations/proxy-header-diagnostic.md
@@ -35,51 +35,75 @@ for trusted-proxy requirements, supported host values, and CIDR matching.
 
 ## Caddy configuration
 
-Add a dedicated handler before the normal dynamic reverse-proxy handler. The
-handler deletes each diagnostic field supplied by the client and replaces it
-with Caddy's own observations.
+Define the snippet below and import it at the site level alongside the normal
+dynamic `reverse_proxy` snippet. It runs only for the diagnostic path and
+replaces each diagnostic field supplied by the client with Caddy's own
+observations.
 
 ```caddyfile
-@proxy_header_debug path /api/colonel/system/proxy-headers
 # Caddy-side snapshot for GET /api/colonel/system/proxy-headers.
 #
-# Imported INSIDE onetime-proxy's reverse_proxy on purpose. A separate handle
-# with its own reverse_proxy carries none of the header_up rules below, so the
-# endpoint's "did Caddy change this?" comparison would describe a handler no
-# production request passes through.
+# Import at the SITE level, next to the reverse_proxy snippet:
+#
+#   uk.onetimesecret.com {
+#     import onetime-proxy-debug
+#     import onetime-proxy
+#   }
+#
+# `route` falls through to the following handlers, so the request still goes
+# through the ordinary reverse_proxy and all of its header_up rules. A separate
+# handle with its own reverse_proxy would carry none of them and the endpoint's
+# "did Caddy change this?" comparison would describe a handler no production
+# request passes through.
+#
+# `request_header` rather than `header_up`: header_up is a reverse_proxy
+# subdirective, unconditional by design, and accepts no matcher (a leading
+# `@matcher` token is silently parsed as a regex-replace on a header named
+# "@matcher"). request_header is the matcher-aware equivalent. It is Set
+# semantics, so a client-supplied value is replaced, and its placeholders read
+# the original request, so the Received-* values are captured before
+# reverse_proxy's header_up rules strip them.
 #
 # NO explicit deletes. Caddy applies Add -> Set -> Delete regardless of source
-# order, so a `header_up -X` next to a `header_up X {val}` deletes the value it
-# just set and the endpoint reports nothing. Two-arg header_up is Set, which
-# already replaces a client-supplied value; an absent source resolves to "",
-# not to the forged value. Verified on caddy v2.10.2.
+# order, so a `-X` next to an `X {val}` deletes the value it just set and the
+# endpoint reports nothing. An absent source resolves to "", not to the forged
+# value. Verified on caddy v2.10.2.
 #
-# Sent on every upstream request. Exposure is gated by the endpoint
-# (auth=sessionauth role=colonel + network=admin), not by Caddy.
+# Only sent upstream for the diagnostic path. On other paths a client-supplied
+# X-Ots-Proxy-Debug-* header passes through unchanged; the application ignores
+# these headers everywhere except the diagnostic route.
 (onetime-proxy-debug) {
-  # These are the values Caddy recieves and makes available to the
-  # application. Peer is the TCP peer after PROXY protocol unwrapping;
-  # client_ip is Caddy's trusted_proxies verdict. They diverge exactly
-  # when the trusted_proxies list has drifted.
-  # TODO: Need to rewrite for multiple scenarios (with/without edge
-  # proxy, with/without PROXY, with/without an LB).
-  header_up X-Ots-Proxy-Debug-Peer      {remote_host}
-  header_up X-Ots-Proxy-Debug-Client-IP {client_ip}
-  header_up X-Ots-Proxy-Debug-Host      {http.request.host}
+  @proxy_header_debug path /api/colonel/system/proxy-headers
+  # Placement in the site block is irrelevant: the Caddyfile adapter sorts
+  # directives into a fixed order (header ... request_header ... route ...
+  # reverse_proxy), not source order, so this runs before reverse_proxy
+  # wherever it is imported. See
+  # https://caddyserver.com/docs/caddyfile/directives#directive-order
+  route @proxy_header_debug {
+    # The values Caddy receives and makes available to the application.
+    # Peer is the TCP peer after PROXY protocol unwrapping; client_ip is
+    # Caddy's trusted_proxies verdict. They diverge exactly when the
+    # trusted_proxies list has drifted.
+    # TODO: Need to rewrite for multiple scenarios (with/without edge
+    # proxy, with/without PROXY, with/without an LB).
+    request_header X-Ots-Proxy-Debug-Peer      {remote_host}
+    request_header X-Ots-Proxy-Debug-Client-IP {client_ip}
+    request_header X-Ots-Proxy-Debug-Host      {http.request.host}
 
-  # These are the values that caddy recieved and removed before
-  # the request reaches the application.
-  header_up X-Ots-Proxy-Debug-Received-X-Forwarded-For   {http.request.header.X-Forwarded-For}
-  header_up X-Ots-Proxy-Debug-Received-X-Forwarded-Host  {http.request.header.X-Forwarded-Host}
-  header_up X-Ots-Proxy-Debug-Received-X-Real-IP         {http.request.header.X-Real-IP}
-  header_up X-Ots-Proxy-Debug-Received-X-Client-IP       {http.request.header.X-Client-IP}
-  header_up X-Ots-Proxy-Debug-Received-Forwarded         {http.request.header.Forwarded}
-  header_up X-Ots-Proxy-Debug-Received-Apx-Incoming-Host {http.request.header.Apx-Incoming-Host}
+    # The values Caddy received and removes before the request reaches
+    # the application.
+    request_header X-Ots-Proxy-Debug-Received-X-Forwarded-For   {http.request.header.X-Forwarded-For}
+    request_header X-Ots-Proxy-Debug-Received-X-Forwarded-Host  {http.request.header.X-Forwarded-Host}
+    request_header X-Ots-Proxy-Debug-Received-X-Real-IP         {http.request.header.X-Real-IP}
+    request_header X-Ots-Proxy-Debug-Received-X-Client-IP       {http.request.header.X-Client-IP}
+    request_header X-Ots-Proxy-Debug-Received-Forwarded         {http.request.header.Forwarded}
+    request_header X-Ots-Proxy-Debug-Received-Apx-Incoming-Host {http.request.header.Apx-Incoming-Host}
+  }
 }
 ```
 
-The exact upstream target should match the deployment's existing dynamic
-`reverse_proxy` target. Restrict the route at the network edge as well when
+The `reverse_proxy` snippet's upstream target should match the deployment's
+existing dynamic target. Restrict the route at the network edge as well when
 possible.
 
 ## How to use it


### PR DESCRIPTION
Extracted from #4240, where it was unrelated to the PR's subject. Four commits, no content changes. Follow-through on the proxy-header diagnostic shipped in #4233.

## What changes

**Constants named by role, not provenance** (`apps/api/colonel/auth_strategies.rb`):

| before | after |
|---|---|
| `PROXY_HEADERS_DEBUG_PATH` | `PROXY_DEBUG_HEADERS_PATH` |
| `CADDY_SNAPSHOT_HEADERS` | `PROXY_DEBUG_HEADERS` |
| `REQUEST_HEADERS` | `FORWARDING_HEADERS` |

`PROXY_DEBUG_HEADERS` mirrors the `X-OTS-Proxy-Debug-*` wire prefix and no longer ties the Ruby side to one proxy implementation. Each constant carries a comment pointing at the others and at the operations doc. Both lists widen to the full forwarding vocabulary the middleware stack consults: `X-OTS-Proxy-Debug-Client-IP` (Caddy's `trusted_proxies` verdict, distinct from the TCP peer) plus received `X-Forwarded-Host` / `X-Real-IP` / `X-Client-IP` on the proxy side; `X-Real-IP` / `X-Client-IP` on the Rack side. Metadata output keys (`caddy_received`, `request_headers`) are unchanged.

**Caddy snippet scoped to the diagnostic path** (`docs/operations/proxy-header-diagnostic.md`):

The previous example used `header_up` inside `reverse_proxy`, which has no matcher support — a leading `@matcher` is silently parsed as a regex-replace on a header literally named `@matcher` — so the debug headers went upstream on every request. The snippet is now a site-level `(onetime-proxy-debug)` wrapping `request_header` directives in `route @proxy_header_debug`, which falls through to the existing `reverse_proxy` so its `header_up` rules still apply and the endpoint's comparison stays valid. Also dropped the explicit `header_up -X` deletes: Caddy orders Add → Set → Delete regardless of source order, so a delete beside a set erased the value it had just set. Verified on Caddy v2.10.2.

## Operator impact

None required. The diagnostic endpoint is unchanged on the wire; operators who pasted the earlier doc snippet should swap to the new one to stop forwarding debug headers on non-diagnostic paths.
