### PR TITLE
Reject malformed multipart bodies with 400 before params are read

### DIFF
--- a/changelog.d/20260825_230000_claude_4283_malformed_multipart_400.rst
+++ b/changelog.d/20260825_230000_claude_4283_malformed_multipart_400.rst
@@ -1,0 +1,21 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- Malformed ``multipart/form-data`` requests now receive a ``400 Bad
+  Request`` with an explanatory JSON message instead of failing deep in the
+  middleware stack (#4283). Previously an empty or truncated multipart body
+  raised a 500 from the first middleware that read request params, and a
+  multipart Content-Type without a boundary parameter silently produced no
+  form fields — surfacing on ``POST /share`` as a misleading "You did not
+  provide anything to share". Well-formed multipart requests are unaffected;
+  their body is now parsed once, up front, and memoized for the rest of the
+  request.
+
+AI Assistance
+-------------
+
+- AI assistance was used to trace the Sentry error signatures to the
+  middleware-level multipart parse, implement the guard middleware, and add
+  regression coverage.

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -16,6 +16,7 @@ require_relative '../middleware/admin_network_isolation'
 require_relative '../middleware/csrf_response_header'
 require_relative '../middleware/normalize_content_type'
 require_relative '../middleware/retry_after_header'
+require_relative '../middleware/validate_multipart'
 require_relative '../middleware/entitlement_preview_context'
 require_relative '../middleware/session_skip'
 require 'otto'
@@ -575,6 +576,17 @@ module Onetime
           # set text/html before application/x-www-form-urlencoded). See
           # Onetime::Middleware::NormalizeContentType for the rationale.
           builder.use Onetime::Middleware::NormalizeContentType
+
+          # Reject malformed multipart bodies with a 400 before ANYTHING
+          # reads request params (#4283). Downstream, Otto's locale
+          # middleware calls req.params on every request; a broken
+          # multipart body raised from there surfaced as a 500 blamed on
+          # an unrelated in-app frame, and a boundary-less or empty one
+          # quietly produced no params at all. Valid multipart bodies are
+          # parsed and memoized here so no later consumer re-reads the
+          # stream. Must stay after NormalizeContentType (Content-Type
+          # repair) and before Rack::Parser/session/locale.
+          builder.use Onetime::Middleware::ValidateMultipart
           builder.use Rack::Parser, parsers: @parsers
           # Add session middleware early in the stack (before other middleware)
           session_config = Onetime.session_config

--- a/lib/onetime/middleware/validate_multipart.rb
+++ b/lib/onetime/middleware/validate_multipart.rb
@@ -77,11 +77,13 @@ module Onetime
         # RFC 2046 §5.1: the boundary parameter is mandatory. Without one
         # Rack cannot multipart-parse and would instead read the raw body
         # as urlencoded data, producing garbage params. parse_boundary also
-        # raises for boundary parameters Rack refuses (duplicated, folded
-        # whitespace, over 70 chars) — same verdict either way.
+        # raises for boundary parameters Rack refuses (duplicated, or with
+        # whitespace before the equals sign) — same verdict either way.
+        # Rack tags every client-caused parse error with Rack::BadRequest;
+        # rescuing only that keeps genuine internal errors loud.
         boundary = begin
           Rack::Multipart::Parser.parse_boundary(env['CONTENT_TYPE'])
-        rescue StandardError
+        rescue Rack::BadRequest
           nil
         end
         return reject(env, 'Content-Type is missing a valid multipart boundary') if boundary.nil?

--- a/lib/onetime/middleware/validate_multipart.rb
+++ b/lib/onetime/middleware/validate_multipart.rb
@@ -1,0 +1,141 @@
+# lib/onetime/middleware/validate_multipart.rb
+#
+# frozen_string_literal: true
+
+require 'json'
+require 'rack'
+require 'rack/multipart'
+
+module Onetime
+  module Middleware
+    # ValidateMultipart
+    #
+    # Front-stop for malformed multipart request bodies (#4283).
+    #
+    # Rack parses a multipart body the first time ANY consumer calls
+    # Rack::Request#POST — and in this stack the first consumer is not the
+    # route handler but Otto::Locale::Middleware, which reads req.params on
+    # every request to honor ?locale=. That has two bad failure modes for
+    # requests whose multipart body is broken:
+    #
+    #   1. Rack's multipart parser raises (Rack::Multipart::EmptyContentError
+    #      for an empty body with no Content-Length,
+    #      Rack::Multipart::BoundaryTooLongError when the declared boundary
+    #      never appears, EOFError for a body shorter than Content-Length).
+    #      The raise happens inside gem middleware, surfaces as a 500, and
+    #      Sentry blames the nearest in-app frame — historically
+    #      EntitlementPreviewContext#call, which never touches the body at
+    #      all (Sentry issues BACKEND-AD, BACKEND-AR).
+    #
+    #   2. Rack does not raise but quietly parses nothing. A multipart
+    #      Content-Type with no boundary parameter makes
+    #      Rack::Multipart.parse_multipart return nil, and Rack then falls
+    #      back to parsing the raw multipart body as urlencoded — yielding
+    #      garbage params. A Content-Length of 0 short-circuits to the same
+    #      empty result. Either way the handler sees no fields and V1
+    #      /share answers "You did not provide anything to share"
+    #      (BACKEND-AH) for what is really a malformed request.
+    #
+    # Every one of these is a client error, so this middleware answers 400
+    # up front instead of letting the break surface downstream as a 500 or
+    # a misleading form error:
+    #
+    #   - multipart Content-Type without a usable boundary parameter → 400
+    #   - multipart request with Content-Length: 0 → 400
+    #   - body Rack's multipart parser rejects → 400
+    #
+    # A parseable body is parsed HERE, eagerly, via Rack::Request#POST.
+    # That is not extra work: Rack memoizes the result into
+    # env['rack.request.form_hash'] / form_pairs keyed against rack.input,
+    # so the locale middleware, CSRF protection, and the route handler all
+    # read the memoized params without touching the stream again. The
+    # input is rewound afterwards for any downstream consumer that reads
+    # env['rack.input'] directly.
+    #
+    # Mounted after NormalizeContentType (which may repair a comma-joined
+    # Content-Type) and before Rack::Parser, the session, and everything
+    # else that could trigger param parsing.
+    class ValidateMultipart
+      # The media types Rack::Request#POST hands to the multipart parser
+      # (FORM_DATA_MEDIA_TYPES + PARSEABLE_DATA_MEDIA_TYPES). Other
+      # multipart/* subtypes are never body-parsed by Rack and pass through.
+      MULTIPART_TYPES = %w[
+        multipart/form-data
+        multipart/related
+        multipart/mixed
+      ].freeze
+
+      def initialize(app)
+        @app    = app
+        @logger = Onetime.get_logger('ValidateMultipart')
+      end
+
+      def call(env)
+        request = Rack::Request.new(env)
+        return @app.call(env) unless MULTIPART_TYPES.include?(request.media_type)
+
+        # RFC 2046 §5.1: the boundary parameter is mandatory. Without one
+        # Rack cannot multipart-parse and would instead read the raw body
+        # as urlencoded data, producing garbage params. parse_boundary also
+        # raises for boundary parameters Rack refuses (duplicated, folded
+        # whitespace, over 70 chars) — same verdict either way.
+        boundary = begin
+          Rack::Multipart::Parser.parse_boundary(env['CONTENT_TYPE'])
+        rescue StandardError
+          nil
+        end
+        return reject(env, 'Content-Type is missing a valid multipart boundary') if boundary.nil?
+
+        # A zero-length multipart body cannot contain the closing boundary,
+        # let alone a form field. Rack short-circuits it to empty params
+        # (no raise), which downstream misreads as "no secret provided".
+        # Compare via .to_i to mirror Rack::Multipart.parse_multipart, which
+        # also treats a malformed Content-Length value as zero.
+        content_length = env['CONTENT_LENGTH']
+        return reject(env, 'multipart request body is empty') if content_length && content_length.to_i.zero?
+
+        begin
+          # Parse and memoize. EmptyContentError is an EOFError subclass;
+          # every other parser/query error Rack classifies as client-caused
+          # includes the Rack::BadRequest module.
+          request.POST
+        rescue EOFError, Rack::BadRequest
+          return reject(env, 'multipart request body could not be parsed')
+        ensure
+          rewind_input(env)
+        end
+
+        @app.call(env)
+      end
+
+      private
+
+      # The multipart parser consumes rack.input; the parsed params are
+      # memoized in env, but a downstream consumer reading the raw stream
+      # (or re-parsing under a different request object) must see the body
+      # from the start. Rack 3 no longer guarantees rewindability, hence
+      # the respond_to? guard.
+      def rewind_input(env)
+        body = env['rack.input']
+        body.rewind if body.respond_to?(:rewind)
+      end
+
+      def reject(env, reason)
+        @logger.warn 'Rejected malformed multipart request',
+          {
+            reason: reason,
+            path: env['PATH_INFO'],
+            method: env['REQUEST_METHOD'],
+            content_type: env['CONTENT_TYPE'],
+            content_length: env['CONTENT_LENGTH'],
+          }
+
+        [
+          400,
+          { 'Content-Type' => 'application/json' },
+          [JSON.generate({ message: "Invalid multipart request: #{reason}" })],
+        ]
+      end
+    end
+  end
+end

--- a/lib/onetime/middleware/validate_multipart.rb
+++ b/lib/onetime/middleware/validate_multipart.rb
@@ -90,7 +90,11 @@ module Onetime
         # let alone a form field. Rack short-circuits it to empty params
         # (no raise), which downstream misreads as "no secret provided".
         # Compare via .to_i to mirror Rack::Multipart.parse_multipart, which
-        # also treats a malformed Content-Length value as zero.
+        # also treats a malformed Content-Length value as zero — including
+        # an empty string, which is truthy but spec-invalid (Rack SPEC
+        # requires digits-only when the key is present). A body behind such
+        # a header is unreadable through Rack either way, so a 400 here
+        # beats silently dropping every field.
         content_length = env['CONTENT_LENGTH']
         return reject(env, 'multipart request body is empty') if content_length && content_length.to_i.zero?
 

--- a/spec/unit/onetime/application/middleware_manifest_spec.rb
+++ b/spec/unit/onetime/application/middleware_manifest_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe 'Middleware manifest (characterization)' do
       'Onetime::Middleware::AdminNetworkIsolation',
       'Rack::RequestId',
       'Onetime::Middleware::NormalizeContentType',
+      'Onetime::Middleware::ValidateMultipart',
       'Rack::Parser',
       'Onetime::Session',
       'Onetime::Middleware::SessionSkip',

--- a/spec/unit/onetime/middleware/validate_multipart_spec.rb
+++ b/spec/unit/onetime/middleware/validate_multipart_spec.rb
@@ -1,0 +1,226 @@
+# spec/unit/onetime/middleware/validate_multipart_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'stringio'
+require 'onetime/middleware/validate_multipart'
+
+# ValidateMultipart (#4283)
+#
+# The downstream stand-in app reads Rack::Request#params, which is exactly
+# what Otto::Locale::Middleware does on every request — the first param
+# read in the real stack, and the frame the Sentry 500s (BACKEND-AD/AR)
+# were raised from. Each rejection example first shows the raw failure
+# mode against the bare downstream app (the repro), then shows the
+# middleware converting it into a 400.
+RSpec.describe Onetime::Middleware::ValidateMultipart do
+  let(:boundary) { 'AaB03x' }
+
+  let(:downstream) do
+    lambda { |env|
+      params = Rack::Request.new(env).params
+      [200, { 'content-type' => 'application/json' }, [JSON.generate(params)]]
+    }
+  end
+
+  let(:middleware) { described_class.new(downstream) }
+
+  def multipart_body(fields = { 'secret' => 'hello world' })
+    fields.map { |name, value|
+      "--#{boundary}\r\nContent-Disposition: form-data; name=\"#{name}\"\r\n\r\n#{value}\r\n"
+    }.join << "--#{boundary}--\r\n"
+  end
+
+  def env_for(content_type:, body: '', content_length: :auto, method: 'POST')
+    env = {
+      'REQUEST_METHOD' => method,
+      'CONTENT_TYPE' => content_type,
+      'PATH_INFO' => '/share',
+      'QUERY_STRING' => '',
+      'rack.input' => StringIO.new(body.dup),
+    }
+    content_length          = body.bytesize.to_s if content_length == :auto
+    env['CONTENT_LENGTH']   = content_length unless content_length.nil?
+    env
+  end
+
+  def parsed_body(response)
+    JSON.parse(response[2].join)
+  end
+
+  describe 'empty multipart body without Content-Length' do
+    let(:env) do
+      env_for(
+        content_type: "multipart/form-data; boundary=#{boundary}",
+        body: '',
+        content_length: nil,
+      )
+    end
+
+    it 'reproduces: Rack raises EmptyContentError from the first params read' do
+      expect { downstream.call(env) }.to raise_error(Rack::Multipart::EmptyContentError)
+    end
+
+    it 'is rejected with a 400 instead of raising' do
+      status, _headers, _body = middleware.call(env)
+      expect(status).to eq(400)
+    end
+  end
+
+  describe 'declared boundary never appears in the body (BACKEND-AR shape)' do
+    # BOUNDARY_START_LIMIT is 16KB: junk beyond that without the declared
+    # boundary makes the parser give up rather than buffer unboundedly.
+    let(:env) do
+      env_for(
+        content_type: "multipart/form-data; boundary=#{boundary}",
+        body: 'x' * (17 * 1024),
+      )
+    end
+
+    it 'reproduces: Rack raises "multipart boundary not found within limit"' do
+      expect { downstream.call(env) }
+        .to raise_error(Rack::Multipart::BoundaryTooLongError, /boundary not found within limit/)
+    end
+
+    it 'is rejected with a 400 instead of raising' do
+      status, _headers, _body = middleware.call(env)
+      expect(status).to eq(400)
+    end
+  end
+
+  describe 'body shorter than Content-Length' do
+    let(:env) do
+      env_for(
+        content_type: "multipart/form-data; boundary=#{boundary}",
+        body: multipart_body[0, 20],
+        content_length: '4096',
+      )
+    end
+
+    it 'reproduces: Rack raises EOFError for the truncated body' do
+      expect { downstream.call(env) }.to raise_error(EOFError)
+    end
+
+    it 'is rejected with a 400 instead of raising' do
+      status, _headers, _body = middleware.call(env)
+      expect(status).to eq(400)
+    end
+  end
+
+  describe 'multipart Content-Type without a boundary parameter' do
+    let(:env) do
+      env_for(content_type: 'multipart/form-data', body: multipart_body)
+    end
+
+    it 'reproduces: Rack silently parses the multipart body as urlencoded garbage' do
+      response = downstream.call(env)
+      expect(response[0]).to eq(200)
+      # No exception, but no 'secret' field either — the raw multipart
+      # syntax was fed through the urlencoded parser. This is what reached
+      # V1 /share as "You did not provide anything to share" (BACKEND-AH).
+      expect(parsed_body(response)).not_to have_key('secret')
+    end
+
+    it 'is rejected with a 400 and an explanatory message' do
+      status, headers, body = middleware.call(env)
+      expect(status).to eq(400)
+      expect(headers['Content-Type']).to eq('application/json')
+      expect(JSON.parse(body.join)['message']).to match(/boundary/)
+    end
+  end
+
+  describe 'multipart request with Content-Length: 0' do
+    let(:env) do
+      env_for(
+        content_type: "multipart/form-data; boundary=#{boundary}",
+        body: '',
+        content_length: '0',
+      )
+    end
+
+    it 'reproduces: Rack short-circuits to empty params without raising' do
+      response = downstream.call(env)
+      expect(response[0]).to eq(200)
+      expect(parsed_body(response)).to eq({})
+    end
+
+    it 'is rejected with a 400' do
+      status, _headers, _body = middleware.call(env)
+      expect(status).to eq(400)
+    end
+  end
+
+  describe 'a well-formed multipart request' do
+    let(:env) do
+      env_for(
+        content_type: "multipart/form-data; boundary=#{boundary}",
+        body: multipart_body('secret' => 'hello world', 'ttl' => '3600'),
+      )
+    end
+
+    it 'passes through with all fields visible downstream' do
+      status, _headers, _body = response = middleware.call(env)
+      expect(status).to eq(200)
+      expect(parsed_body(response)).to eq('secret' => 'hello world', 'ttl' => '3600')
+    end
+
+    it 'memoizes the parsed params into the env' do
+      middleware.call(env)
+      expect(env['rack.request.form_hash']).to include('secret' => 'hello world')
+    end
+
+    it 'rewinds rack.input before calling downstream' do
+      body_seen = nil
+      probe     = described_class.new(lambda { |e|
+        body_seen = e['rack.input'].read
+        [200, {}, []]
+      })
+
+      probe.call(env)
+
+      expect(body_seen).to eq(multipart_body('secret' => 'hello world', 'ttl' => '3600'))
+    end
+  end
+
+  describe 'non-multipart requests' do
+    it 'does not touch a JSON POST' do
+      env      = env_for(content_type: 'application/json', body: '{"secret":"hi"}')
+      original = env['rack.input']
+
+      # Probe downstream instead of the params-reading app: reading params
+      # is itself what memoizes rack.request.form_hash, so the check for
+      # "middleware did not parse" must happen before any downstream read.
+      parsed_at_entry = nil
+      probe = described_class.new(lambda { |e|
+        parsed_at_entry = e.key?('rack.request.form_hash')
+        [200, {}, []]
+      })
+
+      status, _headers, _body = probe.call(env)
+
+      expect(status).to eq(200)
+      expect(parsed_at_entry).to be(false)
+      expect(env['rack.input']).to equal(original)
+      expect(env['rack.input'].pos).to eq(0)
+    end
+
+    it 'does not touch a GET without a body' do
+      env = {
+        'REQUEST_METHOD' => 'GET',
+        'PATH_INFO' => '/share',
+        'QUERY_STRING' => '',
+        'rack.input' => StringIO.new,
+      }
+      status, _headers, _body = middleware.call(env)
+      expect(status).to eq(200)
+    end
+
+    it 'leaves unparseable multipart subtypes alone' do
+      # Rack never body-parses multipart/alternative, so neither do we.
+      env = env_for(content_type: 'multipart/alternative', body: 'anything')
+      status, _headers, _body = middleware.call(env)
+      expect(status).to eq(200)
+    end
+  end
+end

--- a/spec/unit/onetime/middleware/validate_multipart_spec.rb
+++ b/spec/unit/onetime/middleware/validate_multipart_spec.rb
@@ -151,6 +151,33 @@ RSpec.describe Onetime::Middleware::ValidateMultipart do
     end
   end
 
+  describe 'multipart request with an empty-string Content-Length' do
+    # Spec-invalid (Rack SPEC: digits-only when present), but if a server
+    # ever forwards it, Rack's own parse treats ''.to_i == 0 the same as
+    # an explicit zero and never multipart-parses the body — it falls back
+    # to urlencoded-parsing the raw multipart syntax into garbage params
+    # with no usable fields (the BACKEND-AH shape). Rejecting up front is
+    # the honest answer; passing it through could never succeed.
+    let(:env) do
+      env_for(
+        content_type: "multipart/form-data; boundary=#{boundary}",
+        body: multipart_body,
+        content_length: '',
+      )
+    end
+
+    it 'reproduces: Rack drops every field without raising' do
+      response = downstream.call(env)
+      expect(response[0]).to eq(200)
+      expect(parsed_body(response)).not_to have_key('secret')
+    end
+
+    it 'is rejected with a 400' do
+      status, _headers, _body = middleware.call(env)
+      expect(status).to eq(400)
+    end
+  end
+
   describe 'a well-formed multipart request' do
     let(:env) do
       env_for(

--- a/spec/unit/onetime/middleware/validate_multipart_spec.rb
+++ b/spec/unit/onetime/middleware/validate_multipart_spec.rb
@@ -128,6 +128,17 @@ RSpec.describe Onetime::Middleware::ValidateMultipart do
       expect(headers['Content-Type']).to eq('application/json')
       expect(JSON.parse(body.join)['message']).to match(/boundary/)
     end
+
+    it 'rejects a duplicated boundary parameter with a 400' do
+      # parse_boundary raises (Rack::BadRequest-tagged) rather than
+      # returning nil for boundary parameters Rack refuses outright.
+      dup_env = env_for(
+        content_type: "multipart/form-data; boundary=#{boundary}; boundary=evil",
+        body: multipart_body,
+      )
+      status, _headers, _body = middleware.call(dup_env)
+      expect(status).to eq(400)
+    end
   end
 
   describe 'multipart request with Content-Length: 0' do


### PR DESCRIPTION
## Summary

[#4283](https://github.com/onetimesecret/onetimesecret/issues/4283)

The three Sentry signatures in #4283 share one mechanism, but the culprit frame was a red herring: `EntitlementPreviewContext` never touches the request body — it is just the innermost *in-app* frame above the real reader. The first consumer of request params in the stack is `Otto::Locale::Middleware` (gem code), which calls `req.params` on every request to honor `?locale=`. For multipart POSTs that makes gem middleware the first thing to run Rack's multipart parser, with three failure shapes:

- **BACKEND-AD** — empty multipart body with no `Content-Length` → `Rack::Multipart::EmptyContentError` → 500
- **BACKEND-AR** — declared boundary never appears in the body → `Rack::Multipart::BoundaryTooLongError` ("multipart boundary not found within limit") → 500
- **BACKEND-AH** — multipart Content-Type **without a boundary parameter** (or with `Content-Length: 0`): Rack silently falls back to urlencoded-parsing the raw multipart body, producing garbage/empty params. The request reaches V1 `POST /share` with no `secret` field, and `carefully` reports the resulting "You did not provide anything to share" form error to Sentry.

All of these are client errors. This PR adds `Onetime::Middleware::ValidateMultipart`, mounted in the universal stack after `NormalizeContentType` and before `Rack::Parser`/session/locale — i.e. before anything can trigger a param parse:

- 400 (JSON message) for a multipart Content-Type without a usable boundary parameter (RFC 2046 §5.1 makes it mandatory)
- 400 for a multipart request with `Content-Length: 0`
- 400 for a body Rack's multipart parser rejects (empty, truncated, boundary never found) — rescuing `EOFError` and anything tagged `Rack::BadRequest`
- Valid multipart bodies are parsed eagerly via `Rack::Request#POST`, which Rack memoizes into the env, so the locale middleware, CSRF protection, and route handlers all read the memoized params without touching the stream again; `rack.input` is rewound afterwards for raw-body readers

Well-formed multipart requests (e.g. `curl -F secret=hello`) behave exactly as before — the same parse simply happens one middleware earlier and is memoized. Genuinely empty urlencoded/JSON posts still produce the existing form error; only the malformed-multipart shapes are intercepted.

## Related Issues

Fixes #4283

## Test Plan

- New unit spec `spec/unit/onetime/middleware/validate_multipart_spec.rb`: each rejection case first **reproduces** the raw failure against a downstream app that reads `Rack::Request#params` (exactly what the locale middleware does) — the two 500-raising shapes and the two silent empty-params shapes — then asserts the middleware converts it to a 400. Also covers pass-through with field visibility, env memoization, input rewind, and non-multipart requests being untouched.
- `spec/unit/onetime/application/middleware_manifest_spec.rb` updated for the new mount (characterization spec pins stack order).
- All rejection/pass-through paths additionally verified against the exact locked `rack` version (3.2.7) with a standalone harness during development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BecG3f6AXsCKmv3Vnj8mNt

---
_Generated by [Claude Code](https://claude.ai/code/session_01BecG3f6AXsCKmv3Vnj8mNt)_