### PR TITLE
Add backup freshness panel to Colonel

### DIFF
--- a/apps/api/colonel/logic/colonel.rb
+++ b/apps/api/colonel/logic/colonel.rb
@@ -44,6 +44,7 @@ require_relative 'colonel/purge_user'
 # System monitoring
 require_relative 'colonel/get_proxy_headers_debug'
 require_relative 'colonel/get_database_metrics'
+require_relative 'colonel/get_backup_status'
 require_relative 'colonel/get_brand_diagnostics'
 require_relative 'colonel/get_redis_metrics'
 

--- a/apps/api/colonel/logic/colonel/get_backup_status.rb
+++ b/apps/api/colonel/logic/colonel/get_backup_status.rb
@@ -87,8 +87,13 @@ module ColonelAPI
             mode: enum_or_empty(raw['mode'], PRUNE_MODES),
             removed: decimal_or_empty(raw['removed']),
             candidates: decimal_or_empty(raw['candidates']),
+            shipped: decimal_or_empty(raw['shipped']),
+            remote: text_value(raw['remote']),
             duration_secs: decimal_or_empty(raw['duration_secs']),
-            error: text_value(raw['error'], max_bytes: nil),
+            # The writer bounds `error` at 512 chars, so a conforming record is
+            # never truncated here. The keyspace is writable by the shared
+            # valkey ACL user, so this reader must not relay unbounded text.
+            error: text_value(raw['error']),
             version: text_value(raw['version'], max_bytes: 128),
             scheduled: enum_value(raw['scheduled'], SCHEDULED_STATES),
           }

--- a/apps/api/colonel/logic/colonel/get_backup_status.rb
+++ b/apps/api/colonel/logic/colonel/get_backup_status.rb
@@ -90,9 +90,9 @@ module ColonelAPI
             shipped: decimal_or_empty(raw['shipped']),
             remote: text_value(raw['remote']),
             duration_secs: decimal_or_empty(raw['duration_secs']),
-            # The writer bounds `error` at 512 chars, so a conforming record is
-            # never truncated here. The keyspace is writable by the shared
-            # valkey ACL user, so this reader must not relay unbounded text.
+            # The writer bounds `error` at 512 chars. Oversized text is nulled,
+            # not truncated. The keyspace is writable by the shared valkey ACL
+            # user, so this reader must not relay unbounded text.
             error: text_value(raw['error']),
             version: text_value(raw['version'], max_bytes: 128),
             scheduled: enum_value(raw['scheduled'], SCHEDULED_STATES),
@@ -118,7 +118,7 @@ module ColonelAPI
 
         def decimal_or_empty(value)
           return '' if value == ''
-          return unless value.is_a?(String) && value.match?(/\A\d+\z/) && value.length <= 20
+          return unless value.is_a?(String) && value.length <= 20 && value.match?(/\A\d+\z/)
 
           value
         end

--- a/apps/api/colonel/logic/colonel/get_backup_status.rb
+++ b/apps/api/colonel/logic/colonel/get_backup_status.rb
@@ -100,7 +100,7 @@ module ColonelAPI
         end
 
         def timestamp_value(value)
-          return unless value.is_a?(String) && value.match?(/\A\d+\z/)
+          return unless value.is_a?(String) && value.length <= 20 && value.match?(/\A\d+\z/)
 
           timestamp = value.to_i
           timestamp if timestamp <= MAX_TIMESTAMP

--- a/apps/api/colonel/logic/colonel/get_backup_status.rb
+++ b/apps/api/colonel/logic/colonel/get_backup_status.rb
@@ -1,0 +1,138 @@
+# apps/api/colonel/logic/colonel/get_backup_status.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # Read the ots-backup v1 status hashes published beside this application.
+      #
+      # This endpoint deliberately performs only HGETALL reads against the eight
+      # known job hashes. It never scans or writes the datastore, and it does not
+      # read the package's `_check` hash. A malformed or partial external record
+      # is represented with null fields rather than being allowed to break the
+      # Colonel response.
+      class GetBackupStatus < ColonelAPI::Logic::Base
+        SCHEMAS = { response: 'backupStatus' }.freeze
+
+        JOBS               = %w[pg valkey prune ship].freeze
+        STATUS_KEY_PREFIX  = 'ots:backup:status:'
+        EVENTS             = %w[start ok fail].freeze
+        SCHEDULED_STATES   = %w[enabled disabled unknown].freeze
+        PRUNE_MODES        = %w[report delete].freeze
+        MAX_TIMESTAMP      = 8_640_000_000_000 # JavaScript Date's maximum, in seconds.
+        MAX_TEXT_BYTES     = 4_096
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          success_data
+        end
+
+        def success_data
+          {
+            record: {},
+            details: {
+              timestamp: Familia.now.to_i,
+              jobs: JOBS.map { |job| job_status(job) },
+            },
+          }
+        end
+
+        private
+
+        def job_status(job)
+          latest  = read_hash(status_key(job))
+          last_ok = sanitize_record(read_hash(last_ok_key(job)), job) if latest.any?
+          {
+            job: job,
+            configured: latest.any?,
+            latest: latest.any? ? sanitize_record(latest, job) : nil,
+            # A stray or malformed last_ok is not evidence of a successful run.
+            # In particular, freshness must never trust an event other than `ok`.
+            last_ok: last_ok&.fetch(:event) == 'ok' ? last_ok : nil,
+          }
+        end
+
+        def status_key(job)
+          "#{STATUS_KEY_PREFIX}#{job}"
+        end
+
+        def last_ok_key(job)
+          "#{status_key(job)}:last_ok"
+        end
+
+        def read_hash(key)
+          # HGETALL returns an empty Hash only when this known status key is
+          # missing. Permission, wrong-type, and transport failures propagate so
+          # the HTTP endpoint (and its panel) reports a real read error instead
+          # of falsely claiming the backup is not configured.
+          Familia.dbclient.hgetall(key)
+        end
+
+        def sanitize_record(raw, job)
+          {
+            event: enum_value(raw['event'], EVENTS),
+            ts: timestamp_value(raw['ts']),
+            host: text_value(raw['host']),
+            unit: text_value(raw['unit']),
+            job: text_value(raw['job']) == job ? job : nil,
+            file: text_value(raw['file']),
+            bytes: decimal_or_empty(raw['bytes']),
+            sha256: sha256_or_empty(raw['sha256']),
+            mode: enum_or_empty(raw['mode'], PRUNE_MODES),
+            removed: decimal_or_empty(raw['removed']),
+            candidates: decimal_or_empty(raw['candidates']),
+            duration_secs: decimal_or_empty(raw['duration_secs']),
+            error: text_value(raw['error'], max_bytes: nil),
+            version: text_value(raw['version'], max_bytes: 128),
+            scheduled: enum_value(raw['scheduled'], SCHEDULED_STATES),
+          }
+        end
+
+        def timestamp_value(value)
+          return unless value.is_a?(String) && value.match?(/\A\d+\z/)
+
+          timestamp = value.to_i
+          timestamp if timestamp <= MAX_TIMESTAMP
+        end
+
+        def enum_value(value, allowed)
+          value if value.is_a?(String) && allowed.include?(value)
+        end
+
+        def enum_or_empty(value, allowed)
+          return '' if value == ''
+
+          enum_value(value, allowed)
+        end
+
+        def decimal_or_empty(value)
+          return '' if value == ''
+          return unless value.is_a?(String) && value.match?(/\A\d+\z/) && value.length <= 20
+
+          value
+        end
+
+        def sha256_or_empty(value)
+          return '' if value == ''
+          return unless value.is_a?(String) && value.match?(/\A[0-9a-f]{64}\z/i)
+
+          value
+        end
+
+        def text_value(value, max_bytes: MAX_TEXT_BYTES)
+          return unless value.is_a?(String)
+          return unless value.ascii_only? && !value.match?(/[\r\n]/)
+          return if max_bytes && value.bytesize > max_bytes
+
+          value
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -39,6 +39,7 @@ DELETE /users/:user_id                    ColonelAPI::Logic::Colonel::PurgeUser 
 # System Monitoring
 GET    /system/proxy-headers              ColonelAPI::Logic::Colonel::GetProxyHeadersDebug response=json auth=sessionauth role=colonel network=admin scope=internal
 GET    /system/database                   ColonelAPI::Logic::Colonel::GetDatabaseMetrics response=json auth=sessionauth role=colonel scope=internal
+GET    /system/backups                    ColonelAPI::Logic::Colonel::GetBackupStatus response=json auth=sessionauth role=colonel scope=internal
 GET    /system/brand                      ColonelAPI::Logic::Colonel::GetBrandDiagnostics response=json auth=sessionauth role=colonel scope=internal
 GET    /system/redis                      ColonelAPI::Logic::Colonel::GetRedisMetrics response=json auth=sessionauth role=colonel scope=internal
 GET    /queue                             ColonelAPI::Logic::Colonel::GetQueueMetrics response=json auth=sessionauth role=colonel scope=internal

--- a/locales/content/en/admin-system.json
+++ b/locales/content/en/admin-system.json
@@ -143,6 +143,62 @@
     "text": "Unknown",
     "content_hash": "b764cdc0"
   },
