### PR TITLE
Gate passphrase verification on continue; drop correct_passphrase from secret details

### DIFF
--- a/apps/api/v1/logic/secrets/burn_secret.rb
+++ b/apps/api/v1/logic/secrets/burn_secret.rb
@@ -41,12 +41,19 @@ module V1::Logic
           # destroys the secret.
           check_passphrase_rate_limit!(potential_secret.identifier, passphrase_client_ip) if potential_secret.has_passphrase?
 
-          @correct_passphrase = !potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase)
+          # Verify the passphrase ONLY on a committed burn (continue=true): a
+          # request that is not going through with the burn must never learn
+          # whether a guess was right, and never accrues or clears rate-limit
+          # state -- nothing was checked.
+          #
+          # `continue` is the parsed boolean (true / 'true' only), never the
+          # raw param: the raw value treats any non-empty string as truthy, so
+          # a deliberate `continue=false` would burn the secret anyway. Folding
+          # it into correct_passphrase also keeps the wrong-passphrase branch
+          # below from firing on a request that never committed to the burn.
+          @correct_passphrase = continue && (!potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase))
           viewable = potential_secret.viewable?
-          # Use the parsed boolean (true / 'true' only), not the raw param: the
-          # raw value treats any non-empty string as truthy, so a deliberate
-          # `continue=false` would burn the secret anyway.
-          @greenlighted = viewable && correct_passphrase && continue
+          @greenlighted = viewable && correct_passphrase
 
           if greenlighted
             @secret = potential_secret
@@ -64,8 +71,11 @@ module V1::Logic
             # TODO:
             # Onetime::Customer.global.increment_field :secrets_burned
 
-          elsif !correct_passphrase
-            # Record failed attempt for rate limiting
+          elsif continue && !correct_passphrase
+            # Record failed attempt for rate limiting. Only a committed burn
+            # reaches this branch: without the continue guard a probe with a
+            # wrong guess raised while a right one did not, which leaked the
+            # verdict through the HTTP status alone.
             record_failed_passphrase_attempt!(potential_secret.identifier, passphrase_client_ip)
 
             message = I18n.t('web.COMMON.error_passphrase', locale: locale, default: 'Incorrect passphrase')

--- a/apps/api/v1/logic/secrets/show_secret.rb
+++ b/apps/api/v1/logic/secrets/show_secret.rb
@@ -37,15 +37,23 @@ module V1::Logic
       end
 
       def process
-        @correct_passphrase = !secret.has_passphrase? || secret.passphrase?(passphrase)
-        @show_secret = secret.viewable? && correct_passphrase && continue
+        # Verify the passphrase ONLY on a committed reveal (continue=true): a
+        # metadata-only request must never learn whether a guess was right, and
+        # never accrues or clears rate-limit state -- nothing was checked.
+        # Folding continue in here (rather than only into show_secret) is what
+        # closes the oracle: correct_passphrase is false for every
+        # metadata-only request, right guess or wrong.
+        @correct_passphrase = continue && (!secret.has_passphrase? || secret.passphrase?(passphrase))
+        @show_secret = secret.viewable? && correct_passphrase
         @verification = secret.verification.to_s == "true"
         @secret_key = @secret.identifier # Use identifier, not deprecated .key field
 
         # Track passphrase attempts for rate limiting. Only non-empty
-        # submissions count: the initial preview of a passphrase-protected
-        # secret sends an empty passphrase and must not accrue attempts.
-        if secret.has_passphrase? && !passphrase.empty?
+        # submissions on a committed reveal count: the initial preview of a
+        # passphrase-protected secret sends an empty passphrase, and a
+        # continue=false request never had its passphrase checked at all, so
+        # neither must accrue attempts.
+        if continue && secret.has_passphrase? && !passphrase.empty?
           if correct_passphrase
             # Clear rate limit on successful passphrase
             clear_passphrase_rate_limit!(secret.identifier, passphrase_client_ip)
@@ -113,8 +121,6 @@ module V1::Logic
             @secret_value = nil
           end
 
-        elsif continue && secret.has_passphrase? && !correct_passphrase
-
         end
 
         domain = if domains_enabled && !secret.share_domain.to_s.empty?
@@ -138,13 +144,15 @@ module V1::Logic
 
       def success_data
         return nil unless secret
