### PR TITLE
Filter third-party extension and in-app-webview errors

### DIFF
--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -31,14 +31,14 @@ import {
 import * as SentryVue from '@sentry/vue';
 import type { App, Plugin } from 'vue';
 import type { Router, RouteMeta as VueRouteMeta } from 'vue-router';
-import { applyGroupingRules } from './diagnostics/grouping';
-import { collectValuesToRedact, scrubUrlWithValues } from './diagnostics/urlScrubbing';
 import {
   applyActorContext,
   resolveDiagnosticsRef,
   sanitizeEventUser,
   type ActorContextScope,
 } from './diagnostics/actorContext';
+import { applyGroupingRules } from './diagnostics/grouping';
+import { collectValuesToRedact, scrubUrlWithValues } from './diagnostics/urlScrubbing';
 // Re-export scrubbing utilities from dependency-free module for backward compatibility
 export {
   EMAIL_PATTERN,
@@ -692,13 +692,6 @@ export function createDiagnostics(options: EnableDiagnosticsOptions): Plugin {
     // Only the integrations listed here will be used
     integrations,
 
-    // Third-party noise filtering (#4287), consumed by eventFiltersIntegration.
-    // Secret links are opened from email/chat clients, so extension and
-    // in-app-webview errors are an outsized share of events here.
-    ignoreErrors: THIRD_PARTY_IGNORE_ERRORS,
-    denyUrls: THIRD_PARTY_DENY_URLS,
-    allowUrls: FIRST_PARTY_ALLOW_URLS,
-
     /** Session Replay is disabled. See note above. */
     // replaysSessionSampleRate: 0.1, // Capture 10% of the sessions
     // replaysOnErrorSampleRate: 1.0, // Capture 100% of the errors
@@ -712,6 +705,14 @@ export function createDiagnostics(options: EnableDiagnosticsOptions): Plugin {
     // Scrub sensitive URLs from breadcrumbs at capture time
     beforeBreadcrumb: createBeforeBreadcrumbHandler(router),
     ...config.sentry, // includes dsn, environment, etc.
+
+    // Third-party noise filtering (#4287), consumed by eventFiltersIntegration.
+    // Secret links are opened from email/chat clients, so extension and
+    // in-app-webview errors are an outsized share of events here. Keep these
+    // authoritative if the backend Sentry schema later grows matching fields.
+    ignoreErrors: THIRD_PARTY_IGNORE_ERRORS,
+    denyUrls: THIRD_PARTY_DENY_URLS,
+    allowUrls: FIRST_PARTY_ALLOW_URLS,
 
     // Build-time release takes precedence over backend config.
     // This ensures frontend errors match the sourcemaps uploaded during this build,

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -50,6 +50,72 @@ export {
 
 export const SENTRY_KEY = Symbol('sentry');
 
+/**
+ * Message fingerprints of errors thrown by code that is not ours: browser
+ * extensions, in-app webviews, and email-client link scanners. Secret links
+ * are opened from email and chat clients, so this traffic share is unusually
+ * high here (#4287). Consumed by eventFiltersIntegration via `ignoreErrors`
+ * (matched as substring for strings, test for regexes, against the exception
+ * message). Sentry's own default ignore list stays active alongside these.
+ *
+ * Revisit quarterly — the list will need additions as clients change.
+ *
+ * @internal Exported for testing
+ */
+export const THIRD_PARTY_IGNORE_ERRORS: (string | RegExp)[] = [
+  // Firefox iOS reader-mode script injected at document scope
+  /__firefox__/,
+  // Microsoft Outlook SafeLinks scanning webview; the Id varies per event
+  /Object Not Found Matching Id:\d+/,
+  // Android WebView torn down mid-postMessage (Instagram/Meta in-app browser)
+  'Java object is gone',
+  // Zalo in-app browser injection ("zaloJSV2 is not defined" and
+  // "Can't find variable: zaloJSV2")
+  'zaloJSV2',
+  // iOS webview whose host app never answered the bridge call (DuckDuckGo etc.)
+  'WKWebView API client did not respond to this postMessage',
+  // Chrome extension messaging its unloaded background counterpart
+  'Could not establish connection. Receiving end does not exist',
+  // Extensions redefining built-ins (e.g. Symbol.hasInstance); wording varies
+  // by browser, so match the invariant middle
+  /redefine non-configurable property/,
+];
+
+/**
+ * Frame URLs of third-party code, matched against the topmost stack frame.
+ * Consumed by eventFiltersIntegration via `denyUrls`.
+ *
+ * @internal Exported for testing
+ */
+export const THIRD_PARTY_DENY_URLS: RegExp[] = [
+  /^chrome-extension:\/\//,
+  /^moz-extension:\/\//,
+  /^safari-(web-)?extension:\/\//,
+  // Safari masks extension-injected frame URLs behind this scheme
+  /^webkit-masked-url:\/\//,
+  // Meta in-app browser performance instrumentation
+  /^iabjs:\/\//,
+];
+
+/**
+ * Only report errors whose topmost frame is our own bundle. Every first-party
+ * script is served under /dist/ (production: /dist/assets/*.js via the Vite
+ * manifest, dev: /dist/main.ts — see apps/web/core/views/helpers/
+ * vite_manifest.rb), on canonical and custom domains alike, so this is a
+ * path match rather than an origin match.
+ *
+ * Injected webview/extension code frequently executes at document scope, so
+ * its frames are attributed to the page URL itself (observed: Firefox iOS
+ * reader mode frames at /secret/<key>). Those never match /dist/ and get
+ * dropped. Trade-off, accepted in #4287: errors from the inline theme
+ * bootstrap script in index.rue are attributed to the page URL too and would
+ * be dropped — that script is small and stable. Events with no frame URL at
+ * all (e.g. many unhandled rejections) are NOT dropped by allowUrls.
+ *
+ * @internal Exported for testing
+ */
+export const FIRST_PARTY_ALLOW_URLS: RegExp[] = [/\/dist\//];
+
 // Import functions for local use (patterns are re-exported above for external consumers)
 import {
   scrubQueryStringValues,
@@ -594,6 +660,13 @@ export function createDiagnostics(options: EnableDiagnosticsOptions): Plugin {
 
     // Only the integrations listed here will be used
     integrations,
+
+    // Third-party noise filtering (#4287), consumed by eventFiltersIntegration.
+    // Secret links are opened from email/chat clients, so extension and
+    // in-app-webview errors are an outsized share of events here.
+    ignoreErrors: THIRD_PARTY_IGNORE_ERRORS,
+    denyUrls: THIRD_PARTY_DENY_URLS,
+    allowUrls: FIRST_PARTY_ALLOW_URLS,
 
     /** Session Replay is disabled. See note above. */
     // replaysSessionSampleRate: 0.1, // Capture 10% of the sessions

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -398,6 +398,33 @@ function scrubEventMessages(event: ErrorEvent): ErrorEvent {
 }
 
 /**
+ * Scrubs stack-frame locations through the URL pattern net.
+ *
+ * Code injected by extensions/webviews at document scope gets its frames
+ * attributed to the page URL itself — which on a secret link IS the secret
+ * path. Observed live (FRONTEND-155/154/184): events arrived with
+ * `request.url` correctly `[REDACTED]` while the frame filename carried the
+ * raw `/secret/<62-char-key>` verbatim. Our own bundle frames
+ * (/dist/assets/*.js) contain no sensitive segments and pass through
+ * unchanged, so server-side sourcemap resolution is unaffected.
+ *
+ * Runs in beforeSend, i.e. AFTER eventFiltersIntegration's allow/deny
+ * checks — scrubbing here cannot cause a first-party event to be dropped.
+ */
+function scrubStackFrameUrls(event: ErrorEvent): void {
+  for (const exception of event.exception?.values ?? []) {
+    for (const frame of exception.stacktrace?.frames ?? []) {
+      if (frame.filename) {
+        frame.filename = scrubUrlWithPatterns(frame.filename);
+      }
+      if (frame.abs_path) {
+        frame.abs_path = scrubUrlWithPatterns(frame.abs_path);
+      }
+    }
+  }
+}
+
+/**
  * Creates a Sentry beforeSend handler that scrubs sensitive data from events.
  * Handles both URL scrubbing (route-param based) and message scrubbing (regex-based).
  *
@@ -411,6 +438,10 @@ function createBeforeSendHandler(router: Router) {
 
     // Scrub exception messages and standalone messages (regex-based)
     scrubEventMessages(event);
+
+    // Scrub stack-frame filenames/paths (page-URL-attributed frames can carry
+    // the secret path)
+    scrubStackFrameUrls(event);
 
     // Collect route-param values for the current route (opt-out-governed).
     const sortedValues = collectCurrentRouteValues(router);

--- a/src/tests/plugins/core/diagnostics/beforeSend.spec.ts
+++ b/src/tests/plugins/core/diagnostics/beforeSend.spec.ts
@@ -272,6 +272,21 @@ describe('beforeSend handler', () => {
     });
   });
 
+  describe('third-party noise filter wiring (#4287)', () => {
+    it('passes ignoreErrors, denyUrls and allowUrls to the client options', () => {
+      setupWithRouter({ params: {}, meta: {} });
+      const options = getCapturedClientOptions();
+
+      expect(options?.ignoreErrors).toEqual(
+        expect.arrayContaining(['Java object is gone', 'zaloJSV2'])
+      );
+      expect(Array.isArray(options?.denyUrls)).toBe(true);
+      expect((options?.denyUrls as RegExp[]).length).toBeGreaterThan(0);
+      expect(Array.isArray(options?.allowUrls)).toBe(true);
+      expect((options?.allowUrls as RegExp[]).length).toBeGreaterThan(0);
+    });
+  });
+
   describe('URL scrubbing based on route params', () => {
     it('scrubs request.url using route params', () => {
       setupWithRouter({

--- a/src/tests/plugins/core/diagnostics/beforeSend.spec.ts
+++ b/src/tests/plugins/core/diagnostics/beforeSend.spec.ts
@@ -13,10 +13,10 @@
 // file-level max-classes-per-file rule is disabled here.
 /* eslint-disable max-classes-per-file */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ErrorEvent, TransactionEvent } from '@sentry/core';
-import type { Router, RouteLocationNormalizedLoaded } from 'vue-router';
 import type { RouteMeta } from '@/types/router';
+import type { ErrorEvent, TransactionEvent } from '@sentry/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RouteLocationNormalizedLoaded, Router } from 'vue-router';
 
 // ---------------------------------------------------------------------------
 // Mocks - must use vi.hoisted() for variables used in vi.mock factories
@@ -157,17 +157,20 @@ function getBeforeSend(): (event: ErrorEvent) => ErrorEvent | null {
  * Sets up createDiagnostics with a specific router configuration.
  * Must be called in each test that needs a specific route setup.
  */
-function setupWithRouter(routerConfig: {
-  params: Record<string, string | string[]>;
-  meta: Partial<RouteMeta>;
-  resolve?: (path: string) => unknown;
-  path?: string;
-}): void {
+function setupWithRouter(
+  routerConfig: {
+    params: Record<string, string | string[]>;
+    meta: Partial<RouteMeta>;
+    resolve?: (path: string) => unknown;
+    path?: string;
+  },
+  config = baseConfig
+): void {
   resetCapturedOptions();
   const mockRouter = createMockRouter(routerConfig);
   createDiagnostics({
     host: TEST_HOST,
-    config: baseConfig,
+    config,
     router: mockRouter,
   });
 }
@@ -243,10 +246,7 @@ describe('beforeSend handler', () => {
 
       const event: ErrorEvent = {
         exception: {
-          values: [
-            { value: 'Error for user@example.com' },
-            { value: 'At path /private/xyz789' },
-          ],
+          values: [{ value: 'Error for user@example.com' }, { value: 'At path /private/xyz789' }],
         },
       };
 
@@ -308,6 +308,34 @@ describe('beforeSend handler', () => {
       expect(frame?.abs_path).toBe('https://eu.onetimesecret.com/secret/[REDACTED]');
     });
 
+    it('scrubs frames in every exception of a chained error', () => {
+      setupWithRouter({ params: {}, meta: {} });
+      const handler = getBeforeSend();
+
+      const event: ErrorEvent = {
+        exception: {
+          values: [
+            {
+              value: 'outer error',
+              stacktrace: { frames: [{ filename: '/dist/assets/main.js' }] },
+            },
+            {
+              value: 'root cause',
+              stacktrace: {
+                frames: [{ filename: `/secret/${id62}`, abs_path: `/secret/${id62}` }],
+              },
+            },
+          ],
+        },
+      };
+
+      const result = handler(event) as ErrorEvent;
+      const frame = result.exception?.values?.[1].stacktrace?.frames?.[0];
+
+      expect(frame?.filename).toBe('/secret/[REDACTED]');
+      expect(frame?.abs_path).toBe('/secret/[REDACTED]');
+    });
+
     it('leaves first-party bundle frames untouched (sourcemap resolution)', () => {
       setupWithRouter({ params: {}, meta: {} });
       const handler = getBeforeSend();
@@ -346,17 +374,26 @@ describe('beforeSend handler', () => {
   });
 
   describe('third-party noise filter wiring (#4287)', () => {
-    it('passes ignoreErrors, denyUrls and allowUrls to the client options', () => {
-      setupWithRouter({ params: {}, meta: {} });
+    it('keeps ignoreErrors, denyUrls and allowUrls authoritative over backend config', () => {
+      const configWithFilterFields = {
+        ...baseConfig,
+        sentry: {
+          ...baseConfig.sentry,
+          ignoreErrors: ['backend filter'],
+          denyUrls: [/backend-filter/],
+          allowUrls: [/backend-filter/],
+        },
+      };
+
+      setupWithRouter({ params: {}, meta: {} }, configWithFilterFields);
       const options = getCapturedClientOptions();
 
       expect(options?.ignoreErrors).toEqual(
         expect.arrayContaining(['Java object is gone', 'zaloJSV2'])
       );
-      expect(Array.isArray(options?.denyUrls)).toBe(true);
-      expect((options?.denyUrls as RegExp[]).length).toBeGreaterThan(0);
-      expect(Array.isArray(options?.allowUrls)).toBe(true);
-      expect((options?.allowUrls as RegExp[]).length).toBeGreaterThan(0);
+      expect(options?.ignoreErrors).not.toContain('backend filter');
+      expect(options?.denyUrls).not.toEqual([/backend-filter/]);
+      expect(options?.allowUrls).not.toEqual([/backend-filter/]);
     });
   });
 

--- a/src/tests/plugins/core/diagnostics/beforeSend.spec.ts
+++ b/src/tests/plugins/core/diagnostics/beforeSend.spec.ts
@@ -272,6 +272,79 @@ describe('beforeSend handler', () => {
     });
   });
 
+  describe('stack frame scrubbing', () => {
+    // Code injected at document scope (webviews, extensions, Firefox iOS
+    // reader mode) gets frames attributed to the PAGE URL — on a secret link
+    // that is the secret path itself. Observed live in FRONTEND-155/154/184:
+    // request.url arrived redacted while frame filenames carried the raw key.
+    const id62 = 'abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz';
+
+    it('scrubs secret paths from frame filename and abs_path', () => {
+      setupWithRouter({ params: {}, meta: {} });
+      const handler = getBeforeSend();
+
+      const event: ErrorEvent = {
+        exception: {
+          values: [
+            {
+              value: 'boom',
+              stacktrace: {
+                frames: [
+                  {
+                    filename: `/secret/${id62}`,
+                    abs_path: `https://eu.onetimesecret.com/secret/${id62}`,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      };
+
+      const result = handler(event) as ErrorEvent;
+
+      const frame = result.exception?.values?.[0].stacktrace?.frames?.[0];
+      expect(frame?.filename).toBe('/secret/[REDACTED]');
+      expect(frame?.abs_path).toBe('https://eu.onetimesecret.com/secret/[REDACTED]');
+    });
+
+    it('leaves first-party bundle frames untouched (sourcemap resolution)', () => {
+      setupWithRouter({ params: {}, meta: {} });
+      const handler = getBeforeSend();
+
+      const bundleUrl = 'https://eu.onetimesecret.com/dist/assets/main.BbCc7LVY.js';
+      const event: ErrorEvent = {
+        exception: {
+          values: [
+            {
+              value: 'boom',
+              stacktrace: {
+                frames: [{ filename: '/dist/assets/main.BbCc7LVY.js', abs_path: bundleUrl }],
+              },
+            },
+          ],
+        },
+      };
+
+      const result = handler(event) as ErrorEvent;
+
+      const frame = result.exception?.values?.[0].stacktrace?.frames?.[0];
+      expect(frame?.filename).toBe('/dist/assets/main.BbCc7LVY.js');
+      expect(frame?.abs_path).toBe(bundleUrl);
+    });
+
+    it('tolerates exceptions without stacktraces', () => {
+      setupWithRouter({ params: {}, meta: {} });
+      const handler = getBeforeSend();
+
+      const event: ErrorEvent = {
+        exception: { values: [{ value: 'no stack' }] },
+      };
+
+      expect(() => handler(event)).not.toThrow();
+    });
+  });
+
   describe('third-party noise filter wiring (#4287)', () => {
     it('passes ignoreErrors, denyUrls and allowUrls to the client options', () => {
       setupWithRouter({ params: {}, meta: {} });

--- a/src/tests/plugins/core/diagnostics/noiseFilters.spec.ts
+++ b/src/tests/plugins/core/diagnostics/noiseFilters.spec.ts
@@ -1,0 +1,116 @@
+// src/tests/plugins/core/diagnostics/noiseFilters.spec.ts
+//
+// Tests for the third-party noise filter lists (#4287): ignoreErrors,
+// denyUrls, allowUrls. The message fixtures below are verbatim from live
+// production events (FRONTEND-155, -154, -14J, -183, -180, -16W, -16D,
+// -17Z, -18W) so a pattern edit that stops matching the real-world shape
+// fails here, not in production.
+
+import { describe, expect, it } from 'vitest';
+import {
+  FIRST_PARTY_ALLOW_URLS,
+  THIRD_PARTY_DENY_URLS,
+  THIRD_PARTY_IGNORE_ERRORS,
+} from '@/plugins/core/enableDiagnostics';
+
+/**
+ * Mirrors Sentry's stringMatchesSomePattern semantics used by
+ * eventFiltersIntegration: string patterns are substring matches, regex
+ * patterns are tested. None of our regexes carry the `g` flag (which would
+ * make `.test()` stateful via lastIndex); the guard below enforces that.
+ */
+function matchesSome(value: string, patterns: (string | RegExp)[]): boolean {
+  return patterns.some((pattern) =>
+    typeof pattern === 'string' ? value.includes(pattern) : pattern.test(value)
+  );
+}
+
+describe('THIRD_PARTY_IGNORE_ERRORS', () => {
+  it('has no stateful (g-flagged) regex patterns', () => {
+    for (const pattern of THIRD_PARTY_IGNORE_ERRORS) {
+      if (pattern instanceof RegExp) {
+        expect(pattern.flags).not.toContain('g');
+      }
+    }
+  });
+
+  it.each([
+    // Firefox iOS reader mode (FRONTEND-155, FRONTEND-154)
+    "undefined is not an object (evaluating 'window.__firefox__.reader')",
+    "Can't find variable: __firefox__",
+    // Outlook SafeLinks — the Id number varies per event (FRONTEND-14J)
+    'Non-Error promise rejection captured with value: Object Not Found Matching Id:4, MethodName:update, ParamCount:4',
+    'Object Not Found Matching Id:5, MethodName:update, ParamCount:4',
+    // Android WebView teardown in Meta in-app browsers (FRONTEND-183 et al.)
+    'Error invoking postMessage: Java object is gone',
+    // Zalo in-app browser, both browser wordings (FRONTEND-180, FRONTEND-16W)
+    'zaloJSV2 is not defined',
+    "Can't find variable: zaloJSV2",
+    // iOS webview bridge never answered (FRONTEND-16D)
+    'WKWebView API client did not respond to this postMessage',
+    // Chrome extension messaging an unloaded counterpart (FRONTEND-17Z)
+    'Could not establish connection. Receiving end does not exist.',
+    // Extension redefining built-ins, Firefox wording (FRONTEND-18W)
+    "can't redefine non-configurable property Symbol.hasInstance",
+    // Same defect, Chrome wording
+    'Cannot redefine non-configurable property',
+  ])('matches third-party noise: %s', (message) => {
+    expect(matchesSome(message, THIRD_PARTY_IGNORE_ERRORS)).toBe(true);
+  });
+
+  it.each([
+    // First-party failure shapes must keep reporting
+    'Failed to fetch',
+    'Network Error',
+    'Schema validation failed: bootstrap',
+    'Object Not Found', // without the SafeLinks "Matching Id:N" suffix
+    'postMessage handler threw',
+    "undefined is not an object (evaluating 'secret.value')",
+  ])('does not match first-party errors: %s', (message) => {
+    expect(matchesSome(message, THIRD_PARTY_IGNORE_ERRORS)).toBe(false);
+  });
+});
+
+describe('THIRD_PARTY_DENY_URLS', () => {
+  it.each([
+    'chrome-extension://gighmmpiobklfepjocnamgkkbiglidom/content.js',
+    'moz-extension://5f3c1a2b/inject.js',
+    'safari-extension://com.example/script.js',
+    'safari-web-extension://ABC123/content.js',
+    'webkit-masked-url://hidden/',
+    'iabjs://navigation_performance_logger_android',
+  ])('denies extension/webview scheme: %s', (url) => {
+    expect(matchesSome(url, THIRD_PARTY_DENY_URLS)).toBe(true);
+  });
+
+  it.each([
+    'https://eu.onetimesecret.com/dist/assets/main.BbCc7LVY.js',
+    // Scheme must be anchored at the start: a path merely mentioning an
+    // extension scheme is not extension code
+    'https://eu.onetimesecret.com/docs/chrome-extension://faq',
+  ])('does not deny first-party URLs: %s', (url) => {
+    expect(matchesSome(url, THIRD_PARTY_DENY_URLS)).toBe(false);
+  });
+});
+
+describe('FIRST_PARTY_ALLOW_URLS', () => {
+  it.each([
+    // Production bundle, canonical domain
+    'https://eu.onetimesecret.com/dist/assets/main.BbCc7LVY.js',
+    // Custom domains serve the same bundle path
+    'https://secrets.example.ca/dist/assets/main.BbCc7LVY.js',
+    // Dev server entry (see vite_manifest.rb)
+    'https://dev.onetime.dev/dist/main.ts',
+  ])('allows first-party bundle URL: %s', (url) => {
+    expect(matchesSome(url, FIRST_PARTY_ALLOW_URLS)).toBe(true);
+  });
+
+  it.each([
+    // Injected-at-document-scope code is attributed to the page URL itself
+    'https://eu.onetimesecret.com/secret/abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz',
+    'https://eu.onetimesecret.com/',
+    'chrome-extension://abc/content.js',
+  ])('does not allow non-bundle URL: %s', (url) => {
+    expect(matchesSome(url, FIRST_PARTY_ALLOW_URLS)).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds `ignoreErrors`/`denyUrls`/`allowUrls` to the frontend Sentry config, consumed by the already-present `eventFiltersIntegration`. Secret links are opened from email and chat clients, so extension and in-app-webview noise (Firefox iOS reader mode, Outlook SafeLinks, Instagram/Zalo webviews, extension messaging) is an outsized share of frontend events — 121 across the top three fingerprints. Test fixtures are verbatim from live events, so a pattern edit that stops matching the real-world shape fails in CI.

Also scrubs stack-frame `filename`/`abs_path` through the URL pattern net in `beforeSend`: frames from code injected at document scope are attributed to the page URL, which on a secret-link view is the sensitive path (observed live while `request.url` arrived correctly redacted). Bundle frames pass through unchanged, so sourcemap resolution is unaffected.

Known residuals, deliberately unfiltered: bare `SyntaxError` with all-`<anonymous>` frames, and third-party fetch failures surfacing through our instrumented fetch wrapper — both low-volume, both need the quarterly revisit the issue already plans.

Closes #4287