+  "web.admin.system.backups.title": {
+    "text": "Backup Status",
+    "content_hash": "6100b034"
+  },
+  "web.admin.system.backups.description": {
+    "text": "Latest backup events and last successful run from this host.",
+    "content_hash": "19070c41"
+  },
+  "web.admin.system.backups.loadError": {
+    "text": "Could not load backup status.",
+    "content_hash": "9b83029b"
+  },
+  "web.admin.system.backups.notConfigured": {
+    "text": "Not configured here",
+    "content_hash": "d287939f"
+  },
+  "web.admin.system.backups.latest": {
+    "text": "Latest event",
+    "content_hash": "cd7ad68a"
+  },
+  "web.admin.system.backups.lastOk": {
+    "text": "Last successful run",
+    "content_hash": "81120703"
+  },
+  "web.admin.system.backups.artifact": {
+    "text": "Artifact",
+    "content_hash": "e06171a1"
+  },
+  "web.admin.system.backups.unknownUnit": {
+    "text": "Unknown unit",
+    "content_hash": "d120e025"
+  },
+  "web.admin.system.backups.unknownError": {
+    "text": "No error detail",
+    "content_hash": "b2c696e7"
+  },
+  "web.admin.system.backups.freshness.notConfigured": {
+    "text": "Not configured",
+    "content_hash": "dd1841d2"
+  },
+  "web.admin.system.backups.freshness.notMonitored": {
+    "text": "Not monitored",
+    "content_hash": "0f0d1855"
+  },
+  "web.admin.system.backups.freshness.fresh": {
+    "text": "Fresh",
+    "content_hash": "f810b668"
+  },
+  "web.admin.system.backups.freshness.stale": {
+    "text": "Stale — alarm",
+    "content_hash": "c7a9733a"
+  },
+  "web.admin.system.backups.freshness.alarm": {
+    "text": "Alarm",
+    "content_hash": "f3b67957"
+  },
   "web.admin.system.redis.title": {
     "text": "Redis INFO",
     "content_hash": "e762bd3c"

--- a/locales/content/en/admin-system.json
+++ b/locales/content/en/admin-system.json
@@ -179,6 +179,14 @@
     "text": "No error detail",
     "content_hash": "b2c696e7"
   },
+  "web.admin.system.backups.destination": {
+    "text": "Destination",
+    "content_hash": "293d404a"
+  },
+  "web.admin.system.backups.shippedOf": {
+    "text": "Shipped {shipped} of {candidates}",
+    "content_hash": "406119a9"
+  },
   "web.admin.system.backups.freshness.notConfigured": {
     "text": "Not configured",
     "content_hash": "dd1841d2"

--- a/spec/integration/all/colonel_backup_status_spec.rb
+++ b/spec/integration/all/colonel_backup_status_spec.rb
@@ -42,6 +42,8 @@ RSpec.describe 'Colonel backup status', type: :integration do
       'mode' => '',
       'removed' => '',
       'candidates' => '',
+      'shipped' => '',
+      'remote' => '',
       'duration_secs' => '10',
       'error' => '',
       'version' => '0.2.3',
@@ -80,7 +82,60 @@ RSpec.describe 'Colonel backup status', type: :integration do
     expect(jobs.first).to include(configured: true)
     expect(jobs.first[:latest]).to include(event: 'fail', error: 'disk full')
     expect(jobs.first[:last_ok]).to include(event: 'ok', ts: 1_699_999_000, file: '/var/backups/pg.tar.gz')
+    expect(jobs.first[:latest]).to include(shipped: '', remote: '')
+    expect(jobs.first[:last_ok]).to include(shipped: '', remote: '')
     expect(jobs.drop(1)).to all(include(configured: false, latest: nil, last_ok: nil))
+  end
+
+  it 'passes ship-job shipped and remote fields through verbatim' do
+    ship_overrides = {
+      'shipped' => '2',
+      'candidates' => '7',
+      'remote' => 's3:onetime-eu/backups/',
+      'file' => '',
+      'bytes' => '25806368',
+    }
+    write_status('ship', overrides: ship_overrides)
+    write_status('ship', suffix: ':last_ok', overrides: ship_overrides)
+
+    ship_job = status[:details][:jobs].find { |entry| entry[:job] == 'ship' }
+
+    expect(ship_job[:configured]).to be(true)
+    expect(ship_job[:latest]).to include(
+      event: 'ok',
+      shipped: '2',
+      candidates: '7',
+      remote: 's3:onetime-eu/backups/',
+      file: '',
+      bytes: '25806368',
+    )
+    expect(ship_job[:last_ok]).to include(shipped: '2', remote: 's3:onetime-eu/backups/')
+  end
+
+  it 'nulls an error exceeding the 4096-byte text cap while preserving the rest of the record' do
+    oversized_error = 'e' * 4_097
+    write_status('pg', overrides: { 'event' => 'fail', 'error' => oversized_error })
+
+    pg_job = status[:details][:jobs].find { |entry| entry[:job] == 'pg' }
+
+    expect(pg_job[:latest]).to include(
+      event: 'fail',
+      error: nil,
+      ts: 1_700_000_000,
+      host: 'eu-db-01',
+      file: '/var/backups/pg.tar.gz',
+      bytes: '1048576',
+      version: '0.2.3',
+      scheduled: 'enabled',
+    )
+  end
+
+  it 'nulls malformed shipped and remote values' do
+    write_status('ship', overrides: { 'shipped' => '2x', 'remote' => "s3:bucket\nextra" })
+
+    ship_job = status[:details][:jobs].find { |entry| entry[:job] == 'ship' }
+
+    expect(ship_job[:latest]).to include(shipped: nil, remote: nil)
   end
 
   it 'normalizes malformed hash values, preserves long valid errors, and does not trust a malformed last_ok event' do

--- a/spec/integration/all/colonel_backup_status_spec.rb
+++ b/spec/integration/all/colonel_backup_status_spec.rb
@@ -1,0 +1,120 @@
+# spec/integration/all/colonel_backup_status_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'securerandom'
+require 'colonel/application'
+
+RSpec.describe 'Colonel backup status', type: :integration do
+  STATUS_PREFIX = 'ots:backup:status:'
+
+  def strategy_result_for(user)
+    double(
+      'StrategyResult',
+      session: {},
+      user: user,
+      metadata: { ip: '127.0.0.1' },
+      auth_method: 'sessionauth',
+    )
+  end
+
+  def colonel
+    @colonel ||= begin
+      customer          = Onetime::Customer.create!(email: "colonel-#{SecureRandom.hex(4)}@example.com")
+      customer.role     = 'colonel'
+      customer.verified = 'true'
+      customer.save
+      customer
+    end
+  end
+
+  def write_status(job, suffix: '', overrides: {})
+    fields = {
+      'event' => 'ok',
+      'ts' => '1700000000',
+      'host' => 'eu-db-01',
+      'unit' => "ots-backup-#{job}.service",
+      'job' => job,
+      'file' => "/var/backups/#{job}.tar.gz",
+      'bytes' => '1048576',
+      'sha256' => 'a' * 64,
+      'mode' => '',
+      'removed' => '',
+      'candidates' => '',
+      'duration_secs' => '10',
+      'error' => '',
+      'version' => '0.2.3',
+      'scheduled' => 'enabled',
+    }.merge(overrides)
+
+    fields.each { |field, value| Familia.dbclient.hset("#{STATUS_PREFIX}#{job}#{suffix}", field, value) }
+  end
+
+  def status
+    logic = ColonelAPI::Logic::Colonel::GetBackupStatus.new(strategy_result_for(colonel), {})
+    logic.raise_concerns
+    logic.process
+  end
+
+  it 'reads only recognized status hashes and returns missing jobs as not configured' do
+    write_status('pg', overrides: { 'event' => 'fail', 'error' => 'disk full' })
+    write_status('pg', suffix: ':last_ok', overrides: { 'ts' => '1699999000' })
+    write_status('_check', overrides: { 'event' => 'fail', 'error' => 'must be ignored' })
+
+    # Pin `Familia.dbclient` to this instrumented instance: the lane client may
+    # resolve a fresh wrapper on each accessor call, which otherwise makes the
+    # production read invisible to this example's spy.
+    colonel
+    client = Familia.dbclient
+    allow(Familia).to receive(:dbclient).and_return(client)
+    allow(client).to receive(:hgetall).and_call_original
+
+    data = status
+
+    expect(client).to have_received(:hgetall).with("#{STATUS_PREFIX}pg")
+    expect(client).not_to have_received(:hgetall).with("#{STATUS_PREFIX}_check")
+
+    jobs = data[:details][:jobs]
+    expect(jobs.map { |job| job[:job] }).to eq(%w[pg valkey prune ship])
+    expect(jobs.first).to include(configured: true)
+    expect(jobs.first[:latest]).to include(event: 'fail', error: 'disk full')
+    expect(jobs.first[:last_ok]).to include(event: 'ok', ts: 1_699_999_000, file: '/var/backups/pg.tar.gz')
+    expect(jobs.drop(1)).to all(include(configured: false, latest: nil, last_ok: nil))
+  end
+
+  it 'normalizes malformed hash values, preserves long valid errors, and does not trust a malformed last_ok event' do
+    long_error = 'x' * 2_049
+    write_status('valkey', overrides: {
+      'event' => 'unexpected',
+      'ts' => 'not-a-timestamp',
+      'error' => "two\nlines",
+      'scheduled' => 'sometimes',
+      'bytes' => '-1',
+    })
+    write_status('valkey', suffix: ':last_ok', overrides: { 'event' => 'fail' })
+    write_status('pg', overrides: { 'event' => 'fail', 'error' => long_error })
+
+    valkey_job = status[:details][:jobs].find { |entry| entry[:job] == 'valkey' }
+    pg_job     = status[:details][:jobs].find { |entry| entry[:job] == 'pg' }
+
+    expect(valkey_job[:configured]).to be(true)
+    expect(valkey_job[:latest]).to include(event: nil, ts: nil, error: nil, scheduled: nil, bytes: nil)
+    expect(valkey_job[:last_ok]).to be_nil
+    expect(pg_job[:latest]).to include(error: long_error)
+  end
+
+  it 'propagates Valkey read failures instead of reporting a job as not configured' do
+    # See the access pinning in the recognized-hashes example above. Create the
+    # actor before stubbing so Customer persistence cannot consume this failure.
+    colonel
+    client = Familia.dbclient
+    allow(Familia).to receive(:dbclient).and_return(client)
+    allow(client).to receive(:hgetall).and_call_original
+    allow(client).to receive(:hgetall)
+      .with("#{STATUS_PREFIX}pg")
+      .and_raise(StandardError, 'NOPERM this user has no permissions')
+
+    expect { status }.to raise_error(StandardError, /NOPERM/)
+  end
+end

--- a/spec/integration/all/colonel_backup_status_spec.rb
+++ b/spec/integration/all/colonel_backup_status_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe 'Colonel backup status', type: :integration do
       'bytes' => '-1',
     })
     write_status('valkey', suffix: ':last_ok', overrides: { 'event' => 'fail' })
