### PR TITLE
[#4288] Cut the secret link page's render path

### DIFF
--- a/apps/web/core/spec/views/helpers/vite_manifest_spec.rb
+++ b/apps/web/core/spec/views/helpers/vite_manifest_spec.rb
@@ -1,0 +1,186 @@
+# apps/web/core/spec/views/helpers/vite_manifest_spec.rb
+#
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'json'
+require 'tmpdir'
+
+require_relative '../../../../../../spec/spec_helper'
+
+require_relative '../../../views/helpers/vite_manifest'
+
+# Tests for Core::Views::ViteManifest, the helper that turns a Vite manifest
+# into the <script>/<link> tags the HTML shell emits.
+#
+# What these lock down is the render path of the secret link page (#4288):
+# what the shell tells the browser to fetch at high priority before it can
+# paint anything. Two invariants:
+#
+#   1. The shell preloads the ACTIVE locale's messages asset, and only that
+#      one. Whether the fetch in src/i18n.ts overlaps the JS bundle or queues
+#      behind it hangs on this hint being present and correct.
+#   2. The shell preloads no fonts. It used to preload every font in the
+#      manifest -- eight files, ~675 KB, ahead of the bytes the page actually
+#      needs to render.
+RSpec.describe Core::Views::ViteManifest do
+  # Bare includer: the helper needs nothing from BaseView, and going through
+  # the view stack would make these assertions about serializers instead.
+  let(:includer_class) do
+    Class.new do
+      include Core::Views::ViteManifest
+    end
+  end
+
+  subject(:helper) { includer_class.new }
+
+  let(:public_dir) { Dir.mktmpdir('vite-manifest-spec') }
+  let(:nonce) { 'test-nonce' }
+
+  # Mirrors a real build: one chunk, one stylesheet, per-locale JSON assets
+  # for every locale EXCEPT the one bundled into the chunk (en), plus the
+  # font files the stylesheet references.
+  let(:manifest) do
+    {
+      'main.ts' => {
+        'file' => 'assets/main.abc123.js',
+        'name' => 'main',
+        'src' => 'main.ts',
+        'isEntry' => true,
+        'assets' => [
+          'assets/de.d3adb33f.json',
+          'assets/de_AT.c0ffee12.json',
+          'assets/pt_BR.f00dcafe.json',
+          'assets/ZillaSlab-Regular.aaaa1111.woff2',
+          'assets/ZillaSlab-Regular.bbbb2222.woff',
+          'assets/ZillaSlab-Bold.cccc3333.woff2',
+        ],
+      },
+      'style.css' => { 'file' => 'assets/style.def456.css' },
+    }
+  end
+
+  def write_manifest(data = manifest, filename: 'manifest.json')
+    dir = File.join(public_dir, 'dist', '.vite')
+    FileUtils.mkdir_p(dir)
+    File.write(File.join(dir, filename), JSON.generate(data))
+  end
+
+  before do
+    stub_const('Core::Views::ViteManifest::PUBLIC_DIR', public_dir)
+    write_manifest
+  end
+
+  after do
+    FileUtils.remove_entry(public_dir) if Dir.exist?(public_dir)
+  end
+
+  describe 'the shell tags' do
+    subject(:html) { helper.vite_assets(nonce: nonce, development: false, locale: 'de') }
+
+    it 'links the entry chunk and the stylesheet' do
+      expect(html).to include('<script type="module" nonce="test-nonce" src="/dist/assets/main.abc123.js"></script>')
+      expect(html).to include('<link rel="stylesheet" nonce="test-nonce" href="/dist/assets/style.def456.css">')
+    end
+
+    it 'preloads no fonts' do
+      expect(html).not_to include('as="font"')
+      expect(html).not_to include('.woff')
+    end
+  end
+
+  describe 'locale messages preload' do
+    def preloads(locale)
+      helper
+        .vite_assets(nonce: nonce, development: false, locale: locale)
+        .lines
+        .map(&:strip)
+        .select { |line| line.include?('rel="preload"') }
+    end
+
+    it 'preloads the active locale, and only the active locale' do
+      expect(preloads('de')).to contain_exactly(
+        '<link rel="preload" nonce="test-nonce" href="/dist/assets/de.d3adb33f.json" ' \
+        'as="fetch" type="application/json" crossorigin>'
+      )
+    end
+
+    # `crossorigin` is what makes the hint's credentials mode match the plain
+    # fetch(url) in src/i18n.ts. Without it Chrome discards the preloaded
+    # response and downloads the locale a second time.
+    it 'marks the preload crossorigin' do
+      expect(preloads('de').first).to include('crossorigin')
+    end
+
+    # de_AT must not be served the `de` asset, nor match it as a prefix.
+    it 'distinguishes a regional variant from its base language' do
+      expect(preloads('de_AT').first).to include('/dist/assets/de_AT.c0ffee12.json')
+      expect(preloads('pt_BR').first).to include('/dist/assets/pt_BR.f00dcafe.json')
+    end
+
+    # en is bundled into the chunk, so the build emits no asset for it. That
+    # absence -- not a constant duplicated on this side -- is what suppresses
+    # the hint. A preload nothing fetches is wasted bandwidth on the critical
+    # path and a console warning.
+    it 'emits nothing for a locale the build did not externalize' do
+      expect(preloads('en')).to be_empty
+    end
+
+    it 'emits nothing when no locale is known' do
+      expect(preloads(nil)).to be_empty
+    end
+
+    # The locale reaches us from request state (Accept-Language, a custom
+    # domain's brand settings), so it is pattern-checked before it is used to
+    # build a filename matcher.
+    it 'rejects a locale that is not a locale code' do
+      expect(preloads('../../etc/passwd')).to be_empty
+      expect(preloads('de.d3adb33f')).to be_empty
+      expect(preloads('a' * 32)).to be_empty
+    end
+
+    it 'emits nothing for an unbuilt locale' do
+      expect(preloads('zz')).to be_empty
+    end
+
+    # vite.config.local.ts builds without content hashes.
+    it 'matches an unhashed asset name' do
+      write_manifest(
+        {
+          'main.ts' => {
+            'file' => 'assets/main.js',
+            'isEntry' => true,
+            'assets' => ['assets/de.json', 'assets/de_AT.json'],
+          },
+        }
+      )
+
+      expect(preloads('de').first).to include('/dist/assets/de.json')
+      expect(preloads('de_AT').first).to include('/dist/assets/de_AT.json')
+    end
+  end
+
+  describe 'development mode' do
+    it 'serves the entry from the Vite dev server and preloads nothing' do
+      html = helper.vite_assets(nonce: nonce, development: true, locale: 'de')
+
+      expect(html).to include('src="/dist/main.ts"')
+      expect(html).not_to include('rel="preload"')
+    end
+  end
+
+  describe 'the admin shell' do
+    let(:admin_manifest) do
+      { 'admin.ts' => { 'file' => 'assets/admin.999.js', 'isEntry' => true } }
+    end
+
+    it 'resolves against its own manifest' do
+      write_manifest(admin_manifest, filename: 'manifest-admin.json')
+
+      html = helper.vite_assets(nonce: nonce, development: false, entry: 'admin.ts', locale: 'de')
+
+      expect(html).to include('src="/dist/assets/admin.999.js"')
+      expect(html).not_to include('rel="preload"')
+    end
+  end
+end

--- a/apps/web/core/views/base.rb
+++ b/apps/web/core/views/base.rb
@@ -130,6 +130,11 @@ module Core
             nonce: view_vars['nonce'],
             development: view_vars['frontend_development'],
             entry: vite_entry,
+            # Same precedence the frontend uses to pick its display locale
+            # (src/i18n.ts): a custom domain's brand locale, else the request's.
+            # Anything else and the preload would be for a file the page's
+            # first fetch never asks for.
+            locale: serialized_data['domain_locale'] || view_vars['locale'],
           ),
         }
 