+        # correct_passphrase is deliberately NOT serialized: returning the
+        # verdict turned a metadata-only request into a passphrase oracle. It
+        # stays available in-process (attr_reader) for the reveal path.
         ret = {
           record: secret.safe_dump,
           details: {
             continue: @continue,
             is_owner: @is_owner,
             show_secret: @show_secret,
-            correct_passphrase: @correct_passphrase,
             display_lines: @display_lines,
             one_liner: @one_liner,
           },

--- a/apps/api/v1/logic/secrets/show_secret.rb
+++ b/apps/api/v1/logic/secrets/show_secret.rb
@@ -144,9 +144,8 @@ module V1::Logic
 
       def success_data
         return nil unless secret
-        # correct_passphrase is deliberately NOT serialized: returning the
-        # verdict turned a metadata-only request into a passphrase oracle. It
-        # stays available in-process (attr_reader) for the reveal path.
+        # correct_passphrase is not serialized: the verdict is a passphrase
+        # oracle. See #process.
         ret = {
           record: secret.safe_dump,
           details: {

--- a/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/burn_secret_spec.rb
@@ -178,6 +178,24 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
         expect(secret).not_to have_received(:burned!)
       end
 
+      # Passphrase oracle regression: the guess is verified ONLY on a committed
+      # burn (continue=true). A continue=false probe must not distinguish a
+      # right guess from a wrong one, and must not spend a rate-limit attempt
+      # on a guess that was never checked.
+      context 'when continue is false' do
+        subject { described_class.new(session, customer, base_params.merge('continue' => 'false')) }
+
+        it 'does not check the guess, does not burn, and records no attempt' do
+          expect(secret).not_to receive(:passphrase?)
+
+          expect { subject.process }.not_to raise_error
+
+          expect(subject.greenlighted).to be_falsey
+          expect(secret).not_to have_received(:burned!)
+          expect(Onetime::Secret.dbclient.get("passphrase:attempts:#{secret_identifier}")).to be_nil
+        end
+      end
+
       it 'rejects further attempts once locked out, before checking the passphrase' do
         Onetime::Secret.dbclient.setex("passphrase:locked:#{secret_identifier}", 60, '1')
 
@@ -199,6 +217,16 @@ RSpec.describe V1::Logic::Secrets::BurnSecret do
 
         before do
           allow(secret).to receive(:burned!).and_return(true)
+        end
+
+        it 'does not burn, or check the guess, when continue is false' do
+          probe = described_class.new(session, customer, base_params.merge('continue' => 'false'))
+          expect(secret).not_to receive(:passphrase?)
+
+          probe.process
+
+          expect(probe.greenlighted).to be_falsey
+          expect(secret).not_to have_received(:burned!)
         end
 
         it 'clears rate limit state and burns' do

--- a/apps/api/v1/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v1/spec/logic/secrets/show_secret_spec.rb
@@ -116,6 +116,36 @@ RSpec.describe V1::Logic::Secrets::ShowSecret do
         expect(subject.correct_passphrase).to be false
       end
     end
+
+    # Passphrase oracle regression: the guess is verified ONLY on a committed
+    # reveal (continue=true). A metadata-only request must learn nothing about
+    # the guess -- no correct_passphrase in the payload and no rate-limit state
+    # touched, because nothing was checked.
+    context 'when continue is false on a passphrase-protected secret' do
+      subject { described_class.new(session, customer, base_params.merge('continue' => 'false')) }
+
+      before do
+        allow(secret).to receive(:viewable?).and_return(true)
+        allow(secret).to receive(:has_passphrase?).and_return(true)
+        allow(secret).to receive(:passphrase?).and_return(false)
+        allow(secret).to receive(:owner?).with(customer).and_return(false)
+        allow(secret).to receive(:safe_dump).and_return({ key: 'secret123' })
+      end
+
+      it 'never checks the passphrase' do
+        expect(secret).not_to receive(:passphrase?)
+
+        subject.process
+      end
+
+      it 'exposes no correct_passphrase in the response details' do
+        subject.process
+
+        expect(subject.show_secret).to be false
+        expect(subject.success_data[:details]).not_to have_key(:correct_passphrase)
+        expect(subject.success_data[:record]).not_to have_key(:secret_value)
+      end
+    end
   end
 
   # v1 show shares the passphrase rate limiter with v2 show/reveal. Wrong
@@ -162,6 +192,17 @@ RSpec.describe V1::Logic::Secrets::ShowSecret do
       expect(Onetime::Secret.dbclient.get("passphrase:attempts:#{secret_identifier}")).to be_nil
     end
 
+    # A continue=false guess is not an attempt: the passphrase was never
+    # checked, so the limiter must neither accrue nor clear anything.
+    it 'does not count a continue=false guess as an attempt' do
+      probe = described_class.new(session, customer, params.merge('continue' => 'false'))
+      expect(rl_secret).not_to receive(:passphrase?)
+
+      probe.process
+
+      expect(Onetime::Secret.dbclient.get("passphrase:attempts:#{secret_identifier}")).to be_nil
+    end
+
     it 'raises LimitExceeded from raise_concerns once locked out' do
       Onetime::Secret.dbclient.setex("passphrase:locked:#{secret_identifier}", 60, '1')
 
@@ -174,7 +215,6 @@ RSpec.describe V1::Logic::Secrets::ShowSecret do
       allow(secret).to receive(:safe_dump).and_return({key: 'secret123'})
       subject.instance_variable_set(:@show_secret, true)
       subject.instance_variable_set(:@is_owner, false)
-      subject.instance_variable_set(:@correct_passphrase, true)
       subject.instance_variable_set(:@display_lines, 5)
       subject.instance_variable_set(:@one_liner, true)
       subject.instance_variable_set(:@secret_value, 'secret_content')
@@ -186,6 +226,9 @@ RSpec.describe V1::Logic::Secrets::ShowSecret do
       expect(result).to include(:record, :details)
       expect(result[:record]).to include(:secret_value)
       expect(result[:details][:show_secret]).to be true
+      # The passphrase verdict is never serialized to the client -- it is an
+      # oracle for anyone probing with continue=false.
+      expect(result[:details]).not_to have_key(:correct_passphrase)
     end
   end
 

--- a/apps/api/v2/logic/secrets/burn_secret.rb
+++ b/apps/api/v2/logic/secrets/burn_secret.rb
@@ -61,12 +61,19 @@ module V2::Logic
         # destroys the secret.
         check_passphrase_rate_limit!(potential_secret.identifier, passphrase_client_ip) if potential_secret.has_passphrase?
 
-        @correct_passphrase = !potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase)
+        # Verify the passphrase ONLY on a committed burn (continue=true): a
+        # request that is not going through with the burn must never learn
+        # whether a guess was right, and never accrues or clears rate-limit
+        # state -- nothing was checked.
+        #
+        # `continue` is the parsed boolean (true / 'true' only), never the raw
+        # param: the raw value treats any non-empty string as truthy, so a
+        # deliberate `continue=false` would burn the secret anyway. Folding it
+        # into correct_passphrase also keeps the wrong-passphrase branch below
+        # from firing on a request that never committed to the burn.
+        @correct_passphrase = continue && (!potential_secret.has_passphrase? || potential_secret.passphrase?(passphrase))
         viewable            = potential_secret.viewable?
-        # Use the parsed boolean (true / 'true' only), not the raw param: the
-        # raw value treats any non-empty string as truthy, so a deliberate
-        # `continue=false` would burn the secret anyway.
-        @greenlighted       = viewable && correct_passphrase && continue
+        @greenlighted       = viewable && correct_passphrase
 
         secret_logger.debug 'Secret burn initiated',
           {
@@ -124,8 +131,11 @@ module V2::Logic
               }
           end
 
-        elsif !correct_passphrase
-          # Record failed attempt for rate limiting
+        elsif continue && !correct_passphrase
+          # Record failed attempt for rate limiting. Only a committed burn
+          # reaches this branch: without the continue guard a probe with a
+          # wrong guess raised while a right one did not, which leaked the
+          # verdict through the HTTP status alone.
           attempt_count = record_failed_passphrase_attempt!(potential_secret.identifier, passphrase_client_ip)
 
           secret_logger.warn 'Burn failed - incorrect passphrase',

--- a/apps/api/v2/logic/secrets/burn_secret.rb
+++ b/apps/api/v2/logic/secrets/burn_secret.rb
@@ -81,7 +81,8 @@ module V2::Logic
             secret_identifier: potential_secret.shortid,
             viewable: viewable,
             has_passphrase: potential_secret.has_passphrase?,
-            passphrase_correct: correct_passphrase,
+            # nil when continue=false: the guess was never checked.
+            passphrase_correct: (correct_passphrase if continue),
             continue: continue,
             # extid, never custid: custid holds the email address on legacy
             # (pre-v0.22) records, which would put PII in the payload.

--- a/apps/api/v2/logic/secrets/burn_secret.rb
+++ b/apps/api/v2/logic/secrets/burn_secret.rb
@@ -48,18 +48,18 @@ module V2::Logic
         require_guest_route_enabled!(:burn)
         require_entitlement!('api_access')
         raise OT::MissingSecret if receipt.nil?
-      end
-
-      def process
-        potential_secret = @receipt.load_secret
-
-        return unless potential_secret
 
         # Check passphrase rate limit before allowing passphrase attempts.
         # Burn is the same brute-force oracle as show/reveal: each wrong
         # guess confirms the passphrase is wrong, and a correct guess
-        # destroys the secret.
-        check_passphrase_rate_limit!(potential_secret.identifier, passphrase_client_ip) if potential_secret.has_passphrase?
+        # destroys the secret. The gate belongs here, alongside ShowSecret's
+        # and RevealSecret's, so it cannot be stranded behind a guard clause
+        # that a later edit to #process moves ahead of it.
+        check_passphrase_rate_limit!(potential_secret.identifier, passphrase_client_ip) if potential_secret&.has_passphrase?
+      end
+
+      def process
+        return unless potential_secret
 
         # Verify the passphrase ONLY on a committed burn (continue=true): a
         # request that is not going through with the burn must never learn
@@ -211,6 +211,15 @@ module V2::Logic
       end
 
       private
+
+      # The secret behind the receipt, loaded once and memoized: raise_concerns
+      # needs it for the rate-limit gate and #process needs it again. nil when
+      # the secret is already gone (revealed, burned, or expired).
+      def potential_secret
+        return @potential_secret if defined?(@potential_secret)
+
+        @potential_secret = receipt&.load_secret
+      end
 
       # Client IP for the per-secret+IP passphrase rate-limit tier (M-8). Sourced
       # from strategy_result metadata (set for both anonymous and authenticated

--- a/apps/api/v2/logic/secrets/reveal_secret.rb
+++ b/apps/api/v2/logic/secrets/reveal_secret.rb
@@ -104,11 +104,12 @@ module V2::Logic
 
         # Rate-limit bookkeeping is settled on the passphrase verdict alone,
         # before any reveal claim -- the same ordering as ShowSecret. Clearing
-        # it inside the reveal branch below tied the clear to winning the
-        # burn-after-reading race, so two callers with the same correct
-        # passphrase got different rate-limit state. Gated on continue for the
-        # same reason as the verdict above: a guess that was never checked is
-        # neither an attempt nor grounds for a clear.
+        # it inside the reveal branch below gated the clear on the process-time
+        # show_secret verdict: a concurrent consumer claiming the secret after
+        # raise_concerns but before the viewable? recompute above left a
+        # correct passphrase verification without its clear. Gated on continue
+        # for the same reason as the verdict above: a guess that was never
+        # checked is neither an attempt nor grounds for a clear.
         attempt_count = nil
         if continue && secret.has_passphrase?
           if correct_passphrase

--- a/apps/api/v2/logic/secrets/reveal_secret.rb
+++ b/apps/api/v2/logic/secrets/reveal_secret.rb
@@ -102,6 +102,22 @@ module V2::Logic
             user_id: cust&.extid,
           }
 
+        # Rate-limit bookkeeping is settled on the passphrase verdict alone,
+        # before any reveal claim -- the same ordering as ShowSecret. Clearing
+        # it inside the reveal branch below tied the clear to winning the
+        # burn-after-reading race, so two callers with the same correct
+        # passphrase got different rate-limit state. Gated on continue for the
+        # same reason as the verdict above: a guess that was never checked is
+        # neither an attempt nor grounds for a clear.
+        attempt_count = nil
+        if continue && secret.has_passphrase?
+          if correct_passphrase
+            clear_passphrase_rate_limit!(secret.identifier, passphrase_client_ip)
+          else
+            attempt_count = record_failed_passphrase_attempt!(secret.identifier, passphrase_client_ip)
+          end
+        end
+
         owner = secret.load_owner
         if show_secret
           # Compute the actor attribution BEFORE reveal! consumes the secret:
@@ -109,9 +125,6 @@ module V2::Logic
           # reveal! path below so the 'revealed' audit event records who acted
           # (#3639). The anonymous guard lives in lifecycle_actor_context.
           actor_context = lifecycle_actor_context(secret)
-
-          # Clear any rate limit state on successful passphrase entry
-          clear_passphrase_rate_limit!(secret.identifier, passphrase_client_ip) if secret.has_passphrase?
 
           # Decryption is deferred to secret.reveal! below: it decrypts ONLY on
           # the caller that wins the atomic reveal claim, so a request that lost
@@ -219,12 +232,11 @@ module V2::Logic
           @show_secret = false if @secret_value.nil?
 
         elsif continue && secret.has_passphrase? && !correct_passphrase
-          # Record failed attempt for rate limiting. Only a committed reveal
-          # reaches this branch: without the continue guard a metadata-only
-          # request with a wrong guess raised while a right one did not, which
-          # leaked the verdict through the HTTP status alone.
-          attempt_count = record_failed_passphrase_attempt!(secret.identifier, passphrase_client_ip)
-
+          # The failed attempt was already recorded above; attempt_count carries
+          # the count. Only a committed reveal reaches this branch: without the
+          # continue guard a metadata-only request with a wrong guess raised
+          # while a right one did not, which leaked the verdict through the HTTP
+          # status alone.
           secret_logger.warn 'Incorrect passphrase attempt',
             {
               secret_identifier: secret.shortid,

--- a/apps/api/v2/logic/secrets/reveal_secret.rb
+++ b/apps/api/v2/logic/secrets/reveal_secret.rb
@@ -77,8 +77,14 @@ module V2::Logic
       end
 
       def process # rubocop:disable Metrics/PerceivedComplexity
-        @correct_passphrase = secret.passphrase?(passphrase)
-        @show_secret        = secret.viewable? && (correct_passphrase || !secret.has_passphrase?) && continue
+        # Verify the passphrase ONLY on a committed reveal (continue=true): a
+        # metadata-only request must never learn whether a guess was right, and
+        # never accrues or clears rate-limit state -- nothing was checked.
+        # Same shape as ShowSecret: continue is folded into correct_passphrase
+        # so the flag is false for every metadata-only request, right guess or
+        # wrong, and the wrong-passphrase branch below cannot fire on one.
+        @correct_passphrase = continue && (!secret.has_passphrase? || secret.passphrase?(passphrase))
+        @show_secret        = secret.viewable? && correct_passphrase
         @verification       = secret.verification.to_s == 'true'
         @secret_identifier  = @secret.identifier
         @secret_shortid     = @secret.shortid
@@ -211,8 +217,11 @@ module V2::Logic
           # already consumed the secret): do not present it as viewable.
           @show_secret = false if @secret_value.nil?
 
-        elsif secret.has_passphrase? && !correct_passphrase
-          # Record failed attempt for rate limiting
+        elsif continue && secret.has_passphrase? && !correct_passphrase
+          # Record failed attempt for rate limiting. Only a committed reveal
+          # reaches this branch: without the continue guard a metadata-only
+          # request with a wrong guess raised while a right one did not, which
+          # leaked the verdict through the HTTP status alone.
           attempt_count = record_failed_passphrase_attempt!(secret.identifier, passphrase_client_ip)
 
           secret_logger.warn 'Incorrect passphrase attempt',
@@ -251,13 +260,16 @@ module V2::Logic
       def success_data
         return nil unless secret
 
+        # correct_passphrase is deliberately NOT serialized: returning the
+        # verdict turned a metadata-only request into a passphrase oracle. The
+        # server-side debug log above still records passphrase_correct -- that
+        # is diagnostics for the operator, not a response field.
         ret = {
           record: secret.safe_dump,
           details: {
             continue: @continue,
             is_owner: @is_owner,
             show_secret: @show_secret,
-            correct_passphrase: @correct_passphrase,
             display_lines: @display_lines,
             one_liner: @one_liner,
           },

--- a/apps/api/v2/logic/secrets/reveal_secret.rb
+++ b/apps/api/v2/logic/secrets/reveal_secret.rb
@@ -94,7 +94,8 @@ module V2::Logic
             secret_identifier: secret.shortid,
             viewable: secret.viewable?,
             has_passphrase: secret.has_passphrase?,
-            passphrase_correct: correct_passphrase,
+            # nil when continue=false: the guess was never checked.
+            passphrase_correct: (correct_passphrase if continue),
             continue: continue,
             # extid, never custid: custid holds the email address on legacy
             # (pre-v0.22) records, which would put PII in the payload.
@@ -260,10 +261,8 @@ module V2::Logic
       def success_data
         return nil unless secret
 
-        # correct_passphrase is deliberately NOT serialized: returning the
-        # verdict turned a metadata-only request into a passphrase oracle. The
-        # server-side debug log above still records passphrase_correct -- that
-        # is diagnostics for the operator, not a response field.
+        # correct_passphrase is not serialized: the verdict is a passphrase
+        # oracle. See #process. (The server-side debug log still carries it.)
         ret = {
           record: secret.safe_dump,
           details: {

--- a/apps/api/v2/logic/secrets/show_secret.rb
+++ b/apps/api/v2/logic/secrets/show_secret.rb
@@ -13,8 +13,9 @@ module V2::Logic
     # @api Retrieves a secret's metadata and optionally its decrypted content.
     #   When called with continue=true and the correct passphrase, the secret
     #   value is returned and the secret is consumed. Without continue, returns
-    #   only metadata such as whether a passphrase is required. The secret can
-    #   only be viewed once.
+    #   only metadata such as whether a passphrase is required -- and nothing
+    #   about the submitted passphrase, which is not even checked in that case
+    #   (see #process). The secret can only be viewed once.
     class ShowSecret < V2::Logic::Base
       include AccessTelemetry
       include ActorAttribution
@@ -63,13 +64,20 @@ module V2::Logic
       end
 
       def process
-        @correct_passphrase = !secret.has_passphrase? || secret.passphrase?(passphrase)
-        @show_secret        = secret.viewable? && correct_passphrase && continue
+        # Verify the passphrase ONLY on a committed reveal (continue=true): a
+        # metadata-only request must never learn whether a guess was right, and
+        # never accrues or clears rate-limit state -- nothing was checked.
+        # Folding continue in here (rather than only into show_secret) is what
+        # closes the oracle: correct_passphrase is false for every
+        # metadata-only request, right guess or wrong.
+        @correct_passphrase = continue && (!secret.has_passphrase? || secret.passphrase?(passphrase))
+        @show_secret        = secret.viewable? && correct_passphrase
         @verification       = secret.verification.to_s == 'true'
         @secret_identifier  = @secret.identifier
 
-        # Track passphrase attempts for rate limiting
-        if secret.has_passphrase? && !passphrase.empty?
+        # Track passphrase attempts for rate limiting. Gated on continue for
+        # the same reason: a guess that was never checked is not an attempt.
+        if continue && secret.has_passphrase? && !passphrase.empty?
           if correct_passphrase
             # Clear rate limit on successful passphrase
             clear_passphrase_rate_limit!(secret.identifier, passphrase_client_ip)
@@ -124,13 +132,15 @@ module V2::Logic
       def success_data
         return nil unless secret
 
+        # correct_passphrase is deliberately NOT serialized: returning the
+        # verdict turned a metadata-only request into a passphrase oracle. It
+        # stays available in-process (attr_reader) for the reveal path.
         ret = {
           record: secret.safe_dump,
           details: {
             continue: @continue,
             is_owner: @is_owner,
             show_secret: @show_secret,
-            correct_passphrase: @correct_passphrase,
             display_lines: @display_lines,
             one_liner: @one_liner,
           },

--- a/apps/api/v2/logic/secrets/show_secret.rb
+++ b/apps/api/v2/logic/secrets/show_secret.rb
@@ -132,9 +132,8 @@ module V2::Logic
       def success_data
         return nil unless secret
 
-        # correct_passphrase is deliberately NOT serialized: returning the
-        # verdict turned a metadata-only request into a passphrase oracle. It
-        # stays available in-process (attr_reader) for the reveal path.
+        # correct_passphrase is not serialized: the verdict is a passphrase
+        # oracle. See #process.
         ret = {
           record: secret.safe_dump,
           details: {

--- a/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
@@ -299,6 +299,10 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
       secret.update_passphrase!('correct horse battery')
     end
 
+    # Run the controller's ordered entry points, not process alone: the
+    # rate-limit gate lives in raise_concerns (alongside ShowSecret's and
+    # RevealSecret's), so a helper that skipped it would test a flow no
+    # request ever takes.
     def attempt_burn(guess)
       logic = build_logic(
         'identifier' => receipt.identifier,
@@ -306,6 +310,7 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
         'passphrase' => guess,
       )
       logic.process_params
+      logic.raise_concerns
       logic.process
       logic
     end
@@ -329,6 +334,23 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
       # The lockout rejected the request before the burn could happen.
       reloaded = Onetime::Secret.load(secret.identifier)
       expect(reloaded&.viewable?).to be true
+    end
+
+    it 'enforces the lockout in raise_concerns, before process runs at all' do
+      max = Onetime::Security::PassphraseRateLimiter::MAX_ATTEMPTS
+      max.times { expect { attempt_burn('wrong') }.to raise_error(OT::FormError) }
+
+      locked = build_logic(
+        'identifier' => receipt.identifier,
+        'continue'   => 'true',
+        'passphrase' => 'correct horse battery',
+      )
+      locked.process_params
+
+      # raise_concerns alone must refuse it: the controller never reaches
+      # process, so the secret is still there afterwards.
+      expect { locked.raise_concerns }.to raise_error(Onetime::LimitExceeded)
+      expect(Onetime::Secret.load(secret.identifier)&.viewable?).to be true
     end
 
     it 'clears rate limit state and burns on the correct passphrase' do

--- a/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/burn_secret_spec.rb
@@ -339,5 +339,48 @@ RSpec.describe V2::Logic::Secrets::BurnSecret, type: :integration do
       expect(logic.greenlighted).to be true
       expect(Onetime::Secret.dbclient.get("passphrase:attempts:#{secret.identifier}")).to be_nil
     end
+
+    # Passphrase oracle regression: the guess is verified ONLY on a committed
+    # burn (continue=true). Without the gate, continue=false separated a right
+    # guess (200, nothing burned) from a wrong one (form error) and spent a
+    # rate-limit attempt on a guess that was never acted on.
+    context 'when continue is false' do
+      # The secret is loaded inside process via receipt.load_secret, so pin the
+      # instance first: the message expectation has to be on the object process
+      # will actually use.
+      def probe_burn(guess)
+        logic  = build_logic(
+          'identifier' => receipt.identifier,
+          'continue'   => 'false',
+          'passphrase' => guess,
+        )
+        logic.process_params
+        pinned = Onetime::Secret.load(secret.identifier)
+        allow(logic.receipt).to receive(:load_secret).and_return(pinned)
+        expect(pinned).not_to receive(:passphrase?)
+        logic
+      end
+
+      it 'does not raise on a wrong guess, does not burn, and records no attempt' do
+        logic = probe_burn('wrong')
+
+        expect { logic.process }.not_to raise_error
+
+        expect(logic.greenlighted).to be_falsey
+        expect(Onetime::Secret.dbclient.get("passphrase:attempts:#{secret.identifier}")).to be_nil
+        expect(Onetime::Secret.load(secret.identifier)&.viewable?).to be true
+      end
+
+      it 'answers a right guess exactly as it answers a wrong one' do
+        wrong = probe_burn('wrong')
+        wrong.process
+        correct = probe_burn('correct horse battery')
+        correct.process
+
+        expect(correct.success_data[:success]).to eq(wrong.success_data[:success])
+        expect(correct.success_data[:details]).to eq(wrong.success_data[:details])
+        expect(Onetime::Secret.load(secret.identifier)&.viewable?).to be true
+      end
+    end
   end
 end

--- a/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
@@ -122,6 +122,40 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
       expect(logic.secret_value).to be_nil
       expect(logic.success_data[:record]).not_to have_key(:secret_value)
     end
+
+    # The rate-limit clear is settled on the passphrase verdict, not on winning
+    # the claim: a correct guess earns the clear whether or not this caller got
+    # the plaintext. Regression for the ordering that ran the clear inside the
+    # reveal branch, which made it observable only to the winner and diverged
+    # from ShowSecret, where the clear precedes reveal! entirely.
+    it 'still clears the passphrase rate limit on a correct guess' do
+      secret.update_passphrase!('correct horse battery')
+      attempts_key = "passphrase:attempts:#{secret.identifier}"
+
+      wrong = build_logic(
+        { 'identifier' => secret.identifier, 'continue' => 'true', 'passphrase' => 'nope' },
+      )
+      wrong.process_params
+      expect { wrong.process }.to raise_error(Onetime::FormError)
+      expect(Onetime::Secret.dbclient.get(attempts_key).to_i).to eq(1)
+
+      logic = build_logic(
+        { 'identifier' => secret.identifier, 'continue' => 'true', 'passphrase' => 'correct horse battery' },
+      )
+      logic.process_params
+
+      # Same race recipe as above: a concurrent request takes the claim after
+      # this one passed its viewability check.
+      allow(logic.secret).to receive(:viewable?).and_return(true)
+      winner = Onetime::Secret.load(secret.identifier)
+      expect(winner.revealed!).to be true
+
+      logic.process
+
+      expect(logic.show_secret).to be false
+      expect(logic.secret_value).to be_nil
+      expect(Onetime::Secret.dbclient.get(attempts_key)).to be_nil
+    end
   end
 
   # Actor attribution on reveal (#3639). "Who revealed it" is the first

--- a/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
@@ -17,7 +17,7 @@ require_relative '../../support/actor_attribution_helpers'
 # Uses real Receipt/Secret objects (spawn_pair) so the atomic claim runs
 # against Redis exactly as it does in production. process is exercised directly
 # (raise_concerns, which handles guest-gating/entitlements/rate-limits, is out
-# of scope here).
+# of scope except where an example needs its viewability check for ordering).
 RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
   include ActorAttributionSpecHelpers
 
@@ -123,11 +123,16 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
       expect(logic.success_data[:record]).not_to have_key(:secret_value)
     end
 
-    # The rate-limit clear is settled on the passphrase verdict, not on winning
-    # the claim: a correct guess earns the clear whether or not this caller got
-    # the plaintext. Regression for the ordering that ran the clear inside the
-    # reveal branch, which made it observable only to the winner and diverged
-    # from ShowSecret, where the clear precedes reveal! entirely.
+    # The rate-limit clear is settled on the passphrase verdict, not on the
+    # process-time show_secret verdict: a correct guess earns the clear whether
+    # or not this caller got the plaintext. Regression for the ordering that
+    # ran the clear inside the reveal branch: a concurrent consumer claiming
+    # the secret after raise_concerns but before process recomputed viewability
+    # left a correct verification without its corresponding clear. This race
+    # window is deliberately EARLIER than the one above -- no viewable? stub,
+    # because with one held true the old code entered the reveal branch and
+    # cleared anyway, which is exactly what made the earlier draft of this
+    # example pass against the code it was meant to catch.
     it 'still clears the passphrase rate limit on a correct guess' do
       secret.update_passphrase!('correct horse battery')
       attempts_key = "passphrase:attempts:#{secret.identifier}"
@@ -144,9 +149,10 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
       )
       logic.process_params
 
-      # Same race recipe as above: a concurrent request takes the claim after
-      # this one passed its viewability check.
-      allow(logic.secret).to receive(:viewable?).and_return(true)
+      # Production ordering: this request passes the raise_concerns viewability
+      # check, THEN a concurrent request takes the atomic claim, so process
+      # recomputes viewable? as false and show_secret never becomes true.
+      logic.raise_concerns
       winner = Onetime::Secret.load(secret.identifier)
       expect(winner.revealed!).to be true
 

--- a/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
@@ -388,6 +388,53 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
     end
   end
 
+  # Passphrase oracle regression: the guess is verified ONLY on a committed
+  # reveal (continue=true). Without the gate, continue=false separated a right
+  # guess (200, no reveal) from a wrong one (form error) and burned a
+  # rate-limit attempt on a guess that was never acted on -- a free,
+  # non-destructive brute-force oracle.
+  context 'when continue is false on a passphrase-protected secret' do
+    before { secret.update_passphrase!('correct horse battery') }
+
+    def attempts_key
+      "passphrase:attempts:#{secret.identifier}"
+    end
+
+    # The message expectation must be set on logic.secret: build_logic ->
+    # process_params already loaded this request's own instance from Redis.
+    def probe(guess)
+      logic = build_logic(
+        { 'identifier' => secret.identifier, 'continue' => 'false', 'passphrase' => guess },
+      )
+      logic.process_params
+      expect(logic.secret).not_to receive(:passphrase?)
+      expect { logic.process }.not_to raise_error
+      logic
+    end
+
+    it 'does not raise on a wrong guess, verifies nothing, and records no attempt' do
+      logic = probe('wrong')
+
+      expect(logic.show_secret).to be false
+      expect(logic.secret_value).to be_nil
+      expect(logic.success_data[:details]).not_to have_key(:correct_passphrase)
+      expect(logic.success_data[:record]).not_to have_key(:secret_value)
+      expect(Onetime::Secret.dbclient.get(attempts_key)).to be_nil
+
+      # Nothing was consumed either: the secret is still there to be revealed.
+      expect(Onetime::Secret.load(secret.identifier)&.viewable?).to be true
+    end
+
+    it 'answers a wrong guess identically to a right one' do
+      wrong   = probe('wrong').success_data[:details]
+      correct = probe('correct horse battery').success_data[:details]
+
+      expect(wrong).to eq(correct)
+      expect(Onetime::Secret.dbclient.get(attempts_key)).to be_nil
+      expect(Onetime::Secret.load(secret.identifier)&.viewable?).to be true
+    end
+  end
+
   # C10/QS-6: SECRET lifecycle safety.
   #
   # Fast-fail: when the boot-time verifier flagged a key mismatch, a

--- a/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/reveal_secret_spec.rb
@@ -385,6 +385,10 @@ RSpec.describe V2::Logic::Secrets::RevealSecret, type: :integration do
       payload = payload_for(captured, 'Incorrect passphrase attempt')
       expect(payload[:user_id]).to eq('urrevealer')
       expect(payload.values.join(' ')).not_to include('@')
+
+      # Positive control for the continue=false context below, which asserts
+      # this key stays nil: a committed wrong guess must write it.
+      expect(Onetime::Secret.dbclient.get("passphrase:attempts:#{secret.identifier}").to_i).to eq(1)
     end
   end
 

--- a/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
@@ -201,6 +201,63 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
     end
   end
 
+  # Passphrase oracle regression: the guess is verified ONLY on a committed
+  # reveal (continue=true). A metadata-only request must learn nothing about a
+  # guess -- no correct_passphrase in the payload, no difference between a right
+  # and a wrong guess, and no rate-limit state written or cleared, because
+  # nothing was checked. Without the gate, GET ?passphrase=guess&continue=false
+  # is a free, non-destructive brute-force oracle.
+  context 'passphrase-protected secrets and the continue gate' do
+    before { secret.update_passphrase!('correct horse battery') }
+
+    def attempts_key
+      "passphrase:attempts:#{secret.identifier}"
+    end
+
+    # The message expectation must be set on logic.secret: build_logic ->
+    # process_params already loaded this request's own instance from Redis.
+    def probe(guess)
+      logic = build_logic(
+        { 'identifier' => secret.identifier, 'continue' => 'false', 'passphrase' => guess },
+      )
+      logic.process_params
+      expect(logic.secret).not_to receive(:passphrase?)
+      logic.process
+      logic
+    end
+
+    context 'when continue is false on a passphrase-protected secret' do
+      it 'never checks the guess, reveals nothing, and records no attempt' do
+        logic = probe('correct horse battery')
+
+        expect(logic.show_secret).to be false
+        expect(logic.secret_value).to be_nil
+        expect(logic.success_data[:details]).not_to have_key(:correct_passphrase)
+        expect(logic.success_data[:record]).not_to have_key(:secret_value)
+        expect(Onetime::Secret.dbclient.get(attempts_key)).to be_nil
+      end
+
+      it 'answers a wrong guess byte-identically to a right one' do
+        correct = probe('correct horse battery').success_data[:details]
+        wrong   = probe('nope').success_data[:details]
+
+        expect(wrong).to eq(correct)
+        expect(Onetime::Secret.dbclient.get(attempts_key)).to be_nil
+      end
+    end
+
+    it 'omits correct_passphrase from the details on a committed reveal too' do
+      logic = build_logic(
+        { 'identifier' => secret.identifier, 'continue' => 'true', 'passphrase' => 'correct horse battery' },
+      )
+      logic.process_params
+      logic.process
+
+      expect(logic.show_secret).to be true
+      expect(logic.success_data[:details]).not_to have_key(:correct_passphrase)
+    end
+  end
+
   context 'when a concurrent request already won the reveal (this request loses)' do
     it 'does NOT emit the plaintext' do
       logic = build_logic({ 'identifier' => secret.identifier, 'continue' => 'true' })

--- a/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
+++ b/apps/api/v2/spec/logic/secrets/show_secret_spec.rb
@@ -246,6 +246,20 @@ RSpec.describe V2::Logic::Secrets::ShowSecret, type: :integration do
       end
     end
 
+    # Positive control for the attempts_key assertions above: a committed
+    # wrong guess must write the key, otherwise the nil checks would pass
+    # vacuously if the key format ever drifted from the limiter's.
+    it 'records the attempt on a committed wrong guess' do
+      logic = build_logic(
+        { 'identifier' => secret.identifier, 'continue' => 'true', 'passphrase' => 'nope' },
+      )
+      logic.process_params
+      logic.process
+
+      expect(logic.show_secret).to be false
+      expect(Onetime::Secret.dbclient.get(attempts_key).to_i).to eq(1)
+    end
+
     it 'omits correct_passphrase from the details on a committed reveal too' do
       logic = build_logic(
         { 'identifier' => secret.identifier, 'continue' => 'true', 'passphrase' => 'correct horse battery' },

--- a/changelog.d/20260822_101500_passphrase_verification_continue_gate.rst
+++ b/changelog.d/20260822_101500_passphrase_verification_continue_gate.rst
@@ -1,0 +1,15 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Passphrase verification on the secret show, reveal, and burn endpoints
+  (v1 and v2) now runs only when ``continue=true``. A metadata-only
+  request (``continue`` absent or ``false``) no longer evaluates the
+  supplied passphrase, so it cannot be used to test guesses without
+  consuming the secret, and it no longer records or clears rate-limit
+  state. ``details.correct_passphrase`` has been removed from the v1 and
+  v2 secret responses; clients should use ``details.show_secret``, which
+  is true only when the passphrase was correct and the reveal was
+  committed. The v2 reveal and both burn endpoints now return the same
+  status for a right or wrong passphrase when ``continue=false``.

--- a/changelog.d/20260822_101500_passphrase_verification_continue_gate.rst
+++ b/changelog.d/20260822_101500_passphrase_verification_continue_gate.rst
@@ -3,13 +3,15 @@
 Security
 --------
 
-- Passphrase verification on the secret show, reveal, and burn endpoints
-  (v1 and v2) now runs only when ``continue=true``. A metadata-only
-  request (``continue`` absent or ``false``) no longer evaluates the
-  supplied passphrase, so it cannot be used to test guesses without
-  consuming the secret, and it no longer records or clears rate-limit
-  state. ``details.correct_passphrase`` has been removed from the v1 and
-  v2 secret responses; clients should use ``details.show_secret``, which
-  is true only when the passphrase was correct and the reveal was
-  committed. The v2 reveal and both burn endpoints now return the same
-  status for a right or wrong passphrase when ``continue=false``.
+- Passphrase verification on the v2 secret show, reveal, and burn endpoints
+  now runs only when ``continue=true``. A metadata-only request
+  (``continue`` absent or ``false``) no longer evaluates the supplied
+  passphrase, so it cannot be used to test guesses without consuming the
+  secret, and it no longer records or clears rate-limit state.
+  ``details.correct_passphrase`` has been removed from the v2 secret
+  responses; clients should use ``details.show_secret``, which is true only
+  when the passphrase was correct and the reveal was committed. The v2
+  reveal and burn endpoints now return the same status for a right or wrong
+  passphrase when ``continue=false``. The v1 logic classes carry the same
+  change for parity; the v1 API was not exposed, since its controller
+  always commits (``continue=true``) and never returned the verdict.

--- a/src/schemas/contracts/secret.ts
+++ b/src/schemas/contracts/secret.ts
@@ -201,16 +201,22 @@ export const secretWithTimestampsCanonical = secretCanonical.extend({
  * @example
  * ```typescript
  * const details = secretDetailsCanonical.parse(apiResponse.details);
- * if (details.show_secret && details.correct_passphrase) {
+ * if (details.show_secret) {
  *   // Display the secret content
  * }
  * ```
+ *
+ * @remarks
+ * `show_secret` is the only reveal signal. The backend deliberately does not
+ * report whether a supplied passphrase was correct — it only verifies the
+ * passphrase when the caller commits to the reveal (`continue: true`), so a
+ * probe cannot be used as a passphrase oracle. Older backends may still emit
+ * `details.correct_passphrase`; this schema strips it.
  */
 export const secretDetailsCanonical = z.object({
   continue: z.boolean(),
   is_owner: z.boolean(),
   show_secret: z.boolean(),
-  correct_passphrase: z.boolean(),
   display_lines: z.number(),
   one_liner: z.boolean().nullable(),
 });

--- a/src/schemas/shapes/v2/secret.ts
+++ b/src/schemas/shapes/v2/secret.ts
@@ -110,7 +110,6 @@ export const secretDetailsSchema = secretDetailsCanonical.extend({
   continue: transforms.fromString.boolean,
   is_owner: transforms.fromString.boolean,
   show_secret: transforms.fromString.boolean,
-  correct_passphrase: transforms.fromString.boolean,
   display_lines: transforms.fromString.number,
   one_liner: transforms.fromString.boolean.nullable(),
 });

--- a/src/tests/contracts/issue-3424-failing-field-forensics.spec.ts
+++ b/src/tests/contracts/issue-3424-failing-field-forensics.spec.ts
@@ -104,7 +104,6 @@ function secretShowResponse(recordOverrides: Record<string, unknown> = {}) {
       continue: false,
       is_owner: false,
       show_secret: false,
-      correct_passphrase: true,
       display_lines: 4,
       one_liner: null,
     },

--- a/src/tests/contracts/secret-schema-contract.spec.ts
+++ b/src/tests/contracts/secret-schema-contract.spec.ts
@@ -3,9 +3,19 @@
 // Contract snapshot tests that verify the frontend Zod schema declares
 // all fields the backend sends. Prevents silent field stripping (issue #2685).
 
-import { secretSchema } from '@/schemas/shapes/v3/secret';
+import { secretResponseSchema as v2SecretResponseSchema } from '@/schemas/api/v2/responses/secrets';
+import { secretDetailsSchema as v2SecretDetailsSchema } from '@/schemas/shapes/v2/secret';
+import {
+  secretSchema,
+  secretDetailsSchema as v3SecretDetailsSchema,
+} from '@/schemas/shapes/v3/secret';
 import { describe, expect, it } from 'vitest';
 
+import {
+  createV2WireSecret,
+  createV2WireSecretDetails,
+  createV3WireSecretDetails,
+} from '../schemas/shapes/fixtures/secret.fixtures';
 import { SECRET_SAFE_DUMP_FIELDS } from './secret-safe-dump-fields';
 
 // Fields intentionally excluded from secretSchema.
@@ -108,5 +118,66 @@ describe('Secret schema contract (safe_dump_fields)', () => {
       }
       expect(result.success).toBe(true);
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Passphrase-oracle removal: details.correct_passphrase is gone
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('secret details no longer carry correct_passphrase', () => {
+  // The backend used to report whether a supplied passphrase was correct even
+  // when the caller had not committed to the reveal (`continue: false`), which
+  // made the endpoint a passphrase oracle. The field is removed from the wire
+  // and from the schemas; `show_secret` is the only reveal signal. These tests
+  // pin both halves of the contract: the new (absent) shape must parse, and an
+  // older backend that still emits the field must not break the client — the
+  // non-strict object silently strips it rather than surfacing it.
+
+  it('the schemas do not declare correct_passphrase', () => {
+    expect(Object.keys(v2SecretDetailsSchema.shape)).not.toContain('correct_passphrase');
+    expect(Object.keys(v3SecretDetailsSchema.shape)).not.toContain('correct_passphrase');
+  });
+
+  it('parses a V2 secret response whose details omit correct_passphrase', () => {
+    const payload = {
+      record: createV2WireSecret(),
+      details: createV2WireSecretDetails(),
+      shrimp: 'csrf-token-xyz',
+    };
+    expect(payload.details).not.toHaveProperty('correct_passphrase');
+
+    const result = v2SecretResponseSchema.safeParse(payload);
+    if (!result.success) {
+      expect(result.error.issues).toEqual([]);
+    }
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.details).not.toHaveProperty('correct_passphrase');
+  });
+
+  it('tolerates an older backend that still sends correct_passphrase, and strips it', () => {
+    const payload = {
+      record: createV2WireSecret(),
+      // V2 encodes booleans as strings, hence "true" rather than true.
+      details: { ...createV2WireSecretDetails(), correct_passphrase: 'true' },
+      shrimp: 'csrf-token-xyz',
+    };
+
+    const result = v2SecretResponseSchema.safeParse(payload);
+    if (!result.success) {
+      expect(result.error.issues).toEqual([]);
+    }
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.details).not.toHaveProperty('correct_passphrase');
+  });
+
+  it('V3 details likewise strip a legacy correct_passphrase', () => {
+    const parsed = v3SecretDetailsSchema.parse({
+      ...createV3WireSecretDetails(),
+      correct_passphrase: true,
+    });
+
+    expect(parsed).not.toHaveProperty('correct_passphrase');
+    expect(parsed.show_secret).toBe(true);
   });
 });

--- a/src/tests/contracts/v3-schema-null-safety.spec.ts
+++ b/src/tests/contracts/v3-schema-null-safety.spec.ts
@@ -231,7 +231,6 @@ describe('V3 schema null-safety audit', () => {
       'continue',
       'is_owner',
       'show_secret',
-      'correct_passphrase',
     ];
 
     it.each(secretDetailsBareFields)(
@@ -426,7 +425,7 @@ describe('V3 schema null-safety audit', () => {
 
   describe('secret details null-safety audit', () => {
     // The secret details schema has these bare z.boolean() fields:
-    // continue, is_owner, show_secret, correct_passphrase
+    // continue, is_owner, show_secret
     //
     // While the backend may always send booleans for these (because they
     // are computed in the controller, not read from a possibly-nil model),
@@ -449,14 +448,13 @@ describe('V3 schema null-safety audit', () => {
         continue: null,
         is_owner: null,
         show_secret: null,
-        correct_passphrase: null,
         display_lines: 1,
         one_liner: null,
       },
       shrimp: 'csrf-token-xyz',
     };
 
-    it('V3 secret response schema REJECTS null for continue, is_owner, show_secret, correct_passphrase', () => {
+    it('V3 secret response schema REJECTS null for continue, is_owner, show_secret', () => {
       const result = secretResponseSchema.safeParse(secretDetailsPayloadWithNulls);
       expect(result.success).toBe(false);
 
@@ -465,7 +463,6 @@ describe('V3 schema null-safety audit', () => {
         expect(issueFields).toContain('details.continue');
         expect(issueFields).toContain('details.is_owner');
         expect(issueFields).toContain('details.show_secret');
-        expect(issueFields).toContain('details.correct_passphrase');
       }
     });
 
@@ -482,7 +479,6 @@ describe('V3 schema null-safety audit', () => {
           continue: true,
           is_owner: false,
           show_secret: true,
-          correct_passphrase: false,
           display_lines: 1,
           one_liner: false,
         },
@@ -513,7 +509,6 @@ describe('V3 schema null-safety audit', () => {
           continue: true,
           is_owner: false,
           show_secret: false,
-          correct_passphrase: false,
           display_lines: 1,
           one_liner: null,
         },
@@ -588,7 +583,6 @@ describe('V3 schema null-safety audit', () => {
           continue: false,
           is_owner: false,
           show_secret: false,
-          correct_passphrase: true,
           display_lines: 1,
           one_liner: null,
         },
@@ -625,7 +619,6 @@ describe('V3 schema null-safety audit', () => {
           continue: false,
           is_owner: false,
           show_secret: false,
-          correct_passphrase: true,
           display_lines: 1,
           one_liner: null,
         },

--- a/src/tests/fixtures/receipt.fixture.ts
+++ b/src/tests/fixtures/receipt.fixture.ts
@@ -579,7 +579,6 @@ export const mockSecretResponse = {
   details: {
     continue: false,
     show_secret: false,
-    correct_passphrase: false,
     display_lines: 1,
     one_liner: true,
     is_owner: false,
@@ -595,7 +594,6 @@ export const mockSecretRevealed = {
   details: {
     ...mockSecretResponse.details,
     show_secret: true,
-    correct_passphrase: true,
     is_owner: false,
   },
 };
@@ -604,7 +602,6 @@ export const mockSecretDetails = {
   continue: false,
   is_owner: false,
   show_secret: false,
-  correct_passphrase: false,
   display_lines: 1,
   one_liner: true,
 };

--- a/src/tests/schemas/shapes/fixtures/secret.fixtures.ts
+++ b/src/tests/schemas/shapes/fixtures/secret.fixtures.ts
@@ -104,7 +104,6 @@ export function createCanonicalSecretDetails(
     continue: true,
     is_owner: false,
     show_secret: true,
-    correct_passphrase: true,
     display_lines: 5,
     one_liner: null,
     ...overrides,
@@ -294,14 +293,7 @@ export function compareCanonicalSecretDetails(
 ): { equal: boolean; differences: string[] } {
   const differences: string[] = [];
 
-  const fields = [
-    'continue',
-    'is_owner',
-    'show_secret',
-    'correct_passphrase',
-    'display_lines',
-    'one_liner',
-  ] as const;
+  const fields = ['continue', 'is_owner', 'show_secret', 'display_lines', 'one_liner'] as const;
 
   for (const field of fields) {
     if (a[field] !== b[field]) {

--- a/src/tests/schemas/shapes/helpers/serializers.ts
+++ b/src/tests/schemas/shapes/helpers/serializers.ts
@@ -436,7 +436,6 @@ export function toV2WireSecretDetails(canonical: SecretDetailsCanonical): V2Wire
     continue: booleanToString(canonical.continue),
     is_owner: booleanToString(canonical.is_owner),
     show_secret: booleanToString(canonical.show_secret),
-    correct_passphrase: booleanToString(canonical.correct_passphrase),
     display_lines: numberToString(canonical.display_lines),
     one_liner: canonical.one_liner !== null ? booleanToString(canonical.one_liner) : null,
   } as V2WireSecretDetails;
@@ -499,7 +498,6 @@ export function toV3WireSecretDetails(canonical: SecretDetailsCanonical): V3Wire
     continue: canonical.continue,
     is_owner: canonical.is_owner,
     show_secret: canonical.show_secret,
-    correct_passphrase: canonical.correct_passphrase,
     display_lines: canonical.display_lines,
     one_liner: canonical.one_liner,
   } as V3WireSecretDetails;

--- a/src/tests/schemas/shapes/secret.roundtrip.spec.ts
+++ b/src/tests/schemas/shapes/secret.roundtrip.spec.ts
@@ -204,7 +204,6 @@ describe('V2 Secret Round-Trip', () => {
       expect(parsed.continue).toBe(canonical.continue);
       expect(parsed.is_owner).toBe(canonical.is_owner);
       expect(parsed.show_secret).toBe(canonical.show_secret);
-      expect(parsed.correct_passphrase).toBe(canonical.correct_passphrase);
       expect(parsed.display_lines).toBe(canonical.display_lines);
     });
 
@@ -392,7 +391,6 @@ describe('V3 Secret Round-Trip', () => {
       expect(parsed.continue).toBe(canonical.continue);
       expect(parsed.is_owner).toBe(canonical.is_owner);
       expect(parsed.show_secret).toBe(canonical.show_secret);
-      expect(parsed.correct_passphrase).toBe(canonical.correct_passphrase);
       expect(parsed.display_lines).toBe(canonical.display_lines);
     });
 

--- a/src/tests/stores/secretStore-alt.spec.ts
+++ b/src/tests/stores/secretStore-alt.spec.ts
@@ -61,7 +61,6 @@ const createTestStore = () => defineStore('secrets', () => {
         details.value = {
           ...details.value,
           show_secret: true,
-          correct_passphrase: true,
         };
         return { record: record.value, details: details.value };
       }
@@ -78,7 +77,6 @@ const createTestStore = () => defineStore('secrets', () => {
         details.value = {
           ...details.value,
           show_secret: true,
-          correct_passphrase: true,
         };
         return { record: record.value, details: details.value };
       }

--- a/src/tests/stores/secretStore.spec.ts
+++ b/src/tests/stores/secretStore.spec.ts
@@ -306,7 +306,6 @@ describe('secretStore', () => {
         details: {
           continue: false,
           show_secret: true,
-          correct_passphrase: true,
           display_lines: 1,
           one_liner: true,
           is_owner: false, // Add required field

--- a/src/tests/stores/secrets/secretStoreFieldHandling.spec.ts
+++ b/src/tests/stores/secrets/secretStoreFieldHandling.spec.ts
@@ -70,7 +70,6 @@ describe('secretStore', () => {
             continue: false,
             is_owner: false,
             show_secret: false,
-            correct_passphrase: false,
             display_lines: 1,
             one_liner: true,
           },

--- a/try/unit/logic/secrets/reveal_secret_try.rb
+++ b/try/unit/logic/secrets/reveal_secret_try.rb
@@ -239,7 +239,8 @@ logic.process
 logic.display_lines
 #=> 9
 
-## Correctly handles a secret without a passphrase
+## Correctly handles a secret without a passphrase (correct_passphrase is
+## vacuously true on a committed reveal when there is nothing to check)
 receipt = @create_receipt.call
 secret = receipt.load_secret
 params = {
@@ -249,7 +250,7 @@ params = {
 logic = V2::Logic::Secrets::RevealSecret.new(@strategy_result, params, 'en')
 logic.process
 [logic.secret.has_passphrase?, logic.correct_passphrase, logic.show_secret]
-#=> [false, false, true]
+#=> [false, true, true]
 
 ## Correctly handles a secret with an incorrect passphrase
 receipt = @create_receipt.call
@@ -301,6 +302,29 @@ logic = V2::Logic::Secrets::RevealSecret.new(@strategy_result, params, 'en')
 logic.process
 [logic.secret.has_passphrase?, logic.correct_passphrase, logic.show_secret]
 #=> [true, true, true]
+
+## A metadata-only request (continue=false) with a wrong passphrase neither
+## raises nor records an attempt: the guess is only checked on a committed
+## reveal, so the endpoint is not a free brute-force oracle
+receipt = @create_receipt.call
+secret = receipt.load_secret
+secret.update_passphrase('correct_pass')
+secret.save
+params = {
+  'identifier' => receipt.secret_identifier,
+  'passphrase' => 'wrong_pass',
+  'continue' => false
+}
+logic = V2::Logic::Secrets::RevealSecret.new(@strategy_result, params, 'en')
+logic.process
+[
+  logic.correct_passphrase,
+  logic.show_secret,
+  logic.success_data[:details].key?(:correct_passphrase),
+  logic.secret_value.nil?,
+  Onetime::Secret.dbclient.get("passphrase:attempts:#{secret.identifier}").nil?,
+]
+#=> [false, false, false, true, true]
 
 # Teardown
 @receipt.destroy!

--- a/try/unit/logic/secrets/show_secret_try.rb
+++ b/try/unit/logic/secrets/show_secret_try.rb
@@ -215,6 +215,28 @@ logic.process
 logic.display_lines
 #=> 9
 
+## A metadata-only request (continue=false) never verifies the passphrase: the
+## response cannot tell a right guess from a wrong one and no rate-limit attempt
+## is spent on a guess that was never checked
+receipt = @create_receipt.call
+secret = receipt.load_secret
+secret.update_passphrase('correct_pass')
+secret.save
+params = {
+  'identifier' => receipt.secret_identifier,
+  'passphrase' => 'wrong_pass',
+  'continue' => 'false'
+}
+logic = Logic::Secrets::ShowSecret.new(@strategy_result, params, 'en')
+logic.process
+[
+  logic.correct_passphrase,
+  logic.show_secret,
+  logic.success_data[:details].key?(:correct_passphrase),
+  Onetime::Secret.dbclient.get("passphrase:attempts:#{secret.identifier}").nil?,
+]
+#=> [false, false, false, true]
+
 # Anonymous User Tests (verify_owner flow with anonymous_user?)
 
 ## anonymous_user? returns true for anonymous strategy result


### PR DESCRIPTION
## Summary

The v2 secret show, reveal, and burn logic (and the v1 logic classes, see Notes) evaluated `secret.passphrase?` before consulting `continue`, and show/reveal returned the verdict as `details.correct_passphrase`. A request with `continue=false` could therefore test a passphrase guess without consuming the secret. v2 reveal and both burn endpoints also leaked the verdict through the HTTP status (wrong guess → form error; right guess with `continue=false` → 200 without acting).

This PR establishes one invariant across all five classes: **the passphrase is verified only when `continue=true`.** A metadata-only request never runs Argon2, never learns the result, never records or clears rate-limit state, and gets the same body and status for a right or wrong guess. `details.correct_passphrase` is removed from the v2 responses; `details.show_secret` (true only when the passphrase was correct *and* the reveal was committed) is the only reveal signal.

## Changes

**Backend** (`2d4706712f`)
- `apps/api/v2/logic/secrets/{show,reveal,burn}_secret.rb`, `apps/api/v1/logic/secrets/{show,burn}_secret.rb`: `@correct_passphrase = continue && (!has_passphrase? || passphrase?(passphrase))`; failed-attempt/raise branches and the rate-limit record/clear block gated on `continue`; `correct_passphrase:` dropped from `success_data` details. v2 reveal normalised to the show form so the three classes read identically. Server-side `passphrase_correct:` debug-log keys stay (operator diagnostics, not a response field).
- Regression specs in `apps/api/{v1,v2}/spec/logic/secrets/*` and `try/unit/logic/secrets/*`: `continue=false` never calls `passphrase?`, returns byte-identical details for right vs wrong guesses, records no attempt, raises nothing; `continue=true` paths unchanged (with positive controls that a committed wrong guess writes the attempts key). All 15 new examples confirmed red on main before the fix.
- v2 reveal/burn debug logs record `passphrase_correct: nil` when `continue=false` (not checked ≠ wrong).

**Frontend** (`1351f80a86`)
- `src/schemas/contracts/secret.ts`, `src/schemas/shapes/v2/secret.ts`: field removed outright (not `.optional()`) — the detail objects are non-strict `z.object` chains, so a response from an older backend still parses and the field is stripped. `src/tests/contracts/secret-schema-contract.spec.ts` pins both halves. Fixtures/specs updated; boolean-coercion coverage kept on the remaining detail booleans. The UI always sends `continue: true` (`secretStore.reveal`, `receiptStore`), so no flow changes.

**Changelog**: `changelog.d/20260822_101500_passphrase_verification_continue_gate.rst` (Security).

## Verification

- `tests/lanes/run unit` — try:unit 8040/0, spec:fast 5017/0
- `tests/lanes/run api` — 264/0
- `pnpm exec vitest run src/tests/schemas src/tests/contracts src/tests/stores` — 2312/0; `pnpm run type-check` clean
- rubocop clean on changed files

## Notes

- **v1 was not exposed.** `apps/api/v1/controllers/index.rb` forces `continue='true'` before constructing the logic and renders its own JSON (never `success_data`), so neither the metadata-only probe nor `details.correct_passphrase` was reachable on v1. The v1 logic classes carry the same gate for parity only.

- Burn endpoints are keyed on the receipt identifier (held by the creator), so they were not part of the exploitable surface, but they carried the same status-code distinction and are fixed alongside.
- `GET /api/v2/secret/:identifier` still accepts `passphrase` in the query string for `continue=true` reveals; Sentry already scrubs it (`lib/onetime/initializers/setup_diagnostics.rb` `SENSITIVE_QUERY_PARAMS`). With this fix a `continue=false` query-string passphrase is never read, so no further app change; proxy access-log hygiene is operator-side.
- `check_passphrase_rate_limit!` in `raise_concerns` still runs for passphrase-protected secrets regardless of `continue` (pre-existing; a locked-out caller gets 429 on a metadata fetch too).
