### PR TITLE
fix(dev): stop test-mode env leaking into worktrees; write locales atomically

### DIFF
--- a/locales/scripts/i18n/io.py
+++ b/locales/scripts/i18n/io.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import os
 import sys
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterator, Optional
@@ -210,11 +211,19 @@ def save_json_file(file_path: Path, data: dict) -> None:
     # Write to a sibling temp file and rename into place so readers never
     # observe a half-written file (e.g. the Ruby backend booting while
     # `content compile --all` is mid-write, or a compile killed with Ctrl-C).
-    tmp_path = file_path.with_name(f".{file_path.name}.tmp")
+    # The name must be unique per writer: two concurrent compiles of the same
+    # locale sharing one temp name interleave their writes and rename the torn
+    # result into place, which is the failure this function exists to prevent.
+    fd, tmp_name = tempfile.mkstemp(
+        dir=file_path.parent, prefix=f".{file_path.name}.", suffix=".tmp"
+    )
+    tmp_path = Path(tmp_name)
     try:
-        with open(tmp_path, "w", encoding="utf-8") as f:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(data, f, indent=2, ensure_ascii=False)
             f.write("\n")
+        # mkstemp creates 0600; these are generated, world-readable artifacts.
+        os.chmod(tmp_path, 0o644)
         os.replace(tmp_path, file_path)
     finally:
         tmp_path.unlink(missing_ok=True)

--- a/locales/scripts/i18n/io.py
+++ b/locales/scripts/i18n/io.py
@@ -10,6 +10,7 @@ content files.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -206,9 +207,17 @@ def save_json_file(file_path: Path, data: dict) -> None:
     """
     file_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with open(file_path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-        f.write("\n")
+    # Write to a sibling temp file and rename into place so readers never
+    # observe a half-written file (e.g. the Ruby backend booting while
+    # `content compile --all` is mid-write, or a compile killed with Ctrl-C).
+    tmp_path = file_path.with_name(f".{file_path.name}.tmp")
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        os.replace(tmp_path, file_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 class KeyPathConflictError(ValueError):

--- a/scripts/setup/lib.sh
+++ b/scripts/setup/lib.sh
@@ -276,7 +276,7 @@ ensure_secrets() {
 # flags a mismatch. A rev-current file is left alone so local
 # customisations survive re-runs.
 
-ENVRC_REV=2
+ENVRC_REV=3
 
 # envrc_rev_of FILE — the rev stamp of an .envrc, empty if unstamped.
 envrc_rev_of() {
@@ -311,7 +311,7 @@ source_up_if_exists
 # Explicit watch list: dotenv_if_exists also watches, but only the files the
 # active branch touches. Watching all of them (existing or not) means edits —
 # including through the .env symlink — and file creation both trigger a reload.
-watch_file .test-mode .env .env.local .env.test
+watch_file .test-mode .env .env.local .env.test .env.test.example
 
 if [ -f .test-mode ]; then
   export OTS_ENV_LOADED=test
@@ -320,6 +320,25 @@ if [ -f .test-mode ]; then
 else
   export OTS_ENV_LOADED=dev
   export RACK_ENV=development
+
+  # source_up_if_exists can inherit a TEST MODE environment from a parent
+  # checkout (worktrees live under the main checkout; if it has .test-mode,
+  # its .env.test is already exported here). Keys that .env does not also
+  # define survive into dev mode — e.g. PGPORT=2154 retargets a port-less
+  # AUTH_DATABASE_URL (...@authdb/...) at the test Postgres, which has no
+  # ots_* roles; ENABLE_*/HMAC_SECRET/STDOUT_SYNC leak the same way. Clear
+  # every key the test env file declares before loading .env. A dev-only
+  # checkout has no .env.test, so fall back to the tracked example.
+  for _ots_env_file in .env.test .env.test.example; do
+    if [ -f "\$_ots_env_file" ]; then
+      for _ots_var in \$(sed -nE 's/^(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)=.*/\2/p' "\$_ots_env_file"); do
+        unset "\$_ots_var"
+      done
+      break
+    fi
+  done
+  unset _ots_env_file _ots_var
+
   dotenv_if_exists
 
   # .env.local overrides happen last if the file exists. And only in dev mode.


### PR DESCRIPTION
## Summary

Two local-dev boot failures seen today, each with a one-file fix:

**1. `.envrc` template — test-mode env leaks into dev-mode worktrees** (`scripts/setup/lib.sh`, `ENVRC_REV` 2 → 3)

Worktrees live under the main checkout and `.envrc` begins with `source_up_if_exists`. When the main checkout has `.test-mode`, its `.env.test` is exported into every worktree shell *before* the worktree's own dev-mode `.env` loads. Keys `.env` doesn't define survive:

- `PGPORT=2154` retargets a port-less `AUTH_DATABASE_URL` (`…@authdb/…`, `authdb` → 127.0.0.1 via /etc/hosts) at the **test** Postgres container, which has no `ots_*` roles → `password authentication failed for user "ots_migrator"`. Looks like a dropped DB user; the dev PG on :5432 is untouched.
- `ENABLE_MFA`/`ENABLE_WEBAUTHN`/…, `HMAC_SECRET`, `STDOUT_SYNC`, `OIDC_*`, `STRIPE_*` leak the same way.

Fix: the dev branch of the template unsets every key declared in `.env.test` (fallback: tracked `.env.test.example`, for dev-only checkouts) before `dotenv_if_exists`, and `watch_file` includes `.env.test.example`. Stale `.envrc` files regenerate on the next `bin/setup` (old file kept as `.envrc.bak`).

**2. `i18n content compile` torn writes** (`locales/scripts/i18n/io.py`)

`save_json_file` wrote `generated/locales/<loc>.json` in place. A compile killed mid-write (or racing a backend boot) leaves a truncated file and puma dies at `[16/26] Load Locales` with `Familia::SerializerError: Hash/Object not terminated`. Now writes a sibling `.<name>.tmp` and `os.replace()`s it into place.

## Verification

- `direnv exec .` in a worktree under a TEST MODE parent: `PGPORT`, `AUTH_DATABASE_URL_*PG`, `ENABLE_MFA`, `HMAC_SECRET` unset; `OTS_ENV_LOADED=dev`, `RACK_ENV=development`, `AUTH_DATABASE_URL_MIGRATIONS` → `ots_migrator@authdb`.
- Generated `.envrc` passes `bash -n`; rev stamp 3.
- `pnpm run locales:sync` → all 30 locale files parse, no `.tmp` leftovers; `locales/scripts` pytest 102 passed.

Not addressed (flagging): the mirror case — a test-mode worktree under a dev-mode parent inherits `.env` keys `.env.test` doesn't override (only `AUTH_DATABASE_URL`/`_MIGRATIONS` are explicitly blanked there).