### PR TITLE
Stop reporting expected /secret transport outcomes as Sentry errors

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -106,6 +106,22 @@ const createApi = (config: ApiConfig = {}): AxiosInstance => {
       Accept: 'application/json',
       'Content-Type': 'application/json',
     },
+    transitional: {
+      // Timeouts must be distinguishable from cancellations. By default axios
+      // rejects BOTH `xhr.ontimeout` and `xhr.onabort` with code
+      // ECONNABORTED, so a request that ran past its deadline is
+      // indistinguishable from one the user cancelled by navigating away.
+      // That collision matters here because the diagnostics noise filter
+      // drops cancellations (expected: the user left) while a timeout is OUR
+      // failure and must keep reporting — see requestOutcome() in
+      // src/plugins/core/diagnostics/grouping.ts and expectedOutcomes.ts.
+      //
+      // With this flag, timeouts reject as ETIMEDOUT and ECONNABORTED means
+      // abort and only abort. Set unconditionally, not just when a `timeout`
+      // is configured: no timeout is set on this client today, and the point
+      // is that adding one later must not silently blind Sentry.
+      clarifyTimeoutError: true,
+    },
   });
 
   // Only set locale if specified. Seems obvious and it is, but it

--- a/src/plugins/core/diagnostics/expectedOutcomes.ts
+++ b/src/plugins/core/diagnostics/expectedOutcomes.ts
@@ -1,0 +1,58 @@
+// src/plugins/core/diagnostics/expectedOutcomes.ts
+//
+// Drops Sentry events for request-shaped errors whose outcome is the product
+// working as designed, not a defect (#4286 — 474 events across ~35 issues,
+// the largest cluster in the frontend Sentry project):
+//
+//   - 404 — the resource was already consumed. On `/secret/:id` this is a
+//     secret that was already viewed, burned, or expired; the same holds for
+//     any other identifier-addressed resource. HTTP_STATUS_CODES.HUMAN (see
+//     src/schemas/errors/constants.ts) already keeps 404 out of Sentry for
+//     errors that flow through the app's own error handlers (useAsyncHandler,
+//     globalErrorBoundary) — this is the SAME rule enforced one layer
+//     further out, in beforeSend, which every event reaches regardless of
+//     path. That makes it a backstop, not a second policy: an event dropped
+//     here would already have been dropped by those handlers if it had gone
+//     through them.
+//   - 'aborted' — the user navigated away or closed the tab mid-request
+//     (axios ERR_CANCELED/CanceledError/ECONNABORTED, fetch AbortError).
+//   - 'network' — no response at all (offline, DNS, client-side connection
+//     failure) — not something the API did.
+//
+// Deliberately narrow: every other outcome, 5xx included, keeps reporting.
+// A 502/503/520 is OUR failure (deploy, upstream outage), not the client's
+// or the product's, and must not be swallowed by this list — see
+// requestOutcome() in grouping.ts, which only returns 'network' when there
+// is no response at all, never for a response that carries a status.
+
+import type { EventHint } from '@sentry/core';
+
+import { requestOutcome, resolveRequestError } from './grouping';
+
+/**
+ * Outcomes (see `requestOutcome` in grouping.ts) that represent an expected
+ * transport result rather than a defect.
+ *
+ * @internal Exported for testing
+ */
+export const EXPECTED_TRANSPORT_OUTCOMES: ReadonlySet<string> = new Set([
+  'aborted',
+  'network',
+  '404',
+]);
+
+/**
+ * True when the event's original exception is a request-shaped error (see
+ * `resolveRequestError`) whose outcome is expected noise that should never
+ * reach Sentry.
+ *
+ * Consumed by beforeSend BEFORE grouping/scrubbing run (enableDiagnostics.ts)
+ * — there is no point fingerprinting or redacting an event that is about to
+ * be dropped.
+ *
+ * @internal Exported for testing
+ */
+export function isExpectedTransportOutcome(hint: EventHint | undefined): boolean {
+  const resolved = resolveRequestError(hint);
+  return resolved !== null && EXPECTED_TRANSPORT_OUTCOMES.has(requestOutcome(resolved.err));
+}

--- a/src/plugins/core/diagnostics/expectedOutcomes.ts
+++ b/src/plugins/core/diagnostics/expectedOutcomes.ts
@@ -2,44 +2,125 @@
 //
 // Drops Sentry events for request-shaped errors whose outcome is the product
 // working as designed, not a defect (#4286 — 474 events across ~35 issues,
-// the largest cluster in the frontend Sentry project):
+// the largest cluster in the frontend Sentry project).
 //
-//   - 404 — the resource was already consumed. On `/secret/:id` this is a
-//     secret that was already viewed, burned, or expired; the same holds for
-//     any other identifier-addressed resource. HTTP_STATUS_CODES.HUMAN (see
-//     src/schemas/errors/constants.ts) already keeps 404 out of Sentry for
-//     errors that flow through the app's own error handlers (useAsyncHandler,
-//     globalErrorBoundary) — this is the SAME rule enforced one layer
-//     further out, in beforeSend, which every event reaches regardless of
-//     path. That makes it a backstop, not a second policy: an event dropped
-//     here would already have been dropped by those handlers if it had gone
-//     through them.
-//   - 'aborted' — the user navigated away or closed the tab mid-request
-//     (axios ERR_CANCELED/CanceledError/ECONNABORTED, fetch AbortError).
-//   - 'network' — no response at all (offline, DNS, client-side connection
-//     failure) — not something the API did.
+// EVERY RULE HERE IS SCOPED, and that is the whole design. A flat "drop these
+// outcomes" list is cheap to write and expensive to own: the same outcome
+// that is noise on one route is the only evidence of an outage on another,
+// and a filter that cannot tell them apart takes the outage down with the
+// noise. So each outcome carries the condition that makes it expected:
 //
-// Deliberately narrow: every other outcome, 5xx included, keeps reporting.
-// A 502/503/520 is OUR failure (deploy, upstream outage), not the client's
-// or the product's, and must not be swallowed by this list — see
-// requestOutcome() in grouping.ts, which only returns 'network' when there
-// is no response at all, never for a response that carries a status.
+//   404       — only on an identifier-addressed secret/receipt route, where
+//               it means the resource was already viewed, burned, or expired.
+//               A 404 anywhere else is a routing defect (a mis-versioned or
+//               renamed endpoint, a typo in a path) and MUST stay visible;
+//               those are exactly the regressions Sentry is for.
+//   'aborted' — always. The request was cancelled: the user navigated away or
+//               closed the tab mid-request. Never a timeout — the two share a
+//               code on the wire, and src/api/index.ts separates them at the
+//               source so this rule can be unconditional. See ABORT_MARKERS
+//               and TIMEOUT_MARKERS in grouping.ts.
+//   'network' — only while the browser reports itself OFFLINE. An ERR_NETWORK
+//               raised while the client believes it is online is DNS, TLS,
+//               CORS, or an unreachable deployment — ours, and reportable.
+//
+// Everything else keeps reporting, 5xx and 'timeout' included: a 502/503/520
+// or a request that ran past its deadline is OUR failure, not the client's.
+// Those already fan out into one issue per status/method/path through the
+// `apiErrorGroup` fingerprinting in grouping.ts, so keeping them costs issue
+// volume, not issue clarity.
+//
+// Layering note: HTTP_STATUS_CODES.HUMAN (src/schemas/errors/constants.ts)
+// already keeps 404 out of Sentry for errors that flow through the app's own
+// handlers (useAsyncHandler, globalErrorBoundary). This module is the same
+// policy enforced one layer further out, in beforeSend, which every event
+// reaches regardless of the path that produced it — a backstop for manual
+// captureException calls, unhandled rejections, and integration auto-captures.
 
 import type { EventHint } from '@sentry/core';
 
 import { requestOutcome, resolveRequestError } from './grouping';
 
 /**
- * Outcomes (see `requestOutcome` in grouping.ts) that represent an expected
- * transport result rather than a defect.
+ * A path segment that is a verifiable identifier.
+ *
+ * MIRROR — the shape is VERIFIABLE_ID_PATTERN in ./scrubbers.ts: 62-char
+ * base-36 IDs (v0.24+) and legacy 31-char IDs (v0.23). Restated here anchored
+ * to a WHOLE segment and without the `g` flag, deliberately rather than
+ * imported:
+ *   - `.test()` on a `g`-flagged regex is stateful (it advances `lastIndex`),
+ *     which makes the shared constant unusable as a predicate.
+ *   - A substring match would defeat the point. `/secret/conceal` has to fail
+ *     this check; a loose `[^/]+` segment match would classify the conceal
+ *     endpoint as an identifier route and hide its 404s.
+ * Keep the two in step if the identifier width ever changes.
+ */
+const IDENTIFIER_SEGMENT = /^(?:[0-9a-z]{62}|[0-9a-z]{31})$/i;
+
+/**
+ * Resources addressed by a verifiable identifier — the consumable ones, where
+ * a 404 is the expected steady state rather than a defect. Both are one-shot:
+ * once viewed, burned, or expired, the record is gone by design.
+ */
+const IDENTIFIED_RESOURCES = new Set(['secret', 'receipt']);
+
+/**
+ * Sub-actions on an identified resource that share its 404 semantics
+ * (`/secret/:id/reveal`, `/receipt/:id/burn`). Enumerated, not `[a-z]+`, so a
+ * new action has to be considered rather than inheriting the drop silently.
+ */
+const IDENTIFIED_RESOURCE_ACTIONS = new Set(['reveal', 'burn']);
+
+/**
+ * True when the URL addresses a specific secret or receipt by identifier —
+ * `/secret/:id`, `/secret/:id/reveal`, `/receipt/:id`, `/receipt/:id/burn` —
+ * and therefore a 404 means "already consumed", not "endpoint missing".
+ *
+ * Matched from the END of the path so it stays independent of the API prefix
+ * (`/api/v3`, `/api/v3/guest`, or whatever replaces them); the resource word
+ * sits immediately before the identifier and any action immediately after.
  *
  * @internal Exported for testing
  */