--- a/apps/web/core/views/helpers/vite_manifest.rb
+++ b/apps/web/core/views/helpers/vite_manifest.rb
@@ -8,15 +8,22 @@ module Core
   module Views
     # ViteManifest handles asset loading for Vite-managed frontend assets.
     #
-    # This module loads JavaScript, CSS, and font assets based on the Vite manifest,
-    # supporting both production and development configurations. It handles the
-    # complexities of CSS bundling and font preloading.
+    # This module loads the JavaScript and CSS assets for a shell from the Vite
+    # manifest, supporting both production and development configurations, and
+    # emits the preload hint for the active locale's messages asset.
     #
     module ViteManifest
       include Onetime::LoggerMethods
 
       # Public directory for web assets
       PUBLIC_DIR = File.join(ENV.fetch('ONETIME_HOME', '.'), 'public', 'web').freeze
+
+      # Locale code format accepted for the locale preload lookup. The value
+      # reaches us from request state (Accept-Language, a custom domain's brand
+      # settings), so it is pattern-checked before it is used to build the
+      # filename matcher below.
+      LOCALE_CODE_RE = /\A[a-zA-Z0-9_-]{2,16}\z/
+
       # Generates HTML tags for all required Vite assets.
       #
       # @param nonce [String, nil] Content Security Policy nonce
