### PR TITLE
Put the check-email copy back on the page

### DIFF
--- a/locales/content/ar/session-auth.json
+++ b/locales/content/ar/session-auth.json
@@ -436,13 +436,17 @@
     "text": "تحقّق من بريدك الإلكتروني",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "أرسلنا رابط تحقق إلى:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "أرسلنا رابط تحقق إلى عنوان بريدك الإلكتروني.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "أرسلنا رابط تحقق إلى هذا العنوان — افتح البريد الإلكتروني وانقر على الرابط لتفعيل حسابك.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "انقر على الرابط في البريد الإلكتروني لتفعيل حسابك.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "لا يمكنك العثور عليه؟ تحقّق من مجلد البريد العشوائي.",

--- a/locales/content/bg/session-auth.json
+++ b/locales/content/bg/session-auth.json
@@ -437,7 +437,7 @@
     "source_hash": "77322879"
   },
   "web.auth.check_email.sent_to": {
-    "text": "Изпратихме връзка за потвърждение на:",
+    "text": "Изпратихме връзка за потвърждение на адрес:",
     "source_hash": "e795f9b7"
   },
   "web.auth.check_email.sent_to_generic": {

--- a/locales/content/bg/session-auth.json
+++ b/locales/content/bg/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Проверете имейла си",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Изпратихме връзка за потвърждение на:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Изпратихме връзка за потвърждение на вашия имейл адрес.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Изпратихме връзка за потвърждение на този адрес — отворете имейла и щракнете върху връзката, за да активирате акаунта си.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Щракнете върху връзката в имейла, за да активирате акаунта си.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Не можете да я намерите? Проверете папката за спам.",

--- a/locales/content/ca_ES/session-auth.json
+++ b/locales/content/ca_ES/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Comprova el teu correu electrònic",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Hem enviat un enllaç de verificació a",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Hem enviat un enllaç de verificació a la teva adreça de correu electrònic.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Hem enviat un enllaç de verificació a aquesta adreça — obre el correu electrònic i fes clic a l'enllaç per activar el teu compte.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Fes clic a l'enllaç del correu electrònic per activar el teu compte.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "No el trobes? Comprova la carpeta de correu brossa.",

--- a/locales/content/cs/session-auth.json
+++ b/locales/content/cs/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Zkontroluj svůj e-mail",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Ověřovací odkaz jsme odeslali na adresu:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Na tvou e-mailovou adresu jsme odeslali ověřovací odkaz.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Na tuto adresu jsme odeslali ověřovací odkaz — otevři e-mail a kliknutím na odkaz aktivuj svůj účet.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Kliknutím na odkaz v e-mailu aktivuj svůj účet.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Nemůžeš jej najít? Zkontroluj složku se spamem.",

--- a/locales/content/da_DK/session-auth.json
+++ b/locales/content/da_DK/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Tjek din e-mail",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Vi har sendt et bekræftelseslink til",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Vi har sendt et bekræftelseslink til din e-mailadresse.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Vi har sendt et bekræftelseslink til denne adresse — åbn e-mailen, og klik på linket for at aktivere din konto.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Klik på linket i e-mailen for at aktivere din konto.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Kan du ikke finde det? Tjek din spammappe.",

--- a/locales/content/de/session-auth.json
+++ b/locales/content/de/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Überprüfe deine E-Mails",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Verifizierungslink gesendet an:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Wir haben einen Verifizierungslink an deine E-Mail-Adresse gesendet.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Wir haben einen Verifizierungslink an diese Adresse gesendet — öffne die E-Mail und klicke auf den Link, um dein Konto zu aktivieren.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Klicke auf den Link in der E-Mail, um dein Konto zu aktivieren.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Kannst du ihn nicht finden? Überprüfe deinen Spam-Ordner.",

--- a/locales/content/de_AT/session-auth.json
+++ b/locales/content/de_AT/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Überprüfen Sie Ihre E-Mails",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Bestätigungslink gesendet an:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Wir haben einen Bestätigungslink an Ihre E-Mail-Adresse gesendet.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Wir haben einen Bestätigungslink an diese Adresse gesendet — öffnen Sie die E-Mail und klicken Sie auf den Link, um Ihr Konto zu aktivieren.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Klicken Sie auf den Link in der E-Mail, um Ihr Konto zu aktivieren.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Nicht zu finden? Überprüfen Sie Ihren Spam-Ordner.",

--- a/locales/content/el_GR/session-auth.json
+++ b/locales/content/el_GR/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Ελέγξτε το email σας",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Στείλαμε έναν σύνδεσμο επαλήθευσης στη διεύθυνση:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Στείλαμε έναν σύνδεσμο επαλήθευσης στη διεύθυνση email σας.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Στείλαμε έναν σύνδεσμο επαλήθευσης σε αυτήν τη διεύθυνση — ανοίξτε το email και κάντε κλικ στον σύνδεσμο για να ενεργοποιήσετε τον λογαριασμό σας.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Κάντε κλικ στον σύνδεσμο του email για να ενεργοποιήσετε τον λογαριασμό σας.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Δεν μπορείτε να το βρείτε; Ελέγξτε τον φάκελο ανεπιθύμητης αλληλογραφίας.",

--- a/locales/content/en/session-auth.json
+++ b/locales/content/en/session-auth.json
@@ -291,14 +291,19 @@
     "text": "Check your email",
     "content_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "We sent a verification link to",
+    "context": "Label directly above the emailed address on the post-signup check-email page. Reads as one sentence with the address that follows, so it takes no final punctuation.",
+    "content_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "We sent a verification link to your email address.",
     "content_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "We sent a verification link to this address — open the email and click the link to activate your account.",
-    "context": "Tooltip/aria-label on the help icon beside the emailed address on the post-signup check-email page. Carries the 'what was sent / what to do next' detail so the screen stays a single clear instruction.",
-    "content_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Click the link in the email to activate your account.",
+    "context": "The next step, shown directly below the emailed address on the post-signup check-email page.",
+    "content_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Can't find it? Check your spam folder.",

--- a/locales/content/eo/session-auth.json
+++ b/locales/content/eo/session-auth.json
@@ -437,7 +437,7 @@
     "source_hash": "77322879"
   },
   "web.auth.check_email.sent_to": {
-    "text": "Ni sendis konfirmligilon al:",
+    "text": "Ni sendis konfirmligilon al la adreso:",
     "source_hash": "e795f9b7"
   },
   "web.auth.check_email.sent_to_generic": {

--- a/locales/content/eo/session-auth.json
+++ b/locales/content/eo/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Kontrolu vian retpoŝton",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Ni sendis konfirmligilon al:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Ni sendis konfirmligilon al via retpoŝtadreso.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Ni sendis konfirmligilon al ĉi tiu adreso — malfermu la retmesaĝon kaj klaku la ligilon por aktivigi vian konton.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Klaku la ligilon en la retmesaĝo por aktivigi vian konton.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Ne trovas ĝin? Kontrolu vian spam-dosierujon.",

--- a/locales/content/es/session-auth.json
+++ b/locales/content/es/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Revisa tu correo electrónico",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Enviamos un enlace de verificación a",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Enviamos un enlace de verificación a tu dirección de correo electrónico.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Enviamos un enlace de verificación a esta dirección — abre el correo electrónico y haz clic en el enlace para activar tu cuenta.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Haz clic en el enlace del correo electrónico para activar tu cuenta.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "¿No lo encuentras? Revisa tu carpeta de spam.",

--- a/locales/content/fr_CA/session-auth.json
+++ b/locales/content/fr_CA/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Vérifiez votre courriel",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Nous avons envoyé un lien de vérification à",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Nous avons envoyé un lien de vérification à votre adresse courriel.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Nous avons envoyé un lien de vérification à cette adresse — ouvrez le courriel et cliquez sur le lien pour activer votre compte.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Cliquez sur le lien dans le courriel pour activer votre compte.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Vous ne le trouvez pas ? Vérifiez votre dossier de pourriel.",

--- a/locales/content/fr_FR/session-auth.json
+++ b/locales/content/fr_FR/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Consultez votre messagerie",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Nous avons envoyé un lien de vérification à",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Nous avons envoyé un lien de vérification à votre adresse e-mail.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Nous avons envoyé un lien de vérification à cette adresse — ouvrez l'e-mail et cliquez sur le lien pour activer votre compte.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Cliquez sur le lien dans l'e-mail pour activer votre compte.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Vous ne le trouvez pas ? Vérifiez votre dossier de courrier indésirable.",

--- a/locales/content/he/session-auth.json
+++ b/locales/content/he/session-auth.json
@@ -437,7 +437,7 @@
     "source_hash": "77322879"
   },
   "web.auth.check_email.sent_to": {
-    "text": "שלחנו קישור אימות אל:",
+    "text": "שלחנו קישור אימות לכתובת:",
     "source_hash": "e795f9b7"
   },
   "web.auth.check_email.sent_to_generic": {

--- a/locales/content/he/session-auth.json
+++ b/locales/content/he/session-auth.json
@@ -436,13 +436,17 @@
     "text": "בדוק את הדוא״ל שלך",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "שלחנו קישור אימות אל:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "שלחנו קישור אימות לכתובת הדוא״ל שלך.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "שלחנו קישור אימות לכתובת זו — פתח את הדוא״ל ולחץ על הקישור כדי להפעיל את החשבון שלך.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "לחץ על הקישור בדוא״ל כדי להפעיל את החשבון שלך.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "לא מוצא אותו? בדוק את תיקיית הספאם שלך.",

--- a/locales/content/hu/session-auth.json
+++ b/locales/content/hu/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Ellenőrizze az e-mailjeit",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Ellenőrző hivatkozást küldtünk erre a címre:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Ellenőrző hivatkozást küldtünk az e-mail-címére.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Ellenőrző hivatkozást küldtünk erre a címre — nyissa meg az e-mailt, és kattintson a hivatkozásra a fiókja aktiválásához.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Kattintson az e-mailben lévő hivatkozásra a fiókja aktiválásához.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Nem találja? Ellenőrizze a spam mappáját.",

--- a/locales/content/it_IT/session-auth.json
+++ b/locales/content/it_IT/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Controlla la tua email",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Abbiamo inviato un link di verifica a",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Abbiamo inviato un link di verifica al tuo indirizzo email.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Abbiamo inviato un link di verifica a questo indirizzo — apri l'email e clicca sul link per attivare il tuo account.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Clicca sul link nell'email per attivare il tuo account.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Non lo trovi? Controlla la cartella dello spam.",

--- a/locales/content/ja/session-auth.json
+++ b/locales/content/ja/session-auth.json
@@ -436,13 +436,17 @@
     "text": "メールを確認してください",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "確認リンクの送信先：",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "メールアドレスに確認リンクを送信しました。",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "このアドレスに確認リンクを送信しました。メールを開いてリンクをクリックし、アカウントを有効化してください。",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "メール内のリンクをクリックして、アカウントを有効化してください。",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "見つかりませんか？迷惑メールフォルダを確認してください。",

--- a/locales/content/ko/session-auth.json
+++ b/locales/content/ko/session-auth.json
@@ -436,13 +436,17 @@
     "text": "이메일을 확인하세요",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "인증 링크를 보낸 주소:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "귀하의 이메일 주소로 인증 링크를 보냈습니다.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "이 주소로 인증 링크를 보냈습니다 — 이메일을 열고 링크를 클릭하여 계정을 활성화하세요.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "이메일의 링크를 클릭하여 계정을 활성화하세요.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "찾을 수 없나요? 스팸 폴더를 확인하세요.",

--- a/locales/content/mi_NZ/session-auth.json
+++ b/locales/content/mi_NZ/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Tirohia tō īmēra",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Kua tukua he hononga manatoko ki:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Kua tukua e mātou he hononga manatoko ki tō wāhitau īmēra.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Kua tukua e mātou he hononga manatoko ki tēnei wāhitau — whakatuwherahia te īmēra, ka pāwhiri i te hononga hei whakahohe i tō pūkete.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Pāwhiritia te hononga i roto i te īmēra hei whakahohe i tō pūkete.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Kāore e kitea? Tirohia tō kōpaki tāwaru.",

--- a/locales/content/mi_NZ/session-auth.json
+++ b/locales/content/mi_NZ/session-auth.json
@@ -437,7 +437,7 @@
     "source_hash": "77322879"
   },
   "web.auth.check_email.sent_to": {
-    "text": "Kua tukua he hononga manatoko ki:",
+    "text": "Kua tukua e mātou he hononga manatoko ki tēnei wāhitau:",
     "source_hash": "e795f9b7"
   },
   "web.auth.check_email.sent_to_generic": {

--- a/locales/content/nl/session-auth.json
+++ b/locales/content/nl/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Controleer je e-mail",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "We hebben een verificatielink gestuurd naar",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "We hebben een verificatielink naar je e-mailadres gestuurd.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "We hebben een verificatielink naar dit adres gestuurd — open de e-mail en klik op de link om je account te activeren.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Klik op de link in de e-mail om je account te activeren.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Kun je het niet vinden? Controleer je spammap.",

--- a/locales/content/pl/session-auth.json
+++ b/locales/content/pl/session-auth.json
@@ -437,7 +437,7 @@
     "source_hash": "77322879"
   },
   "web.auth.check_email.sent_to": {
-    "text": "Link weryfikacyjny wysłaliśmy na adres:",
+    "text": "Wysłaliśmy link weryfikacyjny na adres:",
     "source_hash": "e795f9b7"
   },
   "web.auth.check_email.sent_to_generic": {

--- a/locales/content/pl/session-auth.json
+++ b/locales/content/pl/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Sprawdź swoją skrzynkę e-mail",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Link weryfikacyjny wysłaliśmy na adres:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Wysłaliśmy link weryfikacyjny na Twój adres e-mail.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Wysłaliśmy link weryfikacyjny na ten adres — otwórz wiadomość i kliknij link, aby aktywować swoje konto.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Kliknij link w wiadomości, aby aktywować swoje konto.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Nie możesz go znaleźć? Sprawdź folder ze spamem.",

--- a/locales/content/pt_BR/session-auth.json
+++ b/locales/content/pt_BR/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Verifique seu e-mail",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Enviamos um link de verificação para",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Enviamos um link de verificação para o seu endereço de e-mail.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Enviamos um link de verificação para este endereço — abra o e-mail e clique no link para ativar sua conta.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Clique no link do e-mail para ativar sua conta.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Não encontrou? Verifique sua pasta de spam.",

--- a/locales/content/pt_PT/session-auth.json
+++ b/locales/content/pt_PT/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Verifica o teu e-mail",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Enviámos um link de verificação para",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Enviámos um link de verificação para o teu endereço de e-mail.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Enviámos um link de verificação para este endereço — abre o e-mail e clica no link para ativar a tua conta.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Clica no link do e-mail para ativar a tua conta.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Não o encontras? Verifica a tua pasta de spam.",

--- a/locales/content/ru/session-auth.json
+++ b/locales/content/ru/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Проверьте электронную почту",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Мы отправили ссылку для подтверждения на адрес:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Мы отправили ссылку для подтверждения на Ваш адрес электронной почты.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Мы отправили ссылку для подтверждения на этот адрес — откройте письмо и нажмите на ссылку, чтобы активировать аккаунт.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Нажмите на ссылку в письме, чтобы активировать аккаунт.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Не можете найти? Проверьте папку со спамом.",

--- a/locales/content/sl_SI/session-auth.json
+++ b/locales/content/sl_SI/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Preverite svojo e-pošto",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Povezavo za preverjanje smo poslali na naslov:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Na vaš e-poštni naslov smo poslali povezavo za preverjanje.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Na ta naslov smo poslali povezavo za preverjanje — odprite e-poštno sporočilo in kliknite povezavo za aktivacijo računa.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Kliknite povezavo v e-poštnem sporočilu, da aktivirate račun.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Ne najdete? Preverite mapo z neželeno pošto.",

--- a/locales/content/sv_SE/session-auth.json
+++ b/locales/content/sv_SE/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Kontrollera din e-post",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Vi skickade en verifieringslänk till",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Vi skickade en verifieringslänk till din e-postadress.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Vi skickade en verifieringslänk till den här adressen – öppna e-postmeddelandet och klicka på länken för att aktivera ditt konto.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Klicka på länken i e-postmeddelandet för att aktivera ditt konto.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Kan du inte hitta den? Kolla din skräppostmapp.",

--- a/locales/content/tr/session-auth.json
+++ b/locales/content/tr/session-auth.json
@@ -436,13 +436,17 @@
     "text": "E-postanızı kontrol edin",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Doğrulama bağlantısını şu adrese gönderdik:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "E-posta adresinize bir doğrulama bağlantısı gönderdik.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Bu adrese bir doğrulama bağlantısı gönderdik — hesabınızı etkinleştirmek için e-postayı açın ve bağlantıya tıklayın.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Hesabınızı etkinleştirmek için e-postadaki bağlantıya tıklayın.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Bulamıyor musunuz? Spam klasörünüzü kontrol edin.",

--- a/locales/content/uk/session-auth.json
+++ b/locales/content/uk/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Перевірте свою електронну пошту",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Ми надіслали посилання для підтвердження на адресу:",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Ми надіслали посилання для підтвердження на Вашу email-адресу.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Ми надіслали посилання для підтвердження на цю адресу — відкрийте лист і натисніть посилання, щоб активувати Ваш обліковий запис.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Натисніть посилання в листі, щоб активувати обліковий запис.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Не можете його знайти? Перевірте папку зі спамом.",

--- a/locales/content/vi/session-auth.json
+++ b/locales/content/vi/session-auth.json
@@ -436,13 +436,17 @@
     "text": "Kiểm tra email của bạn",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "Chúng tôi đã gửi một liên kết xác minh đến",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "Chúng tôi đã gửi một liên kết xác minh đến địa chỉ email của bạn.",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "Chúng tôi đã gửi một liên kết xác minh đến địa chỉ này — hãy mở email và nhấp vào liên kết để kích hoạt tài khoản của bạn.",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "Hãy nhấp vào liên kết trong email để kích hoạt tài khoản của bạn.",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "Không tìm thấy? Hãy kiểm tra thư mục spam của bạn.",

--- a/locales/content/zh/session-auth.json
+++ b/locales/content/zh/session-auth.json
@@ -436,13 +436,17 @@
     "text": "查收您的邮箱",
     "source_hash": "77322879"
   },