-export const EXPECTED_TRANSPORT_OUTCOMES: ReadonlySet<string> = new Set([
-  'aborted',
-  'network',
-  '404',
-]);
+export function isIdentifierAddressedResource(url: string): boolean {
+  let pathname: string;
+  try {
+    // Synthetic base so bare paths parse; only the parser is used.
+    pathname = new URL(url, 'http://_').pathname;
+  } catch {
+    pathname = url.split(/[?#]/)[0];
+  }
+
+  const segments = pathname.split('/').filter((segment) => segment.length > 0);
+  const last = segments.length - 1;
+  const idIndex = IDENTIFIED_RESOURCE_ACTIONS.has(segments[last]?.toLowerCase())
+    ? last - 1
+    : last;
+
+  // idIndex < 1 leaves no room for the resource word that must precede it.
+  if (idIndex < 1) {
+    return false;
+  }
+
+  return (
+    IDENTIFIER_SEGMENT.test(segments[idIndex]) &&
+    IDENTIFIED_RESOURCES.has(segments[idIndex - 1].toLowerCase())
+  );
+}
+
+/**
+ * True when the browser reports no connectivity.
+ *
+ * `navigator.onLine` is only trustworthy in the negative — `false` means
+ * there is no network interface at all, while `true` merely means one exists
+ * (a captive portal or dead upstream still reads as online). That asymmetry
+ * is exactly what this rule needs: it drops only on the trustworthy answer
+ * and reports on the ambiguous one, so a client-side connectivity blip is
+ * silent while a reachability failure the client cannot explain is not.
+ */
+function isClientOffline(): boolean {
+  return typeof navigator !== 'undefined' && navigator.onLine === false;
+}
 
 /**
  * True when the event's original exception is a request-shaped error (see
@@ -50,9 +131,23 @@ export const EXPECTED_TRANSPORT_OUTCOMES: ReadonlySet<string> = new Set([
  * — there is no point fingerprinting or redacting an event that is about to
  * be dropped.
  *
- * @internal Exported for testing
+ * The switch is exhaustive on purpose: an outcome with no case here reports.
+ * New failure classes must be added deliberately, never inherit a drop.
  */
 export function isExpectedTransportOutcome(hint: EventHint | undefined): boolean {
   const resolved = resolveRequestError(hint);
-  return resolved !== null && EXPECTED_TRANSPORT_OUTCOMES.has(requestOutcome(resolved.err));
+  if (resolved === null) {
+    return false;
+  }
+
+  switch (requestOutcome(resolved.err)) {
+    case 'aborted':
+      return true;
+    case 'network':
+      return isClientOffline();
+    case '404':
+      return isIdentifierAddressedResource(resolved.url);
+    default:
+      return false;
+  }
 }

--- a/src/plugins/core/diagnostics/grouping.ts
+++ b/src/plugins/core/diagnostics/grouping.ts
@@ -51,13 +51,41 @@ const SCHEMA_VALIDATION_MESSAGE = /^Schema validation failed for ([\w.$-]+)/;
  * (see the interceptors specs), and fetch wrappers produce similar shapes, so
  * detection is by the presence of `config.url` — the one property every
  * axios-family error carries — rather than by class.
+ *
+ * Exported (with `resolveRequestError` and `requestOutcome` below) so the
+ * expected-outcome noise filter (expectedOutcomes.ts, #4286) agrees with
+ * grouping on what counts as a request-shaped error and what its outcome is,
+ * instead of re-deriving both.
  */
-interface RequestErrorLike {
+export interface RequestErrorLike {
   config?: { url?: unknown; method?: unknown };
   response?: { status?: unknown };
   code?: unknown;
   name?: unknown;
   message?: unknown;
+}
+
+/** A request-shaped error together with the URL that proved its shape. */
+export interface ResolvedRequestError {
+  err: RequestErrorLike;
+  url: string;
+}
+
+/**
+ * Narrows a capture hint's original exception to a request-shaped error, or
+ * null when it isn't one (no `config.url` — see `RequestErrorLike`).
+ */
+export function resolveRequestError(hint: EventHint | undefined): ResolvedRequestError | null {
+  const original = hint?.originalException;
+  if (!original || typeof original !== 'object') {
+    return null;
+  }
+  const err = original as RequestErrorLike;
+  const url = err.config?.url;
+  if (typeof url !== 'string' || url.length === 0) {
+    return null;
+  }
+  return { err, url };
 }
 
 /**
@@ -129,18 +157,18 @@ function normalizeRequestPath(url: string): string {
  *   request-shaped error.
  */
 function apiErrorGroup(hint: EventHint | undefined): string[] | null {
-  const original = hint?.originalException;
-  if (!original || typeof original !== 'object') {
-    return null;
-  }
-  const err = original as RequestErrorLike;
-  const url = err.config?.url;
-  if (typeof url !== 'string' || url.length === 0) {
+  const resolved = resolveRequestError(hint);
+  if (!resolved) {
     // Not a request-shaped error — no config.url, no route to group by.
     return null;
   }
 
-  return ['api-error', requestMethod(err), normalizeRequestPath(url), requestOutcome(err)];
+  return [
+    'api-error',
+    requestMethod(resolved.err),
+    normalizeRequestPath(resolved.url),
+    requestOutcome(resolved.err),
+  ];
 }
 
 /** Uppercased HTTP method; axios stores it lowercase and defaults to GET. */
@@ -153,7 +181,7 @@ function requestMethod(err: RequestErrorLike): string {
 const ABORT_MARKERS = new Set(['ERR_CANCELED', 'ECONNABORTED', 'CanceledError', 'AbortError']);
 
 /** Derives the outcome component: status, else a coarse failure class. */
-function requestOutcome(err: RequestErrorLike): string {
+export function requestOutcome(err: RequestErrorLike): string {
   const status = err.response?.status;
   if (typeof status === 'number') {
     return String(status);

--- a/src/plugins/core/diagnostics/grouping.ts
+++ b/src/plugins/core/diagnostics/grouping.ts
@@ -146,12 +146,18 @@ function normalizeRequestPath(url: string): string {
  *
  * The outcome component is the HTTP status when the server answered, else a
  * coarse failure class:
- *   - 'aborted' — the request was cancelled (unmount, navigation, timeout
- *     abort); axios signals this via ERR_CANCELED/CanceledError, the fetch
- *     path via AbortError.
+ *   - 'timeout' — the request ran past its deadline with no response.
+ *   - 'aborted' — the request was cancelled (unmount, navigation away, tab
+ *     close); axios signals this via ERR_CANCELED/CanceledError/ECONNABORTED,
+ *     the fetch path via AbortError.
  *   - 'network' — no response at all (offline, DNS, CORS, connection reset).
  *   - the error class name as a last resort, so an unrecognized failure mode
  *     still groups by route rather than by stack frame.
+ *
+ * 'timeout' and 'aborted' are deliberately separate classes, not one bucket:
+ * an abort is the user leaving and is dropped as expected noise, while a
+ * timeout is the API failing to answer and must reach Sentry. See
+ * ABORT_MARKERS below and expectedOutcomes.ts.
  *
  * @returns The grouping array, or null when the hint does not carry a
  *   request-shaped error.
@@ -177,7 +183,34 @@ function requestMethod(err: RequestErrorLike): string {
   return typeof method === 'string' && method.length > 0 ? method.toUpperCase() : 'GET';
 }
 
-/** Marker values (axios `code` / error `name`) for a cancelled request. */
+/**
+ * Marker values (axios `code` / error `name`) for a request that ran past its
+ * deadline. Checked BEFORE the abort markers, because the two overlap on the
+ * wire unless the client asks them not to.
+ *
+ * `ETIMEDOUT` is what axios reports for a timeout when
+ * `transitional.clarifyTimeoutError` is set — src/api/index.ts sets it on the
+ * shared client for exactly this reason. `TimeoutError` is the DOMException
+ * name from the fetch path (`AbortSignal.timeout()`).
+ */
+const TIMEOUT_MARKERS = new Set(['ETIMEDOUT', 'TimeoutError']);
+
+/**
+ * Marker values (axios `code` / error `name`) for a CANCELLED request — torn
+ * down before a response arrived, by the caller or by the browser.
+ *
+ * `ECONNABORTED` sits here rather than with the timeouts on purpose, and the
+ * distinction is load-bearing: axios uses that one code for both
+ * `xhr.onabort` (navigation away, tab close) AND, by default, `xhr.ontimeout`.
+ * Left ambiguous, dropping 'aborted' as expected noise would also swallow
+ * every timed-out request during an API slowdown. src/api/index.ts resolves
+ * the ambiguity at the source with `transitional.clarifyTimeoutError`, so a
+ * timeout arrives as ETIMEDOUT and ECONNABORTED means abort and only abort.
+ *
+ * Do not "fix" this by removing ECONNABORTED: on the XHR adapter it is the
+ * ONLY code an actual abort produces, so dropping it would stop the
+ * navigate-away case from ever being recognized.
+ */
 const ABORT_MARKERS = new Set(['ERR_CANCELED', 'ECONNABORTED', 'CanceledError', 'AbortError']);
 
 /** Derives the outcome component: status, else a coarse failure class. */
@@ -185,6 +218,9 @@ export function requestOutcome(err: RequestErrorLike): string {
   const status = err.response?.status;
   if (typeof status === 'number') {
     return String(status);
+  }
+  if (TIMEOUT_MARKERS.has(err.code as string) || TIMEOUT_MARKERS.has(err.name as string)) {
+    return 'timeout';
   }
   if (ABORT_MARKERS.has(err.code as string) || ABORT_MARKERS.has(err.name as string)) {
     return 'aborted';

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -592,6 +592,47 @@ function applyDeploymentTags(scopes: Array<Pick<Scope, 'setTag'>>, host: string)
   }
 }
 
+/** Every character with meaning inside a regex, so a literal stays literal. */
+const REGEXP_METACHARACTERS = /[.*+?^${}()|[\]\\]/g;
+
+/**
+ * Escapes a string for safe interpolation into a `RegExp` source.
+ *
+ * Escaping only `.` — as this did previously — is not enough. `host` comes
+ * from `display_domain`, which on a custom-domain deployment originates in a
+ * value the customer registered. Any other metacharacter reaching the pattern
+ * either breaks construction or, worse, widens the match.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(REGEXP_METACHARACTERS, '\\$&');
+}
+
+/**
+ * Builds the `tracePropagationTargets` pattern for the app's own host:
+ * the host itself or any subdomain of it, over http/https, with an optional
+ * port, and either nothing or a path after it.
+ *
+ * This pattern is a security boundary, not a convenience. Every URL it
+ * matches gets the outbound `sentry-trace` and `baggage` headers attached, so
+ * a pattern that matches more than intended leaks trace context — and the
+ * request correlation it carries — to third-party origins. Two consequences:
+ *
+ *   1. The host is fully escaped (see escapeRegExp), never just dot-escaped.
+ *   2. Both ends are anchored with literal `^` and `$` at the top level of
+ *      the pattern, with the optional path inside `(/.*)?` rather than the
+ *      end anchor being buried in a `(/|$)` alternation. An unanchored tail
+ *      would match `https://evil.test/?x=https://ourhost.example/`, and an
+ *      anchor reachable through only one branch of a group is invisible to
+ *      static analysis (CodeQL js/regex/missing-regexp-anchor) even when it
+ *      does hold.
+ *
+ * The leading `([a-z0-9-]+\.)*` matches subdomain labels only — it cannot
+ * cross a `/`, `@`, or `:`, so it does not admit a userinfo or path prefix.
+ */
+function buildHostPropagationPattern(host: string): RegExp {
+  return new RegExp(`^https?://([a-z0-9-]+\\.)*${escapeRegExp(host)}(:\\d+)?(/.*)?$`, 'i');
+}
+
 interface EnableDiagnosticsOptions {
   // Display domain. This is the domain the user is interacting with, not
   // the Sentry domain. Same meaning as `display_domain`.
@@ -690,19 +731,9 @@ export function createDiagnostics(options: EnableDiagnosticsOptions): Plugin {
     // sendDefaultPii: false, // Default is false
     tracePropagationTargets: [
       /^localhost(:\d+)?$/, // Matches localhost with optional port
-      // Add host domain regexes only if host is provided. Two patterns, not
-      // one combined via `(/|$)`: each ends in an unambiguous terminal token
-      // (a literal `$` or a literal `/`) so static analysis (CodeQL
-      // js/regex/missing-regexp-anchor) can see the end is anchored, not just
-      // reachable via one branch of a group. Same matching behavior as
-      // before — host with optional port and nothing else, OR host with
-      // optional port followed by a path.
-      ...(host
-        ? [
-            new RegExp(`^https?://([a-z0-9-]+\\.)*${host.replaceAll('.', '\\.')}(:\\d+)?$`, 'i'),
-            new RegExp(`^https?://([a-z0-9-]+\\.)*${host.replaceAll('.', '\\.')}(:\\d+)?/`, 'i'),
-          ]
-        : []),
+      // Add the host pattern only if a host is provided. See
+      // buildHostPropagationPattern for why it is shaped the way it is.
+      ...(host ? [buildHostPropagationPattern(host)] : []),
     ],
 
     // Only the integrations listed here will be used

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -37,6 +37,7 @@ import {
   sanitizeEventUser,
   type ActorContextScope,
 } from './diagnostics/actorContext';
+import { isExpectedTransportOutcome } from './diagnostics/expectedOutcomes';
 import { applyGroupingRules } from './diagnostics/grouping';
 import { collectValuesToRedact, scrubUrlWithValues } from './diagnostics/urlScrubbing';
 // Re-export scrubbing utilities from dependency-free module for backward compatibility
@@ -432,6 +433,14 @@ function scrubStackFrameUrls(event: ErrorEvent): void {
  */
 function createBeforeSendHandler(router: Router) {
   return (event: ErrorEvent, hint?: EventHint): ErrorEvent | null | Promise<ErrorEvent | null> => {
+    // #4286: expected transport outcomes (already-consumed secrets,
+    // cancelled requests, client connectivity) are the product working, not
+    // a defect. Drop first — no point scrubbing or fingerprinting an event
+    // that is about to be discarded.
+    if (isExpectedTransportOutcome(hint)) {
+      return null;
+    }
+
     if ('secret' in event && event.secret) {
       delete event.secret;
     }

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -690,11 +690,18 @@ export function createDiagnostics(options: EnableDiagnosticsOptions): Plugin {
     // sendDefaultPii: false, // Default is false
     tracePropagationTargets: [
       /^localhost(:\d+)?$/, // Matches localhost with optional port
-      // Add host domain regex only if host is provided.
-      // Properly anchored: requires host to be at the end of the domain portion,
-      // either at end of string or followed by / or :port
+      // Add host domain regexes only if host is provided. Two patterns, not
+      // one combined via `(/|$)`: each ends in an unambiguous terminal token
+      // (a literal `$` or a literal `/`) so static analysis (CodeQL
+      // js/regex/missing-regexp-anchor) can see the end is anchored, not just
+      // reachable via one branch of a group. Same matching behavior as
+      // before — host with optional port and nothing else, OR host with
+      // optional port followed by a path.
       ...(host
-        ? [new RegExp(`^https?://([a-z0-9-]+\\.)*${host.replaceAll('.', '\\.')}(:\\d+)?(/|$)`, 'i')]
+        ? [
+            new RegExp(`^https?://([a-z0-9-]+\\.)*${host.replaceAll('.', '\\.')}(:\\d+)?$`, 'i'),
+            new RegExp(`^https?://([a-z0-9-]+\\.)*${host.replaceAll('.', '\\.')}(:\\d+)?/`, 'i'),
+          ]
         : []),
     ],
 

--- a/src/plugins/core/globalErrorBoundary.ts
+++ b/src/plugins/core/globalErrorBoundary.ts
@@ -1,9 +1,9 @@
 // src/plugins/core/globalErrorBoundary.ts
 
-import { AsyncHandlerOptions } from '@/shared/composables/useAsyncHandler';
-import { classifyError, errorGuards } from '@/schemas/errors';
+import { classifyError, errorGuards, type ApplicationError } from '@/schemas/errors';
 import { captureException, isDiagnosticsEnabled } from '@/services/diagnostics.service';
 import { loggingService } from '@/services/logging.service';
+import { AsyncHandlerOptions } from '@/shared/composables/useAsyncHandler';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import type { VueComponentLike } from '@/types/ui/vue-internals';
 import type { App, Plugin } from 'vue';
@@ -26,6 +26,71 @@ export function getComponentName(instance: unknown): string {
   // Script setup: $.type.name or $.type.__name (Vue 3 internal component type)
   // Guard i.$ for edge cases (SSR hydration errors, corrupted instances)
   return i.$options?.name || i.$?.type?.name || i.$?.type?.__name || 'unknown';
+}
+
+/**
+ * Optional jurisdiction/planid/role tags read from the bootstrap store,
+ * omitting any that are not currently available.
+ */
+function optionalBootstrapTags(
+  bootstrap: ReturnType<typeof useBootstrapStore>
+): Record<string, unknown> {
+  const tags: Record<string, unknown> = {};
+
+  if (bootstrap.regions?.current_jurisdiction) {
+    tags.jurisdiction = bootstrap.regions.current_jurisdiction;
+  }
+  if (bootstrap.organization?.planid) {
+    tags.planid = bootstrap.organization.planid;
+  }
+  if (bootstrap.cust?.role) {
+    tags.role = bootstrap.cust.role;
+  }
+
+  return tags;
+}
+
+interface ReportToSentryArgs {
+  normalizedError: Error;
+  classifiedError: ApplicationError;
+  instance: unknown;
+  info: string;
+}
+
+/**
+ * Sends a classified error to Sentry via the diagnostics service, unless it
+ * is human-facing — already shown to the user via `notify` in the caller, so
+ * it is an expected outcome, not a defect. This is the same rule
+ * useAsyncHandler.logTechnicalError applies; this handler is the OTHER place
+ * an error can reach captureException, and it must apply it too (#4286).
+ */
+function reportToSentry({
+  normalizedError,
+  classifiedError,
+  instance,
+  info,
+}: ReportToSentryArgs): void {
+  if (!isDiagnosticsEnabled()) {
+    console.debug('[GlobalErrorBoundary] Sentry not initialized');
+    return;
+  }
+  if (errorGuards.isOfHumanInterest(classifiedError)) {
+    console.debug('[GlobalErrorBoundary] Skipping Sentry capture for human-facing error');
+    return;
+  }
+
+  console.debug('[GlobalErrorBoundary] Sending to Sentry');
+
+  // Note: useBootstrapStore() is safe here because Pinia is installed before this plugin
+  const context: Record<string, unknown> = {
+    componentName: getComponentName(instance),
+    componentInfo: info,
+    errorType: classifiedError.type,
+    errorSeverity: classifiedError.severity,
+    ...optionalBootstrapTags(useBootstrapStore()),
+  };
+
+  captureException(normalizedError, context);
 }
 
 /**
@@ -65,39 +130,7 @@ export function createErrorBoundary(options: ErrorBoundaryOptions = {}): Plugin 
           options.notify(classifiedError.message, classifiedError.severity);
         }
 
-        // Send to Sentry via diagnostics service
-        if (isDiagnosticsEnabled()) {
-          console.debug('[GlobalErrorBoundary] Sending to Sentry');
-
-          // Extract searchable tags from bootstrap store
-          // Note: useBootstrapStore() is safe here because Pinia is installed before this plugin
-          const bootstrap = useBootstrapStore();
-          const context: Record<string, unknown> = {
-            componentName: getComponentName(instance),
-            componentInfo: info,
-            errorType: classifiedError.type,
-            errorSeverity: classifiedError.severity,
-          };
-
-          // Add jurisdiction if regions are configured (optional field)
-          if (bootstrap.regions?.current_jurisdiction) {
-            context.jurisdiction = bootstrap.regions.current_jurisdiction;
-          }
-
-          // Add planid from organization if present (organization is optional)
-          if (bootstrap.organization?.planid) {
-            context.planid = bootstrap.organization.planid;
-          }
-
-          // Add role from customer if present (cust is nullable)
-          if (bootstrap.cust?.role) {
-            context.role = bootstrap.cust.role;
-          }
-
-          captureException(normalizedError, context);
-        } else {
-          console.debug('[GlobalErrorBoundary] Sentry not initialized');
-        }
+        reportToSentry({ normalizedError, classifiedError, instance, info });
 
         if (options.debug) {
           loggingService.debug('[ErrorContext]', { instance, info });

--- a/src/tests/api/createApi.spec.ts
+++ b/src/tests/api/createApi.spec.ts
@@ -1,0 +1,38 @@
+// src/tests/api/createApi.spec.ts
+//
+// The shared API client's timeout/cancellation contract.
+//
+// This looks like a test for a config flag, and it is — but the flag is
+// load-bearing for observability, not ergonomics. Axios rejects BOTH
+// `xhr.ontimeout` and `xhr.onabort` with code ECONNABORTED by default, and
+// the diagnostics noise filter DROPS cancellations while REPORTING timeouts
+// (src/plugins/core/diagnostics/expectedOutcomes.ts). Without
+// `clarifyTimeoutError`, those two are the same value on the wire and every
+// timed-out request during an API slowdown would be silently discarded as
+// "the user navigated away". Removing this flag re-blinds Sentry to a class
+// of outage while every other test still passes — hence this one.
+
+import { describe, expect, it } from 'vitest';
+
+import { createApi } from '@/api';
+
+describe('createApi — timeout/cancellation contract', () => {
+  it('clarifies timeout errors so they are distinguishable from cancellations', () => {
+    expect(createApi().defaults.transitional?.clarifyTimeoutError).toBe(true);
+  });
+
+  it('keeps the flag set when a custom domain is configured', () => {
+    // Custom-domain deployments build their own client; the contract must not
+    // depend on which constructor path a deployment takes.
+    expect(
+      createApi({ domain: 'secrets.example.com' }).defaults.transitional?.clarifyTimeoutError
+    ).toBe(true);
+  });
+
+  it('sets no request timeout, so ECONNABORTED can only mean an abort today', () => {
+    // Documents the current state rather than freezing it: the flag above is
+    // what keeps adding a timeout later a safe change. If this assertion is
+    // updated to a real timeout, the flag is what stops Sentry going quiet.
+    expect(createApi().defaults.timeout).toBeFalsy();
+  });
+});

--- a/src/tests/plugins/core/diagnostics/createDiagnostics.spec.ts
+++ b/src/tests/plugins/core/diagnostics/createDiagnostics.spec.ts
@@ -28,6 +28,7 @@ const {
   mockGetBootstrapValue,
   MockBrowserClient,
   MockScope,
+  getCapturedClientOptions,
 } = vi.hoisted(() => {
   const mockSetTag = vi.fn();
   // The user-context boundary writes setUser on the isolated scope.
@@ -46,7 +47,14 @@ const {
   }));
   const mockGetBootstrapValue = vi.fn();
 
+  // Captured so tests can assert on the options createDiagnostics assembles
+  // (tracePropagationTargets, beforeSend, …) without a real Sentry client.
+  let capturedClientOptions: Record<string, unknown> | null = null;
+
   class MockBrowserClient {
+    constructor(options: Record<string, unknown>) {
+      capturedClientOptions = options;
+    }
     init = mockClientInit;
     close = mockClientClose;
   }
@@ -73,6 +81,7 @@ const {
     mockGetBootstrapValue,
     MockBrowserClient,
     MockScope,
+    getCapturedClientOptions: () => capturedClientOptions,
   };
 });
 
@@ -538,5 +547,107 @@ describe('createDiagnostics user context', () => {
 
     expect(mockSetUser).toHaveBeenCalledWith(null);
     expect(mockCurrentScopeSetUser).toHaveBeenCalledWith(null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tracePropagationTargets
+//
+// This pattern decides which outbound requests carry the `sentry-trace` and
+// `baggage` headers, which makes it a security boundary rather than a
+// convenience: anything it matches receives our trace context. The negative
+// cases below are the ones that matter — an over-broad pattern fails open and
+// leaks silently, with nothing in any log to notice.
+// ---------------------------------------------------------------------------
+
+describe('createDiagnostics tracePropagationTargets', () => {
+  const originalConsoleDebug = console.debug;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    console.debug = vi.fn();
+    mockGetBootstrapValue.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    console.debug = originalConsoleDebug;
+  });
+
+  /** The host-derived pattern, as createDiagnostics hands it to Sentry. */
+  function hostPattern(host: string): RegExp {
+    createDiagnostics({ host, config: baseConfig, router: createMockRouter() });
+
+    const options = getCapturedClientOptions();
+    if (!options) throw new Error('BrowserClient constructor was never called');
+
+    const targets = options.tracePropagationTargets as Array<string | RegExp>;
+    const pattern = targets.find(
+      (target): target is RegExp => target instanceof RegExp && target.source.includes('https?')
+    );
+    if (!pattern) throw new Error('no host pattern in tracePropagationTargets');
+    return pattern;
+  }
+
+  it.each([
+    'https://example.com',
+    'https://example.com/',
+    'https://example.com/api/v3/secret',
+    'https://example.com:8443/api/v3/secret',
+    'https://eu.example.com/api/v3/secret',
+    'http://example.com',
+  ])('propagates trace headers to %s', (url) => {
+    expect(hostPattern(TEST_HOST).test(url)).toBe(true);
+  });
+
+  it.each([
+    // The dot must stay literal; an unescaped `.` matches any character.
+    'https://exampleXcom/api',
+    // Suffix attack: our host must not be a prefix of someone else's domain.
+    'https://example.com.evil.test/api',
+    // Prefix attack: our host must not be a suffix of someone else's domain.
+    'https://notexample.com/api',
+    // Unanchored-start attacks — our host appearing inside another URL.
+    'https://evil.test/?next=https://example.com/',
+    'https://evil.test/https://example.com',
+    // Userinfo smuggling: the real host here is evil.test.
+    'https://example.com@evil.test/api',
+    // Non-HTTP schemes.
+    'ftp://example.com/api',
+  ])('does NOT propagate trace headers to %s', (url) => {
+    expect(hostPattern(TEST_HOST).test(url)).toBe(false);
+  });
+
+  it('escapes every regex metacharacter in the host, not just dots', () => {
+    // `host` is `display_domain`, which on a custom-domain deployment comes
+    // from a value the customer registered. Left unescaped, `+` turns the
+    // preceding character into a quantifier and widens the match; `(` breaks
+    // construction outright.
+    const pattern = hostPattern('a+b(c).example.com');
+
+    expect(pattern.test('https://a+b(c).example.com/api')).toBe(true);
+    expect(pattern.test('https://aab(c).example.com/api')).toBe(false);
+    expect(pattern.test('https://abbbbc.example.com/api')).toBe(false);
+  });
+
+  it('anchors both ends at the top level of the pattern', () => {
+    // Not a style preference. An end anchor reachable through only one branch
+    // of a group still holds at runtime but is invisible to static analysis
+    // (CodeQL js/regex/missing-regexp-anchor), so the guarantee cannot be
+    // verified by anything but a human reading it.
+    const { source } = hostPattern(TEST_HOST);
+
+    expect(source.startsWith('^')).toBe(true);
+    expect(source.endsWith('$')).toBe(true);
+  });
+
+  it('omits the host pattern entirely when no host is given', () => {
+    const targets = (() => {
+      createDiagnostics({ host: '', config: baseConfig, router: createMockRouter() });
+      const options = getCapturedClientOptions();
+      if (!options) throw new Error('BrowserClient constructor was never called');
+      return options.tracePropagationTargets as Array<string | RegExp>;
+    })();
+
+    expect(targets.every((t) => t instanceof RegExp && !t.source.includes('https?'))).toBe(true);
   });
 });

--- a/src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts
+++ b/src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts
@@ -219,7 +219,7 @@ describe('beforeSend integration', () => {
     createDiagnostics({
       host: 'example.com',
       config: {
-        sentry: { dsn: 'https://key@sentry.io/123', environment: 'test', release: '1.0.0' },
+        sentry: { dsn: 'https://key@example.com/123', environment: 'test', release: '1.0.0' },
       },
       router: createMockRouter(),
     });

--- a/src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts
+++ b/src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts
@@ -1,0 +1,319 @@
+// src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts
+//
+// Tests for the expected-transport-outcome noise filter (#4286): request-
+// shaped errors that represent the product working (an already-consumed
+// secret, a cancelled request, client connectivity) must never reach Sentry,
+// while everything else — including 5xx, which are OUR failures — must keep
+// reporting.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ErrorEvent, EventHint } from '@sentry/core';
+import type { Router, RouteLocationNormalizedLoaded } from 'vue-router';
+
+import {
+  EXPECTED_TRANSPORT_OUTCOMES,
+  isExpectedTransportOutcome,
+} from '@/plugins/core/diagnostics/expectedOutcomes';
+
+// ---------------------------------------------------------------------------
+// Unit tests (pure module, no Sentry wiring)
+// ---------------------------------------------------------------------------
+
+/** Builds an axios-shaped request error; structural, not instanceof. */
+function requestError(overrides: {
+  url: string;
+  method?: string;
+  status?: number;
+  code?: string;
+  name?: string;
+  message?: string;
+}): Error {
+  const err = new Error(overrides.message ?? 'Request failed') as Error & {
+    config: { url: string; method?: string };
+    response?: { status: number };
+    code?: string;
+  };
+  err.config = { url: overrides.url, method: overrides.method };
+  if (overrides.status !== undefined) {
+    err.response = { status: overrides.status };
+  }
+  if (overrides.code !== undefined) {
+    err.code = overrides.code;
+  }
+  if (overrides.name !== undefined) {
+    Object.defineProperty(err, 'name', { value: overrides.name });
+  }
+  return err;
+}
+
+function hintFor(overrides: Parameters<typeof requestError>[0]): EventHint {
+  return { originalException: requestError(overrides) };
+}
+
+describe('isExpectedTransportOutcome — drops', () => {
+  it('a 404 on the secret-fetch path (already viewed, burned, or expired)', () => {
+    expect(
+      isExpectedTransportOutcome(
+        hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', status: 404 })
+      )
+    ).toBe(true);
+  });
+
+  it('a 404 on the reveal path', () => {
+    expect(
+      isExpectedTransportOutcome(
+        hintFor({ url: '/api/v3/guest/secret/abc123/reveal', method: 'post', status: 404 })
+      )
+    ).toBe(true);
+  });
+
+  it.each([
+    { code: 'ERR_CANCELED', name: 'CanceledError', message: 'canceled' },
+    { code: 'ECONNABORTED', message: 'Request aborted' },
+    { name: 'AbortError' },
+  ])('a cancelled/aborted request: %o', (shape) => {
+    expect(
+      isExpectedTransportOutcome(
+        hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', ...shape })
+      )
+    ).toBe(true);
+  });
+
+  it('a no-response network error', () => {
+    expect(
+      isExpectedTransportOutcome(
+        hintFor({
+          url: '/api/v3/guest/secret/abc123',
+          method: 'get',
+          code: 'ERR_NETWORK',
+          message: 'Network Error',
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+describe('isExpectedTransportOutcome — keeps reporting', () => {
+  it.each([500, 502, 503, 520])(
+    'server failures (status %d) — these are ours, not the client’s',
+    (status) => {
+      expect(
+        isExpectedTransportOutcome(
+          hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', status })
+        )
+      ).toBe(false);
+    }
+  );
+
+  it.each([400, 401, 403, 409, 410, 422, 429])(
+    'other 4xx statuses (status %d) — only 404 is treated as expected noise here',
+    (status) => {
+      expect(
+        isExpectedTransportOutcome(
+          hintFor({ url: '/api/v3/secret/conceal', method: 'post', status })
+        )
+      ).toBe(false);
+    }
+  );
+
+  it('a plain, non-request-shaped error', () => {
+    expect(isExpectedTransportOutcome({ originalException: new Error('boom') })).toBe(false);
+  });
+
+  it.each([undefined, null, 'a string'])(
+    'a missing or non-object originalException: %j',
+    (originalException) => {
+      expect(isExpectedTransportOutcome({ originalException } as EventHint)).toBe(false);
+    }
+  );
+
+  it('an undefined hint', () => {
+    expect(isExpectedTransportOutcome(undefined)).toBe(false);
+  });
+});
+
+describe('EXPECTED_TRANSPORT_OUTCOMES', () => {
+  it('is exactly aborted, network, and 404 — nothing broader', () => {
+    expect([...EXPECTED_TRANSPORT_OUTCOMES].sort()).toEqual(['404', 'aborted', 'network']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// beforeSend integration — the filter runs first and short-circuits the rest
+// of the pipeline (scrubbing, grouping) for dropped events.
+// ---------------------------------------------------------------------------
+
+const {
+  mockGetBootstrapValue,
+  MockBrowserClient,
+  MockScope,
+  getCapturedClientOptions,
+  resetCapturedOptions,
+} = vi.hoisted(() => {
+  const mockGetBootstrapValue = vi.fn();
+  let capturedClientOptions: Record<string, unknown> | null = null;
+
+  class MockBrowserClient {
+    constructor(options: Record<string, unknown>) {
+      capturedClientOptions = options;
+    }
+    init = vi.fn();
+    close = vi.fn().mockResolvedValue(undefined);
+  }
+
+  class MockScope {
+    setClient = vi.fn();
+    setTag = vi.fn();
+    setUser = vi.fn();
+  }
+
+  return {
+    mockGetBootstrapValue,
+    MockBrowserClient,
+    MockScope,
+    getCapturedClientOptions: () => capturedClientOptions,
+    resetCapturedOptions: () => {
+      capturedClientOptions = null;
+    },
+  };
+});
+
+vi.mock('@/services/bootstrap.service', () => ({
+  getBootstrapValue: mockGetBootstrapValue,
+}));
+
+vi.mock('@sentry/browser', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sentry/browser')>();
+  return {
+    ...actual,
+    BrowserClient: MockBrowserClient,
+    Scope: MockScope,
+  };
+});
+
+vi.mock('@sentry/vue', () => ({
+  browserTracingIntegration: vi.fn().mockReturnValue({ name: 'BrowserTracing' }),
+}));
+
+vi.mock('@/services/diagnostics.service', () => ({
+  initDiagnostics: vi.fn(),
+}));
+
+import { createDiagnostics } from '@/plugins/core/enableDiagnostics';
+
+function createMockRouter(): Router {
+  return {
+    resolve: vi.fn(),
+    currentRoute: {
+      value: { params: {}, meta: {}, matched: [] } as unknown as RouteLocationNormalizedLoaded,
+    },
+    afterEach: vi.fn(() => vi.fn()),
+  } as unknown as Router;
+}
+
+describe('beforeSend integration', () => {
+  const originalConsoleDebug = console.debug;
+
+  function getBeforeSend(): (event: ErrorEvent, hint?: EventHint) => ErrorEvent | null {
+    resetCapturedOptions();
+    createDiagnostics({
+      host: 'example.com',
+      config: {
+        sentry: { dsn: 'https://key@sentry.io/123', environment: 'test', release: '1.0.0' },
+      },
+      router: createMockRouter(),
+    });
+    const options = getCapturedClientOptions();
+    if (!options) throw new Error('BrowserClient constructor was never called');
+    return options.beforeSend as (event: ErrorEvent, hint?: EventHint) => ErrorEvent | null;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    console.debug = vi.fn();
+    mockGetBootstrapValue.mockReturnValue(null);
+  });
+
+  afterEach(() => {
+    console.debug = originalConsoleDebug;
+  });
+
+  it('drops a 404 on the secret-fetch path before scrubbing/grouping run', () => {
+    const handler = getBeforeSend();
+
+    const result = handler(
+      {
+        exception: {
+          values: [{ type: 'AxiosError', value: 'Request failed with status code 404' }],
+        },
+      },
+      hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', status: 404 })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('drops an aborted request', () => {
+    const handler = getBeforeSend();
+
+    const result = handler(
+      { exception: { values: [{ type: 'AxiosError', value: 'Request aborted' }] } },
+      hintFor({
+        url: '/api/v3/guest/secret/abc123',
+        method: 'get',
+        code: 'ECONNABORTED',
+        message: 'Request aborted',
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('drops a network error', () => {
+    const handler = getBeforeSend();
+
+    const result = handler(
+      { exception: { values: [{ type: 'AxiosError', value: 'Network Error' }] } },
+      hintFor({
+        url: '/api/v3/guest/secret/abc123',
+        method: 'get',
+        code: 'ERR_NETWORK',
+        message: 'Network Error',
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it('still reports a 503 (ours, not the client’s) and groups it separately from a 404', () => {
+    const handler = getBeforeSend();
+
+    const result = handler(
+      {
+        exception: {
+          values: [{ type: 'AxiosError', value: 'Request failed with status code 503' }],
+        },
+      },
+      hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', status: 503 })
+    ) as ErrorEvent;
+
+    expect(result).not.toBeNull();
+    expect(result.fingerprint).toEqual([
+      'api-error',
+      'GET',
+      '/api/v3/guest/secret/[REDACTED]',
+      '503',
+    ]);
+  });
+
+  it('still reports non-request-shaped errors', () => {
+    const handler = getBeforeSend();
+
+    const result = handler(
+      { exception: { values: [{ type: 'TypeError', value: 'boom' }] } },
+      { originalException: new TypeError('boom') }
+    );
+
+    expect(result).not.toBeNull();
+  });
+});

--- a/src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts
+++ b/src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts
@@ -2,22 +2,36 @@
 //
 // Tests for the expected-transport-outcome noise filter (#4286): request-
 // shaped errors that represent the product working (an already-consumed
-// secret, a cancelled request, client connectivity) must never reach Sentry,
-// while everything else — including 5xx, which are OUR failures — must keep
-// reporting.
+// secret, a cancelled request, a client that is offline) must never reach
+// Sentry, while everything else — 5xx, timeouts, and 404s from anywhere but
+// an identifier-addressed route — must keep reporting.
+//
+// The negative cases below are the point of the suite. A filter like this
+// fails silently by definition: over-dropping produces no error, no test
+// failure, and no Sentry event to notice the absence of. So each drop rule is
+// pinned from BOTH sides — the case it must drop, and the near-miss case it
+// must not.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ErrorEvent, EventHint } from '@sentry/core';
 import type { Router, RouteLocationNormalizedLoaded } from 'vue-router';
 
-import {
-  EXPECTED_TRANSPORT_OUTCOMES,
-  isExpectedTransportOutcome,
-} from '@/plugins/core/diagnostics/expectedOutcomes';
+import { isExpectedTransportOutcome } from '@/plugins/core/diagnostics/expectedOutcomes';
 
 // ---------------------------------------------------------------------------
-// Unit tests (pure module, no Sentry wiring)
+// Fixtures
 // ---------------------------------------------------------------------------
+
+/**
+ * A 62-char base-36 identifier, the current shape (v0.24+). Realistic width
+ * matters here: the filter recognizes an identifier route BY the identifier's
+ * shape, so a placeholder like `abc123` would exercise a path the app never
+ * produces.
+ */
+const SECRET_ID = `${'x9k2m4p7'.repeat(7)}abcdef`;
+
+/** A 31-char legacy identifier (v0.23), still accepted. */
+const LEGACY_ID = 'q1w2e3r4t5y6u7i8o9p0a1s2d3f4g5h';
 
 /** Builds an axios-shaped request error; structural, not instanceof. */
 function requestError(overrides: {
@@ -50,46 +64,120 @@ function hintFor(overrides: Parameters<typeof requestError>[0]): EventHint {
   return { originalException: requestError(overrides) };
 }
 
-describe('isExpectedTransportOutcome — drops', () => {
-  it('a 404 on the secret-fetch path (already viewed, burned, or expired)', () => {
+/**
+ * Overrides `navigator.onLine`, which jsdom hard-codes to true. Defined as a
+ * configurable own property so `delete` restores the prototype getter.
+ */
+function setOnLine(value: boolean): void {
+  Object.defineProperty(globalThis.navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+function restoreOnLine(): void {
+  delete (globalThis.navigator as unknown as { onLine?: boolean }).onLine;
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (pure module, no Sentry wiring)
+// ---------------------------------------------------------------------------
+
+describe('isExpectedTransportOutcome — 404 is scoped to identifier routes', () => {
+  it.each([
+    ['guest secret fetch', `/api/v3/guest/secret/${SECRET_ID}`, 'get'],
+    ['authenticated secret fetch', `/api/v3/secret/${SECRET_ID}`, 'get'],
+    ['secret reveal', `/api/v3/guest/secret/${SECRET_ID}/reveal`, 'post'],
+    ['receipt fetch', `/api/v3/receipt/${SECRET_ID}`, 'get'],
+    ['receipt burn', `/api/v3/receipt/${SECRET_ID}/burn`, 'post'],
+    ['legacy 31-char identifier', `/api/v3/guest/secret/${LEGACY_ID}`, 'get'],
+    ['absolute URL', `https://example.com/api/v3/guest/secret/${SECRET_ID}`, 'get'],
+    ['identifier route with a query string', `/api/v3/guest/secret/${SECRET_ID}?lang=de`, 'get'],
+  ])('drops a 404 on %s (already viewed, burned, or expired)', (_label, url, method) => {
+    expect(isExpectedTransportOutcome(hintFor({ url, method, status: 404 }))).toBe(true);
+  });
+
+  it.each([
+    ['the conceal endpoint', '/api/v3/guest/secret/conceal', 'post'],
+    ['the generate endpoint', '/api/v3/guest/secret/generate', 'post'],
+    ['a mis-versioned path', `/api/v9/guest/secret/${SECRET_ID}/reveal/extra`, 'post'],
+    ['an unknown action on a real identifier', `/api/v3/guest/secret/${SECRET_ID}/shred`, 'post'],
+    ['a non-identifier resource', '/api/v3/organizations/acme', 'get'],
+    ['a bare resource collection', '/api/v3/secret', 'get'],
+    ['an identifier with no resource word before it', `/${SECRET_ID}`, 'get'],
+    ['a too-short identifier', '/api/v3/guest/secret/abc123', 'get'],
+  ])('keeps reporting a 404 on %s — that is a routing defect, not a consumed secret', (
+    _label,
+    url,
+    method
+  ) => {
+    expect(isExpectedTransportOutcome(hintFor({ url, method, status: 404 }))).toBe(false);
+  });
+});
+
+describe('isExpectedTransportOutcome — cancellations', () => {
+  it.each([
+    { code: 'ERR_CANCELED', name: 'CanceledError', message: 'canceled' },
+    { code: 'ECONNABORTED', message: 'Request aborted' },
+    { name: 'AbortError' },
+  ])('drops a cancelled request: %o', (shape) => {
     expect(
       isExpectedTransportOutcome(
-        hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', status: 404 })
+        hintFor({ url: `/api/v3/guest/secret/${SECRET_ID}`, method: 'get', ...shape })
       )
     ).toBe(true);
   });
 
-  it('a 404 on the reveal path', () => {
+  it('drops a cancellation on any route, not just identifier routes', () => {
     expect(
       isExpectedTransportOutcome(
-        hintFor({ url: '/api/v3/guest/secret/abc123/reveal', method: 'post', status: 404 })
+        hintFor({ url: '/api/v3/guest/secret/conceal', method: 'post', code: 'ERR_CANCELED' })
       )
     ).toBe(true);
   });
 
   it.each([
-    { code: 'ERR_CANCELED', name: 'CanceledError', message: 'canceled' },
-    { code: 'ECONNABORTED', message: 'Request aborted' },
-    { name: 'AbortError' },
-  ])('a cancelled/aborted request: %o', (shape) => {
-    expect(
-      isExpectedTransportOutcome(
-        hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', ...shape })
-      )
-    ).toBe(true);
+    { label: 'axios (clarifyTimeoutError)', code: 'ETIMEDOUT', message: 'timeout exceeded' },
+    { label: 'fetch AbortSignal.timeout', name: 'TimeoutError' },
+  ])(
+    'keeps reporting a timeout — $label — a slow API is ours, not a cancellation',
+    ({ code, name, message }) => {
+      expect(
+        isExpectedTransportOutcome(
+          hintFor({ url: `/api/v3/guest/secret/${SECRET_ID}`, method: 'get', code, name, message })
+        )
+      ).toBe(false);
+    }
+  );
+});
+
+describe('isExpectedTransportOutcome — network errors follow connectivity', () => {
+  afterEach(restoreOnLine);
+
+  const networkError = {
+    url: `/api/v3/guest/secret/${SECRET_ID}`,
+    method: 'get',
+    code: 'ERR_NETWORK',
+    message: 'Network Error',
+  };
+
+  it('drops a network error while the browser reports itself offline', () => {
+    setOnLine(false);
+    expect(isExpectedTransportOutcome(hintFor(networkError))).toBe(true);
   });
 
-  it('a no-response network error', () => {
-    expect(
-      isExpectedTransportOutcome(
-        hintFor({
-          url: '/api/v3/guest/secret/abc123',
-          method: 'get',
-          code: 'ERR_NETWORK',
-          message: 'Network Error',
-        })
-      )
-    ).toBe(true);
+  it('keeps reporting a network error raised while the client believes it is online — DNS, TLS, CORS, or an unreachable deployment', () => {
+    setOnLine(true);
+    expect(isExpectedTransportOutcome(hintFor(networkError))).toBe(false);
+  });
+
+  it('keeps reporting when connectivity is unknowable', () => {
+    // No navigator.onLine to consult: report rather than guess.
+    Object.defineProperty(globalThis.navigator, 'onLine', {
+      configurable: true,
+      get: () => undefined,
+    });
+    expect(isExpectedTransportOutcome(hintFor(networkError))).toBe(false);
   });
 });
 
@@ -99,7 +187,7 @@ describe('isExpectedTransportOutcome — keeps reporting', () => {
     (status) => {
       expect(
         isExpectedTransportOutcome(
-          hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', status })
+          hintFor({ url: `/api/v3/guest/secret/${SECRET_ID}`, method: 'get', status })
         )
       ).toBe(false);
     }
@@ -110,11 +198,19 @@ describe('isExpectedTransportOutcome — keeps reporting', () => {
     (status) => {
       expect(
         isExpectedTransportOutcome(
-          hintFor({ url: '/api/v3/secret/conceal', method: 'post', status })
+          hintFor({ url: `/api/v3/guest/secret/${SECRET_ID}`, method: 'get', status })
         )
       ).toBe(false);
     }
   );
+
+  it('an unrecognized failure class', () => {
+    expect(
+      isExpectedTransportOutcome(
+        hintFor({ url: `/api/v3/guest/secret/${SECRET_ID}`, method: 'get', name: 'WeirdError' })
+      )
+    ).toBe(false);
+  });
 
   it('a plain, non-request-shaped error', () => {
     expect(isExpectedTransportOutcome({ originalException: new Error('boom') })).toBe(false);
@@ -129,12 +225,6 @@ describe('isExpectedTransportOutcome — keeps reporting', () => {
 
   it('an undefined hint', () => {
     expect(isExpectedTransportOutcome(undefined)).toBe(false);
-  });
-});
-
-describe('EXPECTED_TRANSPORT_OUTCOMES', () => {
-  it('is exactly aborted, network, and 404 — nothing broader', () => {
-    expect([...EXPECTED_TRANSPORT_OUTCOMES].sort()).toEqual(['404', 'aborted', 'network']);
   });
 });
 
@@ -211,13 +301,15 @@ function createMockRouter(): Router {
   } as unknown as Router;
 }
 
+const TEST_HOST = 'example.com';
+
 describe('beforeSend integration', () => {
   const originalConsoleDebug = console.debug;
 
   function getBeforeSend(): (event: ErrorEvent, hint?: EventHint) => ErrorEvent | null {
     resetCapturedOptions();
     createDiagnostics({
-      host: 'example.com',
+      host: TEST_HOST,
       config: {
         sentry: { dsn: 'https://key@example.com/123', environment: 'test', release: '1.0.0' },
       },
@@ -236,6 +328,7 @@ describe('beforeSend integration', () => {
 
   afterEach(() => {
     console.debug = originalConsoleDebug;
+    restoreOnLine();
   });
 
   it('drops a 404 on the secret-fetch path before scrubbing/grouping run', () => {
@@ -247,7 +340,7 @@ describe('beforeSend integration', () => {
           values: [{ type: 'AxiosError', value: 'Request failed with status code 404' }],
         },
       },
-      hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', status: 404 })
+      hintFor({ url: `/api/v3/guest/secret/${SECRET_ID}`, method: 'get', status: 404 })
     );
 
     expect(result).toBeNull();
@@ -259,7 +352,7 @@ describe('beforeSend integration', () => {
     const result = handler(
       { exception: { values: [{ type: 'AxiosError', value: 'Request aborted' }] } },
       hintFor({
-        url: '/api/v3/guest/secret/abc123',
+        url: `/api/v3/guest/secret/${SECRET_ID}`,
         method: 'get',
         code: 'ECONNABORTED',
         message: 'Request aborted',
@@ -269,13 +362,14 @@ describe('beforeSend integration', () => {
     expect(result).toBeNull();
   });
 
-  it('drops a network error', () => {
+  it('drops a network error raised while offline', () => {
+    setOnLine(false);
     const handler = getBeforeSend();
 
     const result = handler(
       { exception: { values: [{ type: 'AxiosError', value: 'Network Error' }] } },
       hintFor({
-        url: '/api/v3/guest/secret/abc123',
+        url: `/api/v3/guest/secret/${SECRET_ID}`,
         method: 'get',
         code: 'ERR_NETWORK',
         message: 'Network Error',
@@ -283,6 +377,72 @@ describe('beforeSend integration', () => {
     );
 
     expect(result).toBeNull();
+  });
+
+  it('reports an unreachable API while online, grouped as a network outcome', () => {
+    setOnLine(true);
+    const handler = getBeforeSend();
+
+    const result = handler(
+      { exception: { values: [{ type: 'AxiosError', value: 'Network Error' }] } },
+      hintFor({
+        url: `/api/v3/guest/secret/${SECRET_ID}`,
+        method: 'get',
+        code: 'ERR_NETWORK',
+        message: 'Network Error',
+      })
+    ) as ErrorEvent;
+
+    expect(result).not.toBeNull();
+    expect(result.fingerprint).toEqual([
+      'api-error',
+      'GET',
+      '/api/v3/guest/secret/[REDACTED]',
+      'network',
+    ]);
+  });
+
+  it('reports a 404 from a non-identifier endpoint — a routing defect stays visible', () => {
+    const handler = getBeforeSend();
+
+    const result = handler(
+      {
+        exception: {
+          values: [{ type: 'AxiosError', value: 'Request failed with status code 404' }],
+        },
+      },
+      hintFor({ url: '/api/v3/guest/secret/conceal', method: 'post', status: 404 })
+    ) as ErrorEvent;
+
+    expect(result).not.toBeNull();
+    expect(result.fingerprint).toEqual([
+      'api-error',
+      'POST',
+      '/api/v3/guest/secret/[REDACTED]',
+      '404',
+    ]);
+  });
+
+  it('reports a timeout, grouped separately from an abort', () => {
+    const handler = getBeforeSend();
+
+    const result = handler(
+      { exception: { values: [{ type: 'AxiosError', value: 'timeout exceeded' }] } },
+      hintFor({
+        url: `/api/v3/guest/secret/${SECRET_ID}`,
+        method: 'get',
+        code: 'ETIMEDOUT',
+        message: 'timeout of 5000ms exceeded',
+      })
+    ) as ErrorEvent;
+
+    expect(result).not.toBeNull();
+    expect(result.fingerprint).toEqual([
+      'api-error',
+      'GET',
+      '/api/v3/guest/secret/[REDACTED]',
+      'timeout',
+    ]);
   });
 
   it('still reports a 503 (ours, not the client’s) and groups it separately from a 404', () => {
@@ -294,7 +454,7 @@ describe('beforeSend integration', () => {
           values: [{ type: 'AxiosError', value: 'Request failed with status code 503' }],
         },
       },
-      hintFor({ url: '/api/v3/guest/secret/abc123', method: 'get', status: 503 })
+      hintFor({ url: `/api/v3/guest/secret/${SECRET_ID}`, method: 'get', status: 503 })
     ) as ErrorEvent;
 
     expect(result).not.toBeNull();

--- a/src/tests/plugins/core/diagnostics/grouping.spec.ts
+++ b/src/tests/plugins/core/diagnostics/grouping.spec.ts
@@ -220,17 +220,36 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
     expect(event.fingerprint).toEqual(['api-error', 'GET', '/api/v2/status', 'network']);
   });
 
+  it.each([
+    { label: 'axios ETIMEDOUT (clarifyTimeoutError)', shape: { code: 'ETIMEDOUT' } },
+    { label: 'fetch AbortSignal.timeout', shape: { name: 'TimeoutError' } },
+  ])(
+    "keys deadline failures as 'timeout', separate from 'aborted' — $label",
+    ({ shape }) => {
+      // A timeout is the API failing to answer; an abort is the user leaving.
+      // They share code ECONNABORTED on the wire unless the client asks
+      // otherwise (src/api/index.ts sets transitional.clarifyTimeoutError),
+      // and only this split lets the noise filter drop one without the other.
+      const event: ErrorEvent = {};
+      applyGroupingRules(event, {
+        originalException: requestError({ url: '/api/v2/status', method: 'get', ...shape }),
+      });
+
+      expect(event.fingerprint).toEqual(['api-error', 'GET', '/api/v2/status', 'timeout']);
+    }
+  );
+
   it('falls back to the error class name when there is no status and no known code', () => {
     const event: ErrorEvent = {};
     applyGroupingRules(event, {
       originalException: requestError({
         url: '/api/v2/status',
         method: 'get',
-        name: 'TimeoutError',
+        name: 'QuotaExceededError',
       }),
     });
 
-    expect(event.fingerprint).toEqual(['api-error', 'GET', '/api/v2/status', 'TimeoutError']);
+    expect(event.fingerprint).toEqual(['api-error', 'GET', '/api/v2/status', 'QuotaExceededError']);
   });
 
   it('defaults the method to GET when the config omits it', () => {

--- a/src/tests/plugins/core/diagnostics/grouping.spec.ts
+++ b/src/tests/plugins/core/diagnostics/grouping.spec.ts
@@ -98,7 +98,9 @@ describe('applyGroupingRules — schema validation (Rule A)', () => {
   });
 
   it('reads a standalone message as well as exception values', () => {
-    const event: ErrorEvent = { message: 'Schema validation failed for MembersResponse — 1 issue(s) [(root)]: …' };
+    const event: ErrorEvent = {
+      message: 'Schema validation failed for MembersResponse — 1 issue(s) [(root)]: …',
+    };
 
     applyGroupingRules(event);
 
@@ -110,7 +112,8 @@ describe('applyGroupingRules — schema validation (Rule A)', () => {
       message: 'Schema validation failed for BrandSettings — 1 issue(s) [font_family]: …',
     };
     const threeIssues: ErrorEvent = {
-      message: 'Schema validation failed for BrandSettings — 3 issue(s) [corner_style, primary_color, locale]: …',
+      message:
+        'Schema validation failed for BrandSettings — 3 issue(s) [corner_style, primary_color, locale]: …',
     };
 
     applyGroupingRules(oneIssue);
@@ -166,7 +169,11 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
   it('parameterizes receipt endpoints the same way', () => {
     const event: ErrorEvent = {};
     applyGroupingRules(event, {
-      originalException: requestError({ url: `/api/v2/receipt/${'c'.repeat(62)}`, method: 'post', status: 404 }),
+      originalException: requestError({
+        url: `/api/v2/receipt/${'c'.repeat(62)}`,
+        method: 'post',
+        status: 404,
+      }),
     });
 
     expect(event.fingerprint).toEqual(['api-error', 'POST', '/api/v2/receipt/[REDACTED]', '404']);
@@ -175,7 +182,11 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
   it('drops the query string from the grouping path', () => {
     const event: ErrorEvent = {};
     applyGroupingRules(event, {
-      originalException: requestError({ url: '/api/v2/status?cb=1755859200', method: 'get', status: 500 }),
+      originalException: requestError({
+        url: '/api/v2/status?cb=1755859200',
+        method: 'get',
+        status: 500,
+      }),
     });
 
     expect(event.fingerprint).toEqual(['api-error', 'GET', '/api/v2/status', '500']);
@@ -212,7 +223,11 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
   it('falls back to the error class name when there is no status and no known code', () => {
     const event: ErrorEvent = {};
     applyGroupingRules(event, {
-      originalException: requestError({ url: '/api/v2/status', method: 'get', name: 'TimeoutError' }),
+      originalException: requestError({
+        url: '/api/v2/status',
+        method: 'get',
+        name: 'TimeoutError',
+      }),
     });
 
     expect(event.fingerprint).toEqual(['api-error', 'GET', '/api/v2/status', 'TimeoutError']);
@@ -231,7 +246,11 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
 describe('applyGroupingRules — pass-through', () => {
   it('leaves events matching neither rule untouched (default grouping preserved)', () => {
     const event: ErrorEvent = {
-      exception: { values: [{ type: 'TypeError', value: "Cannot read properties of undefined (reading 'foo')" }] },
+      exception: {
+        values: [
+          { type: 'TypeError', value: "Cannot read properties of undefined (reading 'foo')" },
+        ],
+      },
     };
 
     applyGroupingRules(event, { originalException: new TypeError('nope') });
@@ -273,35 +292,40 @@ describe('applyGroupingRules — pass-through', () => {
 // the existing scrubbing pipeline.
 // ---------------------------------------------------------------------------
 
-const { mockGetBootstrapValue, MockBrowserClient, MockScope, getCapturedClientOptions, resetCapturedOptions } =
-  vi.hoisted(() => {
-    const mockGetBootstrapValue = vi.fn();
-    let capturedClientOptions: Record<string, unknown> | null = null;
+const {
+  mockGetBootstrapValue,
+  MockBrowserClient,
+  MockScope,
+  getCapturedClientOptions,
+  resetCapturedOptions,
+} = vi.hoisted(() => {
+  const mockGetBootstrapValue = vi.fn();
+  let capturedClientOptions: Record<string, unknown> | null = null;
 
-    class MockBrowserClient {
-      constructor(options: Record<string, unknown>) {
-        capturedClientOptions = options;
-      }
-      init = vi.fn();
-      close = vi.fn().mockResolvedValue(undefined);
+  class MockBrowserClient {
+    constructor(options: Record<string, unknown>) {
+      capturedClientOptions = options;
     }
+    init = vi.fn();
+    close = vi.fn().mockResolvedValue(undefined);
+  }
 
-    class MockScope {
-      setClient = vi.fn();
-      setTag = vi.fn();
-      setUser = vi.fn();
-    }
+  class MockScope {
+    setClient = vi.fn();
+    setTag = vi.fn();
+    setUser = vi.fn();
+  }
 
-    return {
-      mockGetBootstrapValue,
-      MockBrowserClient,
-      MockScope,
-      getCapturedClientOptions: () => capturedClientOptions,
-      resetCapturedOptions: () => {
-        capturedClientOptions = null;
-      },
-    };
-  });
+  return {
+    mockGetBootstrapValue,
+    MockBrowserClient,
+    MockScope,
+    getCapturedClientOptions: () => capturedClientOptions,
+    resetCapturedOptions: () => {
+      capturedClientOptions = null;
+    },
+  };
+});
 
 vi.mock('@/services/bootstrap.service', () => ({
   getBootstrapValue: mockGetBootstrapValue,
@@ -343,7 +367,9 @@ describe('beforeSend integration', () => {
     resetCapturedOptions();
     createDiagnostics({
       host: 'example.com',
-      config: { sentry: { dsn: 'https://key@sentry.io/123', environment: 'test', release: '1.0.0' } },
+      config: {
+        sentry: { dsn: 'https://key@sentry.io/123', environment: 'test', release: '1.0.0' },
+      },
       router: createMockRouter(),
     });
     const options = getCapturedClientOptions();
@@ -364,6 +390,11 @@ describe('beforeSend integration', () => {
   it('applies grouping AND still runs the existing scrubbers', () => {
     const handler = getBeforeSend();
 
+    // Status 500, not 404: a 404 is expected transport noise (#4286) and is
+    // dropped before grouping/scrubbing ever run — see expectedOutcomes.spec.ts.
+    // This test's own concern is that grouping composes with the scrubbing
+    // pipeline for an event that IS reported, so it needs an outcome that
+    // survives the drop filter.
     const event: ErrorEvent = {
       exception: {
         values: [
@@ -371,21 +402,21 @@ describe('beforeSend integration', () => {
             type: 'AxiosError',
             // An email interpolated into the message must still be scrubbed;
             // grouping composes with the pipeline, it does not replace it.
-            value: 'Request failed with status code 404 for user@example.com',
+            value: 'Request failed with status code 500 for user@example.com',
           },
         ],
       },
     };
     const hint: EventHint = {
-      originalException: requestError({ url: '/api/v2/secret/abc123', method: 'get', status: 404 }),
+      originalException: requestError({ url: '/api/v2/secret/abc123', method: 'get', status: 500 }),
     };
 
     const result = handler(event, hint) as ErrorEvent;
 
     expect(result.exception?.values?.[0].value).toBe(
-      'Request failed with status code 404 for [EMAIL_REDACTED]'
+      'Request failed with status code 500 for [EMAIL_REDACTED]'
     );
-    expect(result.fingerprint).toEqual(['api-error', 'GET', '/api/v2/secret/[REDACTED]', '404']);
+    expect(result.fingerprint).toEqual(['api-error', 'GET', '/api/v2/secret/[REDACTED]', '500']);
   });
 
   it('leaves non-matching events with default grouping through beforeSend', () => {

--- a/src/tests/plugins/core/globalErrorBoundary.errorHandler.spec.ts
+++ b/src/tests/plugins/core/globalErrorBoundary.errorHandler.spec.ts
@@ -156,6 +156,45 @@ describe('createErrorBoundary', () => {
         expect.any(Object)
       );
     });
+
+    it('does not call captureException for human-interest errors (#4286)', () => {
+      // Mirrors useAsyncHandler.logTechnicalError's existing gate: an error
+      // already shown to the user via notify is an expected outcome, not a
+      // defect, regardless of which handler caught it.
+      mockIsOfHumanInterest.mockReturnValue(true);
+      mockClassifyError.mockReturnValue({
+        message: 'Secret not found',
+        type: 'human',
+        severity: 'warning',
+      });
+
+      const plugin = createErrorBoundary();
+      plugin.install(mockApp);
+
+      mockApp.config.errorHandler?.(
+        new Error('Request failed with status code 404'),
+        null,
+        'setup function'
+      );
+
+      expect(mockCaptureException).not.toHaveBeenCalled();
+    });
+
+    it('still calls captureException for technical errors when diagnostics is enabled', () => {
+      mockIsOfHumanInterest.mockReturnValue(false);
+      mockClassifyError.mockReturnValue({
+        message: 'Internal error',
+        type: 'technical',
+        severity: 'error',
+      });
+
+      const plugin = createErrorBoundary();
+      plugin.install(mockApp);
+
+      mockApp.config.errorHandler?.(new Error('boom'), null, 'setup function');
+
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('context tags', () => {


### PR DESCRIPTION
## Summary

[#4286](https://github.com/onetimesecret/onetimesecret/issues/4286)

A 404 on a secret link, a cancelled request, or a client-side network error are the product working as designed — the secret was already viewed/burned/expired, or the user navigated away mid-request — not defects. Per the issue, these were the largest noise cluster in the frontend Sentry project (474 events across ~35 issues, six named issues alone: FRONTEND-15G/17X/17B/15X/17E/15K).

- **Added `src/plugins/core/diagnostics/expectedOutcomes.ts`**, a `beforeSend`-level filter that drops request-shaped errors whose outcome is `404`, `aborted`, or `network`. It reuses `grouping.ts`'s existing outcome classification (`requestOutcome`, now exported, along with a new shared `resolveRequestError` helper) so the two modules agree on what counts as a request-shaped error and what its outcome is, instead of re-deriving the logic. Since it runs in `beforeSend`, it catches these outcomes regardless of which code path produced them (manual `captureException` calls, unhandled rejections, integration auto-captures).
- **5xx keeps reporting.** `requestOutcome()` only returns `'network'`/`'aborted'` when there's no response at all — a 502/503/520 always carries a numeric status, so it's never touched by the new filter. Per the issue ("the 503s and 520s are ours, not the client's... track those separately"): they already group into distinct Sentry issues per status/method/path via the existing `apiErrorGroup` fingerprinting, so no further change was needed there.
- **Closed a gap in `globalErrorBoundary.ts`**: its Vue `app.config.errorHandler` called `captureException()` unconditionally on `isDiagnosticsEnabled()` alone — unlike `useAsyncHandler.logTechnicalError`, it never checked `errorGuards.isOfHumanInterest(...)`. That meant a human-classified error (404 included — `HTTP_STATUS_CODES.HUMAN` already includes it) reaching Sentry through Vue's global error handler bypassed the same filtering `useAsyncHandler` already applies. Extracted the capture logic into `reportToSentry()` (and tag-building into `optionalBootstrapTags()`) while at it, mainly to keep the arrow function under the repo's complexity/param-count lint thresholds after adding the extra branch.

## Related Issues

Fixes #4286

## Test Plan

- Added `src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts`: unit tests for `isExpectedTransportOutcome` (drops 404/aborted/network incl. all three real-world cancel shapes — `ERR_CANCELED`/`CanceledError`, `ECONNABORTED`, `AbortError`; keeps 500/502/503/520 and every other 4xx; ignores non-request-shaped errors) plus a `beforeSend` integration section confirming the wiring drops the right events and still runs grouping/scrubbing for events that survive.
- Added two tests to `globalErrorBoundary.errorHandler.spec.ts` locking in the human-interest gate (no `captureException` for human-classified errors; still captures technical ones).
- Updated one pre-existing `grouping.spec.ts` fixture that used a 404 to exercise "grouping composes with scrubbing" — switched to 500 since 404 is now dropped before grouping/scrubbing run, which was the point of that test.
- `pnpm vitest run` on all directly affected + consuming suites (diagnostics plugins, `useAsyncHandler`, `secretStore`, `apps/secret`, `generated`): 2,644+242 tests passing, 0 failures.
- `pnpm run type-check`: clean.
- `pnpm exec eslint` on every changed file: 0 errors (a few pre-existing warnings, none introduced by this change — verified by linting the original blobs).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3fJ1k1p1aRoyHzuaBwnJL

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3fJ1k1p1aRoyHzuaBwnJL)_