@@ -25,8 +32,12 @@ module Core
       #   'main.ts' (the customer bundle); the admin shell passes 'admin.ts'.
       #   The key is the source path relative to the Vite root (src/), which is
       #   why it is the '.ts' filename and not the input object key.
+      # @param locale [String, nil] Locale the shell will render in. When the
+      #   build emitted a standalone JSON asset for it, that asset is preloaded
+      #   so the fetch src/i18n.ts makes overlaps the bundle download instead of
+      #   queueing behind it.
       # @return [String] HTML tags for all required assets
-      def vite_assets(nonce: nil, development: nil, entry: 'main.ts')
+      def vite_assets(nonce: nil, development: nil, entry: 'main.ts', locale: nil)
         nonce     ||= self['nonce'] if respond_to?(:[]) # we allow overriding the nonce for testing
         development = self['frontend_development'] if development.nil? && respond_to?(:[])
 
@@ -36,7 +47,7 @@ module Core
         end
 
         # Production mode: use manifest
-        build_prod_assets(nonce, entry)
+        build_prod_assets(nonce, entry, locale)
       end
 
       private
@@ -58,8 +69,9 @@ module Core
       # @param nonce [String] Content Security Policy nonce
       # @param entry [String] Vite manifest entry key to resolve (e.g. 'main.ts'
       #   or 'admin.ts'). Each entry is its own single chunk (codeSplitting:false).
+      # @param locale [String, nil] Locale to preload the messages asset for
       # @return [String] HTML tags for production assets
-      def build_prod_assets(nonce, entry = 'main.ts')
+      def build_prod_assets(nonce, entry = 'main.ts', locale = nil)
         # Each entry is built in its own single-input Vite pass and writes its
         # own self-contained manifest (chunk + CSS + fonts). Resolve the file
         # for the requested entry: the admin console has manifest-admin.json,
@@ -100,7 +112,7 @@ module Core
           assets << build_css_tag(style_entry['file'], nonce)
         end
 
-        assets.concat(build_font_preloads(manifest, nonce))
+        assets.concat(build_locale_preloads(entry_data, nonce, locale))
         assets.join("\n")
       end
 
@@ -124,18 +136,38 @@ module Core
         %(    <link rel="stylesheet" nonce="#{nonce}" href="/dist/#{file}">)
       end
 
-      # Builds preload link tags for font assets.
+      # Builds a preload link for the active locale's messages asset.
       #
-      # @param manifest [Hash] Vite manifest data
+      # Only English rides inside the JS chunk; every other locale is emitted as
+      # a standalone hashed JSON asset that src/i18n.ts fetches before the app
+      # mounts (#4288). Without this hint that fetch cannot even start until the
+      # chunk has downloaded and parsed, so the preload is what keeps it
+      # overlapping the chunk rather than queueing behind it.
+      #
+      # There is deliberately no bundled-locale constant to keep in sync here:
+      # the build does not emit an asset for the locale it bundles, so a locale
+      # with no matching asset simply gets no preload.
+      #
+      # `crossorigin` (anonymous) is required, not decorative — it is what makes
+      # the hint's credentials mode match the plain `fetch(url)` in src/i18n.ts.
+      # Drop it (or change the fetch to omit credentials) and Chrome discards
+      # the preloaded response and downloads the file a second time.
+      #
+      # @param entry_data [Hash] Manifest entry for the shell's chunk
       # @param nonce [String] Content Security Policy nonce