-    write_status('pg', overrides: { 'event' => 'fail', 'error' => long_error })
+    write_status('pg', overrides: { 'event' => 'fail', 'error' => long_error, 'ts' => '9' * 21 })
 
     valkey_job = status[:details][:jobs].find { |entry| entry[:job] == 'valkey' }
     pg_job     = status[:details][:jobs].find { |entry| entry[:job] == 'pg' }
@@ -156,7 +156,7 @@ RSpec.describe 'Colonel backup status', type: :integration do
     expect(valkey_job[:configured]).to be(true)
     expect(valkey_job[:latest]).to include(event: nil, ts: nil, error: nil, scheduled: nil, bytes: nil)
     expect(valkey_job[:last_ok]).to be_nil
-    expect(pg_job[:latest]).to include(error: long_error)
+    expect(pg_job[:latest]).to include(error: long_error, ts: nil)
   end
 
   it 'propagates Valkey read failures instead of reporting a job as not configured' do

--- a/src/apps/admin/views/AdminSystem.vue
+++ b/src/apps/admin/views/AdminSystem.vue
@@ -1,12 +1,12 @@
 <!-- src/apps/admin/views/AdminSystem.vue -->
 
 <script setup lang="ts">
-
   import { DataTable, JsonViewer, StatCard } from '@/apps/admin/components/kit';
   import type { DataTableColumn } from '@/apps/admin/components/kit';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
-  import type { QueueMetric } from '@/schemas/api/internal/responses/colonel';
+  import type { BackupStatusRecord, QueueMetric } from '@/schemas/api/internal/responses/colonel';
   import {
+    backupStatusResponseSchema,
     brandDiagnosticsResponseSchema,
     databaseMetricsResponseSchema,
     queueMetricsResponseSchema,
@@ -23,10 +23,11 @@
    * `ColonelSystemRedis` views rebuilt fresh on the Slice-3 template. It does NOT
    * import `src/apps/colonel/*` or `colonelInfoStore`.
    *
-   * Four independent single-GET read-outs via {@link useResourceFetch} (CONTRACT
+   * Five independent single-GET read-outs via {@link useResourceFetch} (CONTRACT
    * 1 — single screens use useResourceFetch, not a paginated store). All reads
    * REUSE the frozen wrapped schemas (CONTRACT 3):
    *   - GET /api/colonel/system/database → server + memory + db sizes + model counts
+   *   - GET /api/colonel/system/backups  → ots-backup status hashes (#4276)
    *   - GET /api/colonel/queue           → connection + worker health + per-queue
    *   - GET /api/colonel/system/redis    → full Redis/Valkey INFO (JsonViewer)
    *   - GET /api/colonel/system/brand    → brand-pack resolution diagnostic (#3822)
@@ -55,9 +56,7 @@
   // Valkey reports both valkey_version and a Redis-compat redis_version. Prefer
   // Valkey when present so the page reflects the real engine (parity with the
   // legacy MainDB view).
-  const engineName = computed(() =>
-    db.value?.redis_info.valkey_version ? 'Valkey' : 'Redis'
-  );
+  const engineName = computed(() => (db.value?.redis_info.valkey_version ? 'Valkey' : 'Redis'));
   const engineVersion = computed(
     () => db.value?.redis_info.valkey_version ?? db.value?.redis_info.redis_version ?? '—'
   );
@@ -80,6 +79,90 @@
       return { name, keys: null, expires: null, raw: String(info) };
     });
   });
+
+  // ---- Backup status (#4276) ------------------------------------------------
+
+  interface BackupJob {
+    job: 'pg' | 'valkey' | 'prune' | 'ship';
+    configured: boolean;
+    latest: BackupStatusRecord | null;
+    last_ok: BackupStatusRecord | null;
+  }
+
+  type BackupFreshness = 'notConfigured' | 'notMonitored' | 'fresh' | 'stale' | 'alarm';
+
+  const {
+    data: backupData,
+    loading: backupLoading,
+    error: backupError,
+    validationError: backupValidationError,
+    load: loadBackups,
+  } = useResourceFetch({
+    url: '/api/colonel/system/backups',
+    schema: backupStatusResponseSchema,
+    context: 'BackupStatusResponse',
+  });
+
+  const backup = computed(() => backupData.value?.details ?? null);
+  const backupFailed = computed(
+    () => backupError.value !== null || backupValidationError.value !== null
+  );
+
+  function freshnessFor(job: BackupJob): BackupFreshness {
+    if (!job.configured) return 'notConfigured';
+    if (job.latest?.scheduled !== 'enabled') return 'notMonitored';
+
+    const now = backup.value?.timestamp;
+    const lastOkTs = job.last_ok?.ts;
+    const latestTs = job.latest?.ts;
+    if (typeof now !== 'number' || typeof lastOkTs !== 'number') return 'alarm';
+    if (lastOkTs > now + 5 * 60 || (typeof latestTs === 'number' && latestTs > now + 5 * 60)) {
+      return 'alarm';
+    }
+    return now - lastOkTs > 26 * 60 * 60 ? 'stale' : 'fresh';
+  }
+
+  function backupBadgeClass(status: BackupFreshness): string {
+    switch (status) {
+      case 'fresh':
+        return 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200';
+      case 'notConfigured':
+      case 'notMonitored':
+        return 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300';
+      default:
+        return 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200';
+    }
+  }
+
+  function relativeAge(timestamp: number | null): string {
+    if (timestamp === null || !backup.value) return '—';
+    const seconds = backup.value.timestamp - timestamp;
+    const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' });
+    if (Math.abs(seconds) < 60) return formatter.format(-seconds, 'second');
+    if (Math.abs(seconds) < 3600) return formatter.format(-Math.round(seconds / 60), 'minute');
+    if (Math.abs(seconds) < 86_400) return formatter.format(-Math.round(seconds / 3600), 'hour');
+    return formatter.format(-Math.round(seconds / 86_400), 'day');
+  }
+
+  function utcTimestamp(timestamp: number | null): string | undefined {
+    return timestamp === null ? undefined : new Date(timestamp * 1000).toISOString();
+  }
+
+  function artifactName(file: string | null): string {
+    return file?.split('/').filter(Boolean).pop() ?? '—';
+  }
+
+  function humanBytes(bytes: string | null): string {
+    if (!bytes) return '—';
+    const value = Number(bytes);
+    if (!Number.isSafeInteger(value) || value < 0) return '—';
+
+    const units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    const index =
+      value === 0 ? 0 : Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1);
+    const scaled = value / 1024 ** index;
+    return `${scaled.toLocaleString(undefined, { maximumFractionDigits: 1 })} ${units[index]}`;
+  }
 
   // ---- Queue metrics --------------------------------------------------------
 
