### PR TITLE
Retire old-shape jq fallback in locale review shell gates

### DIFF
--- a/locales/scripts/pr-per-locale.sh
+++ b/locales/scripts/pr-per-locale.sh
@@ -201,15 +201,13 @@ fi
 
 # validation_count LOCALE -> echoes the report's integer blocking count, or "" if unknown.
 validation_count() {
-  local locale="$1" file="$RESULTS_DIR/i18n-validate-$1.json"
+  local file="$RESULTS_DIR/i18n-validate-$1.json"
   $HAVE_VALIDATION || { echo ""; return; }
   [[ -f "$file" ]] || { echo ""; return; }
   # `.blocking` is the report's own gate count (untranslated keys are reported
-  # but advisory). The per-locale fallbacks keep reports written by a branch
-  # whose CLI predates that field readable.
-  jq --arg l "$locale" \
-    '(.blocking // .summary[$l] // (.summary | to_entries | map(.value) | add) // 0)' \
-    "$file" 2>/dev/null || echo ""
+  # but advisory). No default: a missing/misspelled field prints `null` rather
+  # than being silently read as zero.
+  jq '.blocking' "$file" 2>/dev/null || echo ""
 }
 
 # ---------------------------------------------------------------------------

--- a/locales/scripts/pr-per-locale.sh
+++ b/locales/scripts/pr-per-locale.sh
@@ -199,7 +199,8 @@ if $HAVE_VALIDATION; then
   echo
 fi
 
-# validation_count LOCALE -> echoes the report's integer blocking count, or "" if unknown.
+# validation_count LOCALE -> echoes the report's `.blocking` value verbatim.
+# Emits "" only when validation is unavailable or the report cannot be read.
 validation_count() {
   local file="$RESULTS_DIR/i18n-validate-$1.json"
   $HAVE_VALIDATION || { echo ""; return; }

--- a/locales/scripts/review-locale-branches.sh
+++ b/locales/scripts/review-locale-branches.sh
@@ -115,12 +115,12 @@ cmd_validate() {
     # alone: a genuine failure (no parseable JSON — missing locale, crash, old
     # CLI) must surface as an ERROR, not read as clean; "blocking findings"
     # (valid JSON, rc!=0) reports the count; a clean run prints nothing.
-    # Prefer the report's own `blocking` count (non-advisory findings only;
-    # untranslated keys are coverage, not placeholder defects). Branches whose
-    # CLI predates that field still report a flat per-locale integer summary, and
-    # this validates other branches' worktrees, so keep the old shape working.
-    count="$(jq '.blocking // (.summary | to_entries | map(.value) | add) // 0' \
-      "$out" 2>/dev/null || true)"
+    # `.blocking` is the report's own gate count — every non-advisory category,
+    # summed (untranslated keys are coverage, not placeholder defects). No
+    # default: a missing/misspelled field prints `null`, which fails the
+    # numeric check below and is treated as unparseable rather than silently
+    # read as zero.
+    count="$(jq '.blocking' "$out" 2>/dev/null || true)"
     if ! [[ "$count" =~ ^[0-9]+$ ]]; then
       echo "$locale: ERROR — validation produced no parseable report (exit ${rc}); see $out" >&2
       continue


### PR DESCRIPTION
## Summary

[#4112](https://github.com/onetimesecret/onetimesecret/issues/4112)

PR #4081 added a top-level `blocking` field to the `validate variables --json` report and introduced a jq fallback in two shell gates that also accepted the pre-#4080 flat per-locale integer `summary` shape, since those scripts validate *other* branches' worktrees where a checked-out CLI could predate the field. That compatibility window is now closed: #4081 is merged, and no `i18n/update-*` branches remain open (`git ls-remote --heads origin` returns none), so there is nothing left running a pre-#4080 CLI for the fallback to serve.

- `locales/scripts/review-locale-branches.sh` — `.blocking // (.summary | to_entries | map(.value) | add) // 0` → `.blocking`
- `locales/scripts/pr-per-locale.sh` (`validation_count()`) — `.blocking // .summary[$l] // (.summary | ...) // 0` → `.blocking`, and dropped the now-unused `--arg l "$locale"` plumbing

Also dropped the trailing `// 0` default in both. Keeping it would have reintroduced the same masking risk in miniature: a future `blocking` rename/drop would silently read as "0 blocking findings" instead of surfacing. This mirrors `export-all.sh`'s existing precedent (its Python-side gate does bare `json.load(sys.stdin)["blocking"]` specifically so "a missing `blocking` raises here, which the caller treats as an unparseable report — dirty, never clean"). With bare `.blocking`, a missing/misspelled field now prints `null`, which fails each caller's `^[0-9]+$` numeric check — `review-locale-branches.sh` reports it as `ERROR — validation produced no parseable report`, and `pr-per-locale.sh` surfaces a visibly broken `**null** blocking finding(s)` in the PR body — instead of a clean-looking but wrong `0`.

No changelog fragment: this is internal maintainer tooling (never invoked by CI or product code), which `changelog.d/README.md` says doesn't need one.

## Related Issues

Closes #4112

## Test Plan

- `bash -n` on both scripts.
- Verified the new jq expression against all three shapes piped through `jq`:
  - current shape (`blocking` present) → returns the number, e.g. `3`, `0`.
  - simulated missing/misspelled field → `null`.
  - old pre-#4080 flat `summary`-only shape → also `null` (now correctly unparseable, as intended).
- Verified bash's `[[ "$count" =~ ^[0-9]+$ ]]` classifies `null` and `""` as non-numeric (triggers the existing ERROR/"not run" paths) and `"3"`/`"0"` as numeric, for both call sites.
- `locales/scripts/pr-per-locale.sh --help` still runs cleanly after removing the now-unused `local locale` var.
- Confirmed no CI workflow invokes either script directly, and no test suite exercises the old-shape fallback.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01De9Q2d9titfiwxvhQNN2M4)_