-      # @return [Array<String>] Array of HTML preload link tags
-      def build_font_preloads(manifest, nonce)
-        manifest.values
-          .select { |entry| entry['file'] =~ /\.(woff2?|ttf|otf|eot)$/ }
-          .map do |font|
-            ext = File.extname(font['file']).delete('.')
-            %(    <link rel="preload" nonce="#{nonce}" href="/dist/#{font['file']}" as="font" type="font/#{ext}" crossorigin>)
-        end
+      # @param locale [String, nil] Locale the shell will render in
+      # @return [Array<String>] Zero or one HTML preload link tag
+      def build_locale_preloads(entry_data, nonce, locale)
+        return [] unless locale.is_a?(String) && locale.match?(LOCALE_CODE_RE)
+
+        # `assets/<locale>.<hash>.json` from the hashed build; the hash is
+        # optional because vite.config.local.ts drops it (`assets/<locale>.json`).
+        # Anchored on both sides so `de` cannot claim `de_AT`'s asset.
+        matcher = %r{\A(?:.*/)?#{Regexp.escape(locale)}(?:\.[^./]+)?\.json\z}
+        file    = Array(entry_data['assets']).find { |asset| asset.match?(matcher) }
+        return [] unless file
+
+        [%(    <link rel="preload" nonce="#{nonce}" href="/dist/#{file}" as="fetch" type="application/json" crossorigin>)]
       end
 
       # Builds an error script tag when asset loading fails.

--- a/changelog.d/20260826_030000_claude_4288_secret_link_render_path.rst
+++ b/changelog.d/20260826_030000_claude_4288_secret_link_render_path.rst
@@ -1,0 +1,24 @@
+.. A new scriv changelog fragment.
+
+Changed
+-------
+
+- The customer JS bundle no longer carries every translation. Only English
+  ships inside it; the other locales are built as standalone JSON assets and
+  the page fetches the one it needs. That takes the bundle from 2.66 MB to
+  695 KB gzipped — a 74% cut to the bytes a secret link recipient waits on
+  before the page can render. If a locale asset fails to load the page still
+  renders, in English. (#4288)
+
+- The page no longer preloads fonts. It used to preload every font in the
+  build — eight files, roughly 675 KB, at the browser's highest fetch
+  priority — ahead of the assets the page cannot paint without. The faces now
+  load at normal priority with ``font-display: swap``, so text appears
+  immediately in the fallback serif and restyles when Zilla Slab arrives.
+  (#4288)
+
+AI Assistance
+-------------
+
+- Diagnosis and implementation of the secret link render path work assisted
+  by Claude. (#4288)

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -176,7 +176,18 @@
 }
 
 @layer base {
-  /* Zilla Slab font faces */
+  /* Zilla Slab font faces.
+   *
+   * `swap`, and no <link rel=preload> for any of these (#4288). The shell used
+   * to preload every font in the manifest — eight files, ~675 KB, at the
+   * highest fetch priority — on a page that cannot paint a character of its
+   * own content until the JS bundle lands. On a phone that is bandwidth spent
+   * ahead of the bytes the recipient is waiting for. Unpreloaded, the faces are
+   * discovered when this stylesheet parses and load at normal priority; `swap`
+   * (rather than `fallback`, whose 100ms block period only paid for itself when
+   * the preload usually beat it) means text paints immediately in the serif
+   * fallback and restyles when Zilla Slab arrives.
+   */
   @font-face {
     font-family: 'Zilla Slab';
     src:
@@ -184,7 +195,7 @@
       url('./fonts/zs/ZillaSlab-Regular.woff') format('woff');
     font-weight: 400;
     font-style: normal;
-    font-display: fallback;
+    font-display: swap;
   }
 
   @font-face {
@@ -194,7 +205,7 @@
       url('./fonts/zs/ZillaSlab-Bold.woff') format('woff');
     font-weight: 700;
     font-style: normal;
-    font-display: fallback;
+    font-display: swap;
   }
 
   @font-face {
@@ -204,7 +215,7 @@
       url('./fonts/zs/ZillaSlab-Italic.woff') format('woff');
     font-weight: 400;
     font-style: italic;
-    font-display: fallback;
+    font-display: swap;
   }
 
   @font-face {
@@ -214,7 +225,7 @@
       url('./fonts/zs/ZillaSlab-BoldItalic.woff') format('woff');
     font-weight: 700;
     font-style: italic;
-    font-display: fallback;
+    font-display: swap;
   }
 
   /* Base element styles */

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -8,33 +8,129 @@ import { createI18n, type Composer } from 'vue-i18n';
  * Internationalization configuration and utilities.
  * Sets up Vue i18n instance with locale management and message loading.
  *
- * Locale files are pre-merged by the Python sync script into single files
- * at generated/locales/{locale}.json. This simplifies the frontend loading
- * by eliminating the need for runtime merging of split locale files.
+ * Locale files are pre-merged by the Python sync script
+ * (locales/scripts/i18n content compile) into single files at
+ * generated/locales/{locale}.json.
+ *
+ * Loading strategy (#4288)
+ * ------------------------
+ * Eagerly importing every merged locale put ~8.8 MB of JSON inside the single
+ * customer chunk — 89% of a 2.6 MB gzipped bundle that the secret link page
+ * cannot render one character without. Every recipient downloaded all 30
+ * languages to read one.
+ *
+ * So only English is bundled, and it earns its place: it is the source
+ * language and the tail of every fallback chain, which makes it the safety net
+ * when a locale fetch fails. The other locales are emitted as standalone
+ * hashed JSON assets — `?url` keeps the CONTENT out of the chunk and hands
+ * back the public URL — and are fetched on demand, one request for the one
+ * language the visitor actually reads.
  */
+const BUNDLED_LOCALE = 'en';
 
 /**
- * Import pre-merged locale files directly from generated directory.
- * The Python sync script (locales/scripts/i18n content compile --merged) produces
- * these files during development and build.
+ * Import the pre-merged locale files from the generated directory.
+ *
+ * Note: since vite.config.ts sets root: './src', paths starting with / are
+ * relative to src/. We use /../generated to go up one level to the project
+ * root where generated/ lives.
+ *
+ * Vite requires these patterns to be literals, so 'en' is spelled out rather
+ * than interpolated from BUNDLED_LOCALE — change one and change all three.
  */
-// Using type assertion for Vite's import.meta.glob (types from vite/client reference)
-// Note: Since vite.config.ts sets root: './src', paths starting with / are relative to src/
-// We use /../generated to go up one level to the project root where generated/ lives
-const localeModules = (import.meta as any).glob('/../generated/locales/*.json', {
+const bundledLocaleModules = import.meta.glob('/../generated/locales/en.json', {
   eager: true,
-}) as Record<string, { default: Record<string, any> }>;
+}) as Record<string, { default: Record<string, unknown> }>;
 
+// The bundled locale is excluded from this second glob on purpose: emitting no
+// asset for it is what lets the backend decide whether to preload by asking the
+// manifest, rather than keeping its own copy of BUNDLED_LOCALE that could drift.
+const localeAssetModules = import.meta.glob(
+  ['/../generated/locales/*.json', '!/../generated/locales/en.json'],
+  {
+    eager: true,
+    query: '?url',
+    import: 'default',
+  }
+) as Record<string, string>;
+
+/** Locale code from a merged locale path: /../generated/locales/en.json -> en */
+const localeCodeFromPath = (path: string): string | undefined =>
+  path.match(/\/locales\/([^/]+)\.json$/)?.[1];
+
+/**
+ * Messages loaded so far, keyed by locale code. Seeded with the bundled
+ * locale and filled in by loadLocaleMessages as other locales arrive.
+ */
 const messages: Record<string, any> = {};
 
-// Simple extraction - files are already merged by the Python sync script
-for (const path in localeModules) {
-  // Extract locale code from path: /generated/locales/en.json -> en
-  const match = path.match(/\/locales\/([^/]+)\.json$/);
-  if (match) {
-    const locale = match[1];
-    messages[locale] = localeModules[path].default;
+for (const path in bundledLocaleModules) {
+  const locale = localeCodeFromPath(path);
+  if (locale) {
+    messages[locale] = bundledLocaleModules[path].default;
   }
+}
+
+/** Public URL of each locale's standalone JSON asset, keyed by locale code. */
+const localeAssetUrls: Record<string, string> = {};
+
+for (const path in localeAssetModules) {
+  const locale = localeCodeFromPath(path);
+  if (locale) {
+    localeAssetUrls[locale] = localeAssetModules[path];
+  }
+}
+
+/** In-flight fetches, so concurrent callers share one request per locale. */
+const pendingLoads = new Map<string, Promise<Record<string, unknown> | null>>();
+
+/**
+ * Fetches (once) the messages for a locale that isn't already loaded.
+ *
+ * @param locale - Locale code, e.g. 'de_AT'
+ * @returns The messages, or null when the locale has no asset or the fetch
+ *   failed. Callers treat null as "keep what is already loaded" rather than as
+ *   a reason to abort: an untranslated page beats a blank one.
+ *
+ * The bare `fetch(url)` — default `credentials: 'same-origin'` — is
+ * load-bearing: it is what matches the anonymous `crossorigin` attribute on
+ * the preload link the shell emits for the active locale (see
+ * Core::Views::ViteManifest#build_locale_preloads). Chrome compares the two
+ * credentials modes, and on a mismatch discards the preloaded response and
+ * downloads the file a second time (measured, both ways round). Change one
+ * side and you have to change the other.
+ */
+export function loadLocaleMessages(locale: string): Promise<Record<string, unknown> | null> {
+  const loaded = messages[locale];
+  if (loaded) return Promise.resolve(loaded);
+
+  const url = localeAssetUrls[locale];
+  if (!url) return Promise.resolve(null);
+
+  let pending = pendingLoads.get(locale);
+  if (!pending) {
+    pending = fetch(url)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load locale '${locale}': HTTP ${response.status}`);
+        }
+        return response.json();
+      })
+      .then((localeMessages: Record<string, unknown>) => {
+        messages[locale] = localeMessages;
+        return localeMessages;
+      })
+      .catch((error: unknown) => {
+        console.warn(`[i18n] Falling back to '${BUNDLED_LOCALE}' messages`, error);
+        return null;
+      })
+      .finally(() => {
+        pendingLoads.delete(locale);
+      });
+    pendingLoads.set(locale, pending);
+  }
+
+  return pending;
 }
 
 type GlobalComposer = Composer<{}, {}, {}, Locale>;
@@ -46,7 +142,10 @@ const domainBranding = getBootstrapValue('domain_branding');
 const supportedLocales = getBootstrapValue('supported_locales') || [];
 const fallbackLocale = getBootstrapValue('fallback_locale') || {};
 const defaultLocale = getBootstrapValue('default_locale') || 'en';
-const displayLocale = domainBranding?.locale ?? getBootstrapValue('locale');
+// Resolved (never undefined) so loadDisplayLocaleMessages below has a locale
+// to load; createI18nInstance's default parameter used to absorb the undefined.
+const displayLocale: string =
+  domainBranding?.locale ?? getBootstrapValue('locale') ?? defaultLocale;
 
 /**
  * Creates a completely independent i18n instance with its own locale state and message
@@ -78,7 +177,7 @@ export function createI18nInstance(initialLocale: string = defaultLocale) {
     globalInjection: true, // allows $t to be used globally.
     missingWarn: true, // these enable browser console logging
     fallbackWarn: true, // and are removed from prod builds.
-    messages, // All locales pre-loaded and merged via import.meta.glob()
+    messages: { ...messages }, // whatever has been loaded so far; setLocale adds the rest
     availableLocales: supportedLocales,
   });
 
@@ -102,10 +201,16 @@ export function createI18nInstance(initialLocale: string = defaultLocale) {
    * Updates locale for this instance only
    * @param locale - Target locale to set
    *
-   * Note: All locales are pre-loaded and merged at module load time
-   * via import.meta.glob() in this file, so no dynamic loading is needed.
+   * Awaits the locale's messages before switching, so the instance never
+   * renders a locale it has no messages for. When the load yields nothing
+   * (unknown locale, failed fetch) the switch still happens and vue-i18n
+   * resolves through the fallback chain to the bundled English.
    */
   const setLocale = async (locale: string) => {
+    const localeMessages = await loadLocaleMessages(locale);
+    if (localeMessages) {
+      composer.setLocaleMessage(locale, localeMessages);
+    }
     if (!composer.availableLocales.includes(locale)) {
       console.warn(`Locale ${locale} is not in available locales. Attempting to set anyway.`);
     }
@@ -125,5 +230,18 @@ const {
   composer: globalComposer,
   setLocale: setGlobalLocale,
 } = createI18nInstance(displayLocale);
+
+/**
+ * Loads the messages for the locale the first paint will render in.
+ *
+ * Call this before mounting: with only English in the bundle, mounting first
+ * would flash English at a non-English recipient. Resolves (never rejects)
+ * even when the fetch fails, so a locale asset that 404s costs a translation,
+ * not the page.
+ */
+export function loadDisplayLocaleMessages(): Promise<void> {
+  return setGlobalLocale(displayLocale);
+}
+
 export default i18n;
 export { globalComposer, setGlobalLocale };

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,7 @@ import { createApp } from 'vue';
 import 'vite/modulepreload-polyfill';
 import App from './App.vue';
 import './assets/style.css';
+import { loadDisplayLocaleMessages } from './i18n';
 import { createAppRouter } from './router';
 import { AppInitializer } from './plugins/core/appInitializer';
 import { loggingService } from './services/logging.service';
@@ -30,7 +31,30 @@ window.addEventListener('vite:preloadError', (event) => {
  */
 const app = createApp(App);
 app.use(AppInitializer, { router: createAppRouter(), debug: false });
-app.mount('#app');
+
+/**
+ * Only English rides in the bundle; every other locale is a standalone JSON
+ * asset fetched at runtime (#4288, see src/i18n.ts). Mount after that fetch
+ * settles so a non-English recipient does not watch the page repaint from
+ * English into their own language.
+ *
+ * The wait is bounded by construction: loadDisplayLocaleMessages resolves for
+ * the bundled locale without a request, and swallows a failed fetch rather
+ * than rejecting. The catch below is belt-and-braces — whatever happens, the
+ * app mounts.
+ */
+loadDisplayLocaleMessages()
+  .catch((error: unknown) => {
+    loggingService.error(
+      error instanceof Error
+        ? error
+        : new Error(`[main] Locale messages unavailable: ${String(error)}`)
+    );
+  })
+  .then(() => {
+    app.mount('#app');
+    signalAppReady();
+  });
 
 /**
  * Deterministic app-readiness signal for E2E tests
@@ -48,17 +72,19 @@ app.mount('#app');
  *   asynchronous, so gate the flag on router.isReady(): "ready" then also
  *   means the first navigation has been resolved and rendered.
  */
-app.config.globalProperties.$router
-  .isReady()
-  .then(() => {
-    document.documentElement.dataset.appReady = 'true';
-  })
-  .catch((error: unknown) => {
-    // Deliberately do NOT set the flag: a failed initial navigation means the
-    // app is not usable, and E2E waits should fail loudly with a trace.
-    loggingService.error(
-      error instanceof Error
-        ? error
-        : new Error(`[main] Initial navigation failed; app-ready flag not set: ${String(error)}`)
-    );
-  });
+function signalAppReady() {
+  app.config.globalProperties.$router
+    .isReady()
+    .then(() => {
+      document.documentElement.dataset.appReady = 'true';
+    })
+    .catch((error: unknown) => {
+      // Deliberately do NOT set the flag: a failed initial navigation means the
+      // app is not usable, and E2E waits should fail loudly with a trace.
+      loggingService.error(
+        error instanceof Error
+          ? error
+          : new Error(`[main] Initial navigation failed; app-ready flag not set: ${String(error)}`)
+      );
+    });
+}


### PR DESCRIPTION
## Summary

[#4288](https://github.com/onetimesecret/onetimesecret/issues/4288)

The heavy asset on the secret link page is the JS bundle, and **89% of it is translations nobody on that page reads.**

`src/i18n.ts` eagerly imported all 30 pre-merged locale files, putting ~8.8 MB of JSON inside the single customer chunk. Every recipient downloaded all 30 languages to read one, before the page could render a character.

| | before | after |
|---|---|---|
| `main.js` raw | 9.93 MB | 2.53 MB |
| `main.js` gzipped | **2.66 MB** | **695 KB** (−74%) |
| font preloads | 8 files, ~675 KB, highest priority | none |
| `style.css` gzipped | 36 KB (blocking) | unchanged |

### What changed

**Locales out of the bundle.** English stays in — it is the source language and the tail of every fallback chain, which makes it the safety net when a locale fetch fails. The other locales are emitted as standalone hashed JSON assets (`?url` keeps the content out of the chunk) and fetched on demand: one request, for the one language the visitor reads. `main.ts` mounts after that fetch settles, so a non-English recipient doesn't watch the page repaint from English into their own language.

A failed locale fetch is not fatal: `loadLocaleMessages` resolves to `null`, the app mounts, and the page renders in English rather than raw message keys.

**The shell preloads the active locale's asset** (`as="fetch"`, `crossorigin`). Without the hint that fetch cannot start until the chunk has downloaded *and parsed*; with it, the two overlap. The backend picks the file out of the Vite manifest and there is no bundled-locale constant duplicated on the Ruby side — the build emits no asset for the locale it bundles, so `en` simply gets no preload.

**No more font preloads.** The shell preloaded every font in the manifest — eight files, ~675 KB including four legacy `.woff` fallbacks no modern browser uses — at the browser's highest fetch priority, ahead of the bytes the page cannot paint without. They are now discovered when the stylesheet parses and load at normal priority, with `font-display: swap` (was `fallback`) so text paints immediately in the serif fallback and restyles when Zilla Slab arrives.

### Deliberately not changed

The stylesheet stays render-blocking. It is the only asset the browser actually reports as `renderBlockingStatus: "blocking"`, but at 36 KB gzipped it is far under the detector's size floor, and deferring it in an SPA trades a slightly earlier first paint for FOUC risk on the highest-intent page in the product. Cutting ~2.6 MB of competing traffic ahead of it is the better lever.

Also unchanged: the single-chunk / no-code-splitting build. That is load-bearing for the CSP nonce model, and this change gets the win without touching it.

## Related Issues

Fixes #4288

## Test Plan

**Measured, not assumed.** Probed the built bundle in Chromium (`PerformanceResourceTiming`) to identify what the browser actually flags: `style.css` → `blocking` (36 KB), `main.js` and every font preload → `non-blocking`. That ruled the CSS and fonts out on size and pointed at the bundle.

Booted the real built app in Chromium against a local static server:

- **German** — app mounts, renders fully in German, **exactly one** locale request, no preload-mismatch warning.
- **English** — app mounts, **zero** locale requests (bundled).
- **Locale asset 404s** — app still mounts and renders in English, not raw keys, not blank.

The preload/fetch pairing was verified empirically across four combinations; three of them cause a **double download**. Only `crossorigin` + default `fetch(url)` credentials matches (1 request, no warning) — that pairing is now commented on both sides.

Dev server checked too: the `?url` glob resolves to a working `/dist/@fs/...` URL serving `application/json`.

- `pnpm vitest run` — 8913 passed, 394 files, 0 failures
- `pnpm type-check` — clean
- `eslint` + `prettier --check` on changed files — clean
- New `apps/web/core/spec/views/helpers/vite_manifest_spec.rb` covers: active-locale preload emitted and `crossorigin`; `de_AT` not served `de`'s asset; nothing for a bundled/unknown locale; non-locale-code input rejected; unhashed (`build:local`) asset names matched; no font preloads emitted.

**Not run here:** the Ruby lane (`tests/lanes/run unit`) — this environment has no Docker daemon for the backing services, and no `.test-mode` sentinel. The new spec is syntax-checked and its subject method was exercised directly against a real build manifest; CI runs the lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVuYZ7U8XAhzHANyo8domV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVuYZ7U8XAhzHANyo8domV)_