### PR TITLE
Rework diagnostics actor_ref: extid pre-image, deployment-only keying

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,17 +84,15 @@ FROM_NAME="Secret Links"
 #-----BEGIN INDEPENDENT SECRETS (generated, must be backed up)-----
 #AUTH_SECRET=
 #ARGON2_SECRET=
+# Also keys the pseudonymous Sentry diagnostics references: Sentry receives an
+# opaque keyed digest of the customer external identifier (and of the
+# organization objid), never the identifier itself. Per-installation by
+# construction — do not copy between installations. Rotating this re-keys the
+# references; with no secret set, none are emitted. See .env.reference and
+# docs/development/{backend,frontend}-diagnostics.md.
 #ACCOUNT_ID_SECRET=
 #-----END INDEPENDENT SECRETS-----
 
 #-----BEGIN FEDERATION (shared across instances, auto-generated passphrase)-----
 #FEDERATION_SECRET=
 #-----END FEDERATION-----
-# Optional residency scope for the pseudonymous Sentry actor reference.
-# Set a stable label only when the effective JURISDICTION is not the residency
-# boundary you need. FEDERATION_SECRET is used only with a resolved residency;
-# otherwise ACCOUNT_ID_SECRET is the deployment-local fallback. With no usable
-# secret, no actor reference is emitted. See .env.reference and
-# docs/development/{backend,frontend}-diagnostics.md for fleet and privacy
-# requirements.
-#DIAGNOSTICS_REF_REGION=

--- a/.env.reference
+++ b/.env.reference
@@ -56,13 +56,25 @@ SECRET=
 # [federation] Cross-region subscription federation.
 # Must be identical across all regions in a multi-region deploy.
 # Not auto-generated — set manually and share across instances.
-# Also keys the pseudonymous Sentry diagnostics references (actor AND
-# organization), but only when a data-residency scope is declared — see
-# DIAGNOSTICS_REF_REGION.
 #FEDERATION_SECRET=
 
 # [independent] Obfuscates numeric account IDs in email-verification
 # links and remember-me cookies.
+#
+# Also keys the pseudonymous Sentry diagnostics references
+# (Onetime::Utils::DiagnosticsRef): the actor reference is derived from the
+# customer's external identifier and the organization reference from the
+# organization objid, both HMAC'd under this secret and truncated. Sentry
+# receives only the opaque reference, never the identifier it was derived
+# from. Those references support issue correlation and affected-account
+# counts within this installation; they are not for product usage analytics
+# or behavioral profiling, and a keyed pseudonym is still potentially
+# personal data. Because both pre-images are minted per installation,
+# separately provisioned installations do not correlate — do not copy this
+# secret between installations. Rotating it re-keys every reference, so
+# correlation with already-reported events breaks; under Sentry's retention
+# window that discontinuity ages out on its own. With no secret set, no
+# references are emitted at all.
 #ACCOUNT_ID_SECRET=
 
 # Previous AUTH_SECRET value, set only while rotating AUTH_SECRET
@@ -985,9 +997,7 @@ APPROXIMATED_VHOST_TARGET=
 # ═══════════════════════════════════════════════════════════
 
 REGIONS_ENABLED=false
-# This instance's jurisdiction ID (e.g. EU). Also supplies the
-# data-residency scope for the pseudonymous Sentry diagnostics references
-# when DIAGNOSTICS_REF_REGION is unset — see that entry.
+# This instance's jurisdiction ID (e.g. EU).
 JURISDICTION=
 # Available jurisdictions as ID:domain pairs (e.g., EU:eu.example.com,CA:ca.example.com)
 JURISDICTIONS=
@@ -1841,39 +1851,11 @@ SENTRY_RELEASE=
 # explicitly; leave empty to continue all inbound traces. No default.
 #SENTRY_ORG_ID=
 
-# Data-residency scope for the pseudonymous Sentry actor reference
-# (Onetime::Utils::DiagnosticsRef). Sentry receives an opaque keyed reference,
-# rather than a direct identifier such as an account email or customer ID. The
-# reference supports issue correlation and affected-account counts within its
-# configured scope; it is not for product usage analytics, behavioral profiling,
-# or cross-region identity joins. A keyed pseudonym is still potentially
-# personal data and must be handled accordingly.
-#
-# Resolution order: DIAGNOSTICS_REF_REGION, then JURISDICTION, then nothing.
-# With a resolved residency, FEDERATION_SECRET produces `federated` references.
-# Without a resolved residency, FEDERATION_SECRET is refused and
-# ACCOUNT_ID_SECRET produces `deployment` references instead. With neither
-# usable secret, no actor reference is emitted. The residency label itself is
-# never sent; it is mixed into the derivation. Any short stable string works:
-# eu, us, ca-central.
-#
-# Fleet rules: instances expected to correlate must share the same effective
-# FEDERATION_SECRET and residency scope. Different residencies must use different
-# effective scopes. Do not copy ACCOUNT_ID_SECRET between installations: doing so
-# can recreate cross-install correlation under the `deployment` label.
-#
-# Changing DIAGNOSTICS_REF_REGION, or JURISDICTION when no explicit region is
-# set, re-keys references. Changing FEDERATION_SECRET for federated references
-# or ACCOUNT_ID_SECRET for deployment references also re-keys them. These changes
-# break correlation with previously reported events.
-#
-# See docs/development/backend-diagnostics.md and
-# docs/development/frontend-diagnostics.md for the Sentry fields and current
-# behavior. Organization correlation is not active: the frontend does not attach
-# the backend organization reference to Sentry. No default.
-#DIAGNOSTICS_REF_REGION=
-
-
+# Pseudonymous Sentry references (actor and organization) are keyed by
+# ACCOUNT_ID_SECRET — see that entry for what is derived, what Sentry
+# receives, and what rotating it costs. There is no diagnostics-specific
+# secret and no residency knob: both pre-images are minted per installation,
+# so separately provisioned installations do not correlate by default.
 
 
 # ═══════════════════════════════════════════════════════════

--- a/apps/api/account/logic/account/update_password.rb
+++ b/apps/api/account/logic/account/update_password.rb
@@ -151,7 +151,7 @@ module AccountAPI::Logic
       # with the full-mode hook). Never let a delivery problem surface as a
       # password-change failure.
       def send_password_changed_notification
-        Onetime::ErrorHandler.safe_execute('password_changed_email', customer_id: cust.extid) do
+        Onetime::ErrorHandler.safe_execute('password_changed_email', external_id: cust.extid) do
           # Customers default locale to "" (matches Redis string load), which
           # is truthy and would slip past a bare `||`. Treat blank as missing.
           locale = cust.locale

--- a/apps/api/colonel/spec/logic/colonel/get_organization_detail_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/get_organization_detail_spec.rb
@@ -71,15 +71,10 @@ RSpec.describe ColonelAPI::Logic::Colonel::GetOrganizationDetail do
   end
 
   describe 'diagnostics references' do
-    # Pin a known keying rather than inheriting whatever the lane exports.
-    # DiagnosticsRef refuses the shared federation secret when no residency
-    # resolves, so an unpinned lane could make every example here assert
-    # against nil and pass for the wrong reason.
-    let(:keying) do
-      Onetime::Utils::DiagnosticsRef::Keying.new(
-        secret: 'a-known-diagnostics-key', scope: 'federated', residency: 'stub-region'
-      )
-    end
+    # Pin a known keying rather than inheriting whatever the lane exports, so
+    # an unpinned lane cannot make every example here assert against nil and
+    # pass for the wrong reason.
+    let(:keying) { 'a-known-diagnostics-key' }
 
     before { allow(Onetime::Utils::DiagnosticsRef).to receive(:keying).and_return(keying) }
 
@@ -104,10 +99,11 @@ RSpec.describe ColonelAPI::Logic::Colonel::GetOrganizationDetail do
       expect(record[:organization_ref]).not_to eq(other)
     end
 
-    it 'is domain separated from the user namespace' do
-      # A pre-image both entry points treat identically — already lowercase,
-      # unpadded, NFC — so the only difference left is the purpose prefix.
-      probe = 'domain-separation-probe'
+    it 'is domain separated from the actor namespace' do
+      # An extid-shaped pre-image, which is what the actor namespace digests.
+      # Both entry points treat it identically (no normalization on either
+      # side), so the only difference left is the purpose prefix.
+      probe = 'ur00fedcba9876543210zyxwvu'
 
       expect(Onetime::Utils::DiagnosticsRef.organization_ref(probe))
         .not_to eq(Onetime::Utils::DiagnosticsRef.actor_ref(probe))

--- a/apps/api/domains/logic/sender_config/auto_provisioning.rb
+++ b/apps/api/domains/logic/sender_config/auto_provisioning.rb
@@ -51,7 +51,11 @@ module DomainsAPI
             from_domain: from_domain,
             provider: provider,
             org_id: @organization&.extid,
-            user_id: respond_to?(:cust) ? cust&.extid : nil,
+            # Canonical key for a customer extid at the ErrorHandler boundary:
+            # capture_error consumes `external_id:` as the pseudonymous actor
+            # and scrubs it from the forwarded Sentry context. `org_id` above is
+            # NOT that — an org extid is not an actor pre-image.
+            external_id: respond_to?(:cust) ? cust&.extid : nil,
           }
 
           Onetime::ErrorHandler.safe_execute('auto_provision_sender_domain', **context) do

--- a/apps/web/auth/config/hooks/account.rb
+++ b/apps/web/auth/config/hooks/account.rb
@@ -190,7 +190,13 @@ module Auth::Config::Hooks
                                 'canonical_signup'
                               end
 
-        customer = Onetime::ErrorHandler.safe_execute('create_customer', account_id: account_id, extid: account[:extid]) do
+        # No identity key here on purpose. The accounts row has no `extid`
+        # column (it is `external_id`, see auth/migrations/001_initial.rb) and
+        # the Customer this hook is about to create does not exist yet, so
+        # there is no extid to attribute a failure to. Accepted attribution
+        # loss: the event is still captured and grouped, but actor cardinality
+        # is unanswerable for the create-customer class.
+        customer = Onetime::ErrorHandler.safe_execute('create_customer', account_id: account_id) do
           Auth::Operations::CreateCustomer.new(
             account_id: account_id,
             account: account,
@@ -214,7 +220,7 @@ module Auth::Config::Hooks
             # already validated the token and that the signup email matches the
             # invited email, so we can mark the customer verified here without
             # a separate email round-trip.
-            Onetime::ErrorHandler.safe_execute('auto_verify_invite_signup', extid: customer.extid) do
+            Onetime::ErrorHandler.safe_execute('auto_verify_invite_signup', external_id: customer.extid) do
               customer.verified    = true
               customer.verified_by = 'invite_token'
               customer.save
@@ -266,7 +272,7 @@ module Auth::Config::Hooks
             # CreateDefaultWorkspace#apply_pending_federation! and #initialize.
             require_verification = Onetime.auth_config.verify_account_enabled?
 
-            Onetime::ErrorHandler.safe_execute('create_default_workspace', extid: customer.extid) do
+            Onetime::ErrorHandler.safe_execute('create_default_workspace', external_id: customer.extid) do
               Auth::Operations::CreateDefaultWorkspace.new(
                 customer: customer,
                 require_verification: require_verification,
@@ -331,7 +337,7 @@ module Auth::Config::Hooks
             email: account[:email],
           )
 
-          Onetime::ErrorHandler.safe_execute('verify_customer', extid: account[:external_id]) do
+          Onetime::ErrorHandler.safe_execute('verify_customer', external_id: account[:external_id]) do
             next unless account[:external_id]
 
             customer = Onetime::Customer.find_by_extid(account[:external_id])
@@ -351,7 +357,7 @@ module Auth::Config::Hooks
           # here we apply it to the workspace created at signup. Idempotent and a
           # safe no-op when nothing is pending or it was already claimed. Re-fetch
           # the customer so verified? reflects the state just persisted above.
-          Onetime::ErrorHandler.safe_execute('claim_pending_federation', extid: account[:external_id]) do
+          Onetime::ErrorHandler.safe_execute('claim_pending_federation', external_id: account[:external_id]) do
             next unless account[:external_id]
 
             verified_customer = Onetime::Customer.find_by_extid(account[:external_id])
@@ -363,7 +369,7 @@ module Auth::Config::Hooks
           # Surface pending plan intent for checkout redirect (issue #3126)
           # If the user had selected a plan before signup, redirect them to checkout
           # after verification completes.
-          Onetime::ErrorHandler.safe_execute('surface_plan_intent', extid: account[:extid]) do
+          Onetime::ErrorHandler.safe_execute('surface_plan_intent', external_id: account[:external_id]) do
             # account[:external_id] (Rodauth/SQL) == customer.extid (Familia/Redis)
             customer = Onetime::Customer.find_by_extid(account[:external_id])
 
@@ -932,7 +938,7 @@ module Auth::Config::Hooks
           email: account[:email],
         )
 
-        Onetime::ErrorHandler.safe_execute('delete_customer', account_id: account_id, extid: account[:extid]) do
+        Onetime::ErrorHandler.safe_execute('delete_customer', account_id: account_id, external_id: account[:external_id]) do
           Auth::Operations::DeleteCustomer.new(account: account).call
         end
       end

