### PR TITLE
Fix the Caddyfile example: serve /dist/* by allowlist, not file existence

### DIFF
--- a/docker/variants/caddy.dockerfile
+++ b/docker/variants/caddy.dockerfile
@@ -112,9 +112,10 @@ RUN caddy version
 # PUBLIC_DIR ships empty: the app container serves its own built assets
 # (ADR-025), and public/web no longer holds tracked static files (they were
 # retired in favor of brand packs, ADR-029). The Caddyfile only static-serves
-# files that exist under PUBLIC_DIR (`@exists file`) and proxies everything
-# else to the app, so an empty dir means "proxy everything". Operators can
-# still mount assets into ${PUBLIC_DIR} at run time to have Caddy serve them.
+# /dist/* from PUBLIC_DIR (an allowlist, not a file-existence test — brand
+# assets must always reach the app) and proxies everything else, so an empty
+# dir means "proxy everything". Operators can still mount a dist/ tree into
+# ${PUBLIC_DIR} at run time to have Caddy serve it.
 RUN mkdir -p /etc/caddy ${PUBLIC_DIR}
 ENV PUBLIC_DIR=${PUBLIC_DIR}
 

--- a/etc/examples/Caddyfile-example
+++ b/etc/examples/Caddyfile-example
@@ -178,9 +178,15 @@
 	# favicon.ico) using a UUID.
 	header @always O-Request-ID "{http.request.uuid}"
 
-	# Serve static files if they exist
-	@exists file
-	handle @exists {
+	# Serve build output from disk. ALLOWLIST, not a file-existence test: an
+	# `@exists file` matcher lets any stale file under $PUBLIC_DIR silently
+	# outrank the app's brand resolution (public/branding/<pack>). In
+	# particular /favicon.ico and /site.webmanifest are route-served by the
+	# app so they can vary per custom domain — a file on disk defeats that.
+	# /dist (Vite build output) is the only tree the app itself treats as
+	# never-overlaid (lib/onetime/middleware/static_files.rb).
+	@dist path /dist/*
+	handle @dist {
 		file_server
 	}
 


### PR DESCRIPTION
Extracted from #4240, where it was unrelated to the PR's subject. One commit, no content changes.

`etc/examples/Caddyfile-example` used an `@exists file` matcher to decide when Caddy should serve from `$PUBLIC_DIR` instead of proxying. That is a file-existence test, not an allowlist: any stale file under `$PUBLIC_DIR` silently outranks the app's own routing. It bit on `/favicon.ico` and `/site.webmanifest`, which the app route-serves so they can vary per custom domain (brand packs, ADR-029) — a file on disk defeats that, and a UK-branded host was showing the default favicon for exactly this reason.

The matcher is now `@dist path /dist/*`: Vite build output is the only tree the app itself treats as never-overlaid (`lib/onetime/middleware/static_files.rb`). The comment in `docker/variants/caddy.dockerfile` is updated to match.

## Operator impact

Operators running the example Caddyfile should apply the same change. Anything mounted into `$PUBLIC_DIR` outside `dist/` will now be proxied to the app rather than served from disk — which is the intended behaviour; brand assets must always reach the app.
