### PR TITLE
Adjust Renovate update controls

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -12,7 +12,7 @@
 
   // Update control and scheduling
   timezone: 'America/Vancouver',
-  schedule: ['before 5am on Thursday'],
+  schedule: ['before 5am on Sunday'],
   minimumReleaseAge: '14 days',
   separateMinorPatch: false,
   separateMultipleMajor: true,
@@ -28,8 +28,12 @@
   },
 
   // PR management
+  dependencyDashboard: true,
+  dependencyDashboardAutoclose: true,
+  dependencyDashboardLabels: ['auto-update', 'dependencies'],
+  prCreation: 'no-pending',
   prConcurrentLimit: 10,
-  prHourlyLimit: 5,
+  prHourlyLimit: 4,
   labels: ['auto-update'],
   assignees: ['delano'],
   reviewers: [],
@@ -94,9 +98,7 @@
   customManagers: [
     {
       customType: 'regex',
-      fileMatch: [
-        '^\\.github/workflows/(resolved-derive-gate|validate-register)\\.yml$',
-      ],
+      fileMatch: ['^\\.github/workflows/(resolved-derive-gate|validate-register)\\.yml$'],
       matchStrings: [
         // Optional quotes tolerated: the workflows emit the bare form
         // (TRANSLATION_RULES_REF: v0.1.1), but a quoted value ('v0.1.1' or


### PR DESCRIPTION
Tunes Renovate's cadence and PR flow. Weekly run moves from Thursday to Sunday
so dependency PRs land ahead of the week rather than mid-week, and the hourly PR
limit drops 5 → 4.

Enables the dependency dashboard (auto-closing, labelled `auto-update` /
`dependencies`) so pending and rate-limited updates are visible in one issue
instead of being invisible until Renovate gets around to them, and sets
`prCreation: 'no-pending'` so PRs only open once branch status checks settle.

Also collapses the `customManagers` `fileMatch` array onto one line (formatting
only).