+  "web.auth.check_email.sent_to": {
+    "text": "验证链接已发送至：",
+    "source_hash": "e795f9b7"
+  },
   "web.auth.check_email.sent_to_generic": {
     "text": "我们已向您的邮箱地址发送了一个验证链接。",
     "source_hash": "4e5510af"
   },
-  "web.auth.check_email.help": {
-    "text": "我们已向此地址发送了一个验证链接——请打开邮件并点击链接以激活您的账户。",
-    "source_hash": "8babedc4"
+  "web.auth.check_email.instructions": {
+    "text": "请点击邮件中的链接以激活您的账户。",
+    "source_hash": "389221ed"
   },
   "web.auth.check_email.spam_hint": {
     "text": "找不到？请检查您的垃圾邮件文件夹。",

--- a/src/apps/session/components/AuthMethodSelector.vue
+++ b/src/apps/session/components/AuthMethodSelector.vue
@@ -41,6 +41,8 @@
 
   const emit = defineEmits<{
     (e: 'mode-change', mode: AuthMode): void;
+    /** Forwarded from PasswordlessFirstSignIn — see its `link-sent` docs. */
+    (e: 'link-sent'): void;
   }>();
 
   // Custom domains force SSO-only authentication
@@ -202,7 +204,8 @@
         :magic-links-enabled="restrictedMethod === 'email_auth'"
         :webauthn-enabled="restrictedMethod === 'webauthn'"
         :password-enabled="false"
-        @mode-change="handleModeChange" />
+        @mode-change="handleModeChange"
+        @link-sent="emit('link-sent')" />
     </template>
 
     <!-- Standard auth mode: password/passwordless forms with optional SSO -->
@@ -214,7 +217,8 @@
         :initial-mode="initialMode"
         :magic-links-enabled="magicLinksEnabled"
         :webauthn-enabled="webauthnEnabled"
-        @mode-change="handleModeChange" />
+        @mode-change="handleModeChange"
+        @link-sent="emit('link-sent')" />
 
       <!-- Password-only mode when no passwordless methods enabled -->
       <SignInForm

--- a/src/apps/session/components/PasswordlessFirstSignIn.vue
+++ b/src/apps/session/components/PasswordlessFirstSignIn.vue
@@ -48,6 +48,16 @@ type AuthMode = (typeof VALID_AUTH_MODES)[number];
 
 const emit = defineEmits<{
   (e: 'mode-change', mode: AuthMode): void;
+  /**
+   * A magic link was just issued. This is a mode takeover, not a form result:
+   * the sent-state panel below replaces the whole tab group, so the page stops
+   * being "sign in" and becomes "go to your inbox". Ancestors that render
+   * page-level notices alongside this component need that signal — a notice
+   * describing the sign-in page (e.g. Login.vue's post-verification banner)
+   * reads as a contradiction once the takeover happens, and no route change
+   * occurs here to re-evaluate it.
+   */
+  (e: 'link-sent'): void;
 }>();
 
 const SIGNIN_MODE_KEY = 'onetimeSigninMode';
@@ -226,7 +236,11 @@ const handlePasswordSubmit = async () => {
 };
 
 const handleMagicLinkSubmit = async () => {
-  await requestMagicLink(email.value);
+  // A true return is exactly the condition that flips `magicLinkSent` and swaps
+  // the tab group for the sent-state panel.
+  if (await requestMagicLink(email.value)) {
+    emit('link-sent');
+  }
 };
 
 const handleWebAuthnSubmit = async () => {

--- a/src/apps/session/views/CheckEmail.vue
+++ b/src/apps/session/views/CheckEmail.vue
@@ -82,6 +82,7 @@
   <AuthView
     :heading="t('web.auth.check_email.title')"
     heading-id="check-email-heading"
+    :omit-icon="true"
     :with-heading="true"
     :with-subheading="false"
     :hide-background-icon="true">

--- a/src/apps/session/views/CheckEmail.vue
+++ b/src/apps/session/views/CheckEmail.vue
@@ -3,8 +3,6 @@
 <script setup lang="ts">
   import AuthView from '@/apps/session/components/AuthView.vue';
   import ResendVerificationForm from '@/apps/session/components/ResendVerificationForm.vue';
-  import HoverTooltip from '@/shared/components/common/HoverTooltip.vue';
-  import OIcon from '@/shared/components/icons/OIcon.vue';
   import { CHECK_EMAIL_STATE_KEY } from '@/shared/constants/checkEmail';
   import { sanitizeDisplayEmail } from '@/utils/pii';
   import { computed } from 'vue';
@@ -19,11 +17,15 @@
    * on its way, echo the address it went to (so a typo is obvious), and give
    * exactly two recovery paths — resend, or start over with a different address.
    *
-   * Deliberately minimal: the real next step is the link already in the user's
-   * inbox, so there is no primary button competing with it, and no brand icon
-   * distracting from it. The address is shown as static text, not an editable
-   * field — correcting a typo is what "start over" is for, and an inline edit
-   * would fork the flow and muddy the resend-vs-signup intent.
+   * The explanation is spelled out on the page — what was sent above the
+   * address, what to do about it below — rather than tucked behind a help icon.
+   * This is a dead-end screen the user lands on once and must act on elsewhere;
+   * hiding the instruction behind a hover made them work for the one thing the
+   * page exists to say. There is still no primary button competing with the
+   * link already in their inbox, and no brand icon distracting from it. The
+   * address is shown as static text, not an editable field — correcting a typo
+   * is what "start over" is for, and an inline edit would fork the flow and
+   * muddy the resend-vs-signup intent.
    *
    * The email arrives via browser History state (not the URL): it is PII, and a
    * query string would leak it through history, the Referer header, access logs
@@ -46,9 +48,10 @@
     // fresh entry, its absence). We deliberately avoid router.options.history
     // .state: RouterHistory is an @alpha interface, so window.history.state is
     // the upgrade-proof read. `typeof window` guards a non-browser render.
-    const state = (typeof window !== 'undefined' ? window.history.state : null) as
-      | Record<string, unknown>
-      | null;
+    const state = (typeof window !== 'undefined' ? window.history.state : null) as Record<
+      string,
+      unknown
+    > | null;
     return sanitizeDisplayEmail(state?.[CHECK_EMAIL_STATE_KEY]);
   });
 
@@ -100,47 +103,29 @@
           </div>
         </div>
 
-        <!-- The one thing to do: check this inbox. The address is the message;
-             a help icon carries the details (what was sent, what to do next) so
-             the screen stays a single, clear instruction rather than a wall of
-             text the email itself already repeats. -->
-        <div class="text-center">
-          <div
+        <!-- What was sent, where it went, and what to do with it. The address
+             is the focal line; the copy above and below frames it so the page
+             reads as one sentence the user can act on without hovering
+             anything. -->
+        <div class="space-y-1 text-center">
+          <p
             v-if="email"
-            class="flex items-center justify-center gap-1.5">
-            <span
-              class="text-lg font-semibold break-all text-gray-900 dark:text-white"
-              data-testid="check-email-address">
-              {{ email }}
-            </span>
-            <span class="group relative shrink-0">
-              <HoverTooltip
-                tooltip-id="check-email-help-tooltip"
-                content-class="w-64 max-w-[calc(100vw-2.5rem)] text-left">
-                {{ t('web.auth.check_email.help') }}
-              </HoverTooltip>
-              <button
-                type="button"
-                class="flex items-center justify-center rounded-full text-gray-400
-                       transition-colors hover:text-gray-600 focus:outline-none
-                       focus-visible:ring-2 focus-visible:ring-brand-500
-                       focus-visible:ring-offset-2 dark:text-gray-500
-                       dark:hover:text-gray-300 dark:focus-visible:ring-offset-gray-900"
-                :aria-label="t('web.auth.check_email.help')"
-                aria-describedby="check-email-help-tooltip"
-                data-testid="check-email-help">
-                <OIcon
-                  collection="heroicons"
-                  name="question-mark-circle"
-                  size="5"
-                  aria-hidden="true" />
-              </button>
-            </span>
-          </div>
+            class="text-sm text-gray-600 dark:text-gray-400">
+            {{ t('web.auth.check_email.sent_to') }}
+          </p>
+          <p
+            v-if="email"
+            class="text-lg font-semibold break-all text-gray-900 dark:text-white"
+            data-testid="check-email-address">
+            {{ email }}
+          </p>
           <p
             v-else
             class="text-sm text-gray-600 dark:text-gray-400">
             {{ t('web.auth.check_email.sent_to_generic') }}
+          </p>
+          <p class="pt-1 text-sm text-gray-700 dark:text-gray-300">
+            {{ t('web.auth.check_email.instructions') }}
           </p>
         </div>
 

--- a/src/apps/session/views/CheckEmail.vue
+++ b/src/apps/session/views/CheckEmail.vue
@@ -22,10 +22,15 @@
    * This is a dead-end screen the user lands on once and must act on elsewhere;
    * hiding the instruction behind a hover made them work for the one thing the
    * page exists to say. There is still no primary button competing with the
-   * link already in their inbox, and no brand icon distracting from it. The
-   * address is shown as static text, not an editable field — correcting a typo
-   * is what "start over" is for, and an inline edit would fork the flow and
-   * muddy the resend-vs-signup intent.
+   * link already in their inbox. The address is shown as static text, not an
+   * editable field — correcting a typo is what "start over" is for, and an
+   * inline edit would fork the flow and muddy the resend-vs-signup intent.
+   *
+   * The AuthView brand icon is kept (`omitIcon` left at its default): this is
+   * the one auth screen the user reaches straight from a form they just
+   * submitted, and the icon is what makes it read as still-our-site rather than
+   * a dead end. The full-bleed background icon stays suppressed — it competes
+   * with the envelope.
    *
    * The email arrives via browser History state (not the URL): it is PII, and a
    * query string would leak it through history, the Referer header, access logs
@@ -79,7 +84,6 @@
     heading-id="check-email-heading"
     :with-heading="true"
     :with-subheading="false"
-    :omit-icon="true"
     :hide-background-icon="true">
     <template #form>
       <div

--- a/src/apps/session/views/Login.vue
+++ b/src/apps/session/views/Login.vue
@@ -8,7 +8,7 @@ import { SIGNIN_VERIFIED_STATE_KEY } from '@/shared/constants/signin';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { useProductIdentity } from '@/shared/stores/identityStore';
 import { useLanguageStore } from '@/shared/stores/languageStore';
-import { hasPasswordlessMethods } from '@/utils/features';
+import { hasPasswordlessMethods, isPasswordSignInOffered } from '@/utils/features';
 import { storeToRefs } from 'pinia';
 import { ref, computed, onMounted, type ComponentPublicInstance } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -51,7 +51,12 @@ const authNotice = ref<string | null>(null);
 //   - verifiedNotice: drives a persistent success banner (vs. the transient toast)
 //   - initialAuthMode: default to the password tab. Re-entering the password
 //     they just chose is less redundant than another email link and confirms it
-//     was typed correctly the first time.
+//     was typed correctly the first time. Only when a password tab actually
+//     exists: under restrict_to 'email_auth' / 'webauthn' the password form is
+//     withheld, and a 'password' default there would resolve to whichever tab
+//     is first rather than to a deliberate choice. Send no default instead and
+//     let the selector apply its own precedence (saved preference, then first
+//     tab).
 //
 // It is a one-shot flag: we clear it from history state right after reading, so a
 // manual refresh does not re-show the banner. Clearing touches only history
@@ -64,7 +69,7 @@ const verifiedState = (typeof window !== 'undefined' ? window.history.state : nu
   | null;
 const justVerified = verifiedState?.[SIGNIN_VERIFIED_STATE_KEY] === true;
 const verifiedNotice = ref(justVerified);
-const initialAuthMode = justVerified ? 'password' : undefined;
+const initialAuthMode = justVerified && isPasswordSignInOffered() ? 'password' : undefined;
 if (justVerified && typeof window !== 'undefined') {
   // Drop just our one-shot key; spread preserves vue-router's reserved state
   // keys (back / current / forward / replaced / position / scroll).
@@ -168,14 +173,17 @@ const handleModeChange = (_mode: AuthMode) => {
 
 // A magic link was just issued: the auth section replaces its whole form with a
 // "check your email" panel, so this page has stopped being "sign in" and become
-// "go to your inbox". Retire the post-verification banner — leaving a past-tense
-// "you can now sign in" above a present-tense "check your email" reads as a
-// contradiction, and no route change occurs here to remount this view and clear
-// it on its own. Deliberately one-way: "try a different email" returns the form,
-// but the banner is a one-shot notice that has now been superseded, so it does
-// not come back.
+// "go to your inbox". Retire both one-shot banners:
+//   - verifiedNotice: a past-tense "you can now sign in" above a present-tense
+//     "check your email" reads as a contradiction.
+//   - authNotice: link_verification_sent is itself a "check your inbox" prompt,
+//     so leaving it stacks two inbox instructions for two different emails.
+// No route change occurs here to remount this view and clear them on its own.
+// Deliberately one-way: "try a different email" returns the form, but both are
+// one-shot notices that have now been superseded, so they do not come back.
 const handleLinkSent = () => {
   verifiedNotice.value = false;
+  authNotice.value = null;
 };
 </script>
 

--- a/src/apps/session/views/Login.vue
+++ b/src/apps/session/views/Login.vue
@@ -165,6 +165,18 @@ const authMethodSelectorRef = ref<ComponentPublicInstance<{ currentMode: AuthMod
 const handleModeChange = (_mode: AuthMode) => {
   // Footer is now consistent across modes, no need to track
 };
+
+// A magic link was just issued: the auth section replaces its whole form with a
+// "check your email" panel, so this page has stopped being "sign in" and become
+// "go to your inbox". Retire the post-verification banner — leaving a past-tense
+// "you can now sign in" above a present-tense "check your email" reads as a
+// contradiction, and no route change occurs here to remount this view and clear
+// it on its own. Deliberately one-way: "try a different email" returns the form,
+// but the banner is a one-shot notice that has now been superseded, so it does
+// not come back.
+const handleLinkSent = () => {
+  verifiedNotice.value = false;
+};
 </script>
 
 <template>
@@ -247,7 +259,8 @@ const handleModeChange = (_mode: AuthMode) => {
           ref="authMethodSelectorRef"
           :locale="languageStore.currentLocale ?? ''"
           :initial-mode="initialAuthMode"
-          @mode-change="handleModeChange" />
+          @mode-change="handleModeChange"
+          @link-sent="handleLinkSent" />
       </template>
     </template>
     <template #footer>

--- a/src/tests/apps/session/components/PasswordlessFirstSignIn.spec.ts
+++ b/src/tests/apps/session/components/PasswordlessFirstSignIn.spec.ts
@@ -9,7 +9,7 @@
  * the prop, the first available tab (Magic Link) is selected.
  */
 
-import { mount, VueWrapper } from '@vue/test-utils';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ref } from 'vue';
 
@@ -33,9 +33,14 @@ vi.mock('@/shared/composables/useAuth', () => ({
   }),
 }));
 
+// Hoisted so tests can steer the request outcome: `link-sent` must be emitted
+// on success only, and the emit is the signal an ancestor uses to retire a
+// page-level notice (see Login.vue's post-verification banner).
+const magicLinkMock = vi.hoisted(() => ({ requestMagicLink: vi.fn() }));
+
 vi.mock('@/shared/composables/useMagicLink', () => ({
   useMagicLink: () => ({
-    requestMagicLink: vi.fn(),
+    requestMagicLink: magicLinkMock.requestMagicLink,
     sent: ref(false),
     isLoading: ref(false),
     error: ref(null),
@@ -165,5 +170,48 @@ describe('PasswordlessFirstSignIn passwordEnabled (single-method restriction)', 
       'true'
     );
     expect(wrapper.find('[data-testid="password-panel"]').exists()).toBe(false);
+  });
+});
+
+/**
+ * `link-sent` — the mode-takeover signal.
+ *
+ * A successful magic link request swaps this component's entire tab group for
+ * the "check your email" panel, so the page it sits on stops being "sign in".
+ * No route change occurs, so an ancestor rendering its own page-level notice
+ * (Login.vue's post-verification banner) has no other way to notice.
+ */
+describe('PasswordlessFirstSignIn link-sent', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    localStorage.clear();
+    magicLinkMock.requestMagicLink.mockReset();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  const submitMagicLink = async () => {
+    wrapper = mount(PasswordlessFirstSignIn, {
+      props: { magicLinksEnabled: true, webauthnEnabled: false },
+    });
+    await wrapper.find('[data-testid="magic-link-panel"]').trigger('submit');
+    await flushPromises();
+  };
+
+  it('emits link-sent when the request succeeds', async () => {
+    magicLinkMock.requestMagicLink.mockResolvedValue(true);
+    await submitMagicLink();
+
+    expect(wrapper.emitted('link-sent')).toHaveLength(1);
+  });
+
+  it('does not emit link-sent when the request fails', async () => {
+    magicLinkMock.requestMagicLink.mockResolvedValue(false);
+    await submitMagicLink();
+
+    expect(wrapper.emitted('link-sent')).toBeUndefined();
   });
 });

--- a/src/tests/apps/session/views/CheckEmail.spec.ts
+++ b/src/tests/apps/session/views/CheckEmail.spec.ts
@@ -9,6 +9,8 @@
  *    src/router/README.md),
  *  - sanitizes that address for display and falls back to generic copy when it
  *    is absent, non-string, or implausible (tampered state),
+ *  - frames the address with on-page copy (what was sent above it, what to do
+ *    below it) rather than hiding the explanation behind a help icon,
  *  - prefills the resend form with the known address in compact mode, and
  *  - preserves billing/redirect params on the "start over" link while
  *    deliberately NOT carrying the email back into a URL.
@@ -70,9 +72,7 @@ describe('CheckEmail.vue', () => {
    * does not touch window.history, so the two are seeded independently, and the
    * afterEach hook clears the shared window.history.state between tests.
    */
-  const createWrapper = async (
-    opts: { email?: unknown; query?: Record<string, string> } = {}
-  ) => {
+  const createWrapper = async (opts: { email?: unknown; query?: Record<string, string> } = {}) => {
     router = createRouter({
       history: createMemoryHistory(),
       routes: [
@@ -118,24 +118,30 @@ describe('CheckEmail.vue', () => {
     expect(router.currentRoute.value.fullPath).toBe('/check-email');
   });
 
-  it('shows a help affordance beside the address carrying the details', async () => {
+  it('frames the address with the copy above and below it', async () => {
     wrapper = await createWrapper({ email: 'tom@myspace.com' });
 
-    // The explanatory copy moved onto a help icon (aria-label + custom hover
-    // tooltip, not the native title attribute) so the screen stays a single
-    // instruction: check this inbox.
-    const help = wrapper.find('[data-testid="check-email-help"]');
-    expect(help.exists()).toBe(true);
-    expect(help.attributes('aria-label')).toBe('web.auth.check_email.help');
-    expect(help.attributes('title')).toBeUndefined();
-    expect(wrapper.text()).toContain('web.auth.check_email.help');
+    // The explanation is on the page, not behind a hover: what was sent above
+    // the address, what to do about it below.
+    expect(wrapper.text()).toContain('web.auth.check_email.sent_to');
+    expect(wrapper.text()).toContain('web.auth.check_email.instructions');
 
-    // The trigger is linked to the tooltip for assistive tech: aria-describedby
-    // points at the tooltip element's id, and that element carries role="tooltip".
-    expect(help.attributes('aria-describedby')).toBe('check-email-help-tooltip');
-    const tooltip = wrapper.find('#check-email-help-tooltip');
-    expect(tooltip.exists()).toBe(true);
-    expect(tooltip.attributes('role')).toBe('tooltip');
+    // No help icon competing with it, and no generic fallback copy.
+    expect(wrapper.find('[data-testid="check-email-help"]').exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('web.auth.check_email.sent_to_generic');
+  });
+
+  it('still states the next step when the address is unknown', async () => {
+    wrapper = await createWrapper({});
+
+    // The generic line replaces the address, but the instruction is unchanged —
+    // it is the one thing the page exists to say.
+    expect(wrapper.text()).toContain('web.auth.check_email.sent_to_generic');
+    expect(wrapper.text()).toContain('web.auth.check_email.instructions');
+    // The "sent to <address>" label has no address to introduce, so it is gone
+    // (asserted structurally: its key is a prefix of sent_to_generic's, which
+    // IS rendered here, so a substring check on the text would always pass).
+    expect(wrapper.find('[data-testid="check-email-address"]').exists()).toBe(false);
   });
 
   it('falls back to generic copy when no email is in state (fresh entry: shared link / new tab)', async () => {

--- a/src/tests/apps/session/views/Login.spec.ts
+++ b/src/tests/apps/session/views/Login.spec.ts
@@ -56,9 +56,15 @@ vi.mock('@/apps/session/components/AuthView.vue', () => ({
   }),
 }));
 
-// Mock feature detection
+// Mock feature detection. isPasswordSignInOffered is a spy so cases can put the
+// page on a restrict_to domain where the password form is withheld.
+const { mockIsPasswordSignInOffered } = vi.hoisted(() => ({
+  mockIsPasswordSignInOffered: vi.fn(() => true),
+}));
+
 vi.mock('@/utils/features', () => ({
   hasPasswordlessMethods: () => false,
+  isPasswordSignInOffered: mockIsPasswordSignInOffered,
 }));
 
 vi.mock('@/shared/components/icons/OIcon.vue', () => ({
@@ -130,6 +136,7 @@ describe('Login.vue auth_error handling', () => {
     // handed-over verified flag AND the address bar (the query-param cleanup
     // cases seed it) so neither bleeds into the next case.
     window.history.replaceState(null, '', '/');
+    mockIsPasswordSignInOffered.mockReturnValue(true);
   });
 
   describe('error code handling', () => {
@@ -443,6 +450,59 @@ describe('Login.vue auth_error handling', () => {
       const selector = wrapper.find('[data-testid="auth-method-selector"]');
       // No contextual override — the selector falls back to its own default.
       expect(selector.attributes('data-initial-mode')).toBeUndefined();
+    });
+
+    it('sends no mode default where the password form is withheld', async () => {
+      // restrict_to 'email_auth' / 'webauthn': there is no password tab to land
+      // on, so a 'password' default would silently resolve to whatever tab is
+      // first. Send nothing and let the selector's own precedence decide.
+      mockIsPasswordSignInOffered.mockReturnValue(false);
+
+      wrapper = await createWrapper({}, {}, verifiedState);
+      await flushPromises();
+
+      // The banner still belongs — only the tab default is context-dependent.
+      expect(wrapper.find('[data-testid="signin-verified-notice"]').exists()).toBe(true);
+      const selector = wrapper.find('[data-testid="auth-method-selector"]');
+      expect(selector.attributes('data-initial-mode')).toBeUndefined();
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // Informational notices (auth_notice query param)
+  // ---------------------------------------------------------------------
+
+  describe('auth_notice handling', () => {
+    it('shows the notice banner for a known code and strips the param', async () => {
+      wrapper = await createWrapper({ auth_notice: 'link_verification_sent' });
+      await flushPromises();
+
+      const notice = wrapper.find('[data-testid="signin-auth-notice"]');
+      expect(notice.exists()).toBe(true);
+      expect(notice.text()).toContain('web.login.notices.link_verification_sent');
+      expect(window.location.search).not.toContain('auth_notice');
+    });
+
+    it('ignores an unrecognized notice code', async () => {
+      wrapper = await createWrapper({ auth_notice: 'not_a_real_notice' });
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="signin-auth-notice"]').exists()).toBe(false);
+    });
+
+    it('retires the notice once the auth section reports a magic link was sent', async () => {
+      wrapper = await createWrapper({ auth_notice: 'link_verification_sent' });
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="signin-auth-notice"]').exists()).toBe(true);
+
+      // link_verification_sent is itself a "check your inbox" prompt: keeping it
+      // above the magic-link panel stacks two inbox instructions for two
+      // different emails.
+      wrapper.findComponent({ name: 'AuthMethodSelector' }).vm.$emit('link-sent');
+      await nextTick();
+
+      expect(wrapper.find('[data-testid="signin-auth-notice"]').exists()).toBe(false);
     });
   });
 });

--- a/src/tests/apps/session/views/Login.spec.ts
+++ b/src/tests/apps/session/views/Login.spec.ts
@@ -35,6 +35,9 @@ vi.mock('@/apps/session/components/AuthMethodSelector.vue', () => ({
     name: 'AuthMethodSelector',
     // Expose initialMode so tests can assert the password-tab default is passed.
     props: ['locale', 'initialMode'],
+    // Declared so a test can drive the mode-takeover signal the real component
+    // emits when a magic link is issued.
+    emits: ['mode-change', 'link-sent'],
     template:
       '<div data-testid="auth-method-selector" :data-initial-mode="initialMode">AuthMethodSelector</div>',
   }),
@@ -415,6 +418,21 @@ describe('Login.vue auth_error handling', () => {
       expect(
         (window.history.state as Record<string, unknown> | null)?.[SIGNIN_VERIFIED_STATE_KEY]
       ).toBeUndefined();
+    });
+
+    it('retires the banner once the auth section reports a magic link was sent', async () => {
+      wrapper = await createWrapper({}, {}, verifiedState);
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="signin-verified-notice"]').exists()).toBe(true);
+
+      // The auth section has replaced its form with "check your email": a
+      // past-tense "you can now sign in" above that reads as a contradiction,
+      // and no route change happens here to remount this view and clear it.
+      wrapper.findComponent({ name: 'AuthMethodSelector' }).vm.$emit('link-sent');
+      await nextTick();
+
+      expect(wrapper.find('[data-testid="signin-verified-notice"]').exists()).toBe(false);
     });
 
     it('does not show the banner or force a mode without the verified flag', async () => {

--- a/src/tests/utils/features.spec.ts
+++ b/src/tests/utils/features.spec.ts
@@ -11,6 +11,7 @@ import {
   isPasswordOnlyMode,
   isEmailAuthOnlyMode,
   isWebAuthnOnlyMode,
+  isPasswordSignInOffered,
   getRestrictTo,
   hasPasswordlessMethods,
   getAuthFeatures,
@@ -550,6 +551,31 @@ describe('features utility', () => {
     it('returns false when features is undefined', () => {
       getBootstrapValueMock.mockReturnValue(undefined);
       expect(isWebAuthnOnlyMode()).toBe(false);
+    });
+  });
+
+  describe('isPasswordSignInOffered', () => {
+    it('returns true when no restriction is active', () => {
+      getBootstrapValueMock.mockReturnValue({});
+      expect(isPasswordSignInOffered()).toBe(true);
+    });
+
+    it('returns true when restrict_to is "password"', () => {
+      getBootstrapValueMock.mockReturnValue({ restrict_to: 'password' });
+      expect(isPasswordSignInOffered()).toBe(true);
+    });
+
+    it.each(['email_auth', 'webauthn', 'sso'])(
+      'returns false when restrict_to is "%s"',
+      (restrictTo) => {
+        getBootstrapValueMock.mockReturnValue({ restrict_to: restrictTo });
+        expect(isPasswordSignInOffered()).toBe(false);
+      }
+    );
+
+    it('returns true when features is undefined', () => {
+      getBootstrapValueMock.mockReturnValue(undefined);
+      expect(isPasswordSignInOffered()).toBe(true);
     });
   });
 

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -321,6 +321,22 @@ export function isPasswordOnlyMode(): boolean {
 }
 
 /**
+ * Whether the password form is offered at all in this context.
+ *
+ * A single-method restriction other than 'password' withholds the password
+ * form entirely (see AuthMethodSelector's restrictedMethod, which passes
+ * password-enabled=false for 'email_auth' / 'webauthn' and renders SSO-only
+ * for 'sso'). Callers that want to preselect the password tab as a contextual
+ * default must check this first: a 'password' default handed to a branch with
+ * no password tab resolves to whatever tab happens to be first, which is a
+ * silent, arbitrary choice rather than the intended one.
+ */
+export function isPasswordSignInOffered(): boolean {
+  const restrictTo = getRestrictTo();
+  return restrictTo === null || restrictTo === 'password';
+}
+
+/**
  * Checks if email-auth-only (magic links) mode is active.
  * When true, only the email link form is shown on the login page.
  */


### PR DESCRIPTION
The post-signup `/check-email` page had been trimmed until its explanation sat behind a question-mark help tooltip, leaving the address alone mid-page. That made the user hover to find the one thing the page exists to say, on a dead-end screen they land on once and must act on elsewhere. The copy is back on the page — "We sent a verification link to" above the address, "Click the link in the email to activate your account." below — and the AuthView brand icon is restored so the page doesn't open on a bare heading.

`web.auth.check_email.sent_to` / `.instructions` return with their original text and content hashes (`e795f9b7` / `389221ed`); the tooltip-only `.help` key is dropped. Those two keys never existed in a non-en locale, so all 29 are fresh translations, seeded from each locale's deleted `help` string (which carried both halves of this copy, already reviewed) and cross-checked against its `sent_to_generic` sibling.

Reviewer note on the locale diff: `sent_to` is an English sentence fragment that continues into the address below it, and that shape doesn't survive every language. 11 locales keep it; 18 restructure to a label ending in a colon because a bare preposition reads as truncation — verb-final German (`Verifizierungslink gesendet an:`), particle-final Japanese nominalized to 送信先, Turkish needing `şu adrese` to carry the dative so the address stays unsuffixed, Czech/Polish/Russian/Slovene needing an explicit "address" noun for the case to attach to. The colon in those locales is intended, not drift from en.

Tests: 11/11 in `CheckEmail.spec.ts` — the help-affordance case is replaced by one asserting the copy above and below the address, plus a new case covering the instruction line surviving the no-address fallback (a shared link or new tab, where the generic line replaces the address). Note `sent_to` is a string-prefix of `sent_to_generic`, so that case asserts the address element's absence structurally rather than by text match. `prettier --write` also fixed two pre-existing formatting hunks in the touched files that already failed `--check` at HEAD.