### PR TITLE
docs(specs): normalize 3 draft notes into tracked spec files

### DIFF
--- a/docs/specs/domain-ceiling/domain-ceiling.md
+++ b/docs/specs/domain-ceiling/domain-ceiling.md
@@ -1,0 +1,199 @@
+# Custom Domain Creation Ceiling + Velocity Limit
+
+Status: Draft — 2026-08-21
+Related: #3491 (M9 numeric-limit overrides, M10 free_tier drift), #4215
+(domains drift guard / `bin/ots domains repair`)
+
+Free orgs are advertised one custom domain but may add more. Today nothing
+enforces any count, and nothing bounds how fast domains are created. This
+spec adds two complementary, independent controls:
+
+1. **Ceiling** — a per-org maximum that is deliberately higher than the
+   advertised plan limit. Abuse backstop, operator-adjustable per org.
+2. **Velocity** — a per-org creation rate limiter on the established
+   `lib/onetime/security/*_rate_limiter.rb` pattern.
+
+Neither changes what is advertised.
+
+---
+
+## 1. Constraint that shapes the design
+
+`limits_plan` cannot carry a per-org numeric override. Both materialization
+writers do `limits_plan.clear` then re-copy from the plan
+(`organization/features/with_materialized_entitlements.rb:127-128` from
+`Billing::Plan`, `:159-160` from config fallback). Entitlement overrides
+survive only because `entitlements_grants` / `entitlements_revokes` are
+separate collections no reconcile path clears. There is no `limits_grants`
+equivalent. So "operator grants more" needs storage that materialization
+never touches.
+
+## 2. Advertised vs enforced
+
+`limits.custom_domains: 1` in `billing.yaml` stays the advertised number: it
+is the product promise, stays in `limit_for`, stays in both serializers
+(`organization/features/safe_dump_fields.rb:60`,
+`apps/web/core/views/serializers/organization_serializer.rb:161`), stays what
+the UI shows. It is NOT overloaded with enforcement.
+
+Enforcement ceiling is **site config, not a plan key**. Plan limits are
+pushed to Stripe and become product surface; this is an ops knob.
+
+```yaml
+# etc/defaults/config.defaults.yaml — under features.domains (NOT site.domains;
+# features.domains is where enabled/require_verified/default/link_domains live)
+features:
+  domains:
+    # Abuse backstop, NOT the advertised plan limit. Set to 1 to enforce
+    # exactly what billing.yaml advertises for free.
+    creation_ceiling: <%= ENV['DOMAINS_CREATION_CEILING'] || 25 %>
+```
+
+Env naming follows siblings `DOMAINS_ENABLED`, `DOMAINS_REQUIRE_VERIFIED`.
+
+### Resolution rule
+
+```
+advertised = org.limit_for(:custom_domains)      # may raise PlanCacheMissError — let it propagate
+ceiling    = org.limits_overrides['custom_domains.max'] || conf.features.domains.creation_ceiling
+enforced   = advertised == ∞ ? ∞ : [advertised, ceiling.to_i].max
+blocked    = org.domain_count >= enforced
+```
+
+Properties:
+
+- Unlimited tiers (`identity_plus_v1: custom_domains: -1`) stay unlimited;
+  the backstop never undercuts what was paid for.
+- A finite paid tier advertising 100 enforces 100, not 25.
+- "Enforce the advertised limit" is `DOMAINS_CREATION_CEILING=1`. No code
+  change, no plan re-push.
+- The per-org override replaces the **site ceiling** in the max, not the
+  advertised number. An operator can clamp an abusive org below 25
+  (override=1) without banning, and can never clamp below the promise.
+- Standalone (billing disabled): `limit_for` returns ∞, so ceiling and
+  override are dead letters. The override op surfaces `standalone: true`
+  exactly as `Operations::Org::EntitlementOverride` does (D17).
+
+Count source: `org.domain_count` (`organization.rb:230`, ZCARD on the
+auto-generated `domains` zset), not `list_domains.size` (load_multi). Stale
+zset refs overcount, which fails toward blocking — acceptable;
+`bin/ots domains repair` exists for drift.
+
+### Override storage
+
+`hashkey :limits_overrides` on Organization, declared beside `limits_plan` in
+`WithMaterializedEntitlements`, keyed by the same flattened limit key
+(`'custom_domains.max'`). Chosen over a scalar `:domain_ceiling_override`
+field: identical cost, survives materialization by construction (new
+collection), and it IS the missing `limits_grants` — when #3491 M9 lands
+nothing is renamed. `limit_for` does NOT consult it; only the enforcement
+resolver reads it. That is what keeps the advertise/enforce split.
+
+Written by `Onetime::Operations::Org::LimitOverride` (set/clear, audit
+backstop in the op, `standalone:` on Result), modeled on
+`EntitlementOverride`. Adapters: colonel endpoint + `bin/ots org limit`.
+Named by what it stores, not by domains.
+
+## 3. Velocity limiter
+
+`lib/onetime/security/domain_creation_rate_limiter.rb` on the
+`CreateAccountRateLimiter` shape: Lua `CHECK_AND_RECORD_SCRIPT` (atomic
+check + increment, denied tier never incremented), config-gated, audit verb
+on the cap-reaching request only.
+
+- **Subject: organization objid, single tier.** Not IP. Route is
+  `auth=sessionauth` and org-scoped; the resource owner is the natural
+  bucket and it avoids the masked-/24 collapse that forces
+  `CreateAccountRateLimiter` loose. Account fan-out is bounded by
+  composition: free caps at 1 org (after the §5 fix), `create_account_ip`
+  caps signups at 10/hr/masked-IP.
+- **Defaults: 10/hour, 1h window, 1h lockout.** Not 5. With ceiling=25 the
+  limiter barely matters for free orgs; its job is bounding cert-provisioning
+  burst (Approximated/Caddy request, favicon job, DNS) from unlimited tiers —
+  the accounts doing legitimate bulk migrations. 5 turns a paid customer's
+  6-domain onboarding into a lockout and a ticket.
+- Config: `features.domains.creation_rate_limit: {enabled, max_per_org,
+  window, lockout}`; `DOMAINS_CREATION_RATE_LIMIT_ENABLED`, default on.
+  `spec/config.test.yaml` sets `enabled: false` like
+  `create_account_rate_limit`.
+- Keys: `domain_create:attempts:org:%s`, `domain_create:locked:org:%s`.
+- `Operations::Ratelimit::Registry::LIMITERS['domain_create_org']`,
+  subject `'organization objid'`, `dbclient: -> { Onetime::CustomDomain.dbclient }`
+  (same shard as `dns`). Gives `bin/ots ratelimit keys` and
+  `POST /api/colonel/ratelimit/reset` for free.
+- Audit verb: `domains.create_throttled`.
+- Fail semantics: Redis errors propagate (no silent permit).
+
+## 4. Gate placement
+
+Both in `AddDomain#raise_concerns`
+(`apps/api/domains/logic/domains/add_domain.rb`):
+
+1. **Ceiling** immediately after `require_entitlement_in!(@target_organization,
+   'custom_domains')` — cheap, deterministic, should not burn velocity budget.
+2. **Velocity** as the **last line** of `raise_concerns`, after the
+   `existing` (already-in-org / other-org) checks. CHECK_AND_RECORD
+   increments on check; a re-add or typo must not cost budget. CreateAccount
+   charges malformed submissions because they are free to generate and
+   equally good for flooding; here malformed/duplicate requests create
+   nothing, and the protected resource is creation, not request handling.
+
+NOT in `CustomDomain.create!`. The canonical-overlap check there is an
+integrity backstop; this is policy — and console/CLI
+(`Operations::Domains::Create`, colonel `POST /api/colonel/domains`,
+`bin/ots domains create`) is precisely the "operator grants more" path.
+Untouched.
+
+## 5. Fix in the same change
+
+1. `WithPlanEntitlements.free_tier_limits`
+   (`organization/features/with_plan_entitlements.rb:125`) has no
+   `custom_domains.max`, so `free_tier_limit_for` returns its unknown-key
+   default 0 and a billing-enabled, not-yet-materialized org serializes
+   `custom_domains: 0`. Add `'custom_domains.max' => 1`. Fix the M10 drift
+   in the same hash: `'organizations.max' => 5` → `1` (YAML says 1; the
+   §3 fan-out argument depends on it). Leave `secrets_per_day` out (YAML:
+   not yet enforced).
+   Spec fallout: `spec/unit/onetime/models/features/with_entitlements_ttl_env_spec.rb:200,223`
+   assert 5. `with_materialized_entitlements_spec.rb` hits are fixture
+   literals; `create_organization_spec.rb` stubs `at_limit?`.
+2. Error copy must not say "upgrade your plan" — someone hitting 25 when the
+   UI advertises 1 is 24 past it. Ceiling:
+   `raise_form_error(error_key: 'api.domains.errors.domain_ceiling_reached',
+   field: 'domain', error_type: :forbidden)` — explicitly not
+   `:upgrade_required` (`create_organization.rb:173` uses that to drive the
+   upgrade CTA). Copy: "Maximum domains reached for this account. Contact
+   support to request more." Velocity: `Onetime::LimitExceeded` with
+   `retry_after` — `otto_hooks.rb:80` maps to 429, `error_correlation.rb`
+   rounds `retry_after` up to minutes. Copy: "Too many domains added
+   recently. Try again in N minutes." Locale keys
+   `api.domains.errors.domain_ceiling_reached`,
+   `api.domains.errors.rate_limit_exceeded`, all locales.
+
+## 6. Invariant: the split must stay invisible
+
+Nothing in `src/` compares `limits.custom_domains` against the actual count
+(`schemas/contracts/organization.ts:102`, `config/billing.ts:168` only
+carry it). `useEntitlements.ts:105` `limit(resource)` is typed to accept
+`custom_domains` but has no caller for it. Keep it that way — the moment
+something renders "3 of 1 used" the split is visible. Comment on the getter
+and on both serializers.
+
+## 7. Out of scope
+
+- General numeric-limit overrides (#3491 M9). `limits_overrides` is the
+  storage for it; the read path in `limit_for` is not built here.
+- Per-IP or per-customer velocity tiers.
+- Enforcing `secrets_per_day`.
+
+## 8. Checklist
+
+- [ ] `features.domains.creation_ceiling` + `creation_rate_limit` in defaults; test config disables limiter
+- [ ] `hashkey :limits_overrides` beside `limits_plan`
+- [ ] `Operations::Org::LimitOverride` + colonel endpoint + `bin/ots org limit`
+- [ ] `security/domain_creation_rate_limiter.rb` + `try/unit/security/domain_creation_rate_limiter_try.rb`
+- [ ] `Registry::LIMITERS['domain_create_org']`
+- [ ] `AddDomain#raise_concerns`: ceiling after entitlement, velocity last
+- [ ] `free_tier_limits`: add `custom_domains.max => 1`, fix `organizations.max => 1`; update ttl_env spec
+- [ ] Locale keys ×2, all locales; `scripts/i18n` hashes
+- [ ] Invariant comments (§6)

--- a/docs/specs/install-onboarding/install-onboarding-front-door-assessment.md
+++ b/docs/specs/install-onboarding/install-onboarding-front-door-assessment.md
@@ -1,0 +1,180 @@
+---
+title: Install Onboarding — Front-Door Assessment
+type: assessment
+status: draft
+updated: 2026-07-09
+---
+
+Assessment of the repo's onboarding surface — install scripts, the rake
+init task, docs, and Docker setup — against what the best self-hosted
+projects do.
+
+## TL;DR
+
+Your individual pieces are unusually good — `install.sh doctor`, idempotent
+everything, the derived-secrets model, Valkey/Redis fallback, the `.envrc`
+lane switching. The problem is that they're organized by *mode*
+(`install.sh` / `install-dev.sh` / `install-test.sh`) rather than by
+*persona*, the golden paths in the README are broken or contradictory, and
+the version-of-truth for toolchain requirements is scattered across six
+files that disagree with each other. The best comparable projects win on
+exactly the things you're missing: one zero-prerequisite path for
+self-hosters (`docker compose up` that actually works), one canonical
+command for contributors (`bin/setup` on a clean fork, no maintainer config
+required), and a single pinned source of truth for tool versions.
+
+## Where you're going wrong — concrete findings
+
+**1. The README's Docker Compose quick start is broken.** Root
+`README.md:133` says `cp .env.example .env && docker compose up`. But
+`.env.example` ships `SECRET=` empty, and `docker-compose.simple.yml:27`
+has `SECRET=${SECRET:?SECRET must be set — run ./install.sh}`. So the
+documented path fails immediately — and the error message tells a Docker
+user (who chose Docker to avoid the Ruby toolchain) to run a script that
+requires Ruby, Bundler, and Node. `docker/README.md` has the missing step
+(`echo "SECRET=$(openssl rand -hex 32)" >> .env`), but the front-page
+README doesn't. This is the highest-traffic funnel and it 404s at step two.
+
+**2. `install.sh` pins Ruby against a file that doesn't exist.**
+`install.sh:179` checks `.ruby-version` — there is no `.ruby-version` in
+the repo. Every user who runs `./install.sh init` gets "version not
+verified" warnings on the happy path. Meanwhile `ci.yml` watches
+`.ruby-version` and `.node-version` as change-trigger paths (also
+nonexistent) and hardcodes Ruby 3.4.9. The stated Ruby floor is different
+in five places: Gemfile (`>= 3.3.6`), `install-test.sh` (3.4.7), README
+("Ruby 3.4+"), CI (3.4.9), install.sh (undefined). Node is worse: `.nvmrc`
+says 25, CI workflows variously use 20, 22, and 25. Nobody can answer "what
+versions do I need?" from the repo, including its own scripts. Also,
+`check_version` requires *exact* equality with `.ruby-version` — even once
+the file exists, a user on 3.4.8 vs a pinned 3.4.9 gets a hard `die`, which
+is harsher than the Gemfile itself.
+
+**3. `install-dev.sh` is a maintainer tool wearing the contributor script's
+name.** Its primary behavior is symlinking config from `$OTS_DEV_CONFIG`
+(`~/.config/onetimesecret-dev`) — a directory only the maintainer has — and
+pointing a Caddy webroot symlink at `/var/www/public/web` — a path only the
+maintainer's machines have. A fresh forker running it hits: a Bash 4+ hard
+fail on stock macOS, a hard requirement on direnv, warnings for missing
+overmind and pre-commit, "Warning: ~/.config/onetimesecret-dev does not
+exist — config symlinks will be skipped", and "Skip: /var/www/public does
+not exist." The fallback copies (`.env.example` → `.env`, etc.) do
+eventually produce a working state, but the contributor's first-run
+experience is a wall of warnings about the maintainer's environment, and —
+critically — it never generates secrets, so `.env` has `SECRET=` empty and
+the app won't boot correctly until they separately discover
+`install.sh init`. The happy path for outsiders is the fallback path.
+
+**4. Three scripts that overlap and drift.** The `.envrc` heredoc is
+duplicated verbatim in `install-dev.sh` and `install-test.sh` (they will
+diverge). Config seeding is implemented three different ways: `install.sh`
+copies three named defaults, `install-test.sh` globs all of
+`etc/defaults/*`, `install-dev.sh` symlinks from shared config. `install.sh`
+reimplements `.env` parsing, Redis URL resolution, and auth-mode detection
+in sed/bash — logic the app already owns. And nothing tells a new arrival
+*which script is for them*: the names describe lanes, not audiences.
+
+**5. Trust-eroding staleness in the front door.** `.env.example`'s header
+says "Source environment: source .env.sh" — a mechanism `install-dev.sh`
+itself says was replaced by `.envrc`. `README.md:151` says "This version of
+**Familia** was developed with…" — a copy-paste from another project,
+sitting on the repo's landing page. Small things, but a prospective
+self-hoster is pattern-matching for "is this project maintained carefully?"
+and these are the first files they read.
+
+**6. Missing table stakes for OSS onboarding.** No `CONTRIBUTING.md`
+(GitHub surfaces this on every PR/issue). No devcontainer/Codespaces
+config. No `.tool-versions`/`mise.toml`. No seed data or dev account task —
+after setup succeeds, a contributor has an empty app and no test login. And
+no first-run verification: `install.sh` ends with `doctor`, which checks
+files exist, but never proves the app works (create a secret, retrieve
+it). `install-test.sh` actually has the right instinct with its config
+smoke test — the pattern just never made it to the other two scripts.
+
+**7. Heavy host-tool constellation with no containerized escape hatch for
+dev.** The full dev loop wants: Ruby, Bundler, Node, pnpm, Valkey, direnv,
+overmind, pre-commit, Bash 4+, and (full mode) PostgreSQL + RabbitMQ — all
+installed on the host. There is `compose.test.yml` and a mailpit compose
+file, but no "run the *dependencies* in containers, code on host" profile,
+which is how most polyglot projects (Cal.com, Outline, Plausible dev)
+neutralize the "install five services locally" problem.
+
+## What successful projects do that's worth borrowing
+
+- **Zero-prerequisite self-hosting**: Plausible, Umami, Vaultwarden,
+  Outline — `docker compose up` works with at most one documented
+  secret-generation command, and several generate/persist the secret on
+  first boot. Gitea goes further with a web-based first-run wizard. The
+  equivalent here: make the container entrypoint generate `SECRET` on first
+  boot when unset (persisted to the volume, with a loud log line saying
+  where it is and to back it up), or add a
+  `docker compose run --rm app init` bootstrap. Docker users should never
+  be told to run a Ruby script.
+- **One canonical contributor command**: the Rails `bin/setup` convention /
+  GitHub's "scripts to rule them all." Discourse has `discourse-setup`;
+  Mastodon has the interactive `rake mastodon:setup`; Zulip and GitLab
+  (GDK) ship dedicated provisioning that gets a fork to a running app in
+  one command. The key property: it works on a *clean fork with zero
+  pre-existing config* and ends with the app demonstrably running.
+- **Pinned toolchain in one file**: `.tool-versions` (asdf/mise/rbenv all
+  read it) or `mise.toml`, referenced by CI via
+  `ruby-version-file:`/`node-version-file:` so drift is structurally
+  impossible.
+- **Devcontainer + Codespaces**: Discourse, Cal.com, Nextcloud. For
+  drive-by contributors this collapses the entire tool constellation to
+  "click Open in Codespaces." Given the dependency list here, this is
+  probably the single highest-leverage addition.
+- **Seed data**: `rake dev:seed` or equivalent creating a dev admin +
+  sample secrets, so the first `bin/dev` shows a populated, log-in-able
+  app.
+
+## Recommended plan, prioritized
+
+**P0 — fix what's broken (hours, not days):**
+
+1. Fix the compose quick start: entrypoint-generated `SECRET` on first boot
+   (or fix root README + make the compose error message Docker-appropriate).
+2. Add `.ruby-version` and `.node-version`; align Gemfile/README/
+   install-test/CI to read from them. Relax `check_version` to compare
+   sensibly (minor-level, or defer to Bundler).
+3. Fix `.env.example`'s stale `source .env.sh` instruction and the
+   "Familia" paragraph in the README.
+
+**P1 — reorganize around personas:**
+
+4. Create `bin/setup` as the single contributor entry point (fold in the
+   best of `install-test.sh`, which is already the closest-to-ideal
+   script): tool checks with actionable messages, deps, seed configs from
+   defaults, **generate secrets**, start throwaway Valkey if none running,
+   HTTP smoke test, print `bin/dev` next steps. Contributor docs mention
+   exactly one command.
+5. Move the maintainer symlink-farm and Caddy-webroot logic out of
+   `install-dev.sh` into `scripts/` (or behind `--maintainer`), so the
+   script a forker finds doesn't warn about the maintainer's machines.
+6. Keep `install.sh` as the *self-hoster* bare-metal path only, and say so
+   in its header and the README.
+7. Add `CONTRIBUTING.md` with the 5-minute path, the persona map (self-host
+   Docker / self-host bare-metal / contributor / test), and where to get
+   help.
+8. Deduplicate: one shared `.envrc` template, one config-seeding
+   implementation, and have shell scripts shell out to `bin/ots` for
+   env/config resolution instead of re-parsing `.env` with sed.
+
+**P2 — the DX multipliers:**
+
+9. `.devcontainer/` + Codespaces support.
+10. A dev-dependencies compose profile (Valkey, Mailpit, Postgres,
+    RabbitMQ in containers; code on host) so the only host requirements
+    are Ruby, Node, pnpm.
+11. `rake dev:seed` with a dev account and sample data, wired into
+    `bin/setup`.
+12. End every setup path with proof-of-life: boot, create a secret via the
+    API, retrieve it, print the URL. `doctor` checks preconditions;
+    nothing currently checks the *outcome*.
+
+The unifying principle: the project is optimized for the maintainer's own
+workflow (worktree forests, shared config, lane switching — all genuinely
+sophisticated), and the outsider paths have decayed into fallback branches
+and stale docs. The fix is less about writing new tooling than about
+drawing a hard line between maintainer tooling and the two public front
+doors, then making each front door a single command that provably works
+from nothing.

--- a/docs/specs/legal-links/legal-links-config.md
+++ b/docs/specs/legal-links/legal-links-config.md
@@ -1,0 +1,74 @@
+---
+title: Legal & Policy Link Configuration
+type: plan
+status: draft
+updated: 2026-08-22
+---
+
+## Problem
+
+Terms and privacy links in signup flows and branded secret reveal footers
+are hardcoded to removed `/info/terms` and `/info/privacy` routes.
+Meanwhile, the only way to configure these URLs today is inside the
+generic `footer_links` group structure, which is not convenient for
+first-class legal links and is not reused by the affected components.
+
+## Goal
+
+Promote common legal/policy URLs to explicit, top-level config settings so
+they can be configured once and used consistently across the app.
+
+## Proposed config settings
+
+Add explicit environment variables and config schema fields:
+
+| Setting                   | Env var        | Typical use                        |
+| -------------------------- | -------------- | ----------------------------------- |
+| Terms of Service           | `TERMS_URL`    | Signup agreement, branded reveal footer |
+| Privacy Policy             | `PRIVACY_URL`  | Signup agreement, branded reveal footer |
+| Data Processing Agreement  | `DPA_URL`      | Enterprise/legal footer link        |
+| Cookie Policy              | `COOKIE_URL`   | Cookie banner / footer              |
+| Acceptable Use Policy      | `AUP_URL`      | Abuse/legal footer link             |
+| Security                   | `SECURITY_URL` | Security page / footer              |
+
+## Backend work
+
+- [ ] Add `site.legal.terms_url`, `privacy_url`, `dpa_url`, `cookie_url`,
+      `aup_url`, `security_url` (or similar) to
+      `etc/defaults/config.defaults.yaml`.
+- [ ] Expose the values in the bootstrap payload under a new `ui.legal`
+      (or `site.legal`) object.
+- [ ] Update Zod schemas in `src/schemas/contracts/bootstrap.ts` and
+      config shapes.
+- [ ] Keep `footer_links` as the consumer, but allow it to reference these
+      values or default to them.
+
+## Frontend work
+
+- [ ] Add a typed `legalUrls` getter/composable in `bootstrapStore` or a
+      shared helper.
+- [ ] Update `SignUpForm.vue` to use configurable `termsUrl` and
+      `privacyUrl` instead of `/info/terms` and `/info/privacy`.
+- [ ] Update `InviteSignUpForm.vue` similarly.
+- [ ] Update `SecretFooterAttribution.vue` to use configurable URLs when
+      `showTerms=true`.
+- [ ] Hide each link when its URL is not configured.
+- [ ] Use `<a>` for external URLs and `<router-link>` only for relative
+      internal paths.
+
+## Cleanup
+
+- [ ] Remove `/info/privacy` from `e2e/all/brand-customization.spec.ts`
+      `publicPaths`.
+- [ ] Add/update tests for the new bootstrap schema fields and component
+      behavior.
+
+## Acceptance criteria
+
+- [ ] `TERMS_URL`, `PRIVACY_URL`, `DPA_URL`, `COOKIE_URL`, `AUP_URL`,
+      `SECURITY_URL` are documented in defaults and read from env.
+- [ ] Signup forms and branded reveal footer use the configured URLs.
+- [ ] Links are hidden when no URL is configured.
+- [ ] No hardcoded `/info/terms` or `/info/privacy` references remain in
+      the affected components.
+- [ ] Tests pass.

--- a/docs/specs/organization-management/deleting-an-organization.md
+++ b/docs/specs/organization-management/deleting-an-organization.md
@@ -1,0 +1,103 @@
+# Deleting an Organization
+
+Status: draft notes — options and complications, no design decided yet.
+
+## Options
+
+A. Outright delete. Solve the technical complexity and make it a non-issue.
+B. Archive/hide. A user-facing option in the Org Settings. Removes it from
+   the org context dropdown and orgs list page. There's a chance it could
+   cause strange behaviour.
+   - In Django, soft deletes are clean and easy by creating a base
+     Manager/QuerySet class that automatically appends `.active()` to the
+     model's queries. They just don't exist as far as the application is
+     concerned.
+C. Explain in the UI why default orgs are important/necessary? Might just
+   sound like lazy bullshit (which I think it would be).
+
+## Complications with removing a default org
+
+1. A default org is the user's identity container, not a team. Plan,
+   entitlements, limits, Stripe customer/subscription
+   (`with_organization_billing.rb:63-79`), receipts (`receipt.rb:74`), and
+   domains all hang off the org. A customer with no active org is a
+   degraded read-only session (`organization_loader.rb:197-207`). In
+   Clerk/GitHub terms the default org is the personal account, not an
+   organization — and nobody lets you delete a personal account separately
+   from the user.
+2. Deleting it doesn't delete it — it resets it. CreateDefaultWorkspace runs
+   from the account/omniauth hooks and lazily from `auth_org`
+   (`create_default_workspace.rb:78,151`). If the customer has zero other
+   orgs, the next entitlement-gated action mints a fresh `is_default` org
+   (or adopts an orphan via `find_by_contact_email`, line 194). So "delete
+   my only/default org" is semantically account purge
+   (`bin/ots customers purge-one`), which is exactly why `:last_org` is
+   non-overridable.
+3. No cascade, no transaction, no undo. Redis has no FKs; teardown is
+   ordered writes with per-step rescue. After `destroy!`, these still point
+   at the dead objid:
+   - `Receipt#org_id` + the `organization:<objid>:receipts` zset key
+     (never touched by `destroy!`)
+   - `SessionMetadata#org_id`, `ColonelAuditEvent` payloads (fine as
+     tombstone refs, but readers must be nil-tolerant)
+   - `OrganizationMembership` through-model hashes —
+     `remove_members_instance` removes participation; the
+     `ensure_member_through_models` chore exists because this drifts
+   - Stripe: `stripe_customer_id` goes with the org, the Stripe Customer
+     lives on with no back-pointer (the #4205 drift). The op refuses while
+     `billing_live?`, but a canceled-sub org still orphans the Stripe
+     customer.
+   - Materialized entitlement/limit/secret_activity keys — verify whether
+     Familia's `destroy!` clears those DataTypes; unconfirmed.
+4. `is_default` is a label on the org, `default_org_id` is a pointer on the
+   customer, and they can disagree. The op clears the pointer but never
+   promotes a surviving org to `is_default`, so the "personal workspace"
+   badge, colonel `v-if="org.is_default"` branches, and the `:is_default`
+   guard stop protecting anything for that user. If the customer has
+   another org, the correct verb is demote-and-promote, not delete-and-hope.
+5. Audit eviction — refusals are deliberately unaudited because the audit
+   set is COUNT-capped (documented in the op header). Any new reversible
+   path must keep that property.
+
+Common thread: (a) cascade memberships/invitations, never users; (b) hard
+delete is explicit and irreversible, or there is a soft/delayed path —
+never a hidden half-cascade; (c) the personal container is only deleted by
+deleting the user; (d) "must have ≥1 org" is enforced at login by routing
+to create, not by refusing deletion.
+
+## Complications with soft deleting
+
+`archive!` already hides the org everywhere that matters and blocks
+re-creation:
+
+- `ListOrganizations` rejects archived
+  (`apps/api/organizations/logic/organizations/list_organizations.rb:30,36`);
+  `OrganizationLoader` skips archived at steps 3 and 5; `CreateOrganization`
+  counts only non-archived toward the limit.
+- `CreateDefaultWorkspace#workspace_already_exists?` counts
+  `organization_instances` — membership survives archiving, so it returns
+  "exists" and mints nothing (`create_default_workspace.rb:156-170`).
+
+Three things break it, in order of severity:
+
+1. Archived-only customer silently keeps using the "deleted" org. Loader
+   returns nil → `auth_org` calls CreateDefaultWorkspace → nil → fallback
+   `org ||= cust.organization_instances.first`
+   (`lib/onetime/logic/organization_context.rb:91`) has no archived filter
+   and hands back the archived org. So secrets, receipts, limits all keep
+   keying off it; it's invisible, not gone. This is the same trap as
+   #4211's "nil-on-archived". Either keep `:last_org` non-overridable for
+   soft delete too, or fix that fallback to `.reject(&:archived?)` and
+   decide what an org-less session does.
+2. `archived` already means something else. `archive!`/`archived_comment`
+   are the SSO bulk-migration "superseded by domain org" state;
+   `JoinDomainOrganization` re-archives on every domain SSO login and
+   domains doctor check 9 reads it that way
+   (`organization.rb:323-357`). Reusing it for customer-requested deletion
+   conflates states. Use a separate marker (`deleted_at` + reason, or a
+   status field) — or at minimum a reserved `archived_comment` value the
+   SSO paths never write.
+3. `archive!` skips the guards `Org::Delete` has. It warns on domains and
+   never checks `billing_live?`, so a soft-deleted org can keep billing in
+   Stripe and keep owning live domains. And nothing promotes a surviving
+   org to `is_default`/`default_org_id`.


### PR DESCRIPTION
## Summary
- Three notes existed only as gitignored `*.txt` scratch files in `docs/specs/` (untracked, local-only).
- Moved each into its own directory as `.md`, matching `docs/specs/` conventions:
  - `docs/specs/domain-ceiling/domain-ceiling.md`
  - `docs/specs/organization-management/deleting-an-organization.md`
  - `docs/specs/install-onboarding/install-onboarding-front-door-assessment.md` (joins the existing `install-onboarding/` siblings, so it picked up their frontmatter convention)
- `deleting-an-organization.md` and the install-onboarding assessment got light cleanup (stray artifact, conversational scaffolding) without changing their substance; `domain-ceiling.md` was already well-formed and moved as-is.

## Test plan
- [x] Docs-only change; no code paths touched.
- [x] Confirmed the three source `.txt` files were gitignored/untracked (`git check-ignore -v`), so this is a net-new addition, not a rename `git mv` could track.