@@ -193,6 +276,7 @@
 
   function loadAll(): void {
     loadDb().catch(() => {});
+    loadBackups().catch(() => {});
     loadQueue().catch(() => {});
     loadRedis().catch(() => {});
     loadBrand().catch(() => {});
@@ -286,7 +370,8 @@
         <!-- Server info -->
         <div
           class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <h4 class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+          <h4
+            class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
             {{ t('web.admin.system.database.server') }}
           </h4>
           <dl class="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-3">
@@ -344,7 +429,8 @@
         <!-- Memory -->
         <div
           class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-          <h4 class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+          <h4
+            class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
             {{ t('web.admin.system.database.memory') }}
           </h4>
           <dl class="grid grid-cols-2 gap-x-6 gap-y-3 sm:grid-cols-4">
@@ -387,7 +473,8 @@
         <div
           class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
           data-testid="system-database-sizes">
-          <h4 class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+          <h4
+            class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
             {{ t('web.admin.system.database.databases') }}
           </h4>
           <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -400,7 +487,12 @@
               </div>
               <div class="mt-1 text-xs text-gray-600 dark:text-gray-400">
                 <template v-if="row.raw === null">
-                  {{ t('web.admin.system.database.dbSummary', { keys: num(row.keys), expires: num(row.expires) }) }}
+                  {{
+                    t('web.admin.system.database.dbSummary', {
+                      keys: num(row.keys),
+                      expires: num(row.expires),
+                    })
+                  }}
                 </template>
                 <template v-else>
                   {{ row.raw }}
@@ -409,6 +501,128 @@
             </div>
           </div>
         </div>
+      </div>
+    </section>
+
+    <!-- ================= Backup status (#4276) ================= -->
+    <section
+      class="mb-8"
+      data-testid="system-backups">
+      <h3 class="mb-1 text-lg font-medium text-gray-900 dark:text-white">
+        {{ t('web.admin.system.backups.title') }}
+      </h3>
+      <p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
+        {{ t('web.admin.system.backups.description') }}
+      </p>
+
+      <div
+        v-if="backupLoading && !backup"
+        class="flex items-center gap-3 rounded-lg border border-gray-200 bg-white px-4 py-8 text-sm text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-400"
+        data-testid="system-backups-loading">
+        <OIcon
+          collection="heroicons"
+          name="arrow-path"
+          size="5"
+          class="animate-spin motion-reduce:animate-none" />
+        {{ t('web.COMMON.loading') }}
+      </div>
+
+      <div
+        v-else-if="backupFailed"
+        class="flex items-center justify-between gap-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-900/20"
+        role="alert"
+        data-testid="system-backups-error">
+        <span class="text-sm text-red-800 dark:text-red-200">
+          {{ t('web.admin.system.backups.loadError') }}
+        </span>
+        <button
+          type="button"
+          class="inline-flex items-center gap-1 rounded-md border border-red-300 px-3 py-1.5 text-sm font-medium text-red-800 hover:bg-red-100 focus:ring-2 focus:ring-red-500 focus:outline-none dark:border-red-800 dark:text-red-200 dark:hover:bg-red-900/40"
+          @click="loadBackups().catch(() => {})">
+          <OIcon
+            collection="heroicons"
+            name="arrow-path"
+            size="4" />
+          {{ t('web.admin.system.retry') }}
+        </button>
+      </div>
+
+      <div
+        v-else-if="backup"
+        class="grid grid-cols-1 gap-4 sm:grid-cols-2"
+        data-testid="system-backups-loaded">
+        <article
+          v-for="job in backup.jobs"
+          :key="job.job"
+          class="rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-800 dark:bg-gray-900"
+          :data-testid="`backup-job-${job.job}`">
+          <div class="flex items-center justify-between gap-3">
+            <h4 class="font-mono text-sm font-semibold text-gray-900 uppercase dark:text-white">
+              {{ job.job }}
+            </h4>
+            <span
+              class="inline-flex rounded px-2 py-0.5 text-xs font-medium"
+              :class="backupBadgeClass(freshnessFor(job))"
+              :data-testid="`backup-freshness-${job.job}`">
+              {{ t(`web.admin.system.backups.freshness.${freshnessFor(job)}`) }}
+            </span>
+          </div>
+
+          <p
+            v-if="!job.configured"
+            class="mt-3 text-sm text-gray-500 dark:text-gray-400">
+            {{ t('web.admin.system.backups.notConfigured') }}
+          </p>
+
+          <div
+            v-else
+            class="mt-3 space-y-3 text-sm">
+            <dl class="grid grid-cols-2 gap-x-4 gap-y-2">
+              <div>
+                <dt class="text-xs text-gray-500 dark:text-gray-400">
+                  {{ t('web.admin.system.backups.latest') }}
+                </dt>
+                <dd
+                  class="mt-0.5 font-mono text-gray-900 dark:text-white"
+                  :title="utcTimestamp(job.latest?.ts ?? null)">
+                  {{ job.latest?.event ?? '—' }} · {{ relativeAge(job.latest?.ts ?? null) }}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-xs text-gray-500 dark:text-gray-400">
+                  {{ t('web.admin.system.backups.lastOk') }}
+                </dt>
+                <dd
+                  class="mt-0.5 font-mono text-gray-900 dark:text-white"
+                  :title="utcTimestamp(job.last_ok?.ts ?? null)">
+                  {{ relativeAge(job.last_ok?.ts ?? null) }}
+                </dd>
+              </div>
+            </dl>
+
+            <div
+              v-if="job.last_ok?.file"
+              class="rounded border border-gray-200 px-3 py-2 text-xs dark:border-gray-700">
+              <span class="text-gray-500 dark:text-gray-400"
+                >{{ t('web.admin.system.backups.artifact') }}:</span
+              >
+              <span class="ml-1 font-mono text-gray-900 dark:text-white">{{
+                artifactName(job.last_ok.file)
+              }}</span>
+              <span class="ml-1 text-gray-500 dark:text-gray-400"
+                >({{ humanBytes(job.last_ok.bytes) }})</span
+              >
+            </div>
+
+            <span
+              v-if="job.latest?.event === 'fail'"
+              class="inline-flex max-w-full items-center gap-1 rounded bg-red-100 px-2 py-1 font-mono text-xs break-all text-red-800 dark:bg-red-900/40 dark:text-red-200"
+              :data-testid="`backup-failure-${job.job}`">
+              {{ job.latest.unit ?? t('web.admin.system.backups.unknownUnit') }}:
+              {{ job.latest.error ?? t('web.admin.system.backups.unknownError') }}
+            </span>
+          </div>
+        </article>
       </div>
     </section>
 
@@ -459,17 +673,21 @@
         <div class="flex flex-wrap items-center gap-3">
           <span
             class="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium"
-            :class="queue.connection.connected
-              ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
-              : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200'"
+            :class="
+              queue.connection.connected
+                ? 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200'
+                : 'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-200'
+            "
             data-testid="queue-connection">
             <OIcon
               collection="heroicons"
               :name="queue.connection.connected ? 'check-circle' : 'x-circle'"
               size="3" />
-            {{ queue.connection.connected
-              ? t('web.admin.system.queue.connected')
-              : t('web.admin.system.queue.disconnected') }}
+            {{
+              queue.connection.connected
+                ? t('web.admin.system.queue.connected')
+                : t('web.admin.system.queue.disconnected')
+            }}
           </span>
           <span
             v-if="queue.connection.host"
@@ -480,12 +698,21 @@
             class="inline-flex rounded px-2 py-0.5 text-xs font-medium"
             :class="healthBadgeClass(queue.worker_health.status)"
             data-testid="queue-health">
-            {{ t(`web.admin.system.queue.health.${queue.worker_health.status}`, queue.worker_health.status) }}
+            {{
+              t(
+                `web.admin.system.queue.health.${queue.worker_health.status}`,
+                queue.worker_health.status
+              )
+            }}
           </span>
           <span
             v-if="queue.worker_health.active_workers !== undefined"
             class="text-xs text-gray-500 dark:text-gray-400">
-            {{ t('web.admin.system.queue.activeWorkers', { count: queue.worker_health.active_workers }) }}
+            {{
+              t('web.admin.system.queue.activeWorkers', {
+                count: queue.worker_health.active_workers,
+              })
+            }}
           </span>
         </div>
 
@@ -627,9 +854,11 @@
               collection="heroicons"
               :name="brand.fell_back_to_default ? 'exclamation-triangle' : 'check-circle'"
               size="3" />
-            {{ brand.fell_back_to_default
-              ? t('web.admin.system.brand.flags.fellBack.danger')
-              : t('web.admin.system.brand.flags.fellBack.ok') }}
+            {{
+              brand.fell_back_to_default
+                ? t('web.admin.system.brand.flags.fellBack.danger')
+                : t('web.admin.system.brand.flags.fellBack.ok')
+            }}
           </span>
           <span
             class="inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-medium"
@@ -639,9 +868,11 @@
               collection="heroicons"
               :name="brand.boot_vs_live_mismatch ? 'exclamation-triangle' : 'check-circle'"
               size="3" />
-            {{ brand.boot_vs_live_mismatch
-              ? t('web.admin.system.brand.flags.mismatch.danger')
-              : t('web.admin.system.brand.flags.mismatch.ok') }}
+            {{
+              brand.boot_vs_live_mismatch
+                ? t('web.admin.system.brand.flags.mismatch.danger')
+                : t('web.admin.system.brand.flags.mismatch.ok')
+            }}
           </span>
         </div>
 
@@ -668,7 +899,8 @@
         <div
           class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
           data-testid="brand-resolution">
-          <h4 class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+          <h4
+            class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
             {{ t('web.admin.system.brand.resolution') }}
           </h4>
           <dl class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
@@ -695,7 +927,8 @@
         <div
           class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
           data-testid="brand-env-config">
-          <h4 class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+          <h4
+            class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
             {{ t('web.admin.system.brand.envVsConfig') }}
           </h4>
           <dl class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
@@ -738,7 +971,8 @@
         <div
           class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900"
           data-testid="brand-roots">
-          <h4 class="border-b border-gray-100 px-5 py-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:border-gray-800 dark:text-gray-400">
+          <h4
+            class="border-b border-gray-100 px-5 py-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:border-gray-800 dark:text-gray-400">
             {{ t('web.admin.system.brand.roots.title') }}
           </h4>
           <DataTable
@@ -758,9 +992,11 @@
                   collection="heroicons"
                   :name="row.exists ? 'check-circle' : 'x-circle'"
                   size="3" />
-                {{ row.exists
-                  ? t('web.admin.system.brand.exists.yes')
-                  : t('web.admin.system.brand.exists.no') }}
+                {{
+                  row.exists
+                    ? t('web.admin.system.brand.exists.yes')
+                    : t('web.admin.system.brand.exists.no')
+                }}
               </span>
             </template>
           </DataTable>
@@ -770,7 +1006,8 @@
         <div
           class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
           data-testid="brand-manifest">
-          <h4 class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+          <h4
+            class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
             {{ t('web.admin.system.brand.manifest.title') }}
           </h4>
           <dl class="grid grid-cols-1 gap-x-6 gap-y-3 sm:grid-cols-2">
@@ -795,9 +1032,11 @@
                     collection="heroicons"
                     :name="brand.manifest.exists ? 'check-circle' : 'x-circle'"
                     size="3" />
-                  {{ brand.manifest.exists
-                    ? t('web.admin.system.brand.exists.yes')
-                    : t('web.admin.system.brand.exists.no') }}
+                  {{
+                    brand.manifest.exists
+                      ? t('web.admin.system.brand.exists.yes')
+                      : t('web.admin.system.brand.exists.no')
+                  }}
                 </span>
               </dd>
             </div>
@@ -830,7 +1069,8 @@
           <div
             class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
             data-testid="brand-absorbed">
-            <h4 class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+            <h4
+              class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
               {{ t('web.admin.system.brand.absorbed') }}
             </h4>
             <div
@@ -874,7 +1114,8 @@
           <div
             class="rounded-lg border border-gray-200 bg-white p-5 shadow-sm dark:border-gray-800 dark:bg-gray-900"
             data-testid="brand-overlay-assets">
-            <h4 class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
+            <h4
+              class="mb-3 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
               {{ t('web.admin.system.brand.overlayAssets') }}
             </h4>
             <div

--- a/src/apps/admin/views/AdminSystem.vue
+++ b/src/apps/admin/views/AdminSystem.vue
@@ -4,7 +4,8 @@
   import { DataTable, JsonViewer, StatCard } from '@/apps/admin/components/kit';
   import type { DataTableColumn } from '@/apps/admin/components/kit';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
-  import type { BackupStatusRecord, QueueMetric } from '@/schemas/api/internal/responses/colonel';
+  import type { QueueMetric } from '@/schemas/api/internal/responses/colonel';
+  import type { BackupStatusResponse } from '@/schemas/api/internal/responses/colonel-system';
   import {
     backupStatusResponseSchema,
     brandDiagnosticsResponseSchema,
@@ -82,12 +83,12 @@
 
   // ---- Backup status (#4276) ------------------------------------------------
 
-  interface BackupJob {
-    job: 'pg' | 'valkey' | 'prune' | 'ship';
-    configured: boolean;
-    latest: BackupStatusRecord | null;
-    last_ok: BackupStatusRecord | null;
-  }
+  /**
+   * One `jobs[]` element, derived from the zod contract (CONTRACT 3) rather
+   * than hand-written so future schema fields cannot silently drift from the
+   * shape this view renders.
+   */
+  type BackupJob = NonNullable<BackupStatusResponse['details']>['jobs'][number];
 
   type BackupFreshness = 'notConfigured' | 'notMonitored' | 'fresh' | 'stale' | 'alarm';
 
@@ -150,6 +151,16 @@
 
   function artifactName(file: string | null): string {
     return file?.split('/').filter(Boolean).pop() ?? '—';
+  }
+
+  /**
+   * Ship's rclone destination for display (contract v0.3.0: "" means not
+   * applicable, null means malformed). Prefer `latest` — on a fail the
+   * operator needs to see where the transfer was headed — falling back to
+   * the last successful run.
+   */
+  function shipRemote(job: BackupJob): string | null {
+    return job.latest?.remote || job.last_ok?.remote || null;
   }
 
   function humanBytes(bytes: string | null): string {
@@ -612,6 +623,30 @@
               <span class="ml-1 text-gray-500 dark:text-gray-400"
                 >({{ humanBytes(job.last_ok.bytes) }})</span
               >
+            </div>
+
+            <div
+              v-if="shipRemote(job)"
+              class="rounded border border-gray-200 px-3 py-2 text-xs dark:border-gray-700"
+              :data-testid="`backup-ship-detail-${job.job}`">
+              <div>
+                <span class="text-gray-500 dark:text-gray-400"
+                  >{{ t('web.admin.system.backups.destination') }}:</span
+                >
+                <span class="ml-1 font-mono break-all text-gray-900 dark:text-white">{{
+                  shipRemote(job)
+                }}</span>
+              </div>
+              <div
+                v-if="job.last_ok?.shipped"
+                class="mt-1 font-mono text-gray-900 dark:text-white">
+                {{
+                  t('web.admin.system.backups.shippedOf', {
+                    shipped: job.last_ok.shipped,
+                    candidates: job.last_ok.candidates || '—',
+                  })
+                }}
+              </div>
             </div>
 
             <span

--- a/src/schemas/api/internal/responses/colonel-system.ts
+++ b/src/schemas/api/internal/responses/colonel-system.ts
@@ -3,9 +3,10 @@
 // Per-resource schema surface for the colonel System screen (ticket #33).
 // Internal-only; consumed by the Vue admin console.
 //
-// The System screen is a READ-ONLY status/info read-out over four endpoints
+// The System screen is a READ-ONLY status/info read-out over five endpoints
 // that ALREADY have frozen response schemas in ./colonel:
 //   - GET /api/colonel/system/database → databaseMetricsResponseSchema
+//   - GET /api/colonel/system/backups  → backupStatusResponseSchema (#4276)
 //   - GET /api/colonel/system/redis    → redisMetricsResponseSchema
 //   - GET /api/colonel/queue           → queueMetricsResponseSchema
 //   - GET /api/colonel/system/brand    → brandDiagnosticsResponseSchema (#3822)
@@ -16,15 +17,17 @@
 // the registry — the schemas themselves live in ./colonel and are untouched.
 
 export {
-  databaseMetricsResponseSchema,
-  redisMetricsResponseSchema,
-  queueMetricsResponseSchema,
+  backupStatusResponseSchema,
   brandDiagnosticsResponseSchema,
+  databaseMetricsResponseSchema,
+  queueMetricsResponseSchema,
+  redisMetricsResponseSchema,
 } from './colonel';
 
 export type {
-  DatabaseMetricsResponse,
-  RedisMetricsResponse,
-  QueueMetricsResponse,
+  BackupStatusResponse,
   BrandDiagnosticsResponse,
+  DatabaseMetricsResponse,
+  QueueMetricsResponse,
+  RedisMetricsResponse,
 } from './colonel';

--- a/src/schemas/api/internal/responses/colonel.ts
+++ b/src/schemas/api/internal/responses/colonel.ts
@@ -173,6 +173,8 @@ export const backupStatusRecordSchema = z.object({
   mode: z.enum(['report', 'delete', '']).nullable(),
   removed: z.string().nullable(),
   candidates: z.string().nullable(),
+  shipped: z.string().nullable(),
+  remote: z.string().nullable(),
   duration_secs: z.string().nullable(),
   error: z.string().nullable(),
   version: z.string().nullable(),

--- a/src/schemas/api/internal/responses/colonel.ts
+++ b/src/schemas/api/internal/responses/colonel.ts
@@ -156,6 +156,43 @@ export const databaseMetricsDetailsSchema = z.object({
 });
 
 /**
+ * One ots-backup status hash, normalized at the API boundary. Invalid external
+ * values become null; empty strings retain their contract meaning of "not
+ * applicable". Timestamps stay numeric so the System screen can compare them
+ * against the response's server-side `timestamp` without a client clock skew.
+ */
+export const backupStatusRecordSchema = z.object({
+  event: z.enum(['start', 'ok', 'fail']).nullable(),
+  ts: z.number().int().nonnegative().nullable(),
+  host: z.string().nullable(),
+  unit: z.string().nullable(),
+  job: z.enum(['pg', 'valkey', 'prune', 'ship']).nullable(),
+  file: z.string().nullable(),
+  bytes: z.string().nullable(),
+  sha256: z.string().nullable(),
+  mode: z.enum(['report', 'delete', '']).nullable(),
+  removed: z.string().nullable(),
+  candidates: z.string().nullable(),
+  duration_secs: z.string().nullable(),
+  error: z.string().nullable(),
+  version: z.string().nullable(),
+  scheduled: z.enum(['enabled', 'disabled', 'unknown']).nullable(),
+});
+
+/** GET /api/colonel/system/backups — fixed known jobs, read-only status. */
+export const backupStatusDetailsSchema = z.object({
+  timestamp: z.number().int().nonnegative(),
+  jobs: z.array(
+    z.object({
+      job: z.enum(['pg', 'valkey', 'prune', 'ship']),
+      configured: z.boolean(),
+      latest: backupStatusRecordSchema.nullable(),
+      last_ok: backupStatusRecordSchema.nullable(),
+    })
+  ),
+});
+
+/**
  * Brand-pack diagnostics response details (#3822).
  *
  * Read-only diagnostic for the running instance's brand-pack resolution, so ops
@@ -826,9 +863,7 @@ export const colonelAvailablePlansResponseSchema = z.object({
 });
 
 export type ColonelAvailablePlan = z.infer<typeof colonelAvailablePlanSchema>;
-export type ColonelAvailablePlansResponse = z.infer<
-  typeof colonelAvailablePlansResponseSchema
->;
+export type ColonelAvailablePlansResponse = z.infer<typeof colonelAvailablePlansResponseSchema>;
 
 // ============================================================================
 // Wrapped response envelopes ({ record, details } across the API envelope).
@@ -865,6 +900,10 @@ export const investigateOrganizationResponseSchema = createApiResponseSchema(
 export const databaseMetricsResponseSchema = createApiResponseSchema(
   z.object({}),
   databaseMetricsDetailsSchema
+);
+export const backupStatusResponseSchema = createApiResponseSchema(
+  z.object({}),
+  backupStatusDetailsSchema
 );
 export const brandDiagnosticsResponseSchema = createApiResponseSchema(
   z.object({}),
@@ -914,6 +953,8 @@ export type CustomDomainsResponse = z.infer<typeof colonelCustomDomainsResponseS
 export type ColonelOrganizationsResponse = z.infer<typeof colonelOrganizationsResponseSchema>;
 export type InvestigateOrganizationResponse = z.infer<typeof investigateOrganizationResponseSchema>;
 export type DatabaseMetricsResponse = z.infer<typeof databaseMetricsResponseSchema>;
+export type BackupStatusRecord = z.infer<typeof backupStatusRecordSchema>;
+export type BackupStatusResponse = z.infer<typeof backupStatusResponseSchema>;
 export type BrandDiagnosticsResponse = z.infer<typeof brandDiagnosticsResponseSchema>;
 export type RedisMetricsResponse = z.infer<typeof redisMetricsResponseSchema>;
 export type BannedIPsResponse = z.infer<typeof bannedIPsResponseSchema>;

--- a/src/schemas/api/internal/responses/registry.ts
+++ b/src/schemas/api/internal/responses/registry.ts
@@ -10,37 +10,35 @@ import { z } from 'zod';
 
 // Colonel (admin) schemas — internal-only
 import {
-  colonelInfoResponseSchema,
-  colonelStatsResponseSchema,
-  colonelUsersResponseSchema,
-  colonelSecretsResponseSchema,
-  colonelCustomDomainsResponseSchema,
-  colonelOrganizationsResponseSchema,
-  investigateOrganizationResponseSchema,
-  databaseMetricsResponseSchema,
-  brandDiagnosticsResponseSchema,
-  redisMetricsResponseSchema,
+  backupStatusResponseSchema,
   bannedIPsResponseSchema,
-  usageExportResponseSchema,
-  queueMetricsResponseSchema,
-  systemSettingsResponseSchema,
+  brandDiagnosticsResponseSchema,
   colonelCheckoutLinkResponseSchema,
+  colonelCustomDomainsResponseSchema,
+  colonelInfoResponseSchema,
+  colonelOrganizationsResponseSchema,
+  colonelSecretsResponseSchema,
+  colonelStatsResponseSchema,
   colonelUserDetailResponseSchema,
   colonelUserMutationResponseSchema,
+  colonelUsersResponseSchema,
+  databaseMetricsResponseSchema,
+  investigateOrganizationResponseSchema,
+  queueMetricsResponseSchema,
+  redisMetricsResponseSchema,
+  systemSettingsResponseSchema,
+  usageExportResponseSchema,
 } from './colonel';
 
 // Colonel (admin) per-resource ack schemas — Phase-2 screens (tickets #30-33)
+import { colonelBanIpResponseSchema, colonelUnbanIpResponseSchema } from './colonel-bannedips';
 import {
-  colonelSecretReceiptResponseSchema,
-  colonelSecretDeleteResponseSchema,
-} from './colonel-secrets';
-import { colonelDomainVerifyResponseSchema } from './colonel-domains';
-import {
-  colonelDomainConfigsResponseSchema,
-  colonelDomainConfigUpsertResponseSchema,
   colonelDomainConfigDeleteResponseSchema,
   colonelDomainConfigsEnsureResponseSchema,
+  colonelDomainConfigsResponseSchema,
+  colonelDomainConfigUpsertResponseSchema,
 } from './colonel-domain-configs';
+import { colonelDomainVerifyResponseSchema } from './colonel-domains';
 import {
   colonelDeleteOrganizationResponseSchema,
   colonelEntitlementOverrideResponseSchema,
@@ -49,65 +47,68 @@ import {
   colonelReconcileOrganizationResponseSchema,
   colonelTransferOrganizationOwnershipResponseSchema,
 } from './colonel-organizations';
-import { colonelBanIpResponseSchema, colonelUnbanIpResponseSchema } from './colonel-bannedips';
+import {
+  colonelSecretDeleteResponseSchema,
+  colonelSecretReceiptResponseSchema,
+} from './colonel-secrets';
 
 // Colonel (admin) per-resource schemas — Phase-3 screens (tickets #40-45).
 // The DLQ console and the rate-limit inspect/reset UI were removed by design
 // review; their envelopes stay registry-only as the OpenAPI contract for the
 // still-live endpoints (list_dlqs.rb declares `response: 'colonelDlqList'`).
-import {
-  colonelSessionsResponseSchema,
-  colonelSessionDetailResponseSchema,
-  colonelSessionDeleteResponseSchema,
-} from './colonel-sessions';
-import {
-  colonelCustomerSessionsResponseSchema,
-  colonelCustomerSessionRevokeResponseSchema,
-  colonelCustomerSessionRevokeAllResponseSchema,
-} from './colonel-customer-sessions';
 import { colonelAccountDiagnosticsResponseSchema } from './colonel-account-diagnostics';
 import {
+  colonelBannerClearResponseSchema,
   colonelBannerResponseSchema,
   colonelBannerSetResponseSchema,
-  colonelBannerClearResponseSchema,
 } from './colonel-banner';
 import {
-  colonelDlqListResponseSchema,
-  colonelDlqMessagesResponseSchema,
-  colonelDlqReplayResponseSchema,
-  colonelDlqPurgeResponseSchema,
-} from './colonel-queue';
+  colonelBillingCatalogResponseSchema,
+  colonelStripeOrganizationsResponseSchema,
+} from './colonel-billing';
 import {
-  colonelDomainsOrphanedResponseSchema,
+  colonelCustomerSessionRevokeAllResponseSchema,
+  colonelCustomerSessionRevokeResponseSchema,
+  colonelCustomerSessionsResponseSchema,
+} from './colonel-customer-sessions';
+import {
+  colonelEmailDeliverabilityEventsResponseSchema,
+  colonelEmailDeliverabilityIngestResponseSchema,
+  colonelEmailDeliverabilityResponseSchema,
+  colonelEmailDeliverabilitySyncResponseSchema,
+  colonelEmailMessagesResponseSchema,
+  colonelEmailProviderStatusResponseSchema,
+  colonelEmailRecipientLookupResponseSchema,
+  colonelEmailSuppressionAddResponseSchema,
+  colonelEmailSuppressionRemoveResponseSchema,
+  colonelEmailSuppressionsResponseSchema,
+} from './colonel-deliverability';
+import {
   colonelDomainProbeResponseSchema,
   colonelDomainRepairResponseSchema,
+  colonelDomainsOrphanedResponseSchema,
   colonelDomainTransferResponseSchema,
 } from './colonel-domaintoolbox';
 import {
   colonelEmailConfigResponseSchema,
-  colonelEmailTemplatesResponseSchema,
   colonelEmailPreviewResponseSchema,
+  colonelEmailTemplatesResponseSchema,
   colonelEmailTestResponseSchema,
   colonelRateLimitersResponseSchema,
   colonelRateLimitInspectResponseSchema,
   colonelRateLimitResetResponseSchema,
 } from './colonel-emailtools';
 import {
-  colonelEmailDeliverabilityResponseSchema,
-  colonelEmailSuppressionsResponseSchema,
-  colonelEmailSuppressionRemoveResponseSchema,
-  colonelEmailSuppressionAddResponseSchema,
-  colonelEmailDeliverabilityEventsResponseSchema,
-  colonelEmailDeliverabilityIngestResponseSchema,
-  colonelEmailDeliverabilitySyncResponseSchema,
-  colonelEmailProviderStatusResponseSchema,
-  colonelEmailRecipientLookupResponseSchema,
-  colonelEmailMessagesResponseSchema,
-} from './colonel-deliverability';
+  colonelDlqListResponseSchema,
+  colonelDlqMessagesResponseSchema,
+  colonelDlqPurgeResponseSchema,
+  colonelDlqReplayResponseSchema,
+} from './colonel-queue';
 import {
-  colonelBillingCatalogResponseSchema,
-  colonelStripeOrganizationsResponseSchema,
-} from './colonel-billing';
+  colonelSessionDeleteResponseSchema,
+  colonelSessionDetailResponseSchema,
+  colonelSessionsResponseSchema,
+} from './colonel-sessions';
 
 // Colonel (admin) observability — audit trail reader + overview trends
 import { colonelAuditEventsResponseSchema } from './colonel-audit';
@@ -115,12 +116,12 @@ import { colonelTrendsResponseSchema } from './colonel-trends';
 
 // Organization schemas — internal-only
 import {
+  memberDeleteResponseSchema,
+  memberResponseSchema,
+  membersResponseSchema,
   organizationResponseSchema,
   organizationsResponseSchema,
   orgDeleteResponseSchema,
-  membersResponseSchema,
-  memberResponseSchema,
-  memberDeleteResponseSchema,
 } from './organizations';
 
 // Account schemas (shared with V2/V3 public APIs)
@@ -134,16 +135,16 @@ import {
 // Domain schemas (shared with V2/V3 public APIs)
 import {
   brandSettingsResponseSchema,
-  customDomainResponseSchema,
   customDomainListResponseSchema,
+  customDomainResponseSchema,
   imagePropsResponseSchema,
   jurisdictionResponseSchema,
 } from '@/schemas/api/v3/responses/domains';
 
 // Auth schemas (shared with V2/V3)
 import {
-  loginResponseSchema,
   createAccountResponseSchema,
+  loginResponseSchema,
   logoutResponseSchema,
   resetPasswordRequestResponseSchema,
   resetPasswordResponseSchema,
@@ -186,6 +187,7 @@ export const responseSchemas = {
   colonelEntitlementOverride: colonelEntitlementOverrideResponseSchema,
   colonelMembershipEntitlementOverride: colonelMembershipEntitlementOverrideResponseSchema,
   databaseMetrics: databaseMetricsResponseSchema,
+  backupStatus: backupStatusResponseSchema,
   brandDiagnostics: brandDiagnosticsResponseSchema,
   redisMetrics: redisMetricsResponseSchema,
   bannedIPs: bannedIPsResponseSchema,

--- a/src/tests/apps/admin/AdminSystem.spec.ts
+++ b/src/tests/apps/admin/AdminSystem.spec.ts
@@ -80,6 +80,8 @@ function backupRecord(overrides: Record<string, unknown> = {}) {
     mode: '',
     removed: '',
     candidates: '',
+    shipped: '',
+    remote: '',
     duration_secs: '15',
     error: '',
     version: '0.2.3',
@@ -162,14 +164,33 @@ function brandPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
+/** A configured ship job row (contract v0.3.0: remote + shipped are ship's fields). */
+function shipRecord(overrides: Record<string, unknown> = {}) {
+  return backupRecord({
+    job: 'ship',
+    unit: 'ots-backup-ship.service',
+    file: '',
+    bytes: '',
+    sha256: '',
+    candidates: '12',
+    shipped: '3',
+    remote: 's3:onetime-eu/backups/',
+    ...overrides,
+  });
+}
+
 /**
  * Route each independent single-GET read-out by URL. `brandOverrides` lets a
- * test flip the brand diagnostic into its mount-race shape without a new mock.
+ * test flip the brand diagnostic into its mount-race shape without a new mock;
+ * `backups` swaps in a bespoke backup payload (e.g. a configured ship job).
  */
-function routeGet(brandOverrides: Record<string, unknown> = {}) {
+function routeGet(
+  brandOverrides: Record<string, unknown> = {},
+  backups: ReturnType<typeof backupPayload> = backupPayload()
+) {
   mockApi.get.mockImplementation((url: string) => {
     if (url === DB_URL) return Promise.resolve({ data: dbPayload() });
-    if (url === BACKUPS_URL) return Promise.resolve({ data: backupPayload() });
+    if (url === BACKUPS_URL) return Promise.resolve({ data: backups });
     if (url === QUEUE_URL) return Promise.resolve({ data: queuePayload() });
     if (url === REDIS_URL) return Promise.resolve({ data: redisPayload() });
     if (url === BRAND_URL) return Promise.resolve({ data: brandPayload(brandOverrides) });
@@ -352,6 +373,55 @@ describe('AdminSystem (read-only status read-out — ticket #33)', () => {
     );
     expect(wrapper.find('[data-testid="backup-freshness-pg"]').text()).toContain(
       'web.admin.system.backups.freshness.alarm'
+    );
+  });
+
+  // Ship publishes no artifact (`file` is always ""), so its card is asserted on
+  // the v0.3.0 destination block instead: remote + shipped-of-candidates.
+  it('renders the ship destination block with the shipped-of-candidates count', async () => {
+    const withShip = backupPayload();
+    withShip.details.jobs[3] = {
+      job: 'ship',
+      configured: true,
+      latest: shipRecord(),
+      last_ok: shipRecord(),
+    };
+    routeGet({}, withShip);
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const detail = wrapper.find('[data-testid="backup-ship-detail-ship"]');
+    expect(detail.exists()).toBe(true);
+    expect(detail.text()).toContain('web.admin.system.backups.destination');
+    expect(detail.text()).toContain('s3:onetime-eu/backups/');
+    expect(detail.text()).toContain('web.admin.system.backups.shippedOf');
+
+    // Non-ship jobs carry remote="" (not applicable) — no destination block.
+    expect(wrapper.find('[data-testid="backup-ship-detail-pg"]').exists()).toBe(false);
+  });
+
+  it('keeps the destination visible on a failed ship run so the operator sees the target', async () => {
+    const failedShip = backupPayload();
+    // Per-property assignment: the fixture's inferred union has no
+    // latest-without-last_ok member. last_ok stays null from the fixture.
+    failedShip.details.jobs[3].configured = true;
+    failedShip.details.jobs[3].latest = shipRecord({
+      event: 'fail',
+      ts: 1_699_999_990,
+      error: 'rclone: connection refused',
+      shipped: '',
+    });
+    routeGet({}, failedShip);
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    const detail = wrapper.find('[data-testid="backup-ship-detail-ship"]');
+    expect(detail.exists()).toBe(true);
+    expect(detail.text()).toContain('s3:onetime-eu/backups/');
+    // No successful run — the shipped-of-candidates line stays hidden.
+    expect(detail.text()).not.toContain('web.admin.system.backups.shippedOf');
+    expect(wrapper.find('[data-testid="backup-failure-ship"]').text()).toContain(
+      'rclone: connection refused'
     );
   });
 

--- a/src/tests/apps/admin/AdminSystem.spec.ts
+++ b/src/tests/apps/admin/AdminSystem.spec.ts
@@ -29,6 +29,7 @@ import { createTestI18n } from '@tests/setup';
 const i18n = createTestI18n();
 
 const DB_URL = '/api/colonel/system/database';
+const BACKUPS_URL = '/api/colonel/system/backups';
 const QUEUE_URL = '/api/colonel/queue';
 const REDIS_URL = '/api/colonel/system/redis';
 const BRAND_URL = '/api/colonel/system/brand';
@@ -62,6 +63,43 @@ function dbPayload() {
         mem_fragmentation_ratio: 1.5,
       },
       model_counts: { customers: 42, secrets: 100, receipts: 50 },
+    },
+  };
+}
+
+function backupRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    event: 'ok',
+    ts: 1_699_999_900,
+    host: 'eu-db-01',
+    unit: 'ots-backup-pg.service',
+    job: 'pg',
+    file: '/var/backups/onetimesecret/pg.sql.gz',
+    bytes: '1048576',
+    sha256: 'a'.repeat(64),
+    mode: '',
+    removed: '',
+    candidates: '',
+    duration_secs: '15',
+    error: '',
+    version: '0.2.3',
+    scheduled: 'enabled',
+    ...overrides,
+  };
+}
+
+function backupPayload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      timestamp: 1_700_000_000,
+      jobs: [
+        { job: 'pg', configured: true, latest: backupRecord(), last_ok: backupRecord() },
+        { job: 'valkey', configured: false, latest: null, last_ok: null },
+        { job: 'prune', configured: false, latest: null, last_ok: null },
+        { job: 'ship', configured: false, latest: null, last_ok: null },
+      ],
     },
   };
 }
@@ -131,6 +169,7 @@ function brandPayload(overrides: Record<string, unknown> = {}) {
 function routeGet(brandOverrides: Record<string, unknown> = {}) {
   mockApi.get.mockImplementation((url: string) => {
     if (url === DB_URL) return Promise.resolve({ data: dbPayload() });
+    if (url === BACKUPS_URL) return Promise.resolve({ data: backupPayload() });
     if (url === QUEUE_URL) return Promise.resolve({ data: queuePayload() });
     if (url === REDIS_URL) return Promise.resolve({ data: redisPayload() });
     if (url === BRAND_URL) return Promise.resolve({ data: brandPayload(brandOverrides) });
@@ -162,18 +201,19 @@ describe('AdminSystem (read-only status read-out — ticket #33)', () => {
   });
   afterEach(() => wrapper?.unmount());
 
-  it('issues the four independent GETs on mount', async () => {
+  it('issues the five independent GETs on mount', async () => {
     routeGet();
     wrapper = mountView(pinia);
     await flushPromises();
 
     expect(mockApi.get).toHaveBeenCalledWith(DB_URL, undefined);
+    expect(mockApi.get).toHaveBeenCalledWith(BACKUPS_URL, undefined);
     expect(mockApi.get).toHaveBeenCalledWith(QUEUE_URL, undefined);
     expect(mockApi.get).toHaveBeenCalledWith(REDIS_URL, undefined);
     expect(mockApi.get).toHaveBeenCalledWith(BRAND_URL, undefined);
   });
 
-  it('renders the loaded database, queue, redis and brand read-outs', async () => {
+  it('renders the loaded database, backup, queue, redis and brand read-outs', async () => {
     routeGet();
     wrapper = mountView(pinia);
     await flushPromises();
@@ -185,6 +225,19 @@ describe('AdminSystem (read-only status read-out — ticket #33)', () => {
     expect(db.text()).toContain('42'); // customers count
     expect(wrapper.find('[data-testid="server-version"]').text()).toContain('8.0.1');
     expect(wrapper.find('[data-testid="system-database-sizes"]').text()).toContain('db0');
+
+    // Backups: latest event + retained last-success artifact, and absent jobs.
+    const backups = wrapper.find('[data-testid="system-backups"]');
+    expect(backups.exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-backups-loaded"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="backup-job-pg"]').text()).toContain('pg.sql.gz');
+    expect(wrapper.find('[data-testid="backup-failure-pg"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="backup-job-valkey"]').text()).toContain(
+      'web.admin.system.backups.notConfigured'
+    );
+    expect(wrapper.find('[data-testid="backup-freshness-pg"]').attributes('class')).toContain(
+      'bg-green-100'
+    );
 
     // Queue: connection host + per-queue row render.
     const queue = wrapper.find('[data-testid="system-queue"]');
@@ -215,6 +268,7 @@ describe('AdminSystem (read-only status read-out — ticket #33)', () => {
     await flushPromises();
 
     expect(wrapper.find('[data-testid="system-database-error"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-backups-error"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="system-queue-error"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="system-redis-error"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="system-redis-json"]').exists()).toBe(false);
@@ -230,9 +284,75 @@ describe('AdminSystem (read-only status read-out — ticket #33)', () => {
     // reflect it. The GET never resolves, so loading persists.
     await flushPromises();
     expect(wrapper.find('[data-testid="system-database-loading"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="system-backups-loading"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="system-queue-loading"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="system-redis-loading"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="system-brand-loading"]').exists()).toBe(true);
+  });
+
+  it('keeps recent last_ok fresh after a failed latest event, but alarms a stale one', async () => {
+    const longError = 'disk full: '.concat('x'.repeat(2_049));
+    const recentFailure = backupPayload();
+    recentFailure.details.jobs[0].latest = backupRecord({
+      event: 'fail',
+      ts: 1_699_999_990,
+      error: longError,
+    });
+    mockApi.get.mockImplementation((url: string) => {
+      if (url === DB_URL) return Promise.resolve({ data: dbPayload() });
+      if (url === BACKUPS_URL) return Promise.resolve({ data: recentFailure });
+      if (url === QUEUE_URL) return Promise.resolve({ data: queuePayload() });
+      if (url === REDIS_URL) return Promise.resolve({ data: redisPayload() });
+      if (url === BRAND_URL) return Promise.resolve({ data: brandPayload() });
+      return Promise.reject(new Error(`unexpected GET ${url}`));
+    });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="backup-freshness-pg"]').attributes('class')).toContain(
+      'bg-green-100'
+    );
+    expect(wrapper.find('[data-testid="backup-failure-pg"]').text()).toContain(longError);
+
+    const staleFailure = backupPayload();
+    staleFailure.details.jobs[0].last_ok = backupRecord({ ts: 1_699_900_000 });
+    mockApi.get.mockImplementation((url: string) => {
+      if (url === DB_URL) return Promise.resolve({ data: dbPayload() });
+      if (url === BACKUPS_URL) return Promise.resolve({ data: staleFailure });
+      if (url === QUEUE_URL) return Promise.resolve({ data: queuePayload() });
+      if (url === REDIS_URL) return Promise.resolve({ data: redisPayload() });
+      if (url === BRAND_URL) return Promise.resolve({ data: brandPayload() });
+      return Promise.reject(new Error(`unexpected GET ${url}`));
+    });
+    wrapper.unmount();
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="backup-freshness-pg"]').attributes('class')).toContain(
+      'bg-red-100'
+    );
+  });
+
+  it('alarms an enabled job when a status timestamp is more than five minutes ahead', async () => {
+    const futureBackup = backupPayload();
+    futureBackup.details.jobs[0].latest = backupRecord({ ts: 1_700_000_301 });
+    mockApi.get.mockImplementation((url: string) => {
+      if (url === DB_URL) return Promise.resolve({ data: dbPayload() });
+      if (url === BACKUPS_URL) return Promise.resolve({ data: futureBackup });
+      if (url === QUEUE_URL) return Promise.resolve({ data: queuePayload() });
+      if (url === REDIS_URL) return Promise.resolve({ data: redisPayload() });
+      if (url === BRAND_URL) return Promise.resolve({ data: brandPayload() });
+      return Promise.reject(new Error(`unexpected GET ${url}`));
+    });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="backup-freshness-pg"]').attributes('class')).toContain(
+      'bg-red-100'
+    );
+    expect(wrapper.find('[data-testid="backup-freshness-pg"]').text()).toContain(
+      'web.admin.system.backups.freshness.alarm'
+    );
   });
 
   // The two danger booleans are the reason #3822 exists — assert they read as

--- a/src/tests/apps/admin/backupStatusSchemas.spec.ts
+++ b/src/tests/apps/admin/backupStatusSchemas.spec.ts
@@ -17,6 +17,8 @@ function record(overrides: Record<string, unknown> = {}) {
     mode: '',
     removed: '',
     candidates: '',
+    shipped: '',
+    remote: '',
     duration_secs: '15',
     error: '',
     version: '0.2.3',
@@ -57,6 +59,48 @@ describe('backup status schema (#4276)', () => {
     malformed.details.jobs[0].last_ok = null;
 
     expect(backupStatusResponseSchema.safeParse(malformed).success).toBe(true);
+  });
+
+  it('accepts a ship record with the v0.3.0 transfer fields, including a legitimate "0"', () => {
+    const withShip = payload();
+    const shipRecord = record({
+      job: 'ship',
+      unit: 'ots-backup-ship.service',
+      file: '',
+      bytes: '',
+      sha256: '',
+      candidates: '12',
+      shipped: '0', // remote already held everything — a real success, not malformed
+      remote: 's3:onetime-eu/backups/',
+    });
+    withShip.details.jobs[3] = {
+      job: 'ship',
+      configured: true,
+      latest: shipRecord,
+      last_ok: shipRecord,
+    };
+
+    const parsed = backupStatusResponseSchema.safeParse(withShip);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.details?.jobs[3].last_ok?.shipped).toBe('0');
+      expect(parsed.data.details?.jobs[3].last_ok?.remote).toBe('s3:onetime-eu/backups/');
+    }
+  });
+
+  it('accepts malformed ship transfer values normalized by the backend to null', () => {
+    const malformed = payload();
+    malformed.details.jobs[0].latest = record({ shipped: null, remote: null });
+
+    expect(backupStatusResponseSchema.safeParse(malformed).success).toBe(true);
+  });
+
+  it('rejects a pre-v0.3.0 record missing the shipped/remote keys', () => {
+    const legacy = payload();
+    const { shipped: _shipped, remote: _remote, ...rest } = record();
+    legacy.details.jobs[0].latest = rest as ReturnType<typeof record>; // deliberate contract drift
+
+    expect(backupStatusResponseSchema.safeParse(legacy).success).toBe(false);
   });
 
   it('rejects a job row without the configured discovery result', () => {

--- a/src/tests/apps/admin/backupStatusSchemas.spec.ts
+++ b/src/tests/apps/admin/backupStatusSchemas.spec.ts
@@ -1,0 +1,69 @@
+// src/tests/apps/admin/backupStatusSchemas.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import { backupStatusResponseSchema } from '@/schemas/api/internal/responses/colonel-system';
+
+function record(overrides: Record<string, unknown> = {}) {
+  return {
+    event: 'ok',
+    ts: 1_700_000_000,
+    host: 'eu-db-01',
+    unit: 'ots-backup-pg.service',
+    job: 'pg',
+    file: '/var/backups/onetimesecret/pg.sql.gz',
+    bytes: '1048576',
+    sha256: 'a'.repeat(64),
+    mode: '',
+    removed: '',
+    candidates: '',
+    duration_secs: '15',
+    error: '',
+    version: '0.2.3',
+    scheduled: 'enabled',
+    ...overrides,
+  };
+}
+
+function payload() {
+  return {
+    shrimp: '',
+    record: {},
+    details: {
+      timestamp: 1_700_000_100,
+      jobs: [
+        { job: 'pg', configured: true, latest: record(), last_ok: record() },
+        { job: 'valkey', configured: false, latest: null, last_ok: null },
+        { job: 'prune', configured: false, latest: null, last_ok: null },
+        { job: 'ship', configured: false, latest: null, last_ok: null },
+      ],
+    },
+  };
+}
+
+describe('backup status schema (#4276)', () => {
+  it('accepts configured and not-configured recognized jobs', () => {
+    const parsed = backupStatusResponseSchema.safeParse(payload());
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.details?.jobs[0].last_ok?.file).toContain('pg.sql.gz');
+      expect(parsed.data.details?.jobs[1]).toMatchObject({ job: 'valkey', configured: false });
+    }
+  });
+
+  it('accepts malformed external values normalized by the backend to null', () => {
+    const malformed = payload();
+    malformed.details.jobs[0].latest = record({ event: null, ts: null, error: null });
+    malformed.details.jobs[0].last_ok = null;
+
+    expect(backupStatusResponseSchema.safeParse(malformed).success).toBe(true);
+  });
+
+  it('rejects a job row without the configured discovery result', () => {
+    const invalid = payload();
+    // @ts-expect-error — deliberate contract drift.
+    delete invalid.details.jobs[0].configured;
+
+    expect(backupStatusResponseSchema.safeParse(invalid).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add a Colonel-only, read-only backup-status endpoint that reads the four known ots-backup job hashes, normalizes external values, and exposes the latest event plus the last verified successful run.
- Add Backup Status to the admin System screen with server-time freshness states, failure details, retry handling, and localized labels.
- Register typed response schemas and cover API normalization, datastore read failures, and the new panel's loading, error, and status views.

## Review guide
- Start with `apps/api/colonel/logic/colonel/get_backup_status.rb` to review the fixed-key reads and untrusted-record sanitization; only a valid `ok` last-success record can affect freshness.
- Review `src/apps/admin/views/AdminSystem.vue` for the 26-hour freshness threshold and future-timestamp alarm behavior. The panel is internal and colonel-authorized; it does not write or scan the datastore.

## Validation
- Pre-commit, pre-push, and CI checks will validate this change.

Resolves #4276