### PR TITLE
Accept well-formed BCP 47 locale tags in the frontend locale schema

### DIFF
--- a/changelog.d/20260826_024500_claude_4284_locale_schema_bcp47.rst
+++ b/changelog.d/20260826_024500_claude_4284_locale_schema_bcp47.rst
@@ -1,0 +1,21 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- The frontend locale schema now accepts any well-formed BCP 47 language
+  tag (#4284). Previously it capped tags at 5 characters with an
+  ``xx``/``xx-XX`` regex, rejecting legitimate values browsers actually
+  send — ``en-US-POSIX``, ``zh-Hant-TW``, ``es-419`` — and capturing a
+  Sentry error for each. Validation is now delegated to
+  ``Intl.getCanonicalLocales`` with a 35-character bound, and a
+  malformed visitor locale degrades silently to the supported-locale
+  matching and the default locale instead of being reported as an
+  application error.
+
+AI Assistance
+-------------
+
+- AI assistance was used to trace the Sentry error signatures to the
+  locale schema's length cap, widen validation to real BCP 47, and add
+  regression coverage.

--- a/src/schemas/i18n/locale.ts
+++ b/src/schemas/i18n/locale.ts
@@ -3,16 +3,42 @@
 import { z } from 'zod';
 
 /**
+ * Upper bound for a locale tag. RFC 5646 recommends sizing buffers for
+ * language tags at 35 characters, which covers every registered tag plus
+ * script/region/variant combinations browsers actually send.
+ */
+const MAX_LOCALE_LENGTH = 35;
+
+/**
+ * Whether the tag is structurally well-formed BCP 47 (#4284).
+ *
+ * Delegates to Intl.getCanonicalLocales instead of a hand-rolled regex so
+ * that real-world tags like en-US-POSIX, zh-Hant-TW, and es-419 validate.
+ * Grammar-valid but unassigned tags also pass; that is fine because every
+ * consumer still gates on the supported-locales list before use.
+ * Case is irrelevant (canonicalization normalizes it), and underscores are
+ * treated as hyphens since server-side locales use the it_IT form.
+ */
+function isWellFormedLocale(tag: string): boolean {
+  try {
+    return Intl.getCanonicalLocales(tag.replace(/_/g, '-')).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Validates BCP 47 language tags:
- * - 2-letter language code (en, fr)
- * - Language + region with separator (en_CA, pt-BR, DE-at, eo)
- * Case insensitive.
+ * - language code (en, fr, eo)
+ * - language + region with separator (en_CA, pt-BR, DE-at, es-419)
+ * - language + script and/or variants (zh-Hant-TW, en-US-POSIX)
+ * Case insensitive; accepts both hyphen and underscore separators.
  */
 export const localeCodeSchema = z
   .string()
   .min(2)
-  .max(5)
-  .regex(/^[a-z]{2}(?:[_-][a-z]{2})?$/i, 'Invalid locale format');
+  .max(MAX_LOCALE_LENGTH)
+  .refine(isWellFormedLocale, 'Invalid locale format');
 
 export type Locale = z.infer<typeof localeCodeSchema>;
 

--- a/src/shared/stores/languageStore.ts
+++ b/src/shared/stores/languageStore.ts
@@ -6,7 +6,6 @@ import type { PiniaPluginOptions } from '@/plugins/pinia/types';
 import { localeCodeSchema } from '@/schemas/i18n/locale';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { localeCodes } from '@/sources/languages';
-import { gracefulParse } from '@/utils/schemaValidation';
 import { useApi } from '@/shared/composables/useApi';
 import { defineStore, storeToRefs } from 'pinia';
 import { computed, ref, watch } from 'vue';
@@ -225,8 +224,12 @@ export const useLanguageStore = defineStore('language', () => {
    * validateAndNormalizeLocale('de-CH')  // → 'de' if 'de' available, 'de-CH' otherwise
    */
   const validateAndNormalizeLocale = (locale: string): string => {
-    const localeResult = gracefulParse(localeCodeSchema, locale, 'Locale');
-    const validatedLocale = localeResult.ok ? localeResult.data : locale;
+    // A visitor's locale is untrusted input, not an API contract: malformed
+    // values (mangled Accept-Language, stale stored preferences) are expected
+    // and must degrade to the matching below, never be captured to Sentry
+    // (#4284). Hence safeParse here instead of gracefulParse.
+    const localeResult = localeCodeSchema.safeParse(locale);
+    const validatedLocale = localeResult.success ? localeResult.data : locale;
 
     // Normalize separators for comparison (both hyphen and underscore → underscore)
     const normalizeForComparison = (loc: string) => loc.toLowerCase().replace('-', '_');

--- a/src/shared/stores/languageStore.ts
+++ b/src/shared/stores/languageStore.ts
@@ -231,8 +231,9 @@ export const useLanguageStore = defineStore('language', () => {
     const localeResult = localeCodeSchema.safeParse(locale);
     const validatedLocale = localeResult.success ? localeResult.data : locale;
 
-    // Normalize separators for comparison (both hyphen and underscore → underscore)
-    const normalizeForComparison = (loc: string) => loc.toLowerCase().replace('-', '_');
+    // Normalize separators for comparison (both hyphen and underscore → underscore).
+    // Global replace: BCP 47 tags can carry multiple hyphens (zh-Hant-TW).
+    const normalizeForComparison = (loc: string) => loc.toLowerCase().replaceAll('-', '_');
 
     // Strategy 1: Find exact match (case-insensitive, separator-agnostic)
     // Handles: it-IT → it_IT, IT_IT → it_IT, fr-CA → fr_CA

--- a/src/tests/schemas/i18n/locale.spec.ts
+++ b/src/tests/schemas/i18n/locale.spec.ts
@@ -1,0 +1,57 @@
+// src/tests/schemas/i18n/locale.spec.ts
+//
+// Unit tests for localeCodeSchema (#4284): the schema must accept every
+// well-formed BCP 47 tag browsers actually send, not just xx / xx-XX. The
+// supported-locales gate lives in languageStore, not here — this schema only
+// answers "is this a locale-shaped string at all".
+
+import { describe, expect, it } from 'vitest';
+import { localeCodeSchema } from '@/schemas/i18n/locale';
+
+describe('localeCodeSchema', () => {
+  describe('accepts well-formed BCP 47 tags', () => {
+    it.each([
+      'en',
+      'fr',
+      'eo',
+      'en-CA',
+      'pt-BR',
+      'DE-at', // case-insensitive
+      'it_IT', // server-side underscore form
+      'IT_IT',
+      'es-419', // UN M.49 region (#4284)
+      'zh-Hant-TW', // script subtag (#4284)
+      'en-US-POSIX', // variant subtag (#4284)
+      'sr-Cyrl-RS',
+      'de-DE-u-co-phonebk', // extension subtags survive canonicalization
+    ])('%s', (tag) => {
+      const result = localeCodeSchema.safeParse(tag);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('rejects malformed input', () => {
+    it.each([
+      '', // too short
+      'e', // too short
+      'invalid!', // illegal character
+      'en US', // space is not a separator
+      'a-DE', // one-letter primary subtag is not a language
+      '123', // digits are not a language subtag
+      'en-', // dangling separator
+      'abcdefghij-US', // primary subtag over 8 chars
+      'en-US-'.repeat(10), // over the 35-char bound
+    ])('%s', (tag) => {
+      const result = localeCodeSchema.safeParse(tag);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  it('does not transform the input value', () => {
+    // Consumers (languageStore, brand settings) rely on getting back the
+    // exact string they passed in; normalization to the server's it_IT
+    // format happens in validateAndNormalizeLocale, not in the schema.
+    expect(localeCodeSchema.parse('it_IT')).toBe('it_IT');
+    expect(localeCodeSchema.parse('zh-Hant-TW')).toBe('zh-Hant-TW');
+  });
+});

--- a/src/tests/stores/languageStore.spec.ts
+++ b/src/tests/stores/languageStore.spec.ts
@@ -297,6 +297,27 @@ describe('Language Store', () => {
       // 'ja' not in supportedLocales
       await expect(store.updateLanguage('ja')).rejects.toThrow('Unsupported locale: ja');
     });
+
+    // #4284: tags longer than xx-XX are valid BCP 47 and must fall back to
+    // the primary language instead of failing schema validation.
+    it('should fall back to primary language for script subtags (it-Latn-IT -> it_IT)', () => {
+      store.setCurrentLocale('it-Latn-IT');
+      expect(store.currentLocale).toBe('it_IT');
+    });
+
+    it('should fall back to primary language for variant subtags (en-US-POSIX -> en)', () => {
+      store.setCurrentLocale('en-US-POSIX');
+      expect(store.currentLocale).toBe('en');
+    });
+
+    it('should initialize with default locale when deviceLocale is garbage', () => {
+      vi.spyOn(sessionStorage, 'getItem').mockReturnValue(null);
+
+      const freshStore = useLanguageStore();
+      freshStore.$reset();
+      const result = freshStore.init({ deviceLocale: '!!not-a-locale!!' });
+      expect(result).toBe('en');
+    });
   });
 
   describe('Language Headers', () => {

--- a/src/tests/stores/languageStore.spec.ts
+++ b/src/tests/stores/languageStore.spec.ts
@@ -300,6 +300,13 @@ describe('Language Store', () => {
 
     // #4284: tags longer than xx-XX are valid BCP 47 and must fall back to
     // the primary language instead of failing schema validation.
+    it('should exact-match multi-hyphen tags against supported locales (zh-Hant-TW -> zh_Hant_TW)', () => {
+      // All hyphens must normalize for comparison, not just the first one.
+      store.supportedLocales = ['en', 'zh_Hant_TW'];
+      store.setCurrentLocale('zh-Hant-TW');
+      expect(store.currentLocale).toBe('zh_Hant_TW');
+    });
+
     it('should fall back to primary language for script subtags (it-Latn-IT -> it_IT)', () => {
       store.setCurrentLocale('it-Latn-IT');
       expect(store.currentLocale).toBe('it_IT');


### PR DESCRIPTION
## Summary

[#4284](https://github.com/onetimesecret/onetimesecret/issues/4284)

The `Locale` schema capped tags at 5 characters with an `xx`/`xx-XX` regex, rejecting legitimate tags browsers actually send (`en-US-POSIX`, `zh-Hant-TW`, `es-419`) and capturing 1,100+ Sentry events, re-split into a new issue on every frontend build.

- **Widen `localeCodeSchema` to real BCP 47**: length ≤ 35 (RFC 5646's recommended buffer size), validated via `Intl.getCanonicalLocales` instead of the hand-rolled regex. Underscores are treated as hyphens so the server's `it_IT` form still validates; canonicalization makes matching case-insensitive. Grammar-valid but unassigned tags pass the schema — every consumer still gates on the supported-locales list before use.
- **Stop capturing bad visitor locales to Sentry**: `validateAndNormalizeLocale` in `languageStore` now uses a plain `safeParse` instead of `gracefulParse`. A malformed locale (mangled `Accept-Language`, stale stored preference) is expected input, not a broken API contract; it degrades through the existing supported-locale matching to the default locale, exactly as before, but silently.
- The per-build re-splitting called out in the issue is already handled by the explicit schema-validation grouping rule in `src/plugins/core/diagnostics/grouping.ts` (groups by schema name, not minified frames); with this change the `Locale` capture stops being emitted at all.

No output shape changes: the schema still returns the input string untransformed, so `brand.ts` (`locale: localeCodeSchema.default('en')`) and the `?locale=` query-param handler are unaffected beyond accepting the wider tag set.

## Related Issues

Closes #4284

## Test Plan

- New `src/tests/schemas/i18n/locale.spec.ts`: accepts `es-419`, `zh-Hant-TW`, `en-US-POSIX`, `it_IT`, extension subtags; rejects garbage (`invalid!`, `en-`, `a-DE`, over-length tags); asserts no transform of the input value.
- New `languageStore` regression tests: script/variant subtags fall back to primary-language matches (`it-Latn-IT` → `it_IT`, `en-US-POSIX` → `en`); garbage `deviceLocale` initializes to the default locale without throwing.
- Full vitest suite passes (exit 0). `pnpm type-check` passes; `pnpm type-check:tests` errors are byte-identical to the base branch (pre-existing, unrelated admin specs). ESLint clean on all changed files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEm3sFQXjDzv8DB7jnxjsD)_