--- a/apps/web/auth/config/hooks/omniauth.rb
+++ b/apps/web/auth/config/hooks/omniauth.rb
@@ -782,7 +782,7 @@ module Auth::Config::Hooks
             # Tenant domain SSO → join the domain's organization only
             Onetime::ErrorHandler.safe_execute(
               'join_domain_organization_omniauth',
-              extid: customer.extid,
+              external_id: customer.extid,
               domain_id: domain_id,
             ) do
               Auth::Operations::JoinDomainOrganization.new(
@@ -811,7 +811,7 @@ module Auth::Config::Hooks
             # Canonical domain SSO → create default workspace
             Onetime::ErrorHandler.safe_execute(
               'create_default_workspace_omniauth',
-              extid: customer.extid,
+              external_id: customer.extid,
             ) do
               Auth::Operations::CreateDefaultWorkspace.new(customer: customer).call
             end

--- a/apps/web/auth/config/hooks/two_factor.rb
+++ b/apps/web/auth/config/hooks/two_factor.rb
@@ -63,7 +63,7 @@ module Auth::Config::Hooks
           Onetime::ErrorHandler.safe_execute(
             'sync_session_after_mfa',
             account_id: account_id,
-            email: account[:email],
+            external_id: account[:external_id],
           ) do
             Auth::Operations::SyncSession.call(
               account: account,

--- a/apps/web/auth/spec/integration/full/domain_sso_join_organization_spec.rb
+++ b/apps/web/auth/spec/integration/full/domain_sso_join_organization_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe 'Tenant-SSO Join Domain Organization (issue #3114)', type: :integ
       # Step 1: JoinDomainOrganization fails silently (mirrors safe_execute wrapper)
       Onetime::ErrorHandler.safe_execute(
         'join_domain_organization_omniauth',
-        extid: fresh_sso_customer.extid,
+        external_id: fresh_sso_customer.extid,
         domain_id: bogus_domain_id,
       ) do
         Auth::Operations::JoinDomainOrganization.new(

--- a/apps/web/core/spec/views/serializers/diagnostics_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/diagnostics_serializer_spec.rb
@@ -5,17 +5,21 @@
 # Coverage for DiagnosticsSerializer's pseudonymous actor reference.
 #
 # The bootstrap payload is the only channel that hands the browser Sentry SDK
-# an reference, so this file pins the two directions that can go wrong:
+# a reference, so this file pins the two directions that can go wrong:
 #
-#   OMISSION. Anonymous visitors, awaiting-MFA sessions, and installs with
-#   neither FEDERATION_SECRET nor ACCOUNT_ID_SECRET must produce NO `diagnostics_ref`
-#   key at all. Absence is the contract — not a null, not an empty string —
-#   because an anonymous visitor has no reference to report and an unconfigured
-#   install (the default in dev and test) must render exactly as before.
+#   OMISSION. Anonymous visitors, awaiting-MFA sessions, customers with no
+#   readable extid, and installs with no ACCOUNT_ID_SECRET must produce NO
+#   `diagnostics_ref` key at all. Absence is the contract — not a null, not an
+#   empty string — because an anonymous visitor has no reference to report and
+#   an unconfigured install (the default in dev and test) must render exactly
+#   as before.
 #
-#   DISCLOSURE. When the block IS emitted it may carry EXACTLY the opaque ref
-#   and its scope label — never the email, custid, objid or extid, and never a
-#   third key. The frontend contract (diagnosticsRefSchema — not the unrelated
+#   DISCLOSURE. When the block IS emitted it may carry EXACTLY the opaque ref —
+#   never the email, custid, objid or extid, and never a second key. The extid
+#   matters twice over here: it is the ref's PRE-IMAGE
+#   (docs/specs/diagnostics/actor-ref-preimage-debate-decision.md), so emitting
+#   it alongside the ref would hand the browser both input and output. The
+#   frontend contract (diagnosticsRefSchema — not the unrelated
 #   diagnosticsSchema, which is the Sentry config block) is a Zod strictObject
 #   and is the one schema parsed against live data, so an extra key here makes
 #   the client drop the whole block. A pseudonymous ORGANIZATION ref does exist
@@ -23,8 +27,9 @@
 #   but is per-RESOURCE, not per-session, and must stay off this block.
 #
 #   RENDER SAFETY. This serializer is registered on all three web shells, so it
-#   runs on EVERY authenticated render. A stored email that is not valid UTF-8
-#   must therefore degrade to an omitted block, never to an exception — an
+#   runs on EVERY authenticated render. Familia derives an extid lazily and
+#   raises when the objid is absent or of unknown provenance, so an unreadable
+#   extid must degrade to an omitted block, never to an exception — an
 #   exception here is a 500 page plus a self-inflicted Sentry event.
 #
 # The serializer's declared output_template still lists `diagnostics_ref`, because
@@ -44,8 +49,13 @@ RSpec.describe Core::Views::DiagnosticsSerializer do
 
   let(:email) { 'operator@example.com' }
   let(:objid) { '01JORGABCDEFGHJKMNPQRSTVWX' }
-  let(:extid) { 'on1234567890s' }
+  let(:org_extid) { 'on1234567890s' }
   let(:custid) { 'cust-1234567890' }
+
+  # Shaped like a real Customer extid: Familia's external_identifier feature
+  # under `format: 'ur%<id>s'` emits `ur` plus 25 base36 characters.
+  let(:cust_extid) { 'ur00fedcba9876543210zyxwvu' }
+  let(:cust_objid) { '01JCUSTABCDEFGHJKMNPQRSTVW' }
 
   let(:colonel) { false }
 
@@ -54,48 +64,27 @@ RSpec.describe Core::Views::DiagnosticsSerializer do
       Onetime::Customer,
       email: email,
       custid: custid,
-      objid: '01JCUSTABCDEFGHJKMNPQRSTVW',
-      extid: 'ur1234567890s',
+      objid: cust_objid,
+      extid: cust_extid,
     ).tap { |double| allow(double).to receive(:role?).with(:colonel).and_return(colonel) }
   end
 
-  let(:org) { Struct.new(:objid, :extid).new(objid, extid) }
+  let(:org) { Struct.new(:objid, :extid).new(objid, org_extid) }
 
   let(:view_vars) do
     { 'authenticated' => true, 'cust' => cust, 'organization' => org }
   end
 
-  # Set env vars for the duration of a block and restore them, including
-  # deletion when the original was unset.
-  def with_env(pairs)
-    original = pairs.keys.to_h { |key| [key, ENV.fetch(key, nil)] }
-    pairs.each { |key, value| ENV[key] = value }
-    yield
-  ensure
-    original.each { |key, value| ENV[key] = value }
-  end
-
   # Force a known keying state per context rather than inheriting whatever the
-  # lane happens to export (tests/lanes/base.env sets both secrets).
-  #
-  # A federated keying MUST carry a residency: DiagnosticsRef refuses to derive a
-  # ref from the shared federation secret with no residency resolved, so a stub
-  # that omitted one would silently make every federated example emit nothing.
-  def stub_keying(scope, residency: 'stub-region')
-    if scope.nil?
-      allow(Onetime::Utils::DiagnosticsRef).to receive(:keying).and_return(nil)
-    else
-      keying = Onetime::Utils::DiagnosticsRef::Keying.new(
-        secret: 'a-known-diagnostics-key', scope: scope, residency: residency
-      )
-      allow(Onetime::Utils::DiagnosticsRef).to receive(:keying).and_return(keying)
-    end
+  # lane happens to export (tests/lanes/base.env sets ACCOUNT_ID_SECRET).
+  def stub_keying(secret)
+    allow(Onetime::Utils::DiagnosticsRef).to receive(:keying).and_return(secret)
   end
 
   context 'when the visitor is anonymous' do
     let(:view_vars) { { 'authenticated' => false, 'cust' => nil } }
 
-    before { stub_keying('federated') }
+    before { stub_keying('a-known-diagnostics-key') }
 
     it 'omits the diagnostics_ref key entirely' do
       expect(output).not_to have_key('diagnostics_ref')
@@ -109,7 +98,7 @@ RSpec.describe Core::Views::DiagnosticsSerializer do
   context 'when a customer object exists but the session is not authenticated' do
     let(:view_vars) { { 'authenticated' => false, 'cust' => cust } }
 
-    before { stub_keying('federated') }
+    before { stub_keying('a-known-diagnostics-key') }
 
     it 'omits the diagnostics_ref key' do
       expect(output).not_to have_key('diagnostics_ref')
@@ -124,14 +113,14 @@ RSpec.describe Core::Views::DiagnosticsSerializer do
       { 'authenticated' => true, 'awaiting_mfa' => true, 'cust' => cust }
     end
 
-    before { stub_keying('federated') }
+    before { stub_keying('a-known-diagnostics-key') }
 
     it 'omits the diagnostics_ref key' do
       expect(output).not_to have_key('diagnostics_ref')
     end
   end
 
-  context 'when neither secret is configured' do
+  context 'when ACCOUNT_ID_SECRET is not configured' do
     before { stub_keying(nil) }
 
     it 'omits the diagnostics_ref key for an authenticated user' do
@@ -143,233 +132,105 @@ RSpec.describe Core::Views::DiagnosticsSerializer do
     end
   end
 
-  context 'when FEDERATION_SECRET keys the ref' do
-    before { stub_keying('federated') }
+  # ACCOUNT_ID_SECRET is now the ONLY keying. FEDERATION_SECRET was dropped from
+  # diagnostics entirely, and with it the residency apparatus and the scope
+  # label: an extid is minted per install, so refs are per-install by
+  # construction rather than by configuration.
+  context 'when ACCOUNT_ID_SECRET keys the ref' do
+    before { stub_keying('a-known-diagnostics-key') }
 
-    it 'emits an opaque ref labelled federated' do
-      expect(output['diagnostics_ref']['actor_scope']).to eq('federated')
+    it 'emits an opaque ref' do
       expect(output['diagnostics_ref']['actor_ref']).to match(/\A[0-9a-f]{16}\z/)
     end
 
-    it 'matches the reference the module derives for that email' do
+    it 'matches the reference the module derives for that customer extid' do
       expect(output['diagnostics_ref']['actor_ref'])
-        .to eq(Onetime::Utils::DiagnosticsRef.actor_ref(email))
+        .to eq(Onetime::Utils::DiagnosticsRef.actor_ref(cust_extid))
+    end
+
+    it 'does NOT derive from the email' do
+      expect(output['diagnostics_ref']['actor_ref'])
+        .not_to eq(Onetime::Utils::DiagnosticsRef.actor_ref(email))
+    end
+
+    it 'gives two installs different refs for the same customer' do
+      stub_keying('install-a')
+      region_a = described_class.serialize(view_vars)['diagnostics_ref']['actor_ref']
+
+      stub_keying('install-b')
+      region_b = described_class.serialize(view_vars)['diagnostics_ref']['actor_ref']
+
+      expect(region_a).not_to eq(region_b)
     end
   end
 
-  context 'when only ACCOUNT_ID_SECRET keys the ref' do
-    before { stub_keying('deployment', residency: nil) }
+  # Familia derives an extid lazily from the objid and raises
+  # ExternalIdentifierError when it cannot. This serializer runs on every
+  # authenticated render, so that must cost the ref and nothing else.
+  context 'when the customer extid is unreadable' do
+    before { stub_keying('a-known-diagnostics-key') }
 
-    it 'emits an opaque ref labelled deployment' do
-      expect(output['diagnostics_ref']['actor_scope']).to eq('deployment')
-      expect(output['diagnostics_ref']['actor_ref']).to match(/\A[0-9a-f]{16}\z/)
-    end
-  end
+    context 'because it is nil' do
+      let(:cust_extid) { nil }
 
-  # The keying decision is exercised end to end here — no stub_keying — because
-  # the defect being pinned was that the SAFE state required configuration.
-  # A shared FEDERATION_SECRET plus an operator who declared nothing must not
-  # produce a federated, cross-region-correlatable reference in the payload.
-  context 'when FEDERATION_SECRET is set but no residency scope is declared' do
-    before { allow(OT).to receive(:conf).and_return({}) }
-
-    it 'narrows the emitted label to deployment rather than claiming federated' do
-      with_env('FEDERATION_SECRET' => 'shared-across-regional-instances',
-               'DIAGNOSTICS_REF_REGION' => nil,
-               'ACCOUNT_ID_SECRET' => 'per-install-only') do
-        expect(output['diagnostics_ref']['actor_scope']).to eq('deployment')
-      end
-    end
-
-    it 'omits the block entirely when there is no per-deployment secret to fall back to' do
-      with_env('FEDERATION_SECRET' => 'shared-across-regional-instances',
-               'DIAGNOSTICS_REF_REGION' => nil,
-               'ACCOUNT_ID_SECRET' => nil) do
+      it 'omits the block instead of substituting another identifier' do
         expect(output).not_to have_key('diagnostics_ref')
       end
     end
 
-    it 'gives two installs sharing the secret different refs for the same person' do
-      shared = 'shared-across-regional-instances'
-      env    = { 'FEDERATION_SECRET' => shared, 'DIAGNOSTICS_REF_REGION' => nil }
-
-      region_a = with_env(env.merge('ACCOUNT_ID_SECRET' => 'install-a')) { output['diagnostics_ref'] }
-      region_b = with_env(env.merge('ACCOUNT_ID_SECRET' => 'install-b')) do
-        described_class.serialize(view_vars)['diagnostics_ref']
+    context 'because reading it raises' do
+      let(:cust) do
+        instance_double(Onetime::Customer).tap do |double|
+          allow(double).to receive(:extid).and_raise(StandardError, 'missing objid field')
+        end
       end
 
-      expect(region_a['actor_ref']).not_to eq(region_b['actor_ref'])
-    end
-
-    it 'restores federated keying once a residency scope is declared' do
-      with_env('FEDERATION_SECRET' => 'shared-across-regional-instances',
-               'DIAGNOSTICS_REF_REGION' => 'eu') do
-        expect(output['diagnostics_ref']['actor_scope']).to eq('federated')
+      it 'omits the block instead of raising out of the render' do
+        expect { output }.not_to raise_error
+        expect(output).not_to have_key('diagnostics_ref')
       end
-    end
-  end
-
-  # A residency read that blows up must cost this render its reference, not hand
-  # it a DIFFERENT one — a second ref for the same human forks one Sentry user
-  # in two and destroys "is this one user or fifty?".
-  context 'when the residency config read fails transiently' do
-    # Swapped inline rather than via `allow`, because a raising OT.conf would
-    # still be installed when spec_helper's after hook reads it during teardown.
-    def with_failing_conf
-      original = OT.method(:conf)
-      OT.define_singleton_method(:conf) { raise 'transient config failure' }
-      yield
-    ensure
-      OT.define_singleton_method(:conf, original)
-    end
-
-    it 'omits the block instead of emitting a second reference for the same person' do
-      with_env('FEDERATION_SECRET' => 'shared-across-regional-instances',
-               'DIAGNOSTICS_REF_REGION' => nil,
-               'ACCOUNT_ID_SECRET' => 'per-install-only') do
-        with_failing_conf { expect(output).not_to have_key('diagnostics_ref') }
-      end
-    end
-
-    it 'still renders rather than raising out of the view' do
-      with_env('DIAGNOSTICS_REF_REGION' => nil) do
-        with_failing_conf { expect { output }.not_to raise_error }
-      end
-    end
-  end
-
-  # A residency read that changes MID-DERIVATION is the sharper version of the
-  # transient failure above: nothing raises, so the raise-based guard never
-  # engages. The ref and the label the browser receives must still describe ONE
-  # read of the config — before the fix the ref was keyed with the shared
-  # federation secret over an 'unscoped' pre-image (identical on every install
-  # sharing that secret) while the label read 'deployment'.
-  context 'when the residency config changes mid-derivation' do
-    let(:shared) { 'shared-across-regional-instances' }
-
-    let(:env) do
-      { 'FEDERATION_SECRET' => shared,
-        'DIAGNOSTICS_REF_REGION' => nil,
-        'ACCOUNT_ID_SECRET' => 'per-install-only' }
-    end
-
-    # OT.conf is swapped inline rather than via `allow` throughout this context,
-    # because a conf installed by these helpers must be gone before
-    # spec_helper's teardown reads it.
-    def with_conf(conf)
-      original = OT.method(:conf)
-      OT.define_singleton_method(:conf) { conf }
-      yield
-    ensure
-      OT.define_singleton_method(:conf, original)
-    end
-
-    def conf_object(&dig)
-      Object.new.tap { |obj| obj.define_singleton_method(:dig, &dig) }
-    end
-
-    # Answers a healthy jurisdiction for the FIRST residency resolution, then
-    # goes falsy. Triggered by the resolution itself rather than by counting
-    # OT.conf reads, so it does not depend on the implementation's read count.
-    def with_conf_falsy_after_first_resolution(jurisdiction)
-      resolved = false
-      conf     = conf_object do |*path|
-        next nil unless path == %w[features regions current_jurisdiction]
-
-        resolved = true
-        jurisdiction
-      end
-
-      original = OT.method(:conf)
-      OT.define_singleton_method(:conf) { resolved ? nil : conf }
-      yield
-    ensure
-      OT.define_singleton_method(:conf, original)
-    end
-
-    # No nil anywhere: the declared jurisdiction simply drifts between
-    # resolutions, as an operator edit or a config reload would make it.
-    def with_drifting_jurisdiction(*sequence)
-      queue = sequence.dup
-      conf  = conf_object do |*path|
-        next nil unless path == %w[features regions current_jurisdiction]
-
-        queue.length > 1 ? queue.shift : queue.first
-      end
-
-      with_conf(conf) { yield }
-    end
-
-    def diagnostics_ref
-      described_class.serialize(view_vars)['diagnostics_ref']
-    end
-
-    def healthy(jurisdiction)
-      conf = { 'features' => { 'regions' => { 'current_jurisdiction' => jurisdiction } } }
-      with_env(env) { with_conf(conf) { diagnostics_ref } }
-    end
-
-    def faulted(jurisdiction)
-      with_env(env) { with_conf_falsy_after_first_resolution(jurisdiction) { diagnostics_ref } }
-    end
-
-    it 'emits the same reference during the window as outside it' do
-      expect(faulted('eu')).to eq(healthy('eu'))
-    end
-
-    it 'does not collide two jurisdictions onto one ref' do
-      expect(faulted('eu')['actor_ref']).not_to eq(faulted('us')['actor_ref'])
-    end
-
-    it 'does not invert the label downward over a federation-keyed ref' do
-      expected = OpenSSL::HMAC.hexdigest(
-        'SHA256', shared,
-        [Onetime::Utils::DiagnosticsRef::ACTOR_INFO, 'eu', email]
-          .join(Onetime::Utils::DiagnosticsRef::SEPARATOR),
-      )[0, Onetime::Utils::DiagnosticsRef::REF_LENGTH]
-
-      expect(faulted('eu')['actor_ref']).to eq(expected)
-      expect(faulted('eu')['actor_scope']).to eq('federated')
-    end
-
-    it 'keys on the read that chose the secret when the jurisdiction drifts' do
-      drifted = with_env(env) { with_drifting_jurisdiction('eu', 'us') { diagnostics_ref } }
-
-      expect(drifted).to eq(healthy('eu'))
-      expect(drifted['actor_ref']).not_to eq(healthy('us')['actor_ref'])
     end
   end
 
   describe 'disclosure' do
-    before { stub_keying('federated') }
+    before { stub_keying('a-known-diagnostics-key') }
 
-    let(:colonel) { true } # even a colonel gets only the two-key block here
+    let(:colonel) { true } # even a colonel gets only the one-key block here
 
     it 'leaks no identifier anywhere in the emitted payload' do
       serialized = output.to_json
 
-      [email, custid, objid, extid, 'ur1234567890s', '01JCUSTABCDEFGHJKMNPQRSTVW'].each do |secret|
+      # cust_extid is in this list because it is the ref's PRE-IMAGE. Emitting
+      # it beside the ref would give the browser the input and the output.
+      [email, custid, objid, org_extid, cust_extid, cust_objid].each do |secret|
         expect(serialized).not_to include(secret)
       end
       expect(serialized).not_to include('@')
     end
 
-    it 'carries exactly the two keys the strict frontend schema accepts' do
-      # A third key fails diagnosticsSchema (z.strictObject) and the client
+    it 'carries exactly the one key the strict frontend schema accepts' do
+      # A second key fails diagnosticsRefSchema (z.strictObject) and the client
       # discards the whole block — so widening this is a silent regression.
-      expect(output['diagnostics_ref'].keys).to contain_exactly('actor_ref', 'actor_scope')
+      expect(output['diagnostics_ref'].keys).to contain_exactly('actor_ref')
+    end
+
+    it 'no longer carries the actor_scope label' do
+      # There is one keying now, so the label was constant. It was dropped from
+      # the wire contract rather than pinned to a constant value; the frontend
+      # schema is a strictObject, so re-adding it here would break the parse.
+      expect(output['diagnostics_ref']).not_to have_key('actor_scope')
     end
 
     # A pseudonymous organization ref DOES exist (DiagnosticsRef.organization_ref,
     # published on the colonel organization-detail record). It must not appear
     # here. This block is per-SESSION and the org ref is per-RESOURCE: a session
     # touches many organizations, so any value pinned here would be tagged onto
-    # later events about other orgs. And mechanically it is a third key in a
-    # strictObject — the client would drop actor_ref and actor_scope with it.
-    it 'stays a two-key per-session block even though org refs now exist' do
+    # later events about other orgs. And mechanically it is a second key in a
+    # strictObject — the client would drop actor_ref with it.
+    it 'stays a one-key per-session block even though org refs now exist' do
       expect(Onetime::Utils::DiagnosticsRef).to respond_to(:organization_ref)
 
-      expect(output['diagnostics_ref'].keys).to contain_exactly('actor_ref', 'actor_scope')
+      expect(output['diagnostics_ref'].keys).to contain_exactly('actor_ref')
       expect(output['diagnostics_ref']).not_to have_key('organization_ref')
     end
 
@@ -384,58 +245,19 @@ RSpec.describe Core::Views::DiagnosticsSerializer do
       expect(output.to_json).not_to include(org_ref)
     end
 
-    # actor_scope is an ACCEPTED disclosure: it tells an authenticated browser
-    # how this install is keyed. That is accepted because the frontend uses it
-    # as the correlation-blast-radius tag on every Sentry event. It is accepted
-    # ONLY while it describes the key — the moment it varies per account it is
-    # account data on an anonymity surface.
-    it 'is a property of the keying, not of the account' do
+    it 'distinguishes one customer from another' do
       other = instance_double(
         Onetime::Customer,
         email: 'someone-else@example.com',
         custid: 'cust-9999999999',
         objid: '01JOTHERABCDEFGHJKMNPQRST',
-        extid: 'ur9999999999s',
+        extid: 'ur00abcdef0123456789vwxyzu',
       ).tap { |double| allow(double).to receive(:role?).with(:colonel).and_return(false) }
 
       other_output = described_class.serialize(view_vars.merge('cust' => other))
 
-      expect(other_output['diagnostics_ref']['actor_scope']).to eq(output['diagnostics_ref']['actor_scope'])
-      expect(other_output['diagnostics_ref']['actor_ref']).not_to eq(output['diagnostics_ref']['actor_ref'])
-    end
-  end
-
-  # Emails reach us from the datastore, from SSO providers and from legacy
-  # rows. String#unicode_normalize raises on anything that is not valid UTF-8,
-  # and normalization sits on this render path.
-  describe 'a stored email that is not valid UTF-8' do
-    before { stub_keying('federated') }
-
-    context 'with an invalid byte' do
-      let(:email) { "a\xFF@b.com" }
-
-      it 'omits the block instead of raising out of the render' do
-        expect { output }.not_to raise_error
-        expect(output).not_to have_key('diagnostics_ref')
-      end
-    end
-
-    context 'with a truncated multibyte sequence' do
-      let(:email) { "\xC3(@b.com" }
-
-      it 'omits the block instead of raising out of the render' do
-        expect { output }.not_to raise_error
-        expect(output).not_to have_key('diagnostics_ref')
-      end
-    end
-
-    context 'with correct UTF-8 bytes under a binary encoding tag' do
-      let(:email) { 'operator@example.com'.dup.force_encoding(Encoding::ASCII_8BIT) }
-
-      it 'still emits the same ref as the correctly tagged address' do
-        expect(output['diagnostics_ref']['actor_ref'])
-          .to eq(Onetime::Utils::DiagnosticsRef.actor_ref('operator@example.com'))
-      end
+      expect(other_output['diagnostics_ref']['actor_ref'])
+        .not_to eq(output['diagnostics_ref']['actor_ref'])
     end
   end
 

--- a/apps/web/core/spec/views/serializers/diagnostics_serializer_spec.rb
+++ b/apps/web/core/spec/views/serializers/diagnostics_serializer_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Core::Views::DiagnosticsSerializer do
   let(:custid) { 'cust-1234567890' }
 
   # Shaped like a real Customer extid: Familia's external_identifier feature
-  # under `format: 'ur%<id>s'` emits `ur` plus 25 base36 characters.
+  # under `format: 'ur%{id}'` emits `ur` plus 25 base36 characters.
   let(:cust_extid) { 'ur00fedcba9876543210zyxwvu' }
   let(:cust_objid) { '01JCUSTABCDEFGHJKMNPQRSTVW' }
 

--- a/apps/web/core/views/serializers/diagnostics_serializer.rb
+++ b/apps/web/core/views/serializers/diagnostics_serializer.rb
@@ -13,17 +13,18 @@ module Core
     # Nothing here counts sessions, measures usage, or profiles behaviour.
     #
     # The frontend Sentry client needs a STABLE actor reference so events group
-    # per human instead of per session, but it must not learn who that human is.
-    # This serializer emits only what Onetime::Utils::DiagnosticsRef derives: an
-    # opaque keyed reference plus the label describing how far that reference
-    # correlates.
+    # per account instead of per session, but it must not learn which account
+    # that is. This serializer emits only what
+    # Onetime::Utils::DiagnosticsRef derives: one opaque keyed reference.
     #
-    #   diagnostics_ref: { actor_ref: "<16 hex>", actor_scope: "federated"|"deployment" }
+    #   diagnostics_ref: { actor_ref: "<16 hex>" }
     #
     # Never emitted, by construction: email, display name, custid, objid, extid,
-    # IP address, or either keying secret. The pre-image never leaves the server.
+    # IP address, or the keying secret. The pre-image — the customer extid — is
+    # hashed here and never leaves the server through this block; the 16-hex
+    # digest is the only thing the browser sees.
     #
-    # EXACTLY TWO KEYS. The frontend contract (diagnosticsRefSchema in
+    # EXACTLY ONE KEY. The frontend contract (diagnosticsRefSchema in
     # src/schemas/contracts/bootstrap.ts) is a Zod strictObject and is the one
     # schema actually parsed against live data — an extra key makes the parse
     # fail and the whole block is dropped rather than forwarded. That strictness
@@ -34,43 +35,23 @@ module Core
     # `diagnosticsSchema`, which is the unrelated Sentry *configuration* block
     # on the same bootstrap payload.
     #
-    # ACCEPTED DISCLOSURE: actor_scope is configuration, not user data. The
-    # label is a property of the KEY, so shipping it to every authenticated
-    # browser tells that browser whether this install has FEDERATION_SECRET set
-    # AND declares a data-residency scope ('federated'), or does not ('deployment').
-    # That is deliberate and accepted, not an oversight:
-    #
-    #   * it is worth almost nothing to an attacker — it discloses no secret, no
-    #     length, no derivation input, and both states are ordinary supported
-    #     configurations, publicly documented in .env.reference;
-    #   * it is only visible to a session that has already authenticated;
-    #   * the frontend genuinely consumes it. It becomes a Sentry tag alongside
-    #     the ref, and it is the ONLY thing that tells an operator reading an
-    #     event how far the id is comparable — whether two matching refs from
-    #     different instances are the same human or a coincidence of scope.
-    #     Collapsing the label would make every ref look install-local and
-    #     silently mislead on federated installs.
-    #
-    # ONE KEYING RESOLUTION. The ref and the label are taken from a single
-    # DiagnosticsRef.actor call, which resolves the residency scope once and
-    # threads it through both. Do not decompose that into #actor_ref plus
-    # #scope: a config change between the two calls would pair a
-    # federation-keyed ref with a 'deployment' label, telling the operator the
-    # id correlates LESS far than it does.
-    #
-    # Re-examine this if the label ever gains a value that encodes something
-    # about the ACCOUNT rather than about the key. It must not.
+    # NO SCOPE LABEL. An earlier revision shipped an `actor_scope` label
+    # describing which secret keyed the ref. There is now exactly one keying
+    # (ACCOUNT_ID_SECRET) and refs are per-install by construction, so the label
+    # had one constant value and was dropped from the wire contract. Do not
+    # reintroduce a second key here to describe the keying; see
+    # docs/specs/diagnostics/actor-ref-preimage-debate-decision.md.
     #
     # NO ORGANIZATION REF HERE. A pseudonymous organization ref DOES exist —
     # Onetime::Utils::DiagnosticsRef.organization_ref, published on the colonel
     # organization-detail record — but it deliberately does not travel through
     # this block, and adding it here would be a regression twice over:
     #
-    #   * MECHANICALLY, it is a third key in a strictObject.
+    #   * MECHANICALLY, it is a second key in a strictObject.
     #     diagnosticsRefSchema rejects the object and the client discards
-    #     actor_ref and actor_scope along with it, so the cost of widening this
-    #     block is losing the actor reference entirely — silently, since a failed
-    #     parse is not an error.
+    #     actor_ref along with it, so the cost of widening this block is losing
+    #     the actor reference entirely — silently, since a failed parse is not
+    #     an error.
     #
     #   * SEMANTICALLY, this block is PER-SESSION and the org ref is
     #     PER-RESOURCE. A session has one user but touches many organizations,
@@ -88,12 +69,10 @@ module Core
     #   * anonymous sessions (no user to identify — an anonymous visitor must
     #     stay unidentified, matching SystemSerializer's withholding posture);
     #   * awaiting-MFA sessions (not yet authenticated);
-    #   * deployments with no usable keying secret, which is the DEFAULT state
-    #     in dev and test. "Usable" is narrower than "set": FEDERATION_SECRET is
-    #     refused unless a data-residency scope is declared (DiagnosticsRef's
-    #     fail-closed default against cross-region correlation), so an install
-    #     with FEDERATION_SECRET, no residency and no ACCOUNT_ID_SECRET has
-    #     nothing to key with and omits the block.
+    #   * deployments with no usable keying secret (ACCOUNT_ID_SECRET), which is
+    #     the DEFAULT state in dev and test;
+    #   * customers with no usable extid — the derivation declines rather than
+    #     substituting some other identifier.
     #
     # Absence is unambiguous ("no reference"), whereas a null or empty-string
     # actor_ref would be a value the client has to special-case. The frontend
@@ -102,8 +81,7 @@ module Core
     # The derivation raises no StandardError (see DiagnosticsRef), so an unconfigured install
     # renders exactly as it did before this serializer existed. That guarantee
     # matters here specifically: this serializer is registered on all three web
-    # shells (apps/web/core/views.rb), so it runs on EVERY authenticated render,
-    # including for accounts whose stored email is not valid UTF-8.
+    # shells (apps/web/core/views.rb), so it runs on EVERY authenticated render.
     module DiagnosticsSerializer
       # Serializes the pseudonymous actor reference from view variables.
       #
@@ -122,10 +100,10 @@ module Core
         # inherited from AuthenticationSerializer's `authenticated` semantics.
         return omit(output) if view_vars['awaiting_mfa']
 
-        # Exactly { 'actor_ref' => ..., 'actor_scope' => ... }, or nil when no
-        # secret is configured / the derivation declined. Passed through
-        # verbatim: the module owns the shape, and the client parses it strictly.
-        diagnostics_ref = Onetime::Utils::DiagnosticsRef.actor(cust.email)
+        # Exactly { 'actor_ref' => ... }, or nil when no secret is configured /
+        # the derivation declined. Passed through verbatim: the module owns the
+        # shape, and the client parses it strictly.
+        diagnostics_ref = Onetime::Utils::DiagnosticsRef.actor(customer_extid(cust))
         return omit(output) if diagnostics_ref.nil?
 
         output['diagnostics_ref'] = diagnostics_ref
@@ -133,6 +111,24 @@ module Core
       end
 
       class << self
+        # The actor pre-image, read defensively.
+        #
+        # DiagnosticsRef swallows everything inside its own derivation, but the
+        # READ happens out here: Familia's extid getter derives lazily and
+        # raises ExternalIdentifierError when the objid is absent or its
+        # provenance is unknown. On a serializer that runs on every
+        # authenticated render, that raise would be a 500 page plus a
+        # self-inflicted Sentry event, so an unreadable extid costs the ref and
+        # nothing more.
+        #
+        # @param cust [Onetime::Customer]
+        # @return [String, nil]
+        def customer_extid(cust)
+          cust.extid if cust.respond_to?(:extid)
+        rescue StandardError
+          nil
+        end
+
         # Declares the output boundary for SerializerRegistry. A key absent
         # here is stripped from the payload, so `diagnostics_ref` must be declared
         # even though it is frequently omitted at runtime.

--- a/changelog.d/20260822_143500_claude_diagnostics_signal_quality.rst
+++ b/changelog.d/20260822_143500_claude_diagnostics_signal_quality.rst
@@ -4,15 +4,18 @@ Added
 -----
 
 - Authenticated browser sessions and selected backend error captures now
-  carry a scoped pseudonymous actor reference, so operators can correlate
-  an issue with affected accounts within its configured scope. The backend
-  derives the 16-hex ``actor_ref`` from the account email, publishes it to
-  the frontend in the ``diagnostics_ref`` bootstrap payload, and attaches
-  it to supported backend captures. No direct identifiers, such as email
-  addresses or customer IDs, are sent; however, the reference must still
-  be handled as potentially personal data. Anonymous sessions and installs
-  without a usable keying secret send no user context, and the frontend
-  clears the reference on logout.
+  carry a pseudonymous actor reference, so operators can correlate an
+  issue with the accounts it affects. The backend derives the 16-hex
+  ``actor_ref`` from the customer external identifier (extid), publishes
+  it to the frontend in the ``diagnostics_ref`` bootstrap payload, and
+  attaches it to supported backend captures. No direct identifiers, such
+  as email addresses or customer IDs, are sent; however, the reference
+  must still be handled as potentially personal data. Anonymous sessions
+  and installs without a usable keying secret send no user context, and
+  the frontend clears the reference on logout. Existing actor and
+  organization references re-key on the deploy that ships this change, so
+  a correlation discontinuity of up to the Sentry retention window is
+  expected rather than a defect.
 
 Fixed
 -----

--- a/docs/development/backend-diagnostics.md
+++ b/docs/development/backend-diagnostics.md
@@ -12,7 +12,7 @@ Sentry at catch.onetimesecret.com. Everything lives in
 - `diagnostics.sentry.workers.dsn` — worker/scheduler processes; falls back to backend DSN.
 - `diagnostics.sentry.backend.org_id` — enables `strict_trace_continuation` (rejects foreign-org trace baggage). Must be set explicitly for self-hosted Sentry.
 - Release: `SENTRY_RELEASE` env var, else `.commit_hash.txt` (baked by CI), else git/dev fallback. Matches frontend so both report the same release.
-- Actor references — `FEDERATION_SECRET` produces `federated` references only when a residency scope resolves; otherwise `ACCOUNT_ID_SECRET` produces `deployment` references. The residency scope is `DIAGNOSTICS_REF_REGION`, falling back to `JURISDICTION`. With neither usable secret, no actor reference is emitted. See [the environment reference](../../.env.reference) for fleet coordination and rotation requirements.
+- Actor references — derived from the customer's external identifier (extid), HMAC'd under `ACCOUNT_ID_SECRET` and truncated to 16 hex chars. That secret is the only keying; there is no scope axis and no residency knob, because the pre-image is minted per installation. With no `ACCOUNT_ID_SECRET`, no actor reference is emitted. References re-key when `ACCOUNT_ID_SECRET` rotates — and once more on the deploy that shipped the extid pre-image — so expect a correlation discontinuity of up to the Sentry retention window after either. See [the environment reference](../../.env.reference) for rotation requirements and [the decision record](../specs/diagnostics/actor-ref-preimage-debate-decision.md) for why the email pre-image was dropped.
 
 Sampling: errors 100%, traces 10%, profiles 10% of sampled traces.
 `send_default_pii` stays at the default (false) — no IP addresses collected.
@@ -24,17 +24,16 @@ Set once at boot via `Sentry.set_tags`:
 - `site_host` — deployment identity
 - `service` — `web` or `worker` (from execution mode)
 - `jurisdiction` — lowercased region code, omitted if unconfigured
-- `actor_scope` — `federated` when `FEDERATION_SECRET` and a residency scope
-  key the actor reference; otherwise `deployment` when `ACCOUNT_ID_SECRET`
-  keys it
 
 Selected request and controller error captures set Sentry `user.id` to the
 same opaque `actor_ref` the frontend receives. This supports issue correlation
-and affected-account counts within the configured scope; it is not product
-analytics, behavioral profiling, or a cross-region identity join. The ref is
-not a direct identifier, but it is potentially personal data. Other capture
+and affected-account counts within this installation; it is not product
+analytics, behavioral profiling, or a cross-installation identity join. The ref
+is not a direct identifier, but it is potentially personal data. Other capture
 paths can remain unattributed, so a missing `user.id` does not establish that
-an event came from an anonymous session or an unconfigured deployment.
+an event came from an anonymous session or an unconfigured deployment — capture
+sites that hold no extid (account creation, email-only credential flows,
+datastore-outage rescues) are unattributed by design.
 
 Organization correlation is not active: although the backend may emit an
 `organization_ref` on the Colonel organization-detail response, the current

--- a/docs/development/frontend-diagnostics.md
+++ b/docs/development/frontend-diagnostics.md
@@ -42,26 +42,29 @@ traces), `functionToString`, `browserTracing({ router })`.
 ## Actor context and tags
 
 For authenticated sessions, the bootstrap payload can include
-`diagnostics_ref` with an opaque `actor_ref` and an `actor_scope`. The client
-sets Sentry `user.id` to `actor_ref` and adds `actor_scope` as an indexed tag.
-It sends no direct identifier such as an email address or customer ID, but the
-stable pseudonymous reference is still potentially personal data.
+`diagnostics_ref`. It is a single-key block — `{ "actor_ref": "<16 lowercase
+hex>" }` — and the client sets Sentry `user.id` to `actor_ref`. Nothing else:
+no tag accompanies it. It sends no direct identifier such as an email address
+or customer ID, but the stable pseudonymous reference is still potentially
+personal data.
 
-`actor_scope` describes the correlation boundary, not the authentication
-method:
+`actor_ref` is a keyed one-way digest of the customer's external identifier
+(extid), derived server-side with this installation's `ACCOUNT_ID_SECRET`.
+There is no scope, residency, or federation axis: the ref means "this customer
+record, on this install". Separately provisioned regional records therefore do
+not correlate by default — correlation would require the same secret and the
+same customer record, which is what copying `ACCOUNT_ID_SECRET` between
+installations would produce. Do not copy it.
 
-- `federated` uses `FEDERATION_SECRET` and a resolved residency scope. Instances
-  expected to correlate must share both the effective secret and residency
-  scope; distinct residencies must use distinct scopes.
-- `deployment` uses `ACCOUNT_ID_SECRET` for the current installation. Do not
-  copy this secret between installations.
+The correlation subject is the customer RECORD, not the person: the ref
+survives an email change and does not re-link an account that was deleted and
+re-created. Rotating `ACCOUNT_ID_SECRET` re-keys every ref and breaks
+correlation with prior events; the discontinuity ages out of Sentry retention.
 
-The server resolves residency from `DIAGNOSTICS_REF_REGION`, then
-`JURISDICTION`. If `FEDERATION_SECRET` has no resolved residency, it is not
-used for diagnostics references; `ACCOUNT_ID_SECRET` is the fallback. If no
-usable secret exists, and for anonymous or malformed bootstrap data, the client
-clears user context. Changing the effective scope or selected secret re-keys
-references and breaks correlation with prior events.
+For anonymous sessions the block is absent, and absence is the signal — the
+client clears user context and mints no fallback id. Malformed bootstrap data
+(unknown key, wrong ref shape, a legacy block still carrying the retired
+`actor_scope`) fails closed the same way.
 
 On the base scope: `service: web`, `site_host` (display domain),
 `jurisdiction` (from bootstrap regions). Per-event indexed tags via the

--- a/docs/specs/diagnostics/actor-ref-preimage-debate-decision.md
+++ b/docs/specs/diagnostics/actor-ref-preimage-debate-decision.md
@@ -1,0 +1,66 @@
+# [DECISION] Actor ref pre-image: extid, not email
+
+**Keywords:** Sentry user.id, DiagnosticsRef, actor_ref, pre-image, HMAC, extid, email hash, ACCOUNT_ID_SECRET, FEDERATION_SECRET, residency, PR #4250, pseudonymous diagnostics, erasure, enumeration, dictionary attack, capture_error scrubbing, organization_ref, actor_scope, re-key discontinuity, external_id, customer_id
+
+**Date:** 2026-08-22 (rev 4, implementation-ready per reviewer) · **Branch:** `feat/diagnostics-signal-quality` (PR #4250)
+**Status:** GO — rework PR #4250 from email pre-image (candidate A) to extid pre-image (candidate B).
+
+## Decision
+
+`DiagnosticsRef.actor_ref` derives from the customer **extid**, HMAC'd and truncated, keyed by **`ACCOUNT_ID_SECRET`**. `FEDERATION_SECRET` is dropped from diagnostics. The residency apparatus is deleted: extid pre-images are minted per-region, so separately provisioned regional customer records **do not correlate by default** (see Threat model for why not "structurally impossible").
+
+Candidates C (stored federation email hash) and D (federation-keyed `actor_identifier`) rejected with prejudice — do not re-litigate. (Editorial note accepted: C's "buys nothing" was overstated; independent keying does alter compromise behavior. Its availability, join-key, browser-exposure, and lifecycle costs remain sufficient grounds.)
+
+## Correlation subject (reframed per review)
+
+The subject is the **customer record**, not the human. This makes B affirmatively better, not a privacy concession:
+
+- Extid is stable across email change (`change_email` mutates email without replacing the record); email-derived refs split one account on email change.
+- Email-derived refs conflate different people on address reassignment or delete-and-recreate; extid refs cannot.
+- Consequence: "returning user after deletion counts as new" is correct behavior under this definition, not a price.
+
+## Why B won (Round 5 values ordering)
+
+A answered "maximize diagnostic correlation subject to no raw disclosure"; B answers "minimize identity involvement, accepting narrower diagnostics" — the operator's actual ordering. Decisive costs of A:
+
+1. **Enumerability.** `HMAC(secret, email)` under key compromise → offline dictionary re-identification against cheap email lists.
+2. **Erasure.** Email refs re-link a data subject across deletion + re-signup within retention.
+
+## Threat model, stated precisely (review corrections #4, #5)
+
+- Extids are **not** datastore-only: they appear in bootstrap payloads, authenticated serializers, API responses, logs. That is their job — extids are external identifiers, deterministically derived one-way from high-entropy objids. Not an authentication or integrity token; non-enumerable, not secret.
+- Narrowed claim: B moves the attack from "leaked secret + public email list" (A) to "leaked secret + an auxiliary extid dataset" (B). Material improvement, not immunity.
+- Cross-region: no cryptographic enforcement — a cloned datastore plus copied secret reporting to the same Sentry project reproduces refs. **Decision: accept this; no residency discriminator.** That scenario is operator self-misconfiguration, and a discriminator resurrects the apparatus B exists to delete.
+
+## Keying — coupling to ACCOUNT_ID_SECRET accepted (operator decision)
+
+The purpose prefix (`ACTOR_INFO` in the HMAC message) namespaces but does not enable independent rotation; refs are only as strong as `ACCOUNT_ID_SECRET`. **Decision: accept the coupling; no dedicated `DIAGNOSTICS_REF_SECRET`.** The extra secret would buy robustness in a compromise scenario whose marginal exposure is already small, at zero diagnostic gain. Rotating `ACCOUNT_ID_SECRET` rotates diagnostics refs; under 14-day Sentry retention the discontinuity ages out and is a non-event. Note this in module docs.
+
+## Implementation requirements (regression traps)
+
+1. **Scrub all extid aliases at the capture boundary.** `ErrorHandler.capture_error` currently removes only `email`/`cust`/`customer`; hooks pass extids raw into Sentry context today under multiple keys — `extid:` (account hooks, e.g. around `create_default_workspace`), `external_id:`, and extid-valued `customer_id:` (e.g. `update_password`). Under B the extid is the sensitive pre-image: consume and remove **`:extid`, `:external_id`, and known extid-valued `:customer_id`** before setting context — or first standardize callers on one explicit key, then scrub that.
+2. **Kill the bare-string candidate API.** `diagnostics_actor` treats any string as email; leaving it would let existing `email:` callers silently hash emails under the new key. Require an explicit customer object or explicit `extid:`; reject generic string fallback.
+
+## Coverage (review correction #7)
+
+- B **improves** attribution for hooks already supplying `extid` that A ignores (verification, workspace provisioning, etc.), with no datastore read.
+- Account deletion retains attribution: `account[:external_id]` is available pre-delete.
+- Genuine losses: account creation before extid exists; email-only credential flows; datastore-outage rescues holding only an email. Events still captured and grouped by grouping rules + volume; **actor cardinality ("one account or many?") is unanswerable for this class** — that is the accepted price. True identity needs on the auth surface resolve at support time by asking the user.
+
+## organization_ref and actor_scope — nothing to decide, one note to write
+
+The org ref's pre-image is already the per-install org objid; **separately provisioned organization records do not correlate cross-install** (same clone exception as the threat model). Dropping `FEDERATION_SECRET` touches org refs only mechanically: installs deriving under `federated` scope re-key once to the deployment key. Existing org (and actor) ref values in Sentry stop matching new ones for up to 14 days, then the discontinuity ages out of retention. No semantics change, no privacy change. **Action: one-line PR note that refs re-key at deploy, so the discontinuity window isn't investigated as a bug.**
+
+`actor_scope` collapses to constant `deployment`: drop it from the wire contract (TypeScript type, tags, tests, docs) or leave it as a constant — implementation-time taste call, whichever churns less.
+
+Symmetry note: post-rework, actor and org refs both key on server-minted per-install identifiers; Round 1's "deliberate asymmetry" inverts into an argument for B.
+
+## Scope of rework
+
+`DiagnosticsRef`, `ErrorHandler.diagnostics_actor` + `capture_error` alias scrubbing, specs, module docs (rotation coupling, boundary-attribution loss noted so the trade was visibly bought), PR note on the re-key discontinuity. PR description leads with: no-cross-region-correlation-by-default replaces discipline-maintained residency mixing; net code shrinks.
+
+## Principles carried forward
+
+Purpose test (diagnostics, not analytics); disclosure-boundary parties (Stripe may know, Sentry must not); default non-correlation beats enforced invariants beats configuration; consistency binds cross-surface, not cross-time; pre-image entropy is a privacy property; erasure semantics are part of the design; values ordering is an input, not an output; the correlation subject is the record, not the human.
+
+*Sources: uploaded debate brief "actorrefpreimagedebate.md"; external reviewer feedback rounds 1–2 with file/line citations (recorded as reviewer's claims, spot-verify in repo); operator decisions on keying coupling and org scope, session 2026-08-22. Reviewer declared rev 4 implementation-ready.*

--- a/docs/specs/diagnostics/actor-ref-preimage-debate.md
+++ b/docs/specs/diagnostics/actor-ref-preimage-debate.md
@@ -1,0 +1,252 @@
+# Debate Brief: The Actor Reference Pre-Image
+
+**Date:** 2026-08-22
+**Branch:** `feat/diagnostics-signal-quality` (PR #4250)
+**Question:** What value should be fed into the keyed derivation that produces the
+pseudonymous Sentry `user.id` (`DiagnosticsRef.actor_ref`)?
+**Status:** Unresolved. PR #4250 ships the email pre-image; a rework to the
+extid pre-image is on the table following the values clarification in Round 5.
+
+---
+
+## Candidates
+
+| # | Pre-image | Origin |
+|---|-----------|--------|
+| A | Normalized account email (shipped) | `lib/onetime/utils/diagnostics_ref.rb` |
+| B | Customer/organization extid | Proposed in Round 1, revived in Round 5 |
+| C | Precalculated federation email hash (stored field) | Proposed in Rounds 2–3 |
+| D | New stored `actor_identifier` field, federation-keyed, identical across fleet regions | Proposed in Round 4 |
+
+All candidates assume the ref itself remains a keyed, truncated,
+purpose-prefixed HMAC. The debate is about the input, not about sending
+anything raw.
+
+---
+
+## Round 1 — Why email over extid (the original decision)
+
+**Case for A (email):**
+
+1. **Federated scope requires a cross-install identity.** Regional instances
+   share `FEDERATION_SECRET`; the same human on two federated installs has two
+   unrelated extids but one email. `HMAC(extid)` can never correlate across
+   installs. This mirrors why `EmailHash` (federation) is email-keyed.
+2. **Lifecycle stability.** Extid dies with its record; delete-and-recreate
+   splits one human into two Sentry users. Email keeps "one account or fifty"
+   answerable.
+3. **Uniform availability.** Email is present at boundaries where no loaded
+   customer record exists:
+   - Rodauth account-lifecycle hooks where the Customer is being created
+     (`create_customer`), linked (`claim_pending_federation`), or destroyed
+     (`delete_customer`) — the extid is the thing failing to exist or being
+     deleted.
+   - Credential flows keyed on a submitted email (reset, magic link,
+     verification) where the authdb lookup may itself be what raised.
+   - Controller/middleware rescues during datastore outages: `safe_cust`
+     documents that `#cust` lazily loads from Valkey and can raise, and capture
+     runs exactly when things are failing. Session identity is email-shaped
+     (`custid` is historically the email); extid needs the read that just
+     failed.
+   - Logic-layer `safe_execute` callers holding only an email string.
+4. **The asymmetry is deliberate.** `organization_ref` keys on the org objid
+   because an org is a per-install resource with no cross-instance identity and
+   no reconciliation problem.
+
+**Framing note that held throughout:** the choice of pre-image is about
+correlation semantics, not disclosure. Nothing raw is sent under any candidate;
+email, custid, and extid are equally forbidden as raw values at every capture
+boundary.
+
+**Outcome:** A adopted; B's coverage gaps treated as disqualifying.
+(Re-litigated in Round 5 under different values.)
+
+---
+
+## Round 2 — Why not the precalculated federation hash (C)
+
+**Proposal:** a stored field derived from email + `FEDERATION_SECRET` already
+exists (for purposes of this debate); use it as the derivation input, and put
+it in `/bootstrap/me` so the frontend always has it.
+
+**As server-side pre-image — rejected:**
+
+- **Buys nothing.** The full derivation layer (purpose prefix, residency
+  element, scope fallback, truncation) is needed regardless of input; the email
+  is already in hand at every boundary; hashing a hash gains no privacy
+  (a keyed pseudonym of a pseudonym is still personal data, GDPR Recital 26).
+- **Availability inverts.** A stored field lives on a record; boundaries that
+  haven't loaded it would need a datastore read inside the error path — the
+  exact hazard `DiagnosticsRef`'s failure-tolerance design engineers against.
+- **Scope entanglement.** The deployment-scoped fallback (`ACCOUNT_ID_SECRET`,
+  serving installs with no residency declared — the majority population) would
+  depend on a federation-keyed artifact existing at write time.
+
+**As a bootstrap field — refused outright:**
+
+- The field is simultaneously a queryable Redis index and a Stripe customer
+  metadata value: a live join key into the datastore and billing records.
+  Bootstrap ships it to the browser — devtools, HAR captures, extensions, one
+  breadcrumb away from the event payload — and the browser is precisely what
+  feeds Sentry.
+- It is region-independent by design (one value per person fleet-wide), which
+  is the cross-jurisdiction join the residency derivation exists to prevent.
+- It has no scope-narrowing fallback and couples diagnostics rotation to
+  federation rotation (Stripe metadata rewrite, index rebuild). The `v1`
+  purpose prefix exists so diagnostics can re-key independently.
+- The stated goal ("frontend always has it") is already met: bootstrap carries
+  `actor_ref`/`actor_scope`, which is the same email-plus-secret idea made
+  purpose-bound, residency-scoped, independently rotatable, and shape-distinct.
+
+---
+
+## Round 3 — The staleness challenge
+
+**Challenge:** "A stored value can be missing or stale — who cares? This isn't
+a correlation identifier since the dawn of time; Sentry retains 14 days max."
+
+**Conceded:** staleness-over-time is neutralized by retention. A row hashed
+under an old secret stays self-consistent within any window; the
+"stale since the dawn of time" argument was garnish.
+
+**Survived:**
+
+- **Missing is cohort-bounded, not time-bounded.** Rows written while the
+  secret was unconfigured (the default state) have no stored value in *every*
+  window until backfilled. The fallback is deriving from email — the thing
+  being avoided — producing a two-path scheme.
+- **Redundant or split; no third outcome.** Either the stored value is
+  byte-identical to fresh derivation (a cache of a sub-microsecond HMAC) or it
+  differs, and the same human gets different refs from the two paths *inside
+  the same window*. A mid-window backfill flips accounts between refs.
+- **The binding consistency constraint is cross-surface, not cross-time.** The
+  ref must come out identical at the bootstrap serializer, controller rescues,
+  Rodauth hooks, and middleware simultaneously; several of those boundaries
+  cannot reach a stored field, so fresh derivation is mandatory regardless, and
+  a stored copy is a second source of truth.
+
+---
+
+## Round 4 — The federated `actor_identifier` field (D)
+
+**Proposal:** don't reuse the existing field; add a new federation-keyed
+`actor_identifier` computing to the same value in every fleet region. "If it
+works for carrying Stripe subscriptions across regions, it works for this."
+
+**Rejected — this is the module's own v0, already ruled a defect:** an earlier
+revision keyed refs off `FEDERATION_SECRET` alone and sold region-independence
+as a feature; the residency element was added unconditionally, with no opt-out,
+"because an opt-out would exist only to reconstruct the hazard." A
+region-stable stored field is that opt-out as a schema addition.
+
+**Why the Stripe precedent does not transfer — the disclosure-boundary
+distinction:**
+
+- **Stripe is a party allowed to know it's the same person.** Cross-region
+  linkage is the *purpose* of the federation hash there: subscription carryover
+  is the product feature, server-to-server, inside an already fully identified
+  billing relationship. The hash discloses nothing Stripe doesn't hold.
+- **Sentry is a party deliberately kept unable to know.** All regions report to
+  one shared backend and every event carries a `jurisdiction` tag; a
+  region-stable `user.id` makes "this data subject is present in both EU and
+  US" a standing, searchable fact — the inference the jurisdictional-residency
+  architecture exists to make impossible.
+
+**Purpose test:** every widening must justify itself against diagnosing a
+defect. Cross-region correlation has no defect-diagnosis use (EU traces are
+debugged against EU code/config/datastore); "is this the same human erroring in
+the US" is product analytics, which this data is not allowed to answer.
+
+**The legitimate fleet case already works:** installs sharing
+`FEDERATION_SECRET` within one residency scope derive identical refs today
+(`federated` scope). D's only increment over the shipped design is
+cross-jurisdiction correlation — exactly and only the prohibited part.
+
+---
+
+## Round 5 — The values reordering (the actual position)
+
+**Position stated:** strong preference not to involve the email address at all,
+even at the cost of poorer diagnostics. Bayesian framing: the value of privacy
+(actual and perceived) is not the same order of magnitude as a technocrat's
+ability to debug systems they built.
+
+**Two genuine privacy costs of the email pre-image, previously underweighted,
+conceded:**
+
+1. **Emails are enumerable; extids are not.** `HMAC(secret, email)` is
+   confirmable by anyone holding the secret plus a candidate list, and email
+   lists are cheap: a leaked `FEDERATION_SECRET` plus a Sentry export enables
+   offline dictionary re-identification. `HMAC(secret, extid)` is inert under
+   the same leak — the pre-image is high-entropy and lives only in the
+   datastore. The email pre-image concentrates tail risk on secret compromise;
+   this is precisely the low-probability, high-severity term the Bayesian
+   framing weights.
+2. **Email-derived refs survive erasure.** Delete the account, re-sign-up with
+   the same address inside the retention window, and new events re-link to
+   pre-deletion ones. What Round 1 sold as lifecycle stability is, under this
+   ordering, a privacy defect. An extid-derived ref dies with the record,
+   permanently orphaning old events — which is what deletion should mean.
+
+**Design that follows (B, revised):** extid pre-image, still HMAC'd and
+truncated (extids appear in API responses and logs; an unkeyed hash is a
+trivial join), keyed by `ACCOUNT_ID_SECRET` only.
+
+- Drops `FEDERATION_SECRET` from diagnostics entirely.
+- **Deletes the residency apparatus instead of enforcing it:** extids are
+  minted per-region, so cross-region correlation becomes structurally
+  impossible rather than discipline-dependent. The module shrinks, and the
+  most important property stops depending on future editors maintaining a
+  derivation invariant.
+
+**Price, stated for eyes-open purchase:**
+
+- Attribution disappears at email-only boundaries (auth surface,
+  account-creation/deletion failures, credential flows, datastore-outage
+  rescues). Those events are still captured and still grouped by the grouping
+  rules; they carry no user, so "one account or fifty" goes unanswered for that
+  class.
+- A returning user after deletion counts as a new user.
+- The loss is narrower than Round 1 implied: the bootstrap serializer,
+  controller captures, and most Rodauth hooks have an extid in hand.
+
+---
+
+## Principles that emerged
+
+1. **Purpose test.** This is diagnostics, not analytics. Every widening of
+   disclosure must justify itself against diagnosing a defect; "it would be
+   interesting to know" is a refusal.
+2. **Disclosure-boundary parties.** Distinguish consumers allowed to know an
+   identity fact (Stripe, for federation) from consumers deliberately kept
+   unable to know it (Sentry). A mechanism that "works" for the first class is
+   not a precedent for the second.
+3. **Structural impossibility beats enforced invariants.** A hazard made
+   unrepresentable (per-region pre-images) is stronger than a hazard prevented
+   by derivation discipline (unconditional residency mixing), which is itself
+   stronger than one prevented by configuration (the rejected opt-out).
+4. **Consistency binds cross-surface, not cross-time.** Retention forgives
+   temporal drift; nothing forgives the same human carrying two refs in one
+   window across frontend and backend events. One derivation path, no second
+   source of truth.
+5. **Pre-image entropy is a privacy property.** Deterministic derivation from
+   an enumerable identifier is dictionary-attackable under key compromise;
+   derivation from a high-entropy server-minted token is not. "It's keyed" is
+   not the end of the analysis.
+6. **Erasure semantics are part of the design.** An identifier that re-links a
+   data subject across an account deletion contradicts what deletion promises,
+   independent of retention length.
+7. **Values ordering is an input, not an output.** The email pre-image was the
+   correct engineering answer to "maximize diagnostic correlation subject to no
+   raw disclosure." It is not the answer to "minimize identity involvement,
+   accepting poorer diagnostics." The second ordering was the operator's actual
+   position, and it selects the extid design.
+
+## Decision record
+
+- PR #4250 currently ships candidate A (email pre-image).
+- Candidates C and D are rejected with prejudice (Rounds 2–4).
+- Candidate B (extid pre-image, `ACCOUNT_ID_SECRET`-keyed, residency apparatus
+  removed) is the design implied by the Round 5 values ordering. Rework is a
+  contained change to `DiagnosticsRef`, `ErrorHandler.diagnostics_actor`
+  candidate handling, and specs; net code shrinks. Awaiting go/no-go.

--- a/docs/specs/diagnostics/diagnostics-boundary-concepts.md
+++ b/docs/specs/diagnostics/diagnostics-boundary-concepts.md
@@ -32,5 +32,5 @@ before starting work.
   mechanism only when it is implemented and supported.
 
 Each item is independently revisit-able. Changes should use the current
-`actor_ref` / `actor_scope` bootstrap contract and current diagnostics guides
+single-key `actor_ref` bootstrap contract and current diagnostics guides
 as their starting point.

--- a/lib/onetime/error_handler.rb
+++ b/lib/onetime/error_handler.rb
@@ -158,17 +158,18 @@ module Onetime
     end
 
     # Shape of a customer extid, as minted by Familia's external_identifier
-    # feature under Onetime::Customer's `format: 'ur%<id>s'`: the literal `ur`
-    # prefix followed by a base36 body.
+    # feature under Onetime::Customer's `format: 'ur%{id}'`: the literal `ur`
+    # prefix followed by a lowercase base36 body.
     #
     # This is a STRUCTURAL guard, not an authentication check — its job is to
     # make it impossible for an email (or any other identifier carrying `@`,
     # `.`, `:` or uppercase) to reach the diagnostics derivation as an actor
-    # pre-image. It is deliberately looser on length than
-    # Familia's Customer.extid?, which cannot be used here for two reasons: it
-    # hits the model layer from a rescue path, and it tests
-    # `format.include?('%{id}')` against a format written in sprintf's
-    # `%<id>s` form, so it answers false for every Customer extid.
+    # pre-image. It deliberately does not delegate to Familia's
+    # Customer.extid?: that validator matches case-INSENSITIVELY, while the
+    # ref derivation is case-sensitive — an accepted case-variant would HMAC
+    # to a phantom ref for an account that already has one. Only a string a
+    # customer could actually carry may pass, so the guard is stricter than
+    # the validator, and looser only on length.
     EXTID_FORMAT = /\Aur[0-9a-z]+\z/
 
     # Builds the Sentry `user` hash for whoever this event is about.

--- a/lib/onetime/error_handler.rb
+++ b/lib/onetime/error_handler.rb
@@ -157,6 +157,20 @@ module Onetime
       {}
     end
 
+    # Shape of a customer extid, as minted by Familia's external_identifier
+    # feature under Onetime::Customer's `format: 'ur%<id>s'`: the literal `ur`
+    # prefix followed by a base36 body.
+    #
+    # This is a STRUCTURAL guard, not an authentication check — its job is to
+    # make it impossible for an email (or any other identifier carrying `@`,
+    # `.`, `:` or uppercase) to reach the diagnostics derivation as an actor
+    # pre-image. It is deliberately looser on length than
+    # Familia's Customer.extid?, which cannot be used here for two reasons: it
+    # hits the model layer from a rescue path, and it tests
+    # `format.include?('%{id}')` against a format written in sprintf's
+    # `%<id>s` form, so it answers false for every Customer extid.
+    EXTID_FORMAT = /\Aur[0-9a-z]+\z/
+
     # Builds the Sentry `user` hash for whoever this event is about.
     #
     # Sentry counts "users affected" off event.user.id and nothing else, so
@@ -172,11 +186,30 @@ module Onetime
     # the diagnostics backend, and Sentry's user object is not an exemption
     # from it; feeding one in here would also make it a searchable field.
     #
+    # THE PRE-IMAGE IS THE EXTID, NEVER THE EMAIL. DiagnosticsRef.actor_ref
+    # digests whatever string it is handed, so a candidate this method cannot
+    # positively identify as an extid must be REFUSED rather than passed
+    # through — an accepted bare-string fallback is how an `email:` caller ends
+    # up with an email hashed under the diagnostics key. See
+    # docs/specs/diagnostics/actor-ref-preimage-debate-decision.md.
+    #
+    # Accepted candidates:
+    #
+    #   - an object responding to #extid (a Customer). NOT #external_identifier:
+    #     on Onetime::Customer that name is shadowed by the deprecated_fields
+    #     feature, which memoizes a RANDOM id per process
+    #     (lib/onetime/models/customer/features/deprecated_fields.rb) and would
+    #     hand every process a different ref for the same account.
+    #   - a String in extid shape (EXTID_FORMAT). Anything else — an email, a
+    #     custid, a session id, an objid — is nil.
+    #
     # Returns nil rather than a partial hash in every declining case:
     #
-    #   - anonymous (no candidate, blank email, or #anonymous? is true) — an
-    #     anonymous request has no user to report, and a placeholder id would
-    #     silently merge every anonymous visitor into one "affected user".
+    #   - anonymous (no candidate, or #anonymous? is true) — an anonymous
+    #     request has no user to report, and a placeholder id would silently
+    #     merge every anonymous visitor into one "affected user".
+    #   - no extid available, or a string that is not one. Attribution is lost
+    #     for that event; that boundary loss is accepted by the decision above.
     #   - unconfigured — DiagnosticsRef declines when no keying secret is
     #     usable, which is the default in dev and test. No user is strictly
     #     better than an unkeyed one.
@@ -188,23 +221,23 @@ module Onetime
     # to some other identifier, and it must not set `{ id: nil }` — Sentry
     # treats a nil id as a distinct anonymous-ish user rather than as absence.
     #
-    # @param candidate [#email, #anonymous?, String, nil] customer or email
+    # @param candidate [#extid, #anonymous?, String, nil] customer or extid
     # @return [Hash{Symbol=>String}, nil] { id: <16 hex> }, or nil
     def self.diagnostics_actor(candidate)
       return nil if candidate.nil?
       return nil if candidate.respond_to?(:anonymous?) && candidate.anonymous?
 
-      email = candidate.respond_to?(:email) ? candidate.email : candidate
-      return nil if email.nil? || email.to_s.strip.empty?
+      extid = candidate.respond_to?(:extid) ? candidate.extid : candidate
+      return nil unless extid.is_a?(String) && extid.match?(EXTID_FORMAT)
 
-      ref = Onetime::Utils::DiagnosticsRef.actor_ref(email)
+      ref = Onetime::Utils::DiagnosticsRef.actor_ref(extid)
       return nil if ref.nil? || ref.to_s.empty?
 
       { id: ref }
     rescue StandardError
       # Deliberately silent and deliberately broad: see above. There is no
       # logger call here either, because the failure modes that would reach
-      # this rescue take the email with them into the log line.
+      # this rescue take the pre-image with them into the log line.
       nil
     end
 
@@ -216,7 +249,7 @@ module Onetime
     # every later event on the same thread.
     #
     # @param scope [Sentry::Scope] event-scoped Sentry scope
-    # @param candidate [#email, #anonymous?, String, nil] customer or email
+    # @param candidate [#extid, #anonymous?, String, nil] customer or extid
     # @return [Boolean] true when a user was set
     def self.set_diagnostics_actor(scope, candidate)
       return false unless scope.respond_to?(:set_user)
@@ -273,13 +306,24 @@ module Onetime
 
       # Captures error in Sentry with context
       def capture_error(operation, ex, context)
-        # An `email:`/`cust:` entry is CONSUMED, not forwarded: it becomes the
-        # pseudonymous Sentry user and is removed from the context hash. Every
-        # caller today passes account_id/customer_id instead, so this is
-        # mostly a guard — but the alternative is that the first caller to add
-        # one ships a raw email into an error_handler context.
-        subject = context[:email] || context[:cust] || context[:customer]
-        context = context.except(:email, :cust, :customer)
+        # Identity entries are CONSUMED, not forwarded: one becomes the
+        # pseudonymous Sentry user and ALL of them are removed from the context
+        # hash before it reaches the scope.
+        #
+        # The extid and its aliases are scrubbed because under the extid
+        # derivation the extid IS the sensitive pre-image — forwarding it into
+        # a Sentry context would hand the diagnostics backend both the ref and
+        # the value it was derived from, which defeats the whole boundary. So
+        # every key hooks use to carry one (`extid:`, `external_id:`, and the
+        # extid-valued `customer_id:`) is consumed here, per
+        # docs/specs/diagnostics/actor-ref-preimage-debate-decision.md.
+        #
+        # `email:` is scrubbed but is deliberately NOT a subject: nothing can
+        # be derived from an email any more, and accepting one as a candidate
+        # is exactly how an email ends up hashed under the diagnostics key.
+        subject = context[:cust] || context[:customer] || context[:extid] ||
+                  context[:external_id] || context[:customer_id]
+        context = context.except(:email, :cust, :customer, :extid, :external_id, :customer_id)
 
         event_id = Sentry.capture_exception(ex) do |scope|
           # Event-scoped: capture_exception's block scope is per-event, so

--- a/lib/onetime/models/custom_domain.rb
+++ b/lib/onetime/models/custom_domain.rb
@@ -36,7 +36,7 @@ module Onetime
   #
   # Primary Keys & Identifiers:
   #   - objid - Primary key (UUID), internal
-  #   - extid - External identifier (e.g., cd%<id>s), user-facing
+  #   - extid - External identifier (e.g., cd%{id}), user-facing
   #
   # As a Foreign Key in other models:
   #   - domain_id (w/ underscore) - Foreign key field, stores the objid value
@@ -77,7 +77,7 @@ module Onetime
     feature :safe_dump_fields
     feature :relationships  # Enable Familia v2 features
     feature :object_identifier  # Auto-generates objid
-    feature :external_identifier, format: 'cd%<id>s' # use builtin extid_lookup index
+    feature :external_identifier, format: 'cd%{id}' # use builtin extid_lookup index
     feature :housekeeping
 
     # Migration features - REMOVE after v1→v2 migration complete

--- a/lib/onetime/models/customer.rb
+++ b/lib/onetime/models/customer.rb
@@ -33,7 +33,7 @@ module Onetime
   #
   # Primary Keys & Identifiers:
   #   - objid - Primary key (UUID), internal
-  #   - extid - External identifier (e.g., ur%<id>s), user-facing
+  #   - extid - External identifier (e.g., ur%{id}), user-facing
   #
   # Foreign Keys:
   #   - user_id (underscore) - Foreign key field, stores the objid value
@@ -76,7 +76,11 @@ module Onetime
     feature :expiration
     feature :relationships
     feature :object_identifier
-    feature :external_identifier, format: 'ur%<id>s' # use builtin extid_lookup index
+    # Familia's Customer.extid? validator only understands the '%{id}'
+    # reference form (it splits the format on that literal); the sprintf
+    # '%<id>s' spelling interpolates identically but leaves extid?
+    # unconditionally false.
+    feature :external_identifier, format: 'ur%{id}' # use builtin extid_lookup index
     feature :required_fields
     feature :increment_field
     feature :counter_fields

--- a/lib/onetime/models/customer/features/migration_fields.rb
+++ b/lib/onetime/models/customer/features/migration_fields.rb
@@ -9,7 +9,7 @@
 #
 # v1 → v2 CHANGES:
 # - custid: email address → objid (UUID)
-# - New: objid, extid (ur%<id>s format)
+# - New: objid, extid (ur%{id} format)
 # - stripe_customer_id, stripe_subscription_id → Organization (deprecated here)
 #
 # REMOVAL: See lib/onetime/models/features/with_migration_fields.rb

--- a/lib/onetime/models/organization.rb
+++ b/lib/onetime/models/organization.rb
@@ -12,7 +12,7 @@ module Onetime
   #
   # Primary Keys & Identifiers:
   #   - objid - Primary key (UUID), internal
-  #   - extid - External identifier (e.g., on%<id>s), user-facing
+  #   - extid - External identifier (e.g., on%{id}), user-facing
   #
   # Foreign Keys:
   #   - org_id (underscore) - Foreign key field, stores the objid value
@@ -43,7 +43,7 @@ module Onetime
 
     feature :relationships
     feature :object_identifier
-    feature :external_identifier, format: 'on%<id>s'
+    feature :external_identifier, format: 'on%{id}'
     feature :required_fields
     feature :with_organization_billing
     feature :with_materialized_entitlements

--- a/lib/onetime/utils/diagnostics_ref.rb
+++ b/lib/onetime/utils/diagnostics_ref.rb
@@ -4,8 +4,6 @@
 
 require 'openssl'
 
-require_relative 'strings'
-
 module Onetime
   module Utils
     # DiagnosticsRef - opaque, stable actor and organization references for the
@@ -20,13 +18,79 @@ module Onetime
     # what they disclose has to be justified against THAT purpose, and a
     # justification that reads "it would be interesting to know" is a refusal.
     #
-    # Error reports are far more useful when the same human maps to the same
+    # Error reports are far more useful when the same account maps to the same
     # reference across events ("this crash hits one account, not fifty"). Sending
     # an email address, a customer objid, an extid or an IP to an observability
     # backend to get that is not acceptable, so we send a keyed, one-way
     # reference instead: correlation without disclosure. Same posture, same
     # rationale as Onetime::Security::RequestContext (ADR-022) — this is that
     # idea applied to the actor rather than the network.
+    #
+    # ---------------------------------------------------------------------------
+    # THE CORRELATION SUBJECT IS THE RECORD, NOT THE HUMAN
+    # ---------------------------------------------------------------------------
+    # An actor ref derives from the customer EXTID — the server-minted external
+    # identifier — and never from the email. That is not a concession; it is the
+    # more correct subject:
+    #
+    #   * an extid is stable across an email change (change_email mutates the
+    #     email in place and keeps the record), so an email pre-image would SPLIT
+    #     one account into two Sentry users the moment somebody changed address;
+    #   * an email is reassignable, so an email pre-image would CONFLATE two
+    #     different people after an address reassignment or a
+    #     delete-and-recreate. An extid cannot.
+    #
+    # A returning user who deleted and re-signed-up therefore counts as a new
+    # subject. Under "the subject is the record" that is the right answer.
+    #
+    # Two security properties follow, and neither is immunity:
+    #
+    #   * PRE-IMAGE ENTROPY. Under key compromise, an email pre-image is
+    #     re-identifiable offline against cheap public address lists. An extid
+    #     pre-image moves that attack to "leaked key PLUS an auxiliary extid
+    #     dataset". Extids are not secret — they appear in bootstrap payloads,
+    #     API responses and logs, which is their job — but they are
+    #     non-enumerable and not dictionary-shaped.
+    #   * ERASURE. An email ref re-links a data subject across deletion and
+    #     re-signup inside the retention window. An extid ref does not.
+    #
+    # NO RESIDENCY DISCRIMINATOR. Extids are minted per install from per-install
+    # objids, so separately provisioned regional customer records do not
+    # correlate across regions BY DEFAULT — there is nothing to mix in to
+    # achieve it. The residual case (a cloned datastore plus a copied
+    # ACCOUNT_ID_SECRET reporting into one Sentry project) is operator
+    # self-misconfiguration and is accepted, rather than reintroducing a
+    # residency apparatus to defend against it.
+    #
+    # The full argument, the rejected alternatives and the accepted costs are in
+    # docs/specs/diagnostics/actor-ref-preimage-debate-decision.md. Do not
+    # re-litigate the email pre-image here.
+    #
+    # ---------------------------------------------------------------------------
+    # KEYING: ACCOUNT_ID_SECRET, DELIBERATELY COUPLED
+    # ---------------------------------------------------------------------------
+    # One secret keys both namespaces: ACCOUNT_ID_SECRET, read from ENV only.
+    #
+    #   * Read from ENV, never from Rodauth's configured value. When
+    #     ACCOUNT_ID_SECRET is unset outside production Rodauth substitutes a
+    #     fixed placeholder literal, which would make every dev install on earth
+    #     derive identical refs.
+    #   * The raw secret VALUE is consumed as an HMAC key. This is NOT Rodauth's
+    #     account-id obfuscation cipher — that is an Integer<->13-char bijection
+    #     over the accounts PK, which cannot take an extid.
+    #   * Not configured -> nil, and the caller emits nothing.
+    #
+    # The purpose prefix namespaces the two ref families but does not enable
+    # independent rotation: refs are only as strong as ACCOUNT_ID_SECRET, and
+    # rotating that secret ROTATES EVERY REF. That coupling is an accepted
+    # operator decision rather than an oversight — a dedicated
+    # DIAGNOSTICS_REF_SECRET would buy robustness in a compromise scenario whose
+    # marginal exposure is already small, at zero diagnostic gain. Under the
+    # 14-day Sentry retention the post-rotation discontinuity ages out on its
+    # own and is a non-event.
+    #
+    # FEDERATION_SECRET is NOT used here. Onetime::Utils::EmailHash still owns
+    # it for federation; diagnostics deliberately does not touch it.
     #
     # ---------------------------------------------------------------------------
     # WHY NOT REUSE EmailHash.compute
@@ -40,27 +104,31 @@ module Onetime
     #
     # Shipping it verbatim to Sentry would hand the diagnostics surface a live
     # join key into billing records and our own datastore index. So this module
-    # derives a DISTINCT value under an explicit, versioned purpose prefix and a
-    # residency element:
+    # derives DISTINCT values under explicit, versioned purpose prefixes:
     #
-    #   actor: HMAC(secret, "onetime:sentry:v1:actor" || 0x00
-    #                       || residency_scope || 0x00 || normalized_email)
-    #   org:   HMAC(secret, "onetime:sentry:v1:organization" || 0x00
-    #                       || residency_scope || 0x00 || org_objid)
+    #   actor: HMAC(secret, "onetime:sentry:v2:actor"        || 0x00 || extid)
+    #   org:   HMAC(secret, "onetime:sentry:v2:organization" || 0x00 || objid)
     #
-    # The NUL-separated elements are the domain separation. Three consequences
-    # that the tests pin:
-    #   1. actor_ref(email) != EmailHash.compute(email), even when both are keyed
-    #      with the same FEDERATION_SECRET;
-    #   2. actor_ref(x) under residency "eu" != actor_ref(x) under "us"; and
-    #   3. organization_ref(x) != actor_ref(x) for the identical input string,
-    #      under identical keying and residency — the purpose prefix is what
-    #      separates the two namespaces.
-    # The `v1` element lets us re-key diagnostics reference later without touching
-    # federation reference.
+    # The NUL-separated elements are the domain separation. Two consequences the
+    # tests pin by execution, not assertion:
+    #   1. actor_ref(x) != EmailHash.compute(x); and
+    #   2. organization_ref(x) != actor_ref(x) for the identical input string
+    #      under identical keying — the purpose prefix is the whole of the
+    #      separation between the two namespaces.
     #
     # Refs are truncated to REF_LENGTH hex chars — deliberately HALF the width of
     # a federation email hash, so the two are never confusable by shape either.
+    #
+    # ---------------------------------------------------------------------------
+    # BOUNDARY ATTRIBUTION LOSS (bought knowingly)
+    # ---------------------------------------------------------------------------
+    # Some capture sites hold no extid: account creation before the customer
+    # record exists, email-only credential flows, and datastore-outage rescues
+    # that hold only an email. Those events are still captured and still group
+    # by the ordinary grouping rules — what is unanswerable for that class is
+    # actor cardinality ("one account or many?"). That is the price of the
+    # pre-image choice and it was paid on purpose; a true identity need on the
+    # auth surface resolves at support time by asking the user.
     #
     # ---------------------------------------------------------------------------
     # ORGANIZATION REFERENCE: DEFERRED FRONTEND CONSUMER
@@ -73,196 +141,44 @@ module Onetime
     #
     # This remains a per-resource value, not a per-session value. It must never
     # be added to the bootstrap `diagnostics_ref` block: that block is exactly
-    # {actor_ref, actor_scope} and the frontend parses it as a Zod strictObject.
-    # A third key would make the client discard the entire actor block.
-    #
-    # ---------------------------------------------------------------------------
-    # RESIDENCY SCOPE (why refs deliberately do NOT correlate across regions)
-    # ---------------------------------------------------------------------------
-    # An earlier revision of this module keyed actor refs off FEDERATION_SECRET
-    # alone and sold "one reference per person across regions" as a feature. That
-    # is a defect, not a feature, and it is fixed here.
-    #
-    # The browser SDK tags every event with `jurisdiction`
-    # (src/plugins/core/enableDiagnostics.ts) and the Ruby SDK does the same
-    # (Onetime::Initializers::SetupDiagnostics). Regional instances share one
-    # FEDERATION_SECRET by design and report into ONE diagnostics backend. A
-    # region-independent ref therefore emits the identical user id from the EU
-    # instance and the US instance, distinguished only by that tag — which is a
-    # ready-made join key proving that one data subject is present in both. A
-    # keyed pseudonym is still personal data (GDPR Recital 26), so that join is
-    # exactly the inference the jurisdictional-residency architecture exists to
-    # prevent, and no amount of tagging discipline elsewhere undoes it.
-    #
-    # Against that, cross-region correlation buys nothing operationally, and it
-    # is worth stating plainly rather than hedging: there is NO legitimate
-    # operational use for it here. Error triage is per-instance — a stack trace
-    # raised in the EU instance is debugged against the EU instance's code,
-    # config, and datastore. "Is this the same human as the one erroring in the
-    # US?" is a product-analytics question, not a debugging one, and it is not a
-    # question this data is allowed to answer. So the residency scope is mixed
-    # into the derivation UNCONDITIONALLY and there is no opt-out knob — an
-    # opt-out would exist only to reconstruct the hazard.
-    #
-    # The residency scope resolves in this order:
-    #
-    #   1. DIAGNOSTICS_REF_REGION — explicit operator pin. Use this when
-    #      residency boundaries do not line up with the regions feature: two
-    #      installs that share FEDERATION_SECRET, both with regions disabled,
-    #      but serving different jurisdictions. Any short stable label works
-    #      ('eu', 'us', 'ca-central'); it is never emitted, only mixed in.
-    #
-    #   2. features.regions.current_jurisdiction (JURISDICTION) — the same
-    #      value the Sentry `jurisdiction` tag is derived from, so the
-    #      separation lines up with what an operator sees in the UI.
-    #
-    #   3. Nothing declared -> UNRESOLVED (nil), and the shared key is refused.
-    #      See the next section; this is the case that used to fail open.
-    #
-    # ---------------------------------------------------------------------------
-    # AN UNDECLARED RESIDENCY REFUSES THE SHARED SECRET (the default is safe)
-    # ---------------------------------------------------------------------------
-    # An earlier revision of this fix mixed a constant — RESIDENCY_UNSCOPED —
-    # into the pre-image whenever nothing was declared. That defaulted straight
-    # back into the hazard it documented: two installs sharing FEDERATION_SECRET
-    # and declaring no residency derived IDENTICAL refs into one backend, which
-    # is exactly the cross-region join above. The mechanism only ever engaged if
-    # somebody thought to turn it on.
-    #
-    # That gets the population backwards. FEDERATION_SECRET is shared BECAUSE
-    # instances are regional, so "declared nothing" is the population most at
-    # risk, not the one that is safe — and a residency guarantee that has to be
-    # switched on is not a guarantee. The safe state must be the one an operator
-    # gets for free.
-    #
-    # So an unresolved residency does not widen the ref; it withdraws the key.
-    # #keying declines FEDERATION_SECRET and falls through to ACCOUNT_ID_SECRET,
-    # yielding scope 'deployment'. That is:
-    #
-    #   * strictly safer — per-install correlation is all error triage needs;
-    #   * self-limiting — it can only ever narrow correlation, never widen it;
-    #   * honest — the emitted actor_scope label narrows with it, so an operator
-    #     reading a Sentry event is never told a ref is comparable further than
-    #     it actually is.
-    #
-    # An operator who genuinely wants federated correlation within one
-    # jurisdiction gets it by declaring that jurisdiction. There is no path to
-    # cross-install correlation that requires configuring nothing.
-    #
-    # RESIDENCY_UNSCOPED survives only as the literal pre-image element used
-    # under deployment keying, so the element count in the pre-image never
-    # varies. It no longer grants correlation to anyone. One caveat code cannot
-    # enforce: an operator who copies ACCOUNT_ID_SECRET between installs
-    # rebuilds cross-install correlation under a 'deployment' label. That secret
-    # is generated per install and documented as un-shareable; sharing it is a
-    # configuration error with consequences well beyond diagnostics.
-    #
-    # ---------------------------------------------------------------------------
-    # ONE RESIDENCY RESOLUTION PER DERIVATION
-    # ---------------------------------------------------------------------------
-    # Residency is read ONCE per derivation and then threaded. #keying resolves
-    # it and returns it inside a Keying value alongside the secret it selected
-    # and the label that secret implies; #digest_ref and #actor consume that one
-    # value and never re-resolve.
-    #
-    # This is not tidiness. An earlier revision resolved residency THREE times
-    # per emitted bundle — in #keying to choose the secret, again in #digest_ref
-    # to build the pre-image, a third time via #scope to build the label — from
-    # unsynchronized reads of OT.conf. Any change between those reads produced
-    # three defects at once. A jurisdiction edited between reads was enough; so
-    # was an OT.conf that went FALSY rather than raising, which the raise-based
-    # guard below does not catch because nothing raises:
-    #
-    #   * one human in one process derived TWO different refs — the user split
-    #     that fail-closed residency handling exists to prevent;
-    #   * two installs in DIFFERENT jurisdictions sharing FEDERATION_SECRET
-    #     derived the IDENTICAL ref, because both substituted RESIDENCY_UNSCOPED
-    #     into a pre-image still keyed with the shared secret — the cross-region
-    #     join, reconstructed by a race;
-    #   * the label LIED DOWNWARD, reading 'deployment' over a federation-keyed
-    #     ref, inverting the honesty property claimed two sections up.
-    #
-    # Threading one value makes the first two unrepresentable. The third is now
-    # ENFORCED rather than asserted: #digest_ref emits nothing at all when it is
-    # handed FEDERATION_SECRET keying with no residency, so the constant can
-    # never be substituted under the shared key.
-    #
-    # Stated exactly, so the comment does not outrun the code. Guaranteed: the
-    # residency mixed into a ref and the scope label emitted beside it come from
-    # ONE read of the config, and a 'federated' ref always carries a resolved
-    # residency. NOT guaranteed: that two derivations minutes apart agree — an
-    # operator who changes the declared jurisdiction has re-keyed diagnostics
-    # reference, and that splits the user by design.
-    #
-    # ---------------------------------------------------------------------------
-    # SECRET SELECTION ORDER (and what the scope label means)
-    # ---------------------------------------------------------------------------
-    #   1. FEDERATION_SECRET  -> scope 'federated'
-    #      ONLY when a residency scope resolves. Correlation then holds across
-    #      installs that share the secret AND resolve to the SAME residency
-    #      scope. It does NOT hold across jurisdictions; see above. With no
-    #      residency declared this option is skipped entirely.
-    #
-    #   2. ACCOUNT_ID_SECRET  -> scope 'deployment'
-    #      Per-deployment. Correlation holds within this install only.
-    #      NOTE: we consume the raw secret VALUE as an HMAC key here. We do NOT
-    #      use Rodauth's account-id obfuscation cipher — that is an
-    #      Integer<->13-char bijection over the accounts PK, it cannot take an
-    #      email, and the integer PK is not reachable from an Otto request.
-    #      Read from ENV only, never from Rodauth's configured value: when
-    #      ACCOUNT_ID_SECRET is unset outside production Rodauth substitutes a
-    #      fixed placeholder literal, which would make every dev install on
-    #      earth derive identical refs.
-    #
-    #   3. Neither configured -> nil, and the caller emits nothing.
-    #
-    # The scope label travels with the ref so an operator reading a Sentry event
-    # knows how far the id is comparable. It is a property of the KEY, not of
-    # the account. The label values are a closed enum on the client
-    # (REF_SCOPES in src/schemas/contracts/bootstrap.ts) — adding a value here
-    # without adding it there makes the strict parse fail and drops the whole
-    # `diagnostics_ref` block.
+    # {actor_ref} and the frontend parses it as a Zod strictObject. A second key
+    # would make the client discard the entire actor block.
     #
     # ---------------------------------------------------------------------------
     # FAILURE TOLERANCE
     # ---------------------------------------------------------------------------
-    # Neither secret is configured by default: FEDERATION_SECRET is commented out
-    # in .env.example and .env.reference, and ACCOUNT_ID_SECRET is only required
-    # in production. That is the NORMAL state on a developer box, so an
-    # unconfigured deployment must render pages exactly as before.
+    # ACCOUNT_ID_SECRET is only required in production. Unconfigured is the
+    # NORMAL state on a developer box, so an unconfigured deployment must render
+    # pages exactly as before.
     #
     # No public method therefore propagates a StandardError: each answers nil
-    # instead (false for #available?), and the WHOLE derivation — normalization
-    # included — is wrapped so a surprise from OpenSSL, config access, or a
-    # badly encoded stored email cannot escape into a render path. DiagnosticsSerializer runs on every authenticated render of
-    # all three web shells, so an escaping exception means a 500 page AND a
+    # instead (false for #available?), and the WHOLE derivation is wrapped so a
+    # surprise from OpenSSL or from config access cannot escape into a render
+    # path. DiagnosticsSerializer runs on every authenticated render of all
+    # three web shells, so an escaping exception means a 500 page AND a
     # self-inflicted Sentry event; diagnostics code taking the site down is the
-    # one outcome worth engineering against. Encoding is the live hazard there:
-    # a stored email tagged ASCII-8BIT, or holding an invalid byte, makes
-    # String#unicode_normalize raise Encoding::CompatibilityError or
-    # ArgumentError. See #normalized_email.
+    # one outcome worth engineering against.
     #
     # Failures are logged at debug level with the exception CLASS only; never
     # the value, never the key.
     #
     # Fail-soft is NOT the same as fail-open. Where a failure could change WHICH
-    # reference a human gets rather than whether they get one, the answer is nil
-    # — a gap in diagnostics reference — never a substitute value. See
-    # #resolve_residency for the case that motivated the distinction.
+    # reference a subject gets rather than whether it gets one, the answer is
+    # nil — a gap in diagnostics reference — never a substitute value.
     #
     # @see Onetime::Security::RequestContext (the network-side analogue)
     # @see Onetime::Utils::EmailHash (federation reference — deliberately NOT this)
     module DiagnosticsRef
       extend self
 
-      # Canonical email normalization (NFC + case folding + strip), shared with
-      # OT::Utils rather than copied. EmailHash keeps a parallel private copy
-      # because it loads before Utils during boot; this module has no such
-      # constraint, so it reuses the canonical implementation and cannot drift.
-      extend Onetime::Utils::Strings
-
       # Versioned purpose prefix. Changing the value re-keys actor refs only.
-      ACTOR_INFO = 'onetime:sentry:v1:actor'
+      #
+      # v1 mixed in a data-residency element and, for actors, a normalized EMAIL
+      # pre-image. v2 is a two-element message over the server-minted extid
+      # (actor) or objid (organization). The bump makes the accepted re-key
+      # discontinuity legible: refs derived before this change do not match refs
+      # derived after it.
+      ACTOR_INFO = 'onetime:sentry:v2:actor'
 
       # Versioned purpose prefix for ORGANIZATION refs. Distinct from
       # ACTOR_INFO, which is the whole of the domain separation between the two
@@ -270,91 +186,43 @@ module Onetime
       # digest to the same value, or an operator holding one ref could test it
       # against the other surface. Pinned by execution in the tryouts and in
       # spec, not merely asserted here.
-      ORGANIZATION_INFO = 'onetime:sentry:v1:organization'
+      ORGANIZATION_INFO = 'onetime:sentry:v2:organization'
 
       # Separator between derivation elements. A byte that cannot occur in an
-      # email, a jurisdiction id or an objid, so no element can be shifted into
-      # a neighbour's position by a crafted value.
+      # extid or an objid, so no element can be shifted into a neighbour's
+      # position by a crafted value.
       SEPARATOR = "\x00"
 
-      # Pre-image element used when no residency resolves. Literal rather than
-      # empty string so the element count in the pre-image never varies.
-      #
-      # It is NOT a residency scope and grants no correlation. Two independent
-      # mechanisms keep it off the shared key: #keying declines
-      # FEDERATION_SECRET when no residency resolves, and #digest_ref refuses to
-      # emit anything at all if it is nonetheless handed federated keying with
-      # no residency. So this element only ever reaches a pre-image under a
-      # per-deployment key.
-      RESIDENCY_UNSCOPED = 'unscoped'
-
-      # Explicit operator pin for the residency scope. See the module docstring.
-      RESIDENCY_ENV = 'DIAGNOSTICS_REF_REGION'
-
-      # Hex chars retained (64 bits). Ample to group events by user, and half
+      # Hex chars retained (64 bits). Ample to group events by account, and half
       # the width of EmailHash::HASH_LENGTH so refs are visibly not email hashes.
       REF_LENGTH = 16
 
-      # Correlation scope labels — a property of which secret keyed the ref.
-      SCOPE_FEDERATED  = 'federated'
-      SCOPE_DEPLOYMENT = 'deployment'
-
-      # One derivation's keying decision, resolved together and threaded as a
-      # unit: the HMAC key, the label that key implies, and the residency read
-      # that SELECTED that key. Bundling them is the mechanism — a caller cannot
-      # pair a ref with a label sourced from a different read of the config,
-      # because there is only one read to source either from.
+      # Opaque actor reference derived from the customer's external identifier.
       #
-      # @!attribute [r] secret   [String] HMAC key. Never logged, never emitted.
-      # @!attribute [r] scope    [String] SCOPE_FEDERATED or SCOPE_DEPLOYMENT.
-      # @!attribute [r] residency [String, nil] resolved residency label; nil
-      #   only ever accompanies SCOPE_DEPLOYMENT.
-      Keying = Data.define(:secret, :scope, :residency)
-
-      # Opaque actor reference derived from the account's normalized email.
+      # NOT NORMALIZED — no case folding, no unicode normalization. An extid is
+      # a server-minted canonical token that no human types, so there is nothing
+      # to reconcile, and folding case could map two distinct records onto one
+      # ref. See #pre_image for the encoding guard that survives from the email
+      # era.
       #
-      # @param email [String, nil] account email, any casing/whitespace, any
-      #   encoding (including a mis-tagged or corrupt one).
-      # @return [String, nil] REF_LENGTH hex chars, or nil when the email is
+      # @param extid [String, nil] customer extid (e.g. "ur<base36>").
+      # @return [String, nil] REF_LENGTH hex chars, or nil when the extid is
       #   blank or unusable, no secret is configured, or derivation failed.
-      def actor_ref(email)
-        # The block is evaluated INSIDE digest_ref's rescue. Normalizing out
-        # here would put unicode_normalize outside the guard, which is how a
-        # non-UTF-8 stored email turns into a 500 on every authenticated render.
-        digest_ref(ACTOR_INFO, keying) { normalized_email(email) }
+      def actor_ref(extid)
+        digest_ref(ACTOR_INFO, keying) { pre_image(extid) }
       end
 
       # Opaque organization reference derived from the organization's objid.
       #
-      # Same keying, same residency threading and the same fail-closed
-      # conditions as #actor_ref — both route through #keying and #digest_ref,
-      # so there is one place where "is this key usable?" is decided and the two
-      # cannot drift apart. It returns nil under exactly the conditions
-      # #actor_ref returns nil for a usable email.
-      #
-      # NOT NORMALIZED, unlike an email, and that is deliberate. Emails are
-      # normalized because a human types the same address five ways; an objid is
-      # a server-minted canonical token that no human types, so there is nothing
-      # to reconcile. Case folding it would be actively wrong: objid alphabets
-      # are case-sensitive, so folding could map two distinct organizations onto
-      # one ref — the opposite of the property the ref exists to provide.
-      # Surrounding whitespace is trimmed only so a padded value cannot split
-      # one organization into two refs, and the trim is what the blank check
-      # runs against.
+      # Same keying and the same fail-closed conditions as #actor_ref — both
+      # route through #keying and #digest_ref, so there is one place where "is
+      # this key usable?" is decided and the two cannot drift apart.
       #
       # @param identifier [String, nil] organization objid.
       # @return [String, nil] REF_LENGTH hex chars, or nil when the identifier
       #   is blank or unusable, no secret is configured, or derivation failed.
       def organization_ref(identifier)
-        digest_ref(ORGANIZATION_INFO, keying) { organization_pre_image(identifier) }
-      end
-
-      # Which correlation scope the configured secret provides.
-      #
-      # @return [String, nil] SCOPE_FEDERATED, SCOPE_DEPLOYMENT, or nil when
-      #   neither secret is configured.
-      def scope
-        keying&.scope
+        digest_ref(ORGANIZATION_INFO, keying) { pre_image(identifier) }
       end
 
       # Convenience bundle for the bootstrap payload.
@@ -363,21 +231,19 @@ module Onetime
       # caller can omit the `diagnostics_ref` block entirely for anonymous
       # sessions and unconfigured deployments alike.
       #
-      # ONE keying resolution serves both fields. The ref and the label it is
-      # emitted with therefore always describe the same read of the config;
-      # calling #actor_ref and #scope separately would reintroduce the split
-      # this bundle exists to close.
+      # EXACTLY ONE KEY. The frontend parses this as a Zod strictObject; a
+      # second key makes the parse fail and the client drops the whole block.
       #
-      # @param email [String, nil] account email.
+      # @param extid [String, nil] customer extid.
       # @return [Hash{String=>String}, nil] string-keyed, JSON-ready.
-      def actor(email)
-        key = keying
-        return nil if key.nil?
+      def actor(extid)
+        secret = keying
+        return nil if secret.nil?
 
-        ref = digest_ref(ACTOR_INFO, key) { normalized_email(email) }
+        ref = digest_ref(ACTOR_INFO, secret) { pre_image(extid) }
         return nil if ref.nil?
 
-        { 'actor_ref' => ref, 'actor_scope' => key.scope }
+        { 'actor_ref' => ref }
       end
 
       # True when a secret is available and refs can be derived.
@@ -387,159 +253,49 @@ module Onetime
         !keying.nil?
       end
 
-      # The HMAC key, the scope label it implies, and the residency read that
-      # selected it — resolved together, in that one order, and returned as a
-      # unit. This is the ONLY place a derivation resolves residency.
+      # The HMAC key, or nil when none is usable.
       #
-      # @return [Keying, nil] nil when no secret is usable.
+      # ENV only — see the ACCOUNT_ID_SECRET note in the module docstring.
+      # Raise-free: a surprise from the environment read costs a ref, never a
+      # render.
+      #
+      # @return [String, nil] the secret. Never logged, never emitted.
       def keying
-        residency  = resolve_residency
-        federation = federation_secret
+        secret = ENV.fetch('ACCOUNT_ID_SECRET', nil)
+        return nil if secret.to_s.empty?
 
-        # FEDERATION_SECRET is shared across regional instances BY DESIGN, so
-        # keying an actor ref with it while no residency scope is declared is
-        # precisely the cross-region join this module exists to prevent. An
-        # undeclared residency therefore DECLINES the shared key instead of
-        # widening the ref, and we fall through to the per-deployment one.
-        if residency && !federation.to_s.empty?
-          return Keying.new(secret: federation, scope: SCOPE_FEDERATED, residency: residency)
-        end
-
-        # ENV only — see the ACCOUNT_ID_SECRET note in the module docstring.
-        account = ENV.fetch('ACCOUNT_ID_SECRET', nil)
-        unless account.to_s.empty?
-          # residency may be present here too (declared, but no federation
-          # secret configured); it is carried so the pre-image element and the
-          # label still come from the same read.
-          return Keying.new(secret: account, scope: SCOPE_DEPLOYMENT, residency: residency)
-        end
-
-        nil
+        secret
       rescue StandardError => ex
         OT.ld "[diagnostics-ref] secret lookup failed: #{ex.class}" if defined?(OT)
         nil
       end
 
-      # The data-residency scope this deployment declares, if any.
-      #
-      # Public because it is a deployment property an operator may reasonably
-      # want to assert on in a boot check; it is never sent to Sentry.
-      # The nil answer is load-bearing rather than cosmetic — it is what makes
-      # #keying refuse FEDERATION_SECRET and drop to deployment scope.
-      #
-      # Raise-free for introspection. The derivation path deliberately does NOT
-      # come through here: #keying calls the raising #resolve_residency — once —
-      # so a config fault costs a ref rather than handing back a different one.
-      #
-      # @return [String, nil] lowercase label, never blank; nil when the
-      #   deployment declares no residency or the config read failed.
-      def residency_scope
-        resolve_residency
-      rescue StandardError => ex
-        OT.ld "[diagnostics-ref] residency lookup failed: #{ex.class}" if defined?(OT)
-        nil
-      end
-
       private
 
-      # Residency resolution. RAISES on a failed config read — deliberately.
+      # Pre-image for both namespaces, safe for arbitrary stored bytes.
       #
-      # An earlier revision rescued to RESIDENCY_UNSCOPED here and claimed the
-      # fallback "can only ever widen correlation". That was wrong in the way
-      # that matters. A transient OT.conf failure on some renders and not others
-      # made ONE human derive TWO different refs, splitting one Sentry user in
-      # two — which destroys "is this one user or fifty?", the single question a
-      # pseudonymous id exists to answer — while silently re-widening
-      # correlation for the duration of the fault.
+      # Extids and objids are ASCII by construction, so the encoding guard is
+      # defence rather than a live recovery path — but it is kept, because
+      # String#strip RAISES on an invalid byte sequence even in UTF-8:
       #
-      # Failing closed instead: the raise propagates into the rescue in #keying,
-      # which answers nil, so a fault costs a GAP in diagnostics reference for
-      # as long as it lasts. A gap is honest and self-healing. A second reference
-      # for the same human is neither.
+      #   "a\xFFur".strip  ->  Encoding::CompatibilityError
       #
-      # Raising is only half the guard, and the missing half was a live defect:
-      # a falsy OT.conf resolves to nil WITHOUT raising. That is why residency
-      # is resolved exactly once per derivation and threaded (see the Keying
-      # value and #digest_ref) rather than re-read and defaulted.
+      # (executed, not assumed). digest_ref's rescue would swallow that, so the
+      # guard is not what keeps a render alive; what it buys is determinism. An
+      # unusable identifier takes the SAME '' -> nil route as a blank one
+      # instead of depending on a rescue, and ASCII bytes carrying a binary
+      # encoding tag are re-tagged and still correlate with themselves rather
+      # than being dropped.
       #
-      # @return [String, nil] declared label, or nil when nothing is declared.
-      def resolve_residency
-        pinned = ENV.fetch(RESIDENCY_ENV, nil).to_s.strip
-        return pinned.downcase unless pinned.empty?
-
-        declared = current_jurisdiction.to_s.strip
-        declared.empty? ? nil : declared.downcase
-      end
-
-      # The same source SetupDiagnostics derives the Sentry `jurisdiction` tag
-      # from, so the residency boundary matches what operators see on events.
-      #
-      # @return [String, nil]
-      def current_jurisdiction
-        return nil unless defined?(OT) && OT.respond_to?(:conf) && OT.conf
-
-        OT.conf.dig('features', 'regions', 'current_jurisdiction')
-      end
-
-      # FEDERATION_SECRET from the environment, falling back to site config —
-      # the same resolution order EmailHash#fetch_secret uses, minus the raise.
-      #
-      # @return [String, nil]
-      def federation_secret
-        secret = ENV.fetch('FEDERATION_SECRET', nil)
-        return secret unless secret.to_s.empty?
-
-        return nil unless defined?(OT) && OT.respond_to?(:conf) && OT.conf
-
-        OT.conf.dig('site', 'federation_secret')
-      end
-
-      # Normalized email pre-image, safe for arbitrary stored bytes.
-      #
-      # OT::Utils.normalize_email calls String#unicode_normalize, which raises
-      # on any receiver that is not valid UTF-8. Emails reach us from the
-      # datastore, from SSO providers and from legacy rows, so all three of
-      # these are reachable in production:
-      #
-      #   "a\xFF@b.com"                                -> CompatibilityError
-      #   "alice@example.com".force_encoding('BINARY') -> CompatibilityError
-      #   "\xC3(@b.com"                                -> ArgumentError
-      #
-      # The middle case is the common and recoverable one: correct UTF-8 bytes
-      # carrying the wrong encoding tag. Re-tagging recovers it and yields
-      # byte-identical output to the properly tagged string, so a mis-tagged
-      # row still correlates with itself instead of silently losing its ref.
-      # Genuinely invalid bytes yield '', which digest_ref turns into nil.
-      #
-      # @param email [String, nil]
-      # @return [String] normalized address, or '' when unusable.
-      def normalized_email(email)
-        raw = email.to_s
-        raw = raw.dup.force_encoding(Encoding::UTF_8) unless raw.encoding == Encoding::UTF_8
-        return '' unless raw.valid_encoding?
-
-        normalize_email(raw)
-      end
-
-      # Organization pre-image, safe for arbitrary stored bytes.
-      #
-      # No unicode_normalize here — see #organization_ref for why an objid is
-      # not normalized like an email. The encoding guard is kept anyway, because
-      # dropping unicode_normalize does NOT make this path encoding-safe:
-      #
-      #   "a\xFForg".strip  ->  Encoding::CompatibilityError
-      #
-      # (executed, not assumed — String#strip raises on an invalid byte sequence
-      # even in UTF-8). digest_ref's rescue would swallow that, so the guard is
-      # not what keeps a render alive; what it buys is determinism. An unusable
-      # identifier takes the SAME '' -> nil route as a blank one instead of
-      # depending on a rescue, and ASCII bytes carrying a binary encoding tag
-      # are re-tagged and still correlate with themselves rather than being
-      # dropped.
+      # Surrounding whitespace is trimmed only so a padded value cannot split
+      # one record into two refs, and the trim is what the blank check runs
+      # against. Nothing else is normalized: case folding could collapse two
+      # distinct identifiers onto one ref, which is the opposite of the property
+      # these refs exist to provide.
       #
       # @param identifier [String, nil]
       # @return [String] trimmed identifier, or '' when unusable.
-      def organization_pre_image(identifier)
+      def pre_image(identifier)
         raw = identifier.to_s
         raw = raw.dup.force_encoding(Encoding::UTF_8) unless raw.encoding == Encoding::UTF_8
         return '' unless raw.valid_encoding?
@@ -547,42 +303,25 @@ module Onetime
         raw.strip
       end
 
-      # Keyed, purpose- and residency-separated, truncated digest. NEVER raises.
+      # Keyed, purpose-separated, truncated digest. NEVER raises.
       #
-      # The pre-image is produced by the block so that normalization runs inside
-      # this method's rescue rather than at the call site.
-      #
-      # Residency is NOT re-resolved here. It arrives inside `key`, from the
-      # single resolution #keying performed when it chose the secret, so the
-      # pre-image element and the emitted label cannot disagree.
+      # The pre-image is produced by the block so that the encoding guard runs
+      # inside this method's rescue rather than at the call site.
       #
       # @param info [String] versioned purpose prefix (ACTOR_INFO or
       #   ORGANIZATION_INFO). This element is the only thing separating the two
       #   ref namespaces, so it must never be passed a caller-supplied value.
-      # @param key [Keying, nil] the caller's single keying resolution.
+      # @param secret [String, nil] the caller's keying resolution.
       # @yieldreturn [String, nil] the pre-image.
       # @return [String, nil]
-      def digest_ref(info, key)
-        return nil if key.nil? || key.secret.to_s.empty?
-
-        residency = key.residency.to_s
-
-        # The honesty invariant, enforced rather than asserted. Substituting
-        # RESIDENCY_UNSCOPED under FEDERATION_SECRET is exactly the cross-region
-        # join: every install sharing that secret would derive the same ref.
-        # #keying cannot produce this pairing today; the check is here so that a
-        # future edit which makes it producible fails closed instead of silently
-        # widening correlation.
-        return nil if key.scope == SCOPE_FEDERATED && residency.empty?
+      def digest_ref(info, secret)
+        return nil if secret.to_s.empty?
 
         value = yield.to_s
         return nil if value.empty?
 
-        # RESIDENCY_UNSCOPED therefore only ever reaches the pre-image under
-        # deployment keying, where it grants no cross-install correlation.
-        element = residency.empty? ? RESIDENCY_UNSCOPED : residency
-        message = [info, element, value].join(SEPARATOR)
-        OpenSSL::HMAC.hexdigest('SHA256', key.secret, message)[0, REF_LENGTH]
+        message = [info, value].join(SEPARATOR)
+        OpenSSL::HMAC.hexdigest('SHA256', secret, message)[0, REF_LENGTH]
       rescue StandardError => ex
         # Class only: the message could carry the pre-image or the key.
         OT.ld "[diagnostics-ref] derivation failed: #{ex.class}" if defined?(OT)

--- a/spec/unit/onetime/error_handler_diagnostics_actor_spec.rb
+++ b/spec/unit/onetime/error_handler_diagnostics_actor_spec.rb
@@ -12,19 +12,27 @@
 #
 # The fix cannot be "send the email". Sentry's user object is not exempt from
 # the diagnostics boundary; an id set there is also a searchable field. So the
-# id is always a DiagnosticsRef: opaque, keyed, one-way.
+# id is always a DiagnosticsRef: opaque, keyed, one-way — and its pre-image is
+# the customer EXTID, never the email
+# (docs/specs/diagnostics/actor-ref-preimage-debate-decision.md).
 #
-# The four properties pinned below are the ones whose failure modes are silent:
+# The properties pinned below are the ones whose failure modes are silent:
 #
 #   1. The id IS the ref. Not a truncation of it, not something else that
 #      happens to look opaque.
-#   2. The email appears NOWHERE in the serialized event. Asserted against a
-#      real Sentry::ErrorEvent payload rather than against the scope object,
-#      because it is the serialized form that leaves the process.
-#   3. Anonymous sets NO user. Not `{id: nil}` and not a placeholder — either
+#   2. A candidate that is not positively an extid is REFUSED. DiagnosticsRef
+#      digests whatever string it is handed, so a bare-string fallback here is
+#      how an `email:` caller ends up with an email hashed under the
+#      diagnostics key. Refusal is what makes that unrepresentable.
+#   3. Neither the email NOR the extid appears anywhere in the serialized
+#      event. Asserted against a real Sentry::ErrorEvent payload rather than
+#      against the scope object, because it is the serialized form that leaves
+#      the process — and under the extid derivation the extid is the sensitive
+#      pre-image, so forwarding it would hand Sentry both the ref and its input.
+#   4. Anonymous sets NO user. Not `{id: nil}` and not a placeholder — either
 #      one merges every anonymous visitor into a single "affected user" and
 #      makes the count wrong in the other direction.
-#   4. A derivation failure still captures the EVENT. Attribution is a nice to
+#   5. A derivation failure still captures the EVENT. Attribution is a nice to
 #      have; the exception report is not. Losing the first to save the second
 #      is the correct trade and it must be executed, not assumed.
 #
@@ -34,22 +42,20 @@ require 'spec_helper'
 require 'sentry-ruby'
 
 RSpec.describe Onetime::ErrorHandler do
+  # Shaped like a real Customer extid: Familia's external_identifier feature
+  # under `format: 'ur%<id>s'` emits `ur` plus 25 base36 characters.
+  let(:extid) { 'ur00fedcba9876543210zyxwvu' }
   let(:email) { 'affected.person@example.com' }
 
-  # Pin a known keying rather than inheriting whatever the lane exports.
-  # DiagnosticsRef refuses the shared federation secret when no residency
-  # resolves, so an unpinned lane would make every example here assert against
-  # nil and pass for the wrong reason.
-  let(:keying) do
-    Onetime::Utils::DiagnosticsRef::Keying.new(
-      secret: 'a-known-diagnostics-key', scope: 'federated', residency: 'stub-region'
-    )
-  end
+  # Pin a known keying rather than inheriting whatever the lane exports, so an
+  # unpinned lane cannot make every example here assert against nil and pass
+  # for the wrong reason.
+  let(:keying) { 'a-known-diagnostics-key' }
 
-  let(:expected_ref) { Onetime::Utils::DiagnosticsRef.actor_ref(email) }
+  let(:expected_ref) { Onetime::Utils::DiagnosticsRef.actor_ref(extid) }
 
   let(:customer) do
-    instance_double(Onetime::Customer, email: email, anonymous?: false)
+    instance_double(Onetime::Customer, extid: extid, anonymous?: false)
   end
 
   before do
@@ -61,23 +67,64 @@ RSpec.describe Onetime::ErrorHandler do
       expect(described_class.diagnostics_actor(customer)).to eq({ id: expected_ref })
     end
 
-    it 'returns the same id for a bare email string' do
-      expect(described_class.diagnostics_actor(email)).to eq({ id: expected_ref })
+    it 'returns the same id for a bare extid string' do
+      expect(described_class.diagnostics_actor(extid)).to eq({ id: expected_ref })
     end
 
-    it 'emits a 16-char opaque hex id, never the email' do
+    it 'derives from the extid, not from anything else the customer carries' do
+      # The customer double answers ONLY #extid and #anonymous?. A verifying
+      # double raises on any other message, so this passing is itself the proof
+      # that no other attribute is consulted.
+      expect(described_class.diagnostics_actor(customer)[:id])
+        .to eq(Onetime::Utils::DiagnosticsRef.actor_ref(extid))
+    end
+
+    it 'emits a 16-char opaque hex id, never the extid' do
       user = described_class.diagnostics_actor(customer)
 
       expect(user[:id]).to match(/\A[0-9a-f]{16}\z/)
-      expect(user[:id]).not_to eq(email)
-      expect(user[:id]).not_to include('affected')
-      expect(user[:id]).not_to include('example.com')
+      expect(user[:id]).not_to eq(extid)
+      expect(user[:id]).not_to include('ur00')
     end
 
     it 'carries no key other than :id' do
       # An email/username/ip_address key here would be sent verbatim by the
       # SDK. The absence is the contract, so it is asserted, not assumed.
       expect(described_class.diagnostics_actor(customer).keys).to eq([:id])
+    end
+
+    # The bare-string candidate API is dead ON PURPOSE. Every rejection below
+    # would otherwise be silently hashed under the diagnostics key and become a
+    # searchable Sentry field's pre-image.
+    context 'a candidate that is not positively an extid' do
+      it 'refuses a bare email string rather than hashing it' do
+        expect(described_class.diagnostics_actor(email)).to be_nil
+      end
+
+      it 'refuses an email even when it is the only thing a customer offers' do
+        emailish = instance_double(Onetime::Customer, anonymous?: false)
+        expect(described_class.diagnostics_actor(emailish)).to be_nil
+      end
+
+      it 'refuses a custid' do
+        expect(described_class.diagnostics_actor('cust-1234567890')).to be_nil
+      end
+
+      it 'refuses an objid' do
+        expect(described_class.diagnostics_actor('01JCUSTABCDEFGHJKMNPQRSTVW')).to be_nil
+      end
+
+      it 'refuses an organization-shaped or otherwise foreign prefix' do
+        expect(described_class.diagnostics_actor('org00fedcba9876543210zyxwv')).to be_nil
+      end
+
+      it 'refuses arbitrary garbage' do
+        ['ur', 'UR00FEDCBA9876543210ZYXWVU', 'ur_00fedcba', '  ', 'null', '42'].each do |garbage|
+          expect(described_class.diagnostics_actor(garbage)).to(
+            be_nil, "expected #{garbage.inspect} to be refused"
+          )
+        end
+      end
     end
 
     context 'anonymous' do
@@ -90,8 +137,9 @@ RSpec.describe Onetime::ErrorHandler do
         expect(described_class.diagnostics_actor(anon)).to be_nil
       end
 
-      it 'returns nil for a blank email' do
-        expect(described_class.diagnostics_actor('   ')).to be_nil
+      it 'returns nil for a customer with no extid yet' do
+        fresh = instance_double(Onetime::Customer, extid: nil, anonymous?: false)
+        expect(described_class.diagnostics_actor(fresh)).to be_nil
       end
     end
 
@@ -128,6 +176,11 @@ RSpec.describe Onetime::ErrorHandler do
 
     it 'leaves the scope userless for anonymous and reports false' do
       expect(described_class.set_diagnostics_actor(scope, nil)).to be(false)
+      expect(scope.user).to be_empty
+    end
+
+    it 'leaves the scope userless for an email candidate' do
+      expect(described_class.set_diagnostics_actor(scope, email)).to be(false)
       expect(scope.user).to be_empty
     end
 
@@ -171,7 +224,7 @@ RSpec.describe Onetime::ErrorHandler do
       expect(payload_for(customer)[:user]).to eq({ id: expected_ref })
     end
 
-    it 'contains the email nowhere at all' do
+    it 'contains neither the email nor the extid anywhere at all' do
       serialized = payload_for(customer).inspect
 
       expect(serialized).not_to include(email)
@@ -179,6 +232,9 @@ RSpec.describe Onetime::ErrorHandler do
       # The local part alone is enough to identify; assert on the domain too so
       # a future partial-redaction regression cannot pass this example.
       expect(serialized).not_to include('example.com')
+      # The extid is the PRE-IMAGE under this derivation. Shipping it alongside
+      # the ref would hand Sentry the input and the output together.
+      expect(serialized).not_to include(extid)
       expect(serialized).to include(expected_ref)
     end
 
@@ -206,20 +262,62 @@ RSpec.describe Onetime::ErrorHandler do
       described_class.send(:capture_error, 'password_changed_email', exception, context)
     end
 
-    it 'sets the pseudonymous user when the context names the subject' do
-      capture({ account_id: 42, email: email })
-
-      expect(scope.user).to eq({ id: expected_ref })
-    end
-
-    it 'CONSUMES the email rather than forwarding it into the Sentry context' do
+    def forwarded_context(context)
       captured = nil
       allow(scope).to receive(:set_context) do |key, value|
         captured = value if key == 'error_handler'
       end
+      capture(context)
+      captured
+    end
 
-      capture({ account_id: 42, email: email })
+    # Every key a hook uses to carry an extid is both a SUBJECT and a SCRUB
+    # target. Subject, because attribution is the point; scrub, because the
+    # extid is the pre-image and must not travel beside the ref it produced.
+    {
+      external_id: 'the canonical key',
+      extid: 'the account-hook alias',
+      customer_id: 'the extid-valued alias',
+    }.each do |key, description|
+      context "when the context carries #{key} (#{description})" do
+        it 'sets the pseudonymous user from it' do
+          capture({ account_id: 42, key => extid })
 
+          expect(scope.user).to eq({ id: expected_ref })
+        end
+
+        it 'CONSUMES it rather than forwarding it into the Sentry context' do
+          captured = forwarded_context({ account_id: 42, key => extid })
+
+          expect(captured).to eq({ operation: 'password_changed_email', account_id: 42 })
+          expect(captured.inspect).not_to include(extid)
+        end
+      end
+    end
+
+    [:cust, :customer].each do |key|
+      context "when the context carries a customer object under #{key}" do
+        it 'sets the pseudonymous user from its extid' do
+          capture({ account_id: 42, key => customer })
+
+          expect(scope.user).to eq({ id: expected_ref })
+        end
+
+        it 'CONSUMES the object rather than forwarding it' do
+          captured = forwarded_context({ account_id: 42, key => customer })
+
+          expect(captured).to eq({ operation: 'password_changed_email', account_id: 42 })
+        end
+      end
+    end
+
+    # An email is scrubbed but is NOT a subject: nothing is derivable from it
+    # any more, and accepting one as a candidate is exactly how an email gets
+    # hashed under the diagnostics key.
+    it 'scrubs an email without deriving a user from it' do
+      captured = forwarded_context({ account_id: 42, email: email })
+
+      expect(scope.user).to be_empty
       expect(captured).to eq({ operation: 'password_changed_email', account_id: 42 })
       expect(captured.inspect).not_to include(email)
     end
@@ -236,7 +334,7 @@ RSpec.describe Onetime::ErrorHandler do
 
       expect(Sentry).to receive(:capture_exception).and_return('event-id-1')
 
-      expect { capture({ account_id: 42, email: email }) }.not_to raise_error
+      expect { capture({ account_id: 42, external_id: extid }) }.not_to raise_error
     end
   end
 end

--- a/spec/unit/onetime/error_handler_diagnostics_actor_spec.rb
+++ b/spec/unit/onetime/error_handler_diagnostics_actor_spec.rb
@@ -43,7 +43,7 @@ require 'sentry-ruby'
 
 RSpec.describe Onetime::ErrorHandler do
   # Shaped like a real Customer extid: Familia's external_identifier feature
-  # under `format: 'ur%<id>s'` emits `ur` plus 25 base36 characters.
+  # under `format: 'ur%{id}'` emits `ur` plus 25 base36 characters.
   let(:extid) { 'ur00fedcba9876543210zyxwvu' }
   let(:email) { 'affected.person@example.com' }
 

--- a/spec/unit/onetime/models/customer/extid_validator_spec.rb
+++ b/spec/unit/onetime/models/customer/extid_validator_spec.rb
@@ -1,0 +1,43 @@
+# spec/unit/onetime/models/customer/extid_validator_spec.rb
+#
+# frozen_string_literal: true
+
+# Pins Customer.extid? (Familia's external_identifier shape validator)
+# against the extids the same feature actually mints.
+#
+# Why this exists: the validator extracts its prefix by splitting the
+# declared format on the literal '%{id}'. The model used to declare the
+# format in sprintf's '%<id>s' spelling — which interpolates identically,
+# so minting worked, but the validator answered false for EVERY customer
+# extid and did so silently. A format edit can reintroduce that skew
+# without failing any minting test, so the round-trip is pinned here.
+#
+# Run with:
+#   tests/lanes/run unit --only spec/unit/onetime/models/customer/extid_validator_spec.rb
+require 'spec_helper'
+
+RSpec.describe Onetime::Customer do
+  describe '.extid?' do
+    it 'accepts an extid the feature itself derives' do
+      customer = described_class.new(email: 'extid-validator@example.com')
+
+      extid = customer.extid
+
+      expect(extid).to start_with('ur')
+      expect(described_class.extid?(extid)).to be(true)
+    end
+
+    it 'refuses an email' do
+      expect(described_class.extid?('someone@example.com')).to be(false)
+    end
+
+    it 'refuses a foreign-prefix extid' do
+      expect(described_class.extid?('cd00fedcba9876543210zyxwvu')).to be(false)
+    end
+
+    it 'refuses nil and empty' do
+      expect(described_class.extid?(nil)).to be(false)
+      expect(described_class.extid?('')).to be(false)
+    end
+  end
+end

--- a/src/plugins/core/diagnostics/actorContext.ts
+++ b/src/plugins/core/diagnostics/actorContext.ts
@@ -11,9 +11,11 @@
 // ── What Sentry receives ──────────────────────────────────────────────────────
 //
 //   user = { id: <opaque server-derived ref>, ip_address: null }
-//   tags.actor_scope = "federated" | "deployment"
 //
-// That is the complete set. No `email`, no `username`, no `name`, no
+// That is the complete set — one field on one context, and no tag beside it.
+// The ref is a keyed one-way digest of the customer's external identifier
+// (extid), minted per install; there is no scope, region, or jurisdiction
+// dimension attached to it. No `email`, no `username`, no `name`, no
 // `ip_address` other than the explicit null, and no additional user keys. The
 // shape is built by literal construction (never by spreading the server
 // block), so a new server-side field cannot ride along even if the schema were
@@ -34,14 +36,14 @@
 //      derivation produces — 16 lowercase hex chars, matched against
 //      `DIAGNOSTICS_REF_PATTERN`.
 //
-// Check 2 is not redundant. `{ actor_ref: "alice@example.com", actor_scope:
-// "deployment" }` is a fully VALID block by key set alone — two keys, valid
-// enum, non-empty string. The outbound gate keeps exactly one field, `id`, and
-// drops the rest, so with a key-set check only, that address would be shipped
-// as `user.id` on every error and every transaction while `email` was
-// conscientiously deleted beside it. A strict key set stops an unexpected
-// FIELD; only the content check stops an unexpected VALUE in a permitted
-// field, which is why BOTH the inbound parse and `sanitizeEventUser` apply it.
+// Check 2 is not redundant. `{ actor_ref: "alice@example.com" }` is a fully
+// VALID block by key set alone — the one permitted key, a non-empty string.
+// The outbound gate keeps exactly one field, `id`, and drops the rest, so with
+// a key-set check only, that address would be shipped as `user.id` on every
+// error and every transaction while `email` was conscientiously deleted
+// beside it. A strict key set stops an unexpected FIELD; only the content
+// check stops an unexpected VALUE in a permitted field, which is why BOTH the
+// inbound parse and `sanitizeEventUser` apply it.
 //
 // `DIAGNOSTICS_REF_PATTERN` lives in the contract module and is the single
 // source of truth on this side. It mirrors
@@ -93,21 +95,13 @@ import { getBootstrapValue } from '@/services/bootstrap.service';
 import type { Scope } from '@sentry/browser';
 
 /**
- * The Sentry tag key carrying the ref scope (which secret keyed the ref).
- *
- * Exported so tests and the diagnostics service refer to one literal rather
- * than three copies of the string.
- */
-export const ACTOR_SCOPE_TAG = 'actor_scope';
-
-/**
  * The subset of `Scope` this module touches.
  *
  * Deliberately narrow: it documents at the type level that actor context only
- * ever calls `setUser` and `setTag`, and it lets tests pass plain objects
- * without constructing a real Sentry scope.
+ * ever calls `setUser` — it sets no tags — and it lets tests pass plain
+ * objects without constructing a real Sentry scope.
  */
-export type ActorContextScope = Pick<Scope, 'setUser' | 'setTag'>;
+export type ActorContextScope = Pick<Scope, 'setUser'>;
 
 /**
  * The exact user object shipped to Sentry. Constructed literally, never
@@ -128,11 +122,11 @@ export interface DiagnosticsActor {
  * Validates an untrusted `diagnostics_ref` block against the strict contract.
  *
  * Fail-CLOSED by construction: any deviation — a missing field, a non-string
- * ref, a scope outside the closed enum, or ANY extra key (`email`, `name`,
- * `objid`, …) — yields `null`, and the session runs unidentified. That is the
- * intended trade: losing correlation in Sentry is an observability
- * regression; forwarding an unexpected server field to a third-party
- * processor is a privacy incident.
+ * ref, a ref of the wrong shape, or ANY extra key (`email`, `name`, `objid`,
+ * the retired `actor_scope`, …) — yields `null`, and the session runs
+ * unidentified. That is the intended trade: losing correlation in Sentry is an
+ * observability regression; forwarding an unexpected server field to a
+ * third-party processor is a privacy incident.
  *
  * @param raw - Untrusted value, typically `bootstrap.diagnostics_ref`.
  * @returns The validated block, or null when absent/anonymous/malformed.
@@ -175,12 +169,12 @@ export function resolveDiagnosticsRef(): DiagnosticsRefBlock | null {
  * Idempotent and total: calling it with `null` fully clears the context, so
  * the same function serves initial configuration, account change, and logout.
  * There is deliberately no separate "clear" code path that could drift from
- * the "set" path and leave a tag behind.
+ * the "set" path and leave a stale reference behind.
  *
- * On clear, `actor_scope` is set to `undefined`, which is how Sentry's Scope
- * removes a tag (the key is dropped during event serialization). Leaving a
- * stale `actor_scope` after logout would let an anonymous session be filtered
- * as if it were still the previous, identified session.
+ * User context is the ONLY thing this function writes. It sets no tags, so
+ * `setUser(null)` on every scope is a complete eviction — there is no second
+ * dimension that could survive logout and label an anonymous session as if it
+ * were still the previous, identified one.
  *
  * @param scopes - Every scope that must agree. In practice
  *   `[isolatedScope, getCurrentScope()]` — see the module header.
@@ -204,12 +198,6 @@ export function applyActorContext(
 
   for (const scope of scopes) {
     scope.setUser(user);
-    // Keyed off `user`, not `ref`: when the ref value was refused above there
-    // is no user context, so there must be no scope tag either — a lone
-    // `actor_scope` would label an unidentified session as if it were still
-    // identified. `undefined` clears the tag; Sentry drops undefined tag
-    // values when serializing the event.
-    scope.setTag(ACTOR_SCOPE_TAG, user && ref ? ref.actor_scope : undefined);
   }
 }
 

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -546,35 +546,6 @@ export type Passphrase = z.infer<typeof passphraseSchema>;
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /**
- * The two — and only two — ref scopes the server is permitted to declare.
- *
- * THIS LABEL NAMES WHICH SECRET KEYED THE REF. It says nothing about how the
- * person authenticated. The axis is correlation blast radius, not identity
- * provider — see `Onetime::Utils::DiagnosticsRef#keying`
- * (lib/onetime/utils/diagnostics_ref.rb):
- *
- * - `federated` — the ref was derived with `FEDERATION_SECRET`, shared across
- *   the regional instances of one federation, and mixed with a residency scope
- *   (`DIAGNOSTICS_REF_REGION`, else the configured jurisdiction). The
- *   correlation radius is one jurisdiction, not one federation: the same
- *   person yields DIFFERENT refs on the EU and US instances by design.
- * - `deployment` — the ref was derived with this deployment's own
- *   `ACCOUNT_ID_SECRET`. Correlation stops at this instance.
- *
- * NOT AN SSO SIGNAL. A deployment with `FEDERATION_SECRET` and a resolvable
- * residency emits `federated` for EVERY account it identifies, local password
- * accounts included. Filtering the scope tag in Sentry selects events whose
- * ref is federation-keyed, NOT events from SSO users.
- *
- * Modelled as a closed `z.enum` rather than `z.string()` on purpose: the value
- * becomes an indexed Sentry tag, and an unbounded string on an indexed
- * dimension is exactly how a free-text identifier (an email, a plan name)
- * reaches Sentry one careless server-side commit later. A new scope must be
- * added HERE, in review, before it can reach Sentry.
- */
-export const DIAGNOSTICS_REF_SCOPES = ['federated', 'deployment'] as const;
-
-/**
  * The EXACT permitted shape of `actor_ref`, and the single source of truth for
  * it on the TypeScript side.
  *
@@ -582,12 +553,12 @@ export const DIAGNOSTICS_REF_SCOPES = ['federated', 'deployment'] as const;
  *
  * `z.string().min(1)` validates the SHAPE of the block but says nothing about
  * what is inside the string. That gap is a laundering channel: a server bug,
- * an older build, or a compromised region node emitting
- * `{ actor_ref: "alice@example.com", actor_scope: "deployment" }` satisfies a
- * strictObject with two keys and a valid enum, and the value then flows into
- * `user.id` — where the outbound sanitizer, which strips `email`/`username`/
- * `name`, keeps `id` verbatim on every error and transaction. Validating the
- * CONTENT closes it: an email cannot pass a fixed-width hex test.
+ * an older build, or a compromised node emitting
+ * `{ actor_ref: "alice@example.com" }` satisfies a strictObject with the one
+ * permitted key, and the value then flows into `user.id` — where the outbound
+ * sanitizer, which strips `email`/`username`/`name`, keeps `id` verbatim on
+ * every error and transaction. Validating the CONTENT closes it: an email
+ * cannot pass a fixed-width hex test.
  *
  * ## The contract this mirrors
  *
@@ -625,15 +596,20 @@ export function isDiagnosticsRef(value: unknown): value is string {
  * ## Wire contract
  *
  * ```json
- * { "diagnostics_ref": { "actor_ref": "a1b2c3d4e5f60718",
- *                        "actor_scope": "federated" } }
+ * { "diagnostics_ref": { "actor_ref": "a1b2c3d4e5f60718" } }
  * ```
  *
- * The inner key names (`actor_ref`, `actor_scope`) are the serializer's wire
- * shape and are consumed as-is. The block is **ABSENT for anonymous
- * sessions**. Absence is the signal — there is no anonymous sentinel value,
- * no empty string, no `null`. Hence `.optional()` on the parent field rather
- * than the `.default()` used by every always-emitted serializer field.
+ * ONE key. `actor_ref` is a keyed one-way digest of the customer's EXTERNAL
+ * IDENTIFIER (extid) — never an email, never a raw identifier of any kind.
+ * The digest is minted per install from that install's own secret, so the
+ * same person's separately provisioned records on different installs do not
+ * correlate by default. There is no scope, region, or jurisdiction axis: a
+ * ref means "this customer record, on this install", and nothing else.
+ *
+ * The block is **ABSENT for anonymous sessions**. Absence is the signal —
+ * there is no anonymous sentinel value, no empty string, no `null`. Hence
+ * `.optional()` on the parent field rather than the `.default()` used by every
+ * always-emitted serializer field.
  *
  * ## Why `z.strictObject` and not `z.object`
  *
@@ -641,31 +617,31 @@ export function isDiagnosticsRef(value: unknown): value is string {
  * third-party processor (Sentry `scope.setUser`). Zod's plain `z.object`
  * STRIPS unknown keys silently; `z.strictObject` REJECTS the whole block. For
  * this boundary, rejecting is the correct failure mode: strip-on-unknown
- * means a server that starts emitting `{ actor_ref, actor_scope, email }`
- * produces a *valid* parse whose extra field is one refactor away from being
- * forwarded; reject-on-unknown means that payload fails `safeParse` and the
- * session runs unidentified. Losing correlation is recoverable; leaking an
- * email to a third-party processor is not.
+ * means a server that starts emitting `{ actor_ref, email }` produces a
+ * *valid* parse whose extra field is one refactor away from being forwarded;
+ * reject-on-unknown means that payload fails `safeParse` and the session runs
+ * unidentified. Losing correlation is recoverable; leaking an email to a
+ * third-party processor is not.
+ *
+ * Strictness is also what NARROWS the contract over time: a legacy payload
+ * carrying the retired `actor_scope` key is now rejected outright rather than
+ * quietly stripped.
  *
  * See `src/plugins/core/diagnostics/actorContext.ts`, the only place this
  * schema is parsed against live data.
  */
 export const diagnosticsRefSchema = z.strictObject({
   /**
-   * Opaque, deterministic, server-derived reference. Not a direct identifier,
-   * but still potentially personal data. Content-checked against
-   * DIAGNOSTICS_REF_PATTERN, not merely non-empty.
+   * Opaque, deterministic, server-derived reference — a keyed one-way digest
+   * of the customer extid. Not a direct identifier, but still potentially
+   * personal data. Content-checked against DIAGNOSTICS_REF_PATTERN, not merely
+   * non-empty.
    */
   actor_ref: z.string().regex(DIAGNOSTICS_REF_PATTERN),
-  /** Closed enum; becomes the indexed Sentry `actor_scope` tag. */
-  actor_scope: z.enum(DIAGNOSTICS_REF_SCOPES),
 });
 
 /** Parsed shape of the `diagnostics_ref` bootstrap block. */
 export type DiagnosticsRefBlock = z.infer<typeof diagnosticsRefSchema>;
-
-/** One of the two permitted ref scopes. */
-export type DiagnosticsRefScope = (typeof DIAGNOSTICS_REF_SCOPES)[number];
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // BOOTSTRAP PAYLOAD SCHEMA (full payload for Rhales validation)
@@ -855,10 +831,11 @@ export const bootstrapSchema = z.object({
   // ─────────────────────────────────────────────────────────────────────────────
   // DiagnosticsSerializer fields
   // ─────────────────────────────────────────────────────────────────────────────
-  // Pseudonymous Sentry user context. ABSENT (not empty, not null) for
-  // anonymous sessions — see diagnosticsRefSchema above for the full rationale
-  // and for why the inner object is strict rather than passthrough. Optional
-  // also means an older backend that never emits the block degrades to
+  // Pseudonymous Sentry user context: a single `actor_ref`, the keyed one-way
+  // digest of the customer extid. ABSENT (not empty, not null) for anonymous
+  // sessions — see diagnosticsRefSchema above for the full rationale and for
+  // why the inner object is strict rather than passthrough. Optional also
+  // means an older backend that never emits the block degrades to
   // setUser(null) rather than failing the whole payload parse.
   diagnostics_ref: diagnosticsRefSchema.optional(),
 

--- a/src/services/diagnostics.service.ts
+++ b/src/services/diagnostics.service.ts
@@ -220,12 +220,12 @@ function actorContextScopes(): ActorContextScope[] {
  * `diagnostics_ref` block.
  *
  * The input is UNTRUSTED and is validated against the strict contract before
- * anything is forwarded: an unknown key, a bad scope, or a missing ref all
+ * anything is forwarded: an unknown key, a malformed ref, or a missing ref all
  * resolve to null and CLEAR the context rather than partially applying it.
  * Passing null clears it outright.
  *
- * Emits exactly `user = { id: <ref>, ip_address: null }` and the `actor_scope`
- * tag. Never an email, name, objid, extid, or IP.
+ * Emits exactly `user = { id: <ref>, ip_address: null }` — no tags. Never an
+ * email, name, objid, extid, or IP.
  *
  * Safe to call when diagnostics are disabled — it is a no-op.
  *
@@ -247,13 +247,12 @@ export function setDiagnosticsActorContext(block: unknown): void {
 }
 
 /**
- * Clears the Sentry user context: `setUser(null)` plus removal of the
- * `actor_scope` tag, on every scope.
+ * Clears the Sentry user context: `setUser(null)` on every scope.
  *
  * Call on LOGOUT and on any account change where the new session's ref is not
- * yet known. The tag removal matters as much as the user clear — a stale
- * `actor_scope` would let a now-anonymous session be filtered in Sentry as
- * though it were still the previous, identified session.
+ * yet known. User context is the only dimension the actor boundary writes, so
+ * this is a complete eviction — without it, a now-anonymous session would keep
+ * reporting under the previous, identified session's ref.
  *
  * Only the soft/SPA logout path needs this. Hard logouts navigate with
  * `window.location.href`, which tears down the JS context and the scopes with

--- a/src/shared/stores/authStore.ts
+++ b/src/shared/stores/authStore.ts
@@ -424,8 +424,8 @@ export const useAuthStore = defineStore('auth', () => {
     // third holder, and it is cleared just below.
     bootstrapStore.resetForLogout();
 
-    // Clear the Sentry user context: setUser(null) plus removal of the
-    // `actor_scope` tag, on BOTH the isolated and current scopes.
+    // Clear the Sentry user context: setUser(null) on BOTH the isolated and
+    // current scopes.
     //
     // This is the SOFT (SPA) logout path — no page navigation follows, so the
     // Sentry scopes survive with whatever user context was last written.

--- a/src/tests/plugins/core/diagnostics/actorContext.spec.ts
+++ b/src/tests/plugins/core/diagnostics/actorContext.spec.ts
@@ -7,7 +7,8 @@
 //   2. Anything the strict contract does not recognise CLEARS the context
 //      rather than partially applying it (fail-closed).
 //   3. Anonymous sessions are never given a fallback id.
-//   4. Clearing removes the actor_scope tag as well as the user.
+//   4. User context is the ONLY dimension written, so setUser(null) is a
+//      complete eviction — no tag survives a logout.
 //   5. Both scopes always agree.
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -21,7 +22,6 @@ vi.mock('@/services/bootstrap.service', () => ({
 }));
 
 import {
-  ACTOR_SCOPE_TAG,
   applyActorContext,
   parseDiagnosticsRefBlock,
   resolveDiagnosticsRef,
@@ -29,13 +29,14 @@ import {
   type ActorContextScope,
 } from '@/plugins/core/diagnostics/actorContext';
 
+// No `setTag` on the mock, deliberately: the actor boundary writes user context
+// and nothing else, so a re-introduced tag write would be a TypeError here
+// rather than an unasserted extra call.
 function createScope() {
   return {
     setUser: vi.fn(),
-    setTag: vi.fn(),
   } as unknown as ActorContextScope & {
     setUser: ReturnType<typeof vi.fn>;
-    setTag: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -44,17 +45,16 @@ function createScope() {
 // the contract checks content, not just type.
 const REF = 'a1b2c3d4e5f60718';
 const OTHER_REF = '00112233445566ff';
-const VALID = { actor_ref: REF, actor_scope: 'federated' } as const;
+const VALID = { actor_ref: REF } as const;
 
 describe('parseDiagnosticsRefBlock', () => {
-  it('accepts a well-formed federated block', () => {
+  it('accepts a well-formed single-key block', () => {
     expect(parseDiagnosticsRefBlock(VALID)).toEqual(VALID);
   });
 
-  it('accepts the deployment scope', () => {
-    expect(parseDiagnosticsRefBlock({ actor_ref: OTHER_REF, actor_scope: 'deployment' })).toEqual({
+  it('accepts any ref of the derivation shape', () => {
+    expect(parseDiagnosticsRefBlock({ actor_ref: OTHER_REF })).toEqual({
       actor_ref: OTHER_REF,
-      actor_scope: 'deployment',
     });
   });
 
@@ -70,59 +70,51 @@ describe('parseDiagnosticsRefBlock', () => {
     expect(parseDiagnosticsRefBlock({ ...VALID, email: 'user@example.com' })).toBeNull();
   });
 
-  it('rejects a scope outside the closed enum', () => {
-    expect(parseDiagnosticsRefBlock({ actor_ref: REF, actor_scope: 'anonymous' })).toBeNull();
-    expect(parseDiagnosticsRefBlock({ actor_ref: REF, actor_scope: '' })).toBeNull();
+  // Contract NARROWING, pinned. `actor_scope` was a real wire field; the
+  // deployment/federated axis it named is gone. Because the block is a
+  // strictObject, a legacy payload still carrying it is REJECTED outright
+  // rather than quietly stripped — a mixed-version deploy runs unidentified
+  // instead of half-identified.
+  it('REJECTS a legacy block still carrying the retired actor_scope key', () => {
+    expect(parseDiagnosticsRefBlock({ actor_ref: REF, actor_scope: 'deployment' })).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: REF, actor_scope: 'federated' })).toBeNull();
   });
 
   it('rejects an empty or non-string ref', () => {
-    expect(parseDiagnosticsRefBlock({ actor_ref: '', actor_scope: 'federated' })).toBeNull();
-    expect(parseDiagnosticsRefBlock({ actor_ref: 42, actor_scope: 'federated' })).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: '' })).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: 42 })).toBeNull();
   });
 
   // THE LAUNDERING CASE. A shape-only check (non-empty string) passes this
-  // block: two keys, valid enum. It would become `user.id = "alice@example.com"`
-  // on every error and transaction, with the outbound gate dutifully stripping
-  // the `email` KEY it was never in.
+  // block: the one permitted key, a non-empty string. It would become
+  // `user.id = "alice@example.com"` on every error and transaction, with the
+  // outbound gate dutifully stripping the `email` KEY it was never in.
   it('REJECTS an email in the ref field — content, not just shape', () => {
-    expect(
-      parseDiagnosticsRefBlock({ actor_ref: 'alice@example.com', actor_scope: 'deployment' })
-    ).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: 'alice@example.com' })).toBeNull();
   });
 
   it('rejects refs of the wrong width, case, or alphabet', () => {
-    expect(parseDiagnosticsRefBlock({ actor_ref: 'ref', actor_scope: 'federated' })).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: 'ref' })).toBeNull();
     // Too short / too long by one.
-    expect(
-      parseDiagnosticsRefBlock({ actor_ref: 'a1b2c3d4e5f6071', actor_scope: 'federated' })
-    ).toBeNull();
-    expect(
-      parseDiagnosticsRefBlock({ actor_ref: 'a1b2c3d4e5f607180', actor_scope: 'federated' })
-    ).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: 'a1b2c3d4e5f6071' })).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: 'a1b2c3d4e5f607180' })).toBeNull();
     // Uppercase: Ruby's hexdigest is lowercase, so this is not our value.
-    expect(
-      parseDiagnosticsRefBlock({ actor_ref: 'A1B2C3D4E5F60718', actor_scope: 'federated' })
-    ).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: 'A1B2C3D4E5F60718' })).toBeNull();
     // Non-hex, right length.
-    expect(
-      parseDiagnosticsRefBlock({ actor_ref: 'zzzzzzzzzzzzzzzz', actor_scope: 'federated' })
-    ).toBeNull();
-    // A full-width federation email hash (32 hex) is NOT a diagnostics ref.
+    expect(parseDiagnosticsRefBlock({ actor_ref: 'zzzzzzzzzzzzzzzz' })).toBeNull();
+    // A full-width digest (32 hex) is NOT a diagnostics ref.
     expect(
       parseDiagnosticsRefBlock({
         actor_ref: 'a1b2c3d4e5f60718a1b2c3d4e5f60718',
-        actor_scope: 'federated',
       })
     ).toBeNull();
     // Whitespace padding must not be tolerated (anchored pattern).
-    expect(
-      parseDiagnosticsRefBlock({ actor_ref: ' a1b2c3d4e5f60718', actor_scope: 'federated' })
-    ).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: ' a1b2c3d4e5f60718' })).toBeNull();
   });
 
-  it('rejects a missing field', () => {
-    expect(parseDiagnosticsRefBlock({ actor_ref: REF })).toBeNull();
-    expect(parseDiagnosticsRefBlock({ actor_scope: 'federated' })).toBeNull();
+  it('rejects a block missing actor_ref', () => {
+    expect(parseDiagnosticsRefBlock({})).toBeNull();
+    expect(parseDiagnosticsRefBlock({ actor_ref: undefined })).toBeNull();
   });
 
   it('rejects non-object shapes', () => {
@@ -179,33 +171,23 @@ describe('applyActorContext', () => {
 
   // A TypeScript type is not a runtime guarantee: a cast, a hand-built object,
   // or a caller that skips parseDiagnosticsRefBlock all reach here. An
-  // unrecognised ref must clear the context, and must not leave a lone
-  // actor_scope tag behind labelling an unidentified session as identified.
-  it('refuses an unrecognised ref and clears BOTH user and the scope tag', () => {
+  // unrecognised ref must clear the context rather than partially apply it.
+  it('refuses an unrecognised ref and clears the user context', () => {
     const scope = createScope();
 
     applyActorContext([scope], {
       actor_ref: 'alice@example.com',
-      actor_scope: 'federated',
     } as never);
 
     expect(scope.setUser).toHaveBeenCalledWith(null);
-    expect(scope.setTag).toHaveBeenCalledWith(ACTOR_SCOPE_TAG, undefined);
   });
 
-  it('tags actor_scope with the validated enum value', () => {
-    const scope = createScope();
-    applyActorContext([scope], VALID);
-    expect(scope.setTag).toHaveBeenCalledWith(ACTOR_SCOPE_TAG, 'federated');
-  });
-
-  it('clears user AND actor_scope tag when given null (logout / anonymous)', () => {
+  it('clears the user context when given null (logout / anonymous)', () => {
     const scope = createScope();
 
     applyActorContext([scope], null);
 
     expect(scope.setUser).toHaveBeenCalledWith(null);
-    expect(scope.setTag).toHaveBeenCalledWith(ACTOR_SCOPE_TAG, undefined);
   });
 
   it('never mints a fallback id for an anonymous session', () => {
@@ -226,7 +208,6 @@ describe('applyActorContext', () => {
         id: REF,
         ip_address: null,
       });
-      expect(scope.setTag).toHaveBeenCalledWith(ACTOR_SCOPE_TAG, 'federated');
     }
   });
 

--- a/src/tests/plugins/core/diagnostics/createDiagnostics.spec.ts
+++ b/src/tests/plugins/core/diagnostics/createDiagnostics.spec.ts
@@ -195,15 +195,14 @@ describe('createDiagnostics jurisdiction tagging', () => {
       router: createMockRouter(),
     });
 
-    // 3 setTag calls: service, site_host, and the actor_scope CLEAR (undefined).
+    // 2 setTag calls: service and site_host. The actor boundary sets NO tags.
     // The shared getBootstrapValue mock returns the same regions-shaped object
     // for every key, so the `diagnostics_ref` read yields a block the strict
     // contract rejects — the user context fails closed and clears rather than
     // partially applying. See src/plugins/core/diagnostics/actorContext.ts.
-    expect(mockSetTag).toHaveBeenCalledTimes(3);
+    expect(mockSetTag).toHaveBeenCalledTimes(2);
     expect(mockSetTag).toHaveBeenCalledWith('service', 'web');
     expect(mockSetTag).toHaveBeenCalledWith('site_host', TEST_HOST);
-    expect(mockSetTag).toHaveBeenCalledWith('actor_scope', undefined);
     expect(mockSetUser).toHaveBeenCalledWith(null);
   });
 
@@ -216,15 +215,14 @@ describe('createDiagnostics jurisdiction tagging', () => {
       router: createMockRouter(),
     });
 
-    // 3 setTag calls: service, site_host, and the actor_scope CLEAR (undefined).
+    // 2 setTag calls: service and site_host. The actor boundary sets NO tags.
     // The shared getBootstrapValue mock returns the same regions-shaped object
     // for every key, so the `diagnostics_ref` read yields a block the strict
     // contract rejects — the user context fails closed and clears rather than
     // partially applying. See src/plugins/core/diagnostics/actorContext.ts.
-    expect(mockSetTag).toHaveBeenCalledTimes(3);
+    expect(mockSetTag).toHaveBeenCalledTimes(2);
     expect(mockSetTag).toHaveBeenCalledWith('service', 'web');
     expect(mockSetTag).toHaveBeenCalledWith('site_host', TEST_HOST);
-    expect(mockSetTag).toHaveBeenCalledWith('actor_scope', undefined);
     expect(mockSetUser).toHaveBeenCalledWith(null);
   });
 
@@ -237,15 +235,14 @@ describe('createDiagnostics jurisdiction tagging', () => {
       router: createMockRouter(),
     });
 
-    // 3 setTag calls: service, site_host, and the actor_scope CLEAR (undefined).
+    // 2 setTag calls: service and site_host. The actor boundary sets NO tags.
     // The shared getBootstrapValue mock returns the same regions-shaped object
     // for every key, so the `diagnostics_ref` read yields a block the strict
     // contract rejects — the user context fails closed and clears rather than
     // partially applying. See src/plugins/core/diagnostics/actorContext.ts.
-    expect(mockSetTag).toHaveBeenCalledTimes(3);
+    expect(mockSetTag).toHaveBeenCalledTimes(2);
     expect(mockSetTag).toHaveBeenCalledWith('service', 'web');
     expect(mockSetTag).toHaveBeenCalledWith('site_host', TEST_HOST);
-    expect(mockSetTag).toHaveBeenCalledWith('actor_scope', undefined);
     expect(mockSetUser).toHaveBeenCalledWith(null);
   });
 
@@ -258,15 +255,14 @@ describe('createDiagnostics jurisdiction tagging', () => {
       router: createMockRouter(),
     });
 
-    // 3 setTag calls: service, site_host, and the actor_scope CLEAR (undefined).
+    // 2 setTag calls: service and site_host. The actor boundary sets NO tags.
     // The shared getBootstrapValue mock returns the same regions-shaped object
     // for every key, so the `diagnostics_ref` read yields a block the strict
     // contract rejects — the user context fails closed and clears rather than
     // partially applying. See src/plugins/core/diagnostics/actorContext.ts.
-    expect(mockSetTag).toHaveBeenCalledTimes(3);
+    expect(mockSetTag).toHaveBeenCalledTimes(2);
     expect(mockSetTag).toHaveBeenCalledWith('service', 'web');
     expect(mockSetTag).toHaveBeenCalledWith('site_host', TEST_HOST);
-    expect(mockSetTag).toHaveBeenCalledWith('actor_scope', undefined);
     expect(mockSetUser).toHaveBeenCalledWith(null);
   });
 
@@ -279,15 +275,14 @@ describe('createDiagnostics jurisdiction tagging', () => {
       router: createMockRouter(),
     });
 
-    // 3 setTag calls: service, site_host, and the actor_scope CLEAR (undefined).
+    // 2 setTag calls: service and site_host. The actor boundary sets NO tags.
     // The shared getBootstrapValue mock returns the same regions-shaped object
     // for every key, so the `diagnostics_ref` read yields a block the strict
     // contract rejects — the user context fails closed and clears rather than
     // partially applying. See src/plugins/core/diagnostics/actorContext.ts.
-    expect(mockSetTag).toHaveBeenCalledTimes(3);
+    expect(mockSetTag).toHaveBeenCalledTimes(2);
     expect(mockSetTag).toHaveBeenCalledWith('service', 'web');
     expect(mockSetTag).toHaveBeenCalledWith('site_host', TEST_HOST);
-    expect(mockSetTag).toHaveBeenCalledWith('actor_scope', undefined);
     expect(mockSetUser).toHaveBeenCalledWith(null);
   });
 
@@ -461,7 +456,7 @@ describe('createDiagnostics user context', () => {
       regions: null,
       // 16 lowercase hex — the shape DiagnosticsRef derives and the contract
       // enforces by content.
-      diagnostics_ref: { actor_ref: 'a1b2c3d4e5f60718', actor_scope: 'federated' },
+      diagnostics_ref: { actor_ref: 'a1b2c3d4e5f60718' },
     });
 
     createDiagnostics({ host: TEST_HOST, config: baseConfig, router: createMockRouter() });
@@ -469,19 +464,22 @@ describe('createDiagnostics user context', () => {
     const expectedUser = { id: 'a1b2c3d4e5f60718', ip_address: null };
     expect(mockSetUser).toHaveBeenCalledWith(expectedUser);
     expect(mockCurrentScopeSetUser).toHaveBeenCalledWith(expectedUser);
-    expect(mockSetTag).toHaveBeenCalledWith('actor_scope', 'federated');
-    expect(mockCurrentScopeSetTag).toHaveBeenCalledWith('actor_scope', 'federated');
   });
 
-  it('carries the deployment scope through verbatim', () => {
+  // The ref carries NO second dimension. Deployment tags are the only tags
+  // createDiagnostics writes; identifying a session must not add one.
+  it('writes no tag alongside the user context', () => {
     mockBootstrap({
       regions: null,
-      diagnostics_ref: { actor_ref: '00112233445566ff', actor_scope: 'deployment' },
+      diagnostics_ref: { actor_ref: '00112233445566ff' },
     });
 
     createDiagnostics({ host: TEST_HOST, config: baseConfig, router: createMockRouter() });
 
-    expect(mockSetTag).toHaveBeenCalledWith('actor_scope', 'deployment');
+    expect(mockSetUser).toHaveBeenCalledWith({ id: '00112233445566ff', ip_address: null });
+    // service + site_host only — no jurisdiction (regions null), no actor tag.
+    expect(mockSetTag).toHaveBeenCalledTimes(2);
+    expect(mockSetTag.mock.calls.map((call) => call[0])).toEqual(['service', 'site_host']);
   });
 
   it('leaves an anonymous session unidentified — no fallback id', () => {
@@ -493,7 +491,6 @@ describe('createDiagnostics user context', () => {
     expect(mockSetUser).toHaveBeenCalledTimes(1);
     expect(mockSetUser).toHaveBeenCalledWith(null);
     expect(mockCurrentScopeSetUser).toHaveBeenCalledWith(null);
-    expect(mockSetTag).toHaveBeenCalledWith('actor_scope', undefined);
   });
 
   it('fails closed when the block carries an unexpected field', () => {
@@ -501,7 +498,6 @@ describe('createDiagnostics user context', () => {
       regions: null,
       diagnostics_ref: {
         actor_ref: 'a1b2c3d4e5f60718',
-        actor_scope: 'federated',
         email: 'user@example.com',
       },
     });
@@ -514,19 +510,33 @@ describe('createDiagnostics user context', () => {
     );
   });
 
-  // The block a server bug / older build / compromised region node could emit:
-  // two keys, valid enum, non-empty string. Shape-only validation accepts it
-  // and the address becomes user.id on every event.
-  it('fails closed when the ref is an email rather than an opaque value', () => {
+  // Wire-contract narrowing at the boot seam: `actor_scope` was a real field on
+  // this block. A server that still emits it is an older build, and the strict
+  // contract refuses the whole block rather than stripping the stale key.
+  it('fails closed on a legacy block still carrying actor_scope', () => {
     mockBootstrap({
       regions: null,
-      diagnostics_ref: { actor_ref: 'alice@example.com', actor_scope: 'deployment' },
+      diagnostics_ref: { actor_ref: 'a1b2c3d4e5f60718', actor_scope: 'deployment' },
     });
 
     createDiagnostics({ host: TEST_HOST, config: baseConfig, router: createMockRouter() });
 
     expect(mockSetUser).toHaveBeenCalledWith(null);
     expect(mockCurrentScopeSetUser).toHaveBeenCalledWith(null);
-    expect(mockSetTag).toHaveBeenCalledWith('actor_scope', undefined);
+  });
+
+  // The block a server bug / older build / compromised node could emit: the one
+  // permitted key, a non-empty string. Shape-only validation accepts it and the
+  // address becomes user.id on every event.
+  it('fails closed when the ref is an email rather than an opaque value', () => {
+    mockBootstrap({
+      regions: null,
+      diagnostics_ref: { actor_ref: 'alice@example.com' },
+    });
+
+    createDiagnostics({ host: TEST_HOST, config: baseConfig, router: createMockRouter() });
+
+    expect(mockSetUser).toHaveBeenCalledWith(null);
+    expect(mockCurrentScopeSetUser).toHaveBeenCalledWith(null);
   });
 });

--- a/src/tests/stores/authStore.spec.ts
+++ b/src/tests/stores/authStore.spec.ts
@@ -715,7 +715,7 @@ describe('authStore', () => {
     // re-resolve would pick up and attach to an anonymous session's events.
     it('evicts the ref from the pre-Pinia bootstrap snapshot on soft logout', async () => {
       updateBootstrapSnapshot({
-        diagnostics_ref: { actor_ref: 'a1b2c3d4e5f60718', actor_scope: 'federated' },
+        diagnostics_ref: { actor_ref: 'a1b2c3d4e5f60718' },
       });
       expect(getBootstrapValue('diagnostics_ref')).toBeDefined();
 

--- a/src/tests/stores/bootstrapStore.spec.ts
+++ b/src/tests/stores/bootstrapStore.spec.ts
@@ -1668,7 +1668,7 @@ describe('bootstrapStore user context', () => {
   // DIAGNOSTICS_REF_PATTERN admits. setDiagnosticsActorContext is mocked here,
   // but fixtures stay honest so a copy-paste into an unmocked test still
   // passes the contract.
-  const REF_BLOCK = { actor_ref: 'a1b2c3d4e5f60718', actor_scope: 'federated' } as const;
+  const REF_BLOCK = { actor_ref: 'a1b2c3d4e5f60718' } as const;
 
   beforeEach(async () => {
     vi.clearAllMocks();
@@ -1715,7 +1715,7 @@ describe('bootstrapStore user context', () => {
       diagnostics_ref: { ...REF_BLOCK },
     } as Partial<BootstrapPayload>);
 
-    const next = { actor_ref: '00112233445566ff', actor_scope: 'deployment' } as const;
+    const next = { actor_ref: '00112233445566ff' } as const;
     store.update({ authenticated: true, diagnostics_ref: { ...next } } as Partial<BootstrapPayload>);
 
     expect(store.diagnostics_ref).toEqual(next);

--- a/try/unit/utils/diagnostics_ref_try.rb
+++ b/try/unit/utils/diagnostics_ref_try.rb
@@ -2,46 +2,47 @@
 #
 # frozen_string_literal: true
 
-# Tests for Onetime::Utils::DiagnosticsRef - opaque user and organization
+# Tests for Onetime::Utils::DiagnosticsRef - opaque actor and organization
 # references for the third-party diagnostics backend (Sentry).
 #
 # Companion to try/unit/utils/email_hash_try.rb, and deliberately in the same
 # lane: EmailHash is FEDERATION reference (a queryable Redis index, and a field
-# in Stripe customer metadata), DiagnosticsRef is DIAGNOSTICS reference. They may
-# be keyed by the same FEDERATION_SECRET but must never produce the same value,
-# or Sentry would hold a live join key into billing and the datastore.
+# in Stripe customer metadata), DiagnosticsRef is DIAGNOSTICS reference. The two
+# must never produce the same value, or Sentry would hold a live join key into
+# billing and the datastore.
 #
-# Security model:
-# - One-way, keyed: the email pre-image is never recoverable
-# - Domain separated: versioned purpose prefix ("onetime:sentry:v1:actor",
-#   "onetime:sentry:v1:organization"). The prefix is the ONLY separation
-#   between the two namespaces, so the same string must digest differently in
-#   each - pinned by executing both entry points, not by reading the constants
-# - Residency separated: refs do NOT correlate across jurisdictions, so two
-#   regional instances sharing FEDERATION_SECRET cannot be joined on user.id
-# - Residency FAIL-CLOSED: with no residency declared, the shared
-#   FEDERATION_SECRET is refused outright and keying drops to the
-#   per-deployment secret. The safe state is the one an operator gets for free.
-# - Fail-soft: nil, never an exception, for an unconfigured secret OR for a
-#   stored email that is not valid UTF-8 (this runs on every authenticated
-#   render, so a raise here is a 500 page plus a self-inflicted Sentry event)
-# - Fail-soft is not fail-open: a failure that could change WHICH reference a
-#   human gets answers nil (a gap) rather than a second, different ref
-# - ONE residency resolution per derivation, threaded through the Keying value:
-#   the residency mixed into a ref and the scope label emitted beside it always
-#   come from the same read, so a config that changes mid-derivation cannot
-#   split one user in two, collide two jurisdictions, or invert the label
+# Security model (see docs/specs/diagnostics/actor-ref-preimage-debate-decision.md):
+# - The correlation subject is the customer RECORD, not the human: the actor
+#   pre-image is the server-minted EXTID, never the email. An email pre-image
+#   would split one account on email change, conflate two people on address
+#   reassignment, re-link a deleted-and-recreated subject, and be re-identifiable
+#   offline against public address lists under key compromise
+# - One-way, keyed by ACCOUNT_ID_SECRET alone. Rotating that secret rotates every
+#   ref; under Sentry's retention window the discontinuity ages out
+# - Domain separated: versioned purpose prefixes ("onetime:sentry:v2:actor",
+#   "onetime:sentry:v2:organization"). The prefix is the ONLY separation between
+#   the two namespaces, so the same string must digest differently in each -
+#   pinned by executing both entry points, not by reading the constants
+# - No residency element and no scope label: extids and objids are minted per
+#   install, so separately provisioned regional records do not correlate by
+#   default. There is nothing to mix in and nothing to label
+# - NOT normalized: no case folding, no unicode normalization. Folding could
+#   collapse two distinct records onto one ref
+# - Fail-soft: nil, never an exception, for an unconfigured secret or an
+#   unusable pre-image (this runs on every authenticated render, so a raise here
+#   is a 500 page plus a self-inflicted Sentry event)
 #
 # Run: pnpm run test:tryouts:agent try/unit/utils/diagnostics_ref_try.rb
 
 require_relative '../../support/test_helpers'
 
-ENV['FEDERATION_SECRET'] ||= 'test-hmac-secret-for-diagnostics-ref-32c'
+# Only filled in when the lane did not export one (tests/lanes/base.env does).
+ENV['ACCOUNT_ID_SECRET'] ||= 'test-account-id-secret-for-diagnostics-ref'
 
-# FEDERATION_SECRET only keys the ref when a residency scope resolves, so the
-# federated cases below need one declared for the file. The cases that pin the
-# undeclared default clear this explicitly.
-ENV['DIAGNOSTICS_REF_REGION'] ||= 'try-region'
+# DiagnosticsRef does NOT use this - it is here solely so EmailHash.compute can
+# answer in the domain-separation cases below. That the two modules key off
+# different secrets entirely is now part of the separation.
+ENV['FEDERATION_SECRET'] ||= 'test-federation-secret-for-email-hash-only'
 
 require 'onetime/utils/diagnostics_ref'
 require 'onetime/utils/email_hash'
@@ -58,488 +59,171 @@ ensure
   original.each { |key, value| ENV[key] = value }
 end
 
-# Replace OT.conf for the duration of a block. Needed because the residency
-# scope reads features.regions.current_jurisdiction, and the tryouts lane shares
-# one process across files - whether OT has been booted by the time this file
-# runs depends on which other files ran first. Pin it rather than inherit it.
-def with_conf(conf)
-  original = OT.method(:conf)
-  OT.define_singleton_method(:conf) { conf }
-  yield
-ensure
-  OT.define_singleton_method(:conf, original)
-end
-
-# Simulate a transient config-read failure on the residency path, which is the
-# fault that used to fork one human into two Sentry users.
-def with_failing_conf
-  original = OT.method(:conf)
-  OT.define_singleton_method(:conf) { raise 'transient config failure' }
-  yield
-ensure
-  OT.define_singleton_method(:conf, original)
-end
-
-# The fault window that used to fork one Sentry user in two: OT.conf answers a
-# healthy jurisdiction for the FIRST residency resolution of a derivation and
-# then goes FALSY. Nothing raises, so the raise-based guard never engages -
-# which is exactly why residency must be resolved once and threaded rather than
-# re-read and defaulted. Degradation is triggered BY the resolution rather than
-# by counting OT.conf reads, so these cases do not depend on how many times the
-# implementation happens to touch OT.conf.
-def with_conf_falsy_after_first_resolution(jurisdiction)
-  original = OT.method(:conf)
-  resolved = false
-  conf     = Object.new
-  conf.define_singleton_method(:dig) do |*path|
-    next nil unless path == %w[features regions current_jurisdiction]
-
-    resolved = true
-    jurisdiction
-  end
-  OT.define_singleton_method(:conf) { resolved ? nil : conf }
-  yield
-ensure
-  OT.define_singleton_method(:conf, original)
-end
-
-# The same window with no nil anywhere: the DECLARED jurisdiction simply changes
-# between resolutions (an operator edit, a config reload). Each resolution takes
-# the next value in the sequence; the last value repeats forever.
-def with_drifting_jurisdiction(*sequence)
-  original = OT.method(:conf)
-  queue    = sequence.dup
-  conf     = Object.new
-  conf.define_singleton_method(:dig) do |*path|
-    next nil unless path == %w[features regions current_jurisdiction]
-
-    queue.length > 1 ? queue.shift : queue.first
-  end
-  OT.define_singleton_method(:conf) { conf }
-  yield
-ensure
-  OT.define_singleton_method(:conf, original)
-end
-
-def jurisdiction_conf(label)
-  { 'features' => { 'regions' => { 'current_jurisdiction' => label } } }
-end
-
-REPO_ROOT = File.expand_path('../../..', __dir__)
-
-@email = 'user@example.com'
-@email_upper = 'USER@EXAMPLE.COM'
-@email_whitespace = '  user@example.com  '
-@other_email = 'other@example.com'
+# Shaped like a real Customer extid: Familia's external_identifier feature under
+# `format: 'ur%<id>s'` emits `ur` plus 25 base36 characters.
+@extid = 'ur00fedcba9876543210zyxwvu'
+@other_extid = 'ur00abcdef0123456789vwxyzu'
 @deployment_key = 'account-id-secret-for-diagnostics-ref-try'
 
-# Two regional installs SHARE this by design - that is what makes a
-# residency-independent ref a cross-region join rather than a convenience.
-@shared_secret = 'shared-federation-secret-across-two-regions'
-
-# The environment the fault-window cases run under: the shared federation
-# secret, no operator pin (so residency comes from the jurisdiction config the
-# helpers drive), and a per-install fallback secret available.
-@fault_env = { 'FEDERATION_SECRET' => @shared_secret,
-               'DIAGNOSTICS_REF_REGION' => nil,
-               'ACCOUNT_ID_SECRET' => @deployment_key }
-
-# The value the pre-fix code emitted during the fault window: the shared
-# federation secret over a RESIDENCY_UNSCOPED pre-image. Every install sharing
-# the secret derives exactly this, whatever jurisdiction it serves, which is the
-# collision the cases below assert never appears.
-@unscoped_collision = OpenSSL::HMAC.hexdigest(
-  'SHA256', @shared_secret,
-  [TR::ACTOR_INFO, TR::RESIDENCY_UNSCOPED, @email].join(TR::SEPARATOR)
-)[0, TR::REF_LENGTH]
-
 ## actor_ref returns a String
-TR.actor_ref(@email).is_a?(String)
+TR.actor_ref(@extid).is_a?(String)
 #=> true
 
 ## actor_ref is REF_LENGTH hex characters
-TR.actor_ref(@email).length
+TR.actor_ref(@extid).length
 #=> 16
 
 ## actor_ref contains only lowercase hex
-TR.actor_ref(@email) =~ /\A[0-9a-f]{16}\z/
+TR.actor_ref(@extid) =~ /\A[0-9a-f]{16}\z/
 #=> 0
 
 ## actor_ref is deterministic
-TR.actor_ref(@email) == TR.actor_ref(@email)
+TR.actor_ref(@extid) == TR.actor_ref(@extid)
 #=> true
 
-## actor_ref distinguishes different emails
-TR.actor_ref(@email) == TR.actor_ref(@other_email)
+## actor_ref distinguishes different customers
+TR.actor_ref(@extid) == TR.actor_ref(@other_extid)
 #=> false
 
-## Email normalization: case-insensitive
-TR.actor_ref(@email) == TR.actor_ref(@email_upper)
-#=> true
+## actor_ref discloses nothing of the extid it derives from
+[TR.actor_ref(@extid) == @extid, @extid.include?(TR.actor_ref(@extid))]
+#=> [false, false]
 
-## Email normalization: whitespace trimmed
-TR.actor_ref(@email) == TR.actor_ref(@email_whitespace)
-#=> true
-
-## Email normalization: NFD and NFC forms of the same address agree
-## (built rather than typed - an editor would silently normalize a literal)
-composed = "jos\u{e9}@example.com".unicode_normalize(:nfc)
-decomposed = composed.unicode_normalize(:nfd)
-[decomposed.bytes == composed.bytes, TR.actor_ref(decomposed) == TR.actor_ref(composed)]
-#=> [false, true]
-
-## Email normalization agrees with the canonical OT::Utils normalizer
-TR.actor_ref(@email_upper) == TR.actor_ref(OT::Utils.normalize_email(@email_upper))
-#=> true
-
-## Blank email returns nil
-TR.actor_ref('')
-#=> nil
-
-## Nil email returns nil
-TR.actor_ref(nil)
-#=> nil
-
-## Whitespace-only email returns nil
-TR.actor_ref('   ')
-#=> nil
-
-## Domain separation: actor ref is NOT the federation email hash
-TR.actor_ref(@email) == Onetime::Utils::EmailHash.compute(@email)
+## NO NORMALIZATION: an extid is a server-minted token, not something a human
+## types, so case is NOT folded. Folding could collapse two distinct records
+## onto one ref, which is the opposite of what the ref exists to provide.
+TR.actor_ref(@extid) == TR.actor_ref(@extid.upcase)
 #=> false
 
-## Domain separation: actor ref is not a prefix of the federation email hash
-Onetime::Utils::EmailHash.compute(@email)[0, TR::REF_LENGTH] == TR.actor_ref(@email)
+## Surrounding whitespace is trimmed, so a padded value cannot split one
+## customer into two refs
+TR.actor_ref("  #{@extid}  ") == TR.actor_ref(@extid)
+#=> true
+
+## Blank, nil and whitespace-only pre-images return nil, never a digest of ''
+[TR.actor_ref(''), TR.actor_ref(nil), TR.actor_ref('   ')]
+#=> [nil, nil, nil]
+
+## ENCODING: a pre-image that is not valid UTF-8 returns nil instead of raising
+## ArgumentError out of String#strip, while ASCII bytes carrying the wrong
+## encoding tag are recovered and still correlate with themselves
+[TR.actor_ref("a\xFFur"),
+ TR.actor_ref(@extid.dup.force_encoding(Encoding::ASCII_8BIT)) == TR.actor_ref(@extid)]
+#=> [nil, true]
+
+## Domain separation: an actor ref is NOT the federation email hash of the same
+## string - Sentry never holds a live join key into billing or the index
+TR.actor_ref(@extid) == Onetime::Utils::EmailHash.compute(@extid)
 #=> false
 
-## Purpose prefix is versioned, so diagnostics reference can be re-keyed alone
-[TR::ACTOR_INFO.include?('v1'), TR::ACTOR_INFO.include?('actor')]
+## Domain separation: nor a prefix of it
+Onetime::Utils::EmailHash.compute(@extid)[0, TR::REF_LENGTH] == TR.actor_ref(@extid)
+#=> false
+
+## Purpose prefix is versioned, so diagnostics reference can be re-keyed alone.
+## v2 is the extid pre-image over a two-element message; v1 was an email
+## pre-image with a residency element.
+[TR::ACTOR_INFO.include?('v2'), TR::ACTOR_INFO.include?('actor')]
 #=> [true, true]
 
 ## Diagnostics refs are narrower than federation email hashes
 TR::REF_LENGTH < Onetime::Utils::EmailHash::HASH_LENGTH
 #=> true
 
-## FEDERATION_SECRET produces the federated correlation scope
-TR.scope
-#=> 'federated'
+## The ref is the derivation an operator can reproduce from the extid and the
+## key, and nothing else - two elements, no residency, recomputed independently
+with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key) { TR.actor_ref(@extid) } ==
+  OpenSSL::HMAC.hexdigest(
+    'SHA256', @deployment_key, [TR::ACTOR_INFO, @extid].join(TR::SEPARATOR)
+  )[0, TR::REF_LENGTH]
+#=> true
 
-## user bundle carries exactly the ref and its scope
-TR.actor(@email).keys.sort
-#=> ['actor_ref', 'actor_scope']
-
-## user bundle is nil for a blank email
-TR.actor('')
-#=> nil
-
-## Emitted bundle discloses no part of the address
-TR.actor(@email).to_json.include?('example.com')
-#=> false
-
-## Emitted bundle discloses neither keying secret
-with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key) do
-  serialized = TR.actor(@email).to_json
-  [serialized.include?(ENV.fetch('FEDERATION_SECRET')), serialized.include?(@deployment_key)]
-end
+## KEYING: ACCOUNT_ID_SECRET is the only key. Two installs derive DIFFERENT refs
+## for the same extid, which is what makes refs per-install by construction.
+install_a = with_env_vars('ACCOUNT_ID_SECRET' => 'per-install-secret-a') { TR.actor_ref(@extid) }
+install_b = with_env_vars('ACCOUNT_ID_SECRET' => 'per-install-secret-b') { TR.actor_ref(@extid) }
+[install_a.nil?, install_a == install_b]
 #=> [false, false]
 
-## ACCOUNT_ID_SECRET alone produces the deployment scope and a well-formed ref
-with_env_vars('FEDERATION_SECRET' => nil, 'ACCOUNT_ID_SECRET' => @deployment_key) do
-  [TR.scope, TR.available?, TR.actor_ref(@email) =~ /\A[0-9a-f]{16}\z/]
+## KEYING: FEDERATION_SECRET is NOT consulted. Setting or clearing it cannot
+## change a ref - diagnostics dropped it entirely.
+with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key, 'FEDERATION_SECRET' => 'shared-across-regions') do
+  TR.actor_ref(@extid)
+end == with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key, 'FEDERATION_SECRET' => nil) do
+  TR.actor_ref(@extid)
 end
-#=> ['deployment', true, 0]
-
-## FEDERATION_SECRET is preferred over ACCOUNT_ID_SECRET, so the refs differ
-federated = with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key) { TR.actor_ref(@email) }
-deployment = with_env_vars('FEDERATION_SECRET' => nil, 'ACCOUNT_ID_SECRET' => @deployment_key) do
-  TR.actor_ref(@email)
-end
-federated == deployment
-#=> false
-
-## RESIDENCY: the same person in two jurisdictions gets DIFFERENT refs even
-## though both instances share one FEDERATION_SECRET. This is the cross-region
-## re-identification join we refuse to hand the diagnostics backend.
-eu = with_env_vars('DIAGNOSTICS_REF_REGION' => 'eu') { TR.actor_ref(@email) }
-us = with_env_vars('DIAGNOSTICS_REF_REGION' => 'us') { TR.actor_ref(@email) }
-eu == us
-#=> false
-
-## RESIDENCY: refs remain deterministic within one jurisdiction
-with_env_vars('DIAGNOSTICS_REF_REGION' => 'eu') { TR.actor_ref(@email) } ==
-  with_env_vars('DIAGNOSTICS_REF_REGION' => 'EU  ') { TR.actor_ref(@email) }
 #=> true
 
-## RESIDENCY: an undeclared residency is not a wildcard that matches every
-## declared one - it is not a residency scope at all, and its ref is keyed by
-## a different (per-deployment) secret entirely
-with_conf({}) do
-  unscoped = with_env_vars('DIAGNOSTICS_REF_REGION' => nil,
-                           'ACCOUNT_ID_SECRET' => @deployment_key) { TR.actor_ref(@email) }
-  unscoped == with_env_vars('DIAGNOSTICS_REF_REGION' => 'eu') { TR.actor_ref(@email) }
-end
+## KEYING: rotating ACCOUNT_ID_SECRET re-keys refs. Accepted and documented:
+## under Sentry's retention window the discontinuity ages out.
+with_env_vars('ACCOUNT_ID_SECRET' => 'before-rotation') { TR.actor_ref(@extid) } ==
+  with_env_vars('ACCOUNT_ID_SECRET' => 'after-rotation') { TR.actor_ref(@extid) }
 #=> false
 
-## RESIDENCY: the explicit pin wins over a declared jurisdiction, and is never blank
-with_conf({ 'features' => { 'regions' => { 'current_jurisdiction' => 'EU' } } }) do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => 'ca-central') { TR.residency_scope }
-end
-#=> 'ca-central'
-
-## RESIDENCY: a blank pin and no declared jurisdiction resolves to NO residency
-## scope. nil is load-bearing here: it is what makes keying refuse the shared
-## FEDERATION_SECRET. The RESIDENCY_UNSCOPED literal is only a pre-image filler
-## so the element count never varies, and never reaches a federated derivation.
-with_conf({}) { with_env_vars('DIAGNOSTICS_REF_REGION' => '   ') { TR.residency_scope } }
-#=> nil
-
-## RESIDENCY: with no pin, the scope comes from features.regions.current_jurisdiction
-## - the same source SetupDiagnostics derives the Sentry `jurisdiction` tag from
-with_conf({ 'features' => { 'regions' => { 'current_jurisdiction' => 'EU' } } }) do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil) { TR.residency_scope }
-end
-#=> 'eu'
-
-## RESIDENCY: the residency label is never part of the emitted bundle
-with_env_vars('DIAGNOSTICS_REF_REGION' => 'eu-central-zzz') { TR.actor(@email).to_json }.include?('eu-central-zzz')
-#=> false
-
-## ENCODING: an invalid byte in a stored email returns nil instead of raising
-## Encoding::CompatibilityError out of unicode_normalize
-TR.actor_ref("a\xFF@b.com")
-#=> nil
-
-## ENCODING: a truncated multibyte sequence returns nil instead of raising
-## ArgumentError out of unicode_normalize
-TR.actor_ref("\xC3(@b.com")
-#=> nil
-
-## ENCODING: an email carrying correct UTF-8 bytes under the wrong encoding tag
-## is recovered, not dropped - it must still correlate with itself
-TR.actor_ref('alice@example.com'.dup.force_encoding(Encoding::ASCII_8BIT)) ==
-  TR.actor_ref('alice@example.com')
-#=> true
-
-## ENCODING: a non-UTF-8 email never escapes as an exception from the bundle
-## entry point either
-[TR.actor("a\xFF@b.com"), TR.actor('alice@example.com'.dup.force_encoding(Encoding::ASCII_8BIT)).nil?]
-#=> [nil, false]
+## keying answers the raw secret, not a struct
+with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key) { TR.keying }
+#=> 'account-id-secret-for-diagnostics-ref-try'
 
 ## Unconfigured deployment: every entry point returns nil instead of raising,
-## even where EmailHash would raise Onetime::Problem for the same address
-with_env_vars('FEDERATION_SECRET' => nil, 'ACCOUNT_ID_SECRET' => nil) do
+## even where EmailHash would raise Onetime::Problem for the same input
+with_env_vars('ACCOUNT_ID_SECRET' => nil, 'FEDERATION_SECRET' => nil) do
   raised = begin
-    Onetime::Utils::EmailHash.compute(@email)
+    Onetime::Utils::EmailHash.compute('user@example.com')
     false
   rescue Onetime::Problem
     true
   end
-  [raised, TR.actor_ref(@email), TR.actor(@email), TR.scope, TR.available?]
+  [raised, TR.actor_ref(@extid), TR.actor(@extid), TR.available?]
 end
-#=> [true, nil, nil, nil, false]
+#=> [true, nil, nil, false]
 
-## DEFECT 1 (fail-open default): with NOTHING declared, a shared
-## FEDERATION_SECRET must not key the ref. Keying drops to the per-deployment
-## secret and the emitted label narrows with it, so an operator is never told
-## the ref correlates further than it does.
-with_conf({}) do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil, 'ACCOUNT_ID_SECRET' => @deployment_key) do
-    [TR.scope, TR.available?]
-  end
-end
-#=> ['deployment', true]
+## available? is true once ACCOUNT_ID_SECRET is set
+with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key) { TR.available? }
+#=> true
 
-## DEFECT 1: the headline regression. Two installs that share FEDERATION_SECRET
-## and configure NO residency - the documented default state - must derive
-## DIFFERENT refs for the same person. Before the fix both derived the identical
-## value, which is the cross-region re-identification join this module exists to
-## prevent, available to anyone who configured nothing.
-same_secret = 'shared-federation-secret-across-two-regions'
-install_a = with_conf({}) do
-  with_env_vars('FEDERATION_SECRET' => same_secret,
-                'DIAGNOSTICS_REF_REGION' => nil,
-                'ACCOUNT_ID_SECRET' => 'per-install-secret-region-a') { TR.actor_ref(@email) }
-end
-install_b = with_conf({}) do
-  with_env_vars('FEDERATION_SECRET' => same_secret,
-                'DIAGNOSTICS_REF_REGION' => nil,
-                'ACCOUNT_ID_SECRET' => 'per-install-secret-region-b') { TR.actor_ref(@email) }
-end
-[install_a.nil?, install_b.nil?, install_a == install_b]
-#=> [false, false, false]
+## The bundle carries EXACTLY one key. The frontend parses it as a Zod
+## strictObject, so a second key makes the client discard the whole block.
+TR.actor(@extid).keys
+#=> ['actor_ref']
 
-## DEFECT 1: refusal, not degradation. With a shared FEDERATION_SECRET, no
-## residency and no per-deployment secret to fall back to, there is nothing safe
-## to key with - so nothing is emitted, rather than reaching for the shared key.
-with_conf({}) do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil, 'ACCOUNT_ID_SECRET' => nil) do
-    [TR.scope, TR.available?, TR.actor_ref(@email), TR.actor(@email)]
-  end
-end
-#=> [nil, false, nil, nil]
+## The bundle's ref is the same value actor_ref derives
+TR.actor(@extid)['actor_ref'] == TR.actor_ref(@extid)
+#=> true
 
-## DEFECT 1: declaring a residency is what unlocks federated keying, and it is
-## enough on its own - JURISDICTION alone, no diagnostics-specific env var.
-with_conf({ 'features' => { 'regions' => { 'current_jurisdiction' => 'EU' } } }) do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil, 'ACCOUNT_ID_SECRET' => @deployment_key) do
-    [TR.scope, TR.residency_scope]
-  end
-end
-#=> ['federated', 'eu']
-
-## DEFECT 1: and the residency mechanism still separates jurisdictions once on,
-## so closing the default did not disable the guarantee it protects.
-eu_scoped = with_conf({ 'features' => { 'regions' => { 'current_jurisdiction' => 'EU' } } }) do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil) { TR.actor_ref(@email) }
-end
-us_scoped = with_conf({ 'features' => { 'regions' => { 'current_jurisdiction' => 'US' } } }) do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil) { TR.actor_ref(@email) }
-end
-[eu_scoped.nil?, eu_scoped == us_scoped]
-#=> [false, false]
-
-## DEFECT 2 (residency rescue fail-open): a transient config failure must not
-## hand the same human a SECOND, different ref. It yields no ref at all - a gap,
-## which is honest and self-healing - and no scope label either.
-with_failing_conf do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil) do
-    [TR.actor_ref(@email), TR.actor(@email), TR.scope, TR.available?]
-  end
-end
-#=> [nil, nil, nil, false]
-
-## DEFECT 2: specifically, the fault does not fork one user into two. The ref
-## derived during the fault is not some other derivable value - it is absent, so
-## it can never be mistaken for a different data subject.
-healthy = with_conf({ 'features' => { 'regions' => { 'current_jurisdiction' => 'EU' } } }) do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil) { TR.actor_ref(@email) }
-end
-faulted = with_failing_conf do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil) { TR.actor_ref(@email) }
-end
-[healthy.nil?, faulted.nil?]
-#=> [false, true]
-
-## DEFECT 2: and the failure still never escapes as an exception - this runs on
-## every authenticated render, where a raise is a 500 plus a self-inflicted
-## Sentry event. residency_scope stays raise-free for boot checks too.
-with_failing_conf do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil) do
-    [TR.residency_scope, TR.actor(@email)]
-  rescue StandardError => ex
-    ex.class
-  end
-end
-#=> [nil, nil]
-
-## DEFECT 3 (false operator-facing comment): DIAGNOSTICS_REF_REGION is documented
-## in both operator env files, so the knob that decides residency keying is
-## discoverable without reading the source.
-[File.read(File.join(REPO_ROOT, '.env.example')).include?('DIAGNOSTICS_REF_REGION'),
- File.read(File.join(REPO_ROOT, '.env.reference')).include?('DIAGNOSTICS_REF_REGION')]
-#=> [true, true]
-
-## DEFECT 3: and .env.example no longer advertises the property the code
-## deliberately does not deliver ("one reference per person across regions").
-File.read(File.join(REPO_ROOT, '.env.example')).include?('reference per person across regions')
-#=> false
-
-## DEFECT 4 (residency resolved three times per derivation): the emitted bundle
-## must come from ONE resolution. keying resolves the secret, the label that
-## secret implies, and the residency that SELECTED it, together, as one value -
-## so nothing downstream can pair a ref with a label from a different read.
-with_conf(jurisdiction_conf('EU')) do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil, 'ACCOUNT_ID_SECRET' => @deployment_key) do
-    key = TR.keying
-    [key.is_a?(TR::Keying), key.scope, key.residency]
-  end
-end
-#=> [true, 'federated', 'eu']
-
-## DEFECT 4 (fault window, falsy-conf variant): ONE human in ONE process gets
-## ONE ref. Before the fix, keying resolved 'eu' and chose FEDERATION_SECRET,
-## then digest_ref re-resolved into the falsy window, substituted
-## RESIDENCY_UNSCOPED, and derived a SECOND ref for the same person.
-healthy_eu = with_conf(jurisdiction_conf('eu')) do
-  with_env_vars(@fault_env) { TR.actor(@email) }
-end
-faulted_eu = with_conf_falsy_after_first_resolution('eu') do
-  with_env_vars(@fault_env) { TR.actor(@email) }
-end
-[faulted_eu.nil?, faulted_eu == healthy_eu]
-#=> [false, true]
-
-## DEFECT 4 (fault window): NO COLLISION. Two installs in DIFFERENT
-## jurisdictions sharing one FEDERATION_SECRET must not derive the same ref
-## during the window. Before the fix both fell back to RESIDENCY_UNSCOPED while
-## still keyed with the shared secret, which IS the cross-region join.
-faulted_a = with_conf_falsy_after_first_resolution('eu') do
-  with_env_vars(@fault_env) { TR.actor_ref(@email) }
-end
-faulted_b = with_conf_falsy_after_first_resolution('us') do
-  with_env_vars(@fault_env) { TR.actor_ref(@email) }
-end
-[faulted_a == faulted_b, faulted_a == @unscoped_collision, faulted_b == @unscoped_collision]
-#=> [false, false, false]
-
-## DEFECT 4 (fault window): NO LABEL INVERSION. The emitted label must describe
-## the key that actually derived the ref. Recomputed independently here from the
-## shared secret and the DECLARED residency: the ref matches that derivation and
-## the label says 'federated'. Before the fix the ref was federation-keyed while
-## the label read 'deployment' - told narrower than it actually correlated.
-faulted = with_conf_falsy_after_first_resolution('eu') do
-  with_env_vars(@fault_env) { TR.actor(@email) }
-end
-expected = OpenSSL::HMAC.hexdigest(
-  'SHA256', @shared_secret, [TR::ACTOR_INFO, 'eu', @email].join(TR::SEPARATOR)
-)[0, TR::REF_LENGTH]
-[faulted['actor_ref'] == expected, faulted['actor_scope']]
-#=> [true, 'federated']
-
-## DEFECT 4 (jurisdiction-changed-between-reads variant, no nil involved): a
-## jurisdiction that drifts eu -> us mid-derivation yields the EU ref, because
-## EU is the read that chose the key. It is not the US ref, and it is not some
-## third value only the fault can produce.
-drifted = with_drifting_jurisdiction('eu', 'us') do
-  with_env_vars(@fault_env) { TR.actor(@email) }
-end
-stable_us = with_conf(jurisdiction_conf('us')) do
-  with_env_vars(@fault_env) { TR.actor(@email) }
-end
-[drifted == healthy_eu, drifted['actor_ref'] == stable_us['actor_ref']]
-#=> [true, false]
-
-## DEFECT 4: the honesty invariant is now ENFORCED, not just asserted. Handed
-## FEDERATION_SECRET keying with no residency - the pairing that would put
-## RESIDENCY_UNSCOPED under the shared key - digest_ref emits nothing at all.
-TR.send(:digest_ref, TR::ACTOR_INFO,
-        TR::Keying.new(secret: @shared_secret, scope: TR::SCOPE_FEDERATED, residency: nil)) { @email }
+## The bundle is nil for a blank pre-image
+TR.actor('')
 #=> nil
 
-## DEFECT 4: and that refusal is specific to the shared key. A per-deployment
-## key with no residency still derives normally - RESIDENCY_UNSCOPED there
-## grants no cross-install correlation, which is the whole reason it survives.
-TR.send(:digest_ref, TR::ACTOR_INFO,
-        TR::Keying.new(secret: @deployment_key, scope: TR::SCOPE_DEPLOYMENT, residency: nil)) { @email } =~ /\A[0-9a-f]{16}\z/
-#=> 0
+## The emitted bundle discloses neither the extid nor the keying secret
+with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key) do
+  serialized = TR.actor(@extid).to_json
+  [serialized.include?(@extid), serialized.include?(@deployment_key)]
+end
+#=> [false, false]
+
+## An email handed to the bundle entry point never escapes as an exception
+## either - it digests like any other string, which is exactly why
+## ErrorHandler.diagnostics_actor refuses to hand one over (see
+## spec/unit/onetime/error_handler_diagnostics_actor_spec.rb)
+TR.actor('someone@example.com').keys
+#=> ['actor_ref']
 
 # ---------------------------------------------------------------------------
 # ORGANIZATION REFS
 # ---------------------------------------------------------------------------
-# Same module, same keying, same residency threading — a SECOND namespace,
-# separated only by the purpose prefix. It exists because Sentry parameterizes
-# the colonel route to /api/colonel/organizations/:org_id and never carries the
-# real id, so an operator cannot otherwise tell "one org is broken" from "every
-# org is broken". The cases below pin the three things that makes safe:
-# separation from the user namespace, identical fail-closed behaviour, and no
-# normalization that could collapse two organizations onto one ref.
+# Same module, same keying — a SECOND namespace, separated only by the purpose
+# prefix. It exists because Sentry parameterizes the colonel route to
+# /api/colonel/organizations/:org_id and never carries the real id, so an
+# operator cannot otherwise tell "one org is broken" from "every org is broken".
+# The cases below pin the three things that makes safe: separation from the
+# actor namespace, identical fail-closed behaviour, and no normalization that
+# could collapse two organizations onto one ref.
 
 @org_objid = '01JORGABCDEFGHJKMNPQRSTVWX'
 @other_org_objid = '01JOTHERABCDEFGHJKMNPQRSTV'
 
-# A pre-image both entry points treat IDENTICALLY — already lowercase,
-# unpadded, NFC — so an user/org comparison over it isolates the purpose
-# prefix as the only difference.
+# A pre-image both entry points treat IDENTICALLY, so an actor/org comparison
+# over it isolates the purpose prefix as the only difference.
 @shared_pre_image = 'domain-separation-probe'
 
 ## organization_ref is REF_LENGTH lowercase hex
@@ -559,32 +243,31 @@ TR.organization_ref(@org_objid) == TR.organization_ref(@other_org_objid)
  @org_objid.downcase.include?(TR.organization_ref(@org_objid))]
 #=> [false, false]
 
-## DOMAIN SEPARATION: the SAME string, the SAME keying and the SAME residency
-## digest differently in the two namespaces. Executed against both entry points
-## rather than asserted from the constants.
+## DOMAIN SEPARATION: the SAME string under the SAME keying digests differently
+## in the two namespaces. Executed against both entry points rather than
+## asserted from the constants.
 TR.organization_ref(@shared_pre_image) == TR.actor_ref(@shared_pre_image)
 #=> false
 
 ## DOMAIN SEPARATION: the org purpose prefix is versioned and distinct from the
-## user one, so either namespace can be re-keyed without touching the other
+## actor one, so either namespace can be re-keyed without touching the other
 [TR::ORGANIZATION_INFO == TR::ACTOR_INFO,
- TR::ORGANIZATION_INFO.include?('v1'),
+ TR::ORGANIZATION_INFO.include?('v2'),
  TR::ORGANIZATION_INFO.include?('organization')]
 #=> [false, true, true]
 
 ## DOMAIN SEPARATION: an org ref is not the federation email hash of the same
-## string either - Sentry never holds a live join key into billing or the index
+## string either
 TR.organization_ref(@shared_pre_image) == Onetime::Utils::EmailHash.compute(@shared_pre_image)
 #=> false
 
-## NO NORMALIZATION, by contrast with emails: an objid alphabet is
-## case-sensitive, so folding it could collapse two distinct organizations onto
-## one ref. actor_ref folds by design; organization_ref must not.
+## NO NORMALIZATION: objid alphabets are case-sensitive, so folding could
+## collapse two distinct organizations onto one ref. Neither namespace folds.
 lower = '01jorgabcdefghjkmnpqrstvwx'
 upper = '01JORGABCDEFGHJKMNPQRSTVWX'
 [TR.organization_ref(lower) == TR.organization_ref(upper),
  TR.actor_ref(lower) == TR.actor_ref(upper)]
-#=> [false, true]
+#=> [false, false]
 
 ## Surrounding whitespace is trimmed, so a padded value cannot split one
 ## organization into two refs
@@ -602,63 +285,25 @@ TR.organization_ref("  #{@org_objid}  ") == TR.organization_ref(@org_objid)
  TR.organization_ref('01JORG'.dup.force_encoding(Encoding::ASCII_8BIT)) == TR.organization_ref('01JORG')]
 #=> [nil, true]
 
-## RESIDENCY: one organization in two jurisdictions gets DIFFERENT refs, even
-## though both instances share one FEDERATION_SECRET - the same cross-region
-## join refusal actor refs get
-eu_org = with_env_vars('DIAGNOSTICS_REF_REGION' => 'eu') { TR.organization_ref(@org_objid) }
-us_org = with_env_vars('DIAGNOSTICS_REF_REGION' => 'us') { TR.organization_ref(@org_objid) }
-[eu_org.nil?, eu_org == us_org]
-#=> [false, false]
-
 ## FAIL-CLOSED PARITY: organization_ref returns nil under EXACTLY the keying
 ## conditions actor_ref does. Executed as a table so the two cannot drift: each
 ## row is [actor_ref.nil?, organization_ref.nil?] and every row must agree.
-usable = [TR.actor_ref(@email).nil?, TR.organization_ref(@org_objid).nil?]
-no_secret = with_env_vars('FEDERATION_SECRET' => nil, 'ACCOUNT_ID_SECRET' => nil) do
-  [TR.actor_ref(@email).nil?, TR.organization_ref(@org_objid).nil?]
+usable = with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key) do
+  [TR.actor_ref(@extid).nil?, TR.organization_ref(@org_objid).nil?]
 end
-shared_no_residency = with_conf({}) do
-  with_env_vars('FEDERATION_SECRET' => @shared_secret,
-                'DIAGNOSTICS_REF_REGION' => nil,
-                'ACCOUNT_ID_SECRET' => nil) do
-    [TR.actor_ref(@email).nil?, TR.organization_ref(@org_objid).nil?]
-  end
+no_secret = with_env_vars('ACCOUNT_ID_SECRET' => nil) do
+  [TR.actor_ref(@extid).nil?, TR.organization_ref(@org_objid).nil?]
 end
-failing_conf = with_failing_conf do
-  with_env_vars('DIAGNOSTICS_REF_REGION' => nil) do
-    [TR.actor_ref(@email).nil?, TR.organization_ref(@org_objid).nil?]
-  end
+blank_pre_image = with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key) do
+  [TR.actor_ref('  ').nil?, TR.organization_ref('  ').nil?]
 end
-[usable, no_secret, shared_no_residency, failing_conf]
-#=> [[false, false], [true, true], [true, true], [true, true]]
-
-## FAIL-CLOSED: two installs sharing FEDERATION_SECRET with NO residency
-## declared must not derive the same org ref. They fall to the per-deployment
-## key, exactly as actor refs do.
-org_a = with_conf({}) do
-  with_env_vars('FEDERATION_SECRET' => @shared_secret,
-                'DIAGNOSTICS_REF_REGION' => nil,
-                'ACCOUNT_ID_SECRET' => 'per-install-secret-region-a') { TR.organization_ref(@org_objid) }
-end
-org_b = with_conf({}) do
-  with_env_vars('FEDERATION_SECRET' => @shared_secret,
-                'DIAGNOSTICS_REF_REGION' => nil,
-                'ACCOUNT_ID_SECRET' => 'per-install-secret-region-b') { TR.organization_ref(@org_objid) }
-end
-[org_a.nil?, org_b.nil?, org_a == org_b]
-#=> [false, false, false]
-
-## FAIL-CLOSED: the honesty invariant applies to the org namespace too. Handed
-## FEDERATION_SECRET keying with no residency, digest_ref emits nothing.
-TR.send(:digest_ref, TR::ORGANIZATION_INFO,
-        TR::Keying.new(secret: @shared_secret, scope: TR::SCOPE_FEDERATED, residency: nil)) { @org_objid }
-#=> nil
+[usable, no_secret, blank_pre_image]
+#=> [[false, false], [true, true], [true, true]]
 
 ## The org ref is the derivation an operator can reproduce from the objid and
 ## the key, and nothing else - recomputed independently here
-with_env_vars('DIAGNOSTICS_REF_REGION' => 'eu') { TR.organization_ref(@org_objid) } ==
+with_env_vars('ACCOUNT_ID_SECRET' => @deployment_key) { TR.organization_ref(@org_objid) } ==
   OpenSSL::HMAC.hexdigest(
-    'SHA256', ENV.fetch('FEDERATION_SECRET'),
-    [TR::ORGANIZATION_INFO, 'eu', @org_objid].join(TR::SEPARATOR)
+    'SHA256', @deployment_key, [TR::ORGANIZATION_INFO, @org_objid].join(TR::SEPARATOR)
   )[0, TR::REF_LENGTH]
 #=> true

--- a/try/unit/utils/diagnostics_ref_try.rb
+++ b/try/unit/utils/diagnostics_ref_try.rb
@@ -60,7 +60,7 @@ ensure
 end
 
 # Shaped like a real Customer extid: Familia's external_identifier feature under
-# `format: 'ur%<id>s'` emits `ur` plus 25 base36 characters.
+# `format: 'ur%{id}'` emits `ur` plus 25 base36 characters.
 @extid = 'ur00fedcba9876543210zyxwvu'
 @other_extid = 'ur00abcdef0123456789vwxyzu'
 @deployment_key = 'account-id-secret-for-diagnostics-ref-try'


### PR DESCRIPTION
Stacked on #4250. Implements the vetted decision record committed at
`docs/specs/diagnostics/actor-ref-preimage-debate-decision.md`.

## What changes

**Default non-correlation replaces discipline-maintained residency mixing, and net code shrinks (−710 lines).**

- `DiagnosticsRef.actor_ref` derives from the customer **extid**, HMAC'd and truncated, keyed solely by `ACCOUNT_ID_SECRET`. `FEDERATION_SECRET` and the entire residency apparatus (`DIAGNOSTICS_REF_REGION`, jurisdiction fallback, federated scope, the fail-closed honesty invariant) are deleted from diagnostics. Extid pre-images are minted per-install, so separately provisioned regional customer records do not correlate by default — no discriminator needed. `FEDERATION_SECRET` is untouched everywhere else (billing, email-hash federation, migrations).
- The correlation subject is now the customer **record**, not the human: refs survive email change, and can't conflate people across address reassignment. Under key compromise, the attack degrades from offline dictionary re-identification against public email lists to requiring an auxiliary extid dataset.
- **Capture boundary hardening:** `capture_error` consumes and scrubs the extid aliases (`:extid`, `:external_id`, extid-valued `:customer_id`) alongside `:email`/`:cust`/`:customer`. The bare-string-as-email API in `diagnostics_actor` is gone — it accepts a customer object or an extid-format string (`/\Aur[0-9a-z]+\z/`), so an email can never be silently hashed under the new key.
- **Call sites standardized** on one canonical `external_id:` context key. This surfaced a real bug: three account hooks read `account[:extid]`, which is always `nil` (the Rodauth column is `external_id`) — `surface_plan_intent` and `delete_customer` were silently losing attribution and now work; `create_customer` drops its identity key (nothing exists to name yet, accepted loss).
- **Wire contract narrows:** `diagnostics_ref` is now the single-key strict object `{actor_ref}`. The `actor_scope` axis, its Zod enum, and the Sentry tag are deleted; a legacy block carrying `actor_scope` fails closed at the strictObject parse.
- Purpose prefixes bump to `v2` (the HMAC message drops the residency element).

## ⚠️ Expected one-time discontinuity

Actor **and** organization refs re-key on the deploy that ships this change (new pre-image/message shape; org refs move off federation keying). Existing ref values in Sentry stop matching new ones for up to the 14-day retention window, then the discontinuity ages out. This is documented in the changelog fragment — don't investigate it as a bug.

## Verification

- `bundle exec try --agent try/unit`: 6933 pass; 20 fail/37 err in 7 files reproduced identically on base content (structural, unrelated — DomainStrategy require path, full-mode-only constants, missing sqlite auth schema)
- rspec: `spec/unit` + `apps/web/core/spec` 4835/0 · `apps/web/auth/spec` (excl. `integration/full/`) 1357/0 · `apps/api` 1757/0
- vitest full run: 390 files, 8820 pass · `vue-tsc` app lane clean · rubocop clean on edited files · `scripts/check-env-reference.sh` PASS
- Residue sweep: zero remaining `DIAGNOSTICS_REF_REGION` / `SCOPE_FEDERATED` / residency / `v1`-prefix hits; every surviving `FEDERATION_SECRET` mention is billing/federation-scoped with no diagnostics claim
- Not covered: `apps/web/auth/spec/integration/full/domain_sso_join_organization_spec.rb` (one kwarg rename mirroring the hook) needs the full-mode lane with a live auth DB

## Known follow-ups (out of scope here)

- `Onetime::Customer.extid?` is unconditionally false: Familia gates on the literal `'%{id}'` but the model declares `format: 'ur%<id>s'` (sprintf named-reference form). Any caller relying on it is dead code — worth its own issue.
- `safe_execute` still logs the unscrubbed context (including `external_id:`) to the application logger before `capture_error` scrubs it for Sentry. Pre-existing; flag if extid-in-logs should also be bounded.