### PR TITLE
Sync customer role vocabulary with backend and stop role failing the account parse

### DIFF
--- a/changelog.d/20260826_201500_claude_4298_customer_role_vocabulary.rst
+++ b/changelog.d/20260826_201500_claude_4298_customer_role_vocabulary.rst
@@ -1,0 +1,25 @@
+.. A new scriv changelog fragment.
+
+Fixed
+-----
+
+- The API Key settings page no longer breaks for accounts promoted to
+  ``admin`` or ``staff`` via ``bin/ots customers role`` (#4298). The
+  frontend role enum now mirrors the backend's assignable roles (enforced
+  by a contract test against ``SetRole::VALID_ROLES``), and an unknown or
+  missing ``role`` degrades to ``customer`` instead of failing the whole
+  account record parse.
+
+Changed
+-------
+
+- Frontend Sentry events now serialize nested extras to depth 6
+  (``normalizeDepth``), so schema-validation failures report their
+  ``issues[]`` payload instead of ``"[Array]"``.
+
+AI Assistance
+-------------
+
+- AI assistance was used to trace the Sentry signatures to the role
+  vocabulary mismatch, sync the enums, and add the drift-guard contract
+  test.

--- a/src/README.md
+++ b/src/README.md
@@ -63,7 +63,7 @@ Three role systems apply at different layers. Do not conflate them.
 
 - **Transaction roles** (resolved by `useSecretContext`): `CREATOR`, `RECIPIENT_AUTH`, `RECIPIENT_ANON`. Answers "who are you relative to *this secret*?". `CREATOR` is singular by design; recipient variance is intentional.
 - **Organization roles**: `OWNER`, `ADMIN`, `MEMBER`. Standard RBAC inside Workspace.
-- **Account roles** (`CustomerRole`): `CUSTOMER`, `COLONEL`, `RECIPIENT`, `USER_DELETED_SELF`. Global account type; `COLONEL` grants `/colonel/*` access.
+- **Account roles** (`CustomerRole`): `CUSTOMER`, `COLONEL`, `ADMIN`, `STAFF`, `RECIPIENT`, `USER_DELETED_SELF`, `ANONYMOUS`. Global account type; `COLONEL` grants `/colonel/*` access. Mirrors the backend's assignable roles (`SetRole::VALID_ROLES`) plus lifecycle values; an unknown role on the wire degrades to `CUSTOMER` rather than failing the record parse.
 
 | Concern        | Secret App                  | Workspace App      |
 |----------------|-----------------------------|--------------------|

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -727,6 +727,15 @@ export function createDiagnostics(options: EnableDiagnosticsOptions): Plugin {
     stackParser: defaultStackParser,
     // tracesSampleRate: Keep low default since YAML doesn't define it and traces are high-volume
     tracesSampleRate: config.sentry.tracesSampleRate ?? 0.01,
+    // Sentry's default normalizeDepth of 3 truncates nested extras to
+    // "[Array]"/"[Object]". That has now hidden the payload of a schema
+    // validation failure twice: gracefulParse attaches `issues[].path`/
+    // `.code`/`.message` as extras, and at depth 3 the issue objects were
+    // unreadable, so diagnosing #4298 (and the colonel-org schema failure
+    // before it) meant inferring the rejected field's value instead of
+    // reading it. Depth 6 covers extra → issues[] → issue → path[] with room
+    // to spare. Bounded cost: extras are already small and scrubbed.
+    normalizeDepth: 6,
     // Note: Sentry 10+ requires sendDefaultPii: true for IP address collection
     // sendDefaultPii: false, // Default is false
     tracePropagationTargets: [

--- a/src/schemas/contracts/customer.ts
+++ b/src/schemas/contracts/customer.ts
@@ -34,8 +34,19 @@ import { z } from 'zod';
  * Roles determine authorization level and user status:
  * - `customer`: Standard authenticated user
  * - `colonel`: Administrative/privileged user
+ * - `admin`: Administrative user (assignable via `bin/ots customers role`)
+ * - `staff`: Staff user (assignable via `bin/ots customers role`)
  * - `recipient`: Read-only secret recipient
  * - `user_deleted_self`: Self-deleted account (soft delete)
+ * - `anonymous`: Unauthenticated sentinel (`Customer#anonymous?` backend check)
+ *
+ * MUST be a superset of the backend's assignable roles —
+ * `Auth::Operations::Customers::SetRole::VALID_ROLES` in
+ * apps/web/auth/operations/customers/set_role.rb. A backend-writable role
+ * missing here broke /account/settings/api for promoted accounts (#4298,
+ * FRONTEND-19V): the strict enum failed the whole AccountResponse parse.
+ * The sync is enforced by src/tests/contracts/customer-role-contract.spec.ts,
+ * which reads VALID_ROLES from the Ruby source.
  *
  * @category Contracts
  * @example
@@ -52,8 +63,11 @@ import { z } from 'zod';
 export const customerRoleValues = [
   'customer',
   'colonel',
+  'admin',
+  'staff',
   'recipient',
   'user_deleted_self',
+  'anonymous',
 ] as const;
 
 export type CustomerRole = (typeof customerRoleValues)[number];
@@ -89,16 +103,39 @@ export type CustomerRole = (typeof customerRoleValues)[number];
 export const CustomerRole = {
   CUSTOMER: 'customer',
   COLONEL: 'colonel',
+  ADMIN: 'admin',
+  STAFF: 'staff',
   RECIPIENT: 'recipient',
   USER_DELETED_SELF: 'user_deleted_self',
+  ANONYMOUS: 'anonymous',
 } as const;
 
 /**
  * Zod schema for validating customer role values.
  *
+ * Strict — rejects anything outside the enum. Use for inputs the frontend
+ * controls (forms, guards). For parsing backend records, use
+ * {@link customerRoleResilientSchema} instead.
+ *
  * @category Contracts
  */
 export const customerRoleSchema = z.enum(customerRoleValues);
+
+/**
+ * Resilient role schema for parsing backend records.
+ *
+ * `.catch('customer')` over the bare enum: `role` is a display/UX field, and
+ * an unrecognized value must degrade the role badge, never take down a whole
+ * page. Before this, a role outside the enum failed the entire
+ * AccountResponse parse and /account/settings/api rendered the error
+ * boundary (#4298 / FRONTEND-19V — an account promoted to `admin` via the
+ * CLI). The catch also absorbs legacy Redis hashes with a missing/null
+ * `role`. Authorization is enforced server-side, so falling back to
+ * 'customer' can only under-display, never over-grant.
+ *
+ * @category Contracts
+ */
+export const customerRoleResilientSchema = customerRoleSchema.catch('customer');
 
 /**
  * Type guard for runtime customer role validation.
@@ -193,8 +230,10 @@ export const customerCanonical = z.object({
   // Status fields
   // ─────────────────────────────────────────────────────────────────────────
 
-  /** User role determining authorization level. */
-  role: customerRoleSchema,
+  /** User role determining authorization level. Unknown values degrade to
+   * 'customer' rather than failing the record parse — see
+   * customerRoleResilientSchema. */
+  role: customerRoleResilientSchema,
 
   /** Whether email address has been verified. */
   verified: z.boolean(),

--- a/src/schemas/shapes/v2/customer.ts
+++ b/src/schemas/shapes/v2/customer.ts
@@ -10,7 +10,7 @@
 // - customerCanonical defines field names and output types
 // - This V2 shape applies string transforms for Redis wire format
 
-import { customerCanonical, customerRoleSchema } from '@/schemas/contracts';
+import { customerCanonical, customerRoleResilientSchema } from '@/schemas/contracts';
 import { transforms } from '@/schemas/transforms';
 import { withFeatureFlags } from '@/schemas/utils/feature_flags';
 import { z } from 'zod';
@@ -108,8 +108,9 @@ export const customerSchema = withFeatureFlags(
       ...v2BooleanOverrides,
       ...v2CounterOverrides,
 
-      // Role uses shared schema (no transform needed)
-      role: customerRoleSchema,
+      // Role uses shared schema (no transform needed). Resilient: unknown
+      // values degrade to 'customer' instead of failing the record parse (#4298).
+      role: customerRoleResilientSchema,
     })
     .strict()
 );

--- a/src/schemas/shapes/v3/customer.ts
+++ b/src/schemas/shapes/v3/customer.ts
@@ -5,7 +5,7 @@
 
 import {
   customerCanonical,
-  customerRoleSchema,
+  customerRoleResilientSchema,
   featureFlagsSchema,
 } from '@/schemas/contracts';
 import { transforms } from '@/schemas/transforms';
@@ -112,8 +112,9 @@ export const customerSchema = customerCanonical.extend({
   ...v3TimestampOverrides,
   ...v3FeatureFlagsOverride,
 
-  // Role enum (re-declare for explicit wire format)
-  role: customerRoleSchema,
+  // Role enum (re-declare for explicit wire format). Resilient: unknown
+  // values degrade to 'customer' instead of failing the record parse (#4298).
+  role: customerRoleResilientSchema,
 
   // Counter fields with defaults (V3 sends native numbers, coerce for resilience)
   // Uses z.coerce.number() per #2699 to handle edge cases where API sends strings

--- a/src/services/diagnostics.service.ts
+++ b/src/services/diagnostics.service.ts
@@ -38,7 +38,7 @@ let diagnosticsClient: DiagnosticsClient | null = null;
  * - service: web, api
  * - jurisdiction: region code from bootstrap.regions.current_jurisdiction
  * - planid: plan identifier from bootstrap.organization.planid
- * - role: customer, colonel, recipient, user_deleted_self from bootstrap.cust.role
+ * - role: a customerRoleValues member (schemas/contracts/customer.ts) from bootstrap.cust.role
  *
  * @see https://github.com/onetimesecret/onetimesecret/issues/2964
  */

--- a/src/tests/contracts/customer-role-contract.spec.ts
+++ b/src/tests/contracts/customer-role-contract.spec.ts
@@ -101,11 +101,14 @@ describe('Customer role contract (SetRole::VALID_ROLES)', () => {
   );
 
   it('frontend-only roles are documented lifecycle values', () => {
-    // Values the frontend knows but the CLI cannot assign. Each is set by a
-    // backend feature rather than the SetRole op. If this list grows,
-    // document where the new value comes from.
+    // Values the frontend knows but the CLI cannot assign. If this list
+    // grows, document where the new value comes from.
     const lifecycleRoles: Record<string, string> = {
-      recipient: 'Read-only secret recipient',
+      // No backend writer exists (checked current tree and legacy tags back
+      // to v0.9.0). Kept for parse compatibility with any stored records;
+      // not to be confused with the per-secret ActorRole in
+      // useSecretContext (RECIPIENT_AUTH/RECIPIENT_ANON).
+      recipient: 'Frontend-only; never written by the backend',
       user_deleted_self: 'right_to_be_forgotten feature (lib/onetime/models/features)',
       anonymous: 'Customer#anonymous? sentinel (lib/onetime/models/customer.rb)',
     };

--- a/src/tests/contracts/customer-role-contract.spec.ts
+++ b/src/tests/contracts/customer-role-contract.spec.ts
@@ -1,0 +1,148 @@
+// src/tests/contracts/customer-role-contract.spec.ts
+//
+// Contract tests keeping the frontend role vocabulary in sync with the
+// backend's assignable roles, and pinning the degradation behavior for
+// values outside it (#4298 / FRONTEND-19V).
+//
+// The backend's single source of truth for assignable roles is
+// Auth::Operations::Customers::SetRole::VALID_ROLES
+// (apps/web/auth/operations/customers/set_role.rb) — every value there is
+// writable to a live customer record via `bin/ots customers role promote`.
+// The frontend enum silently missed `admin`/`staff`, so a promoted account
+// failed the whole AccountResponse parse and /account/settings/api rendered
+// the error boundary. These tests read VALID_ROLES from the Ruby source, so
+// a backend role the frontend cannot parse fails CI instead of production.
+
+import {
+  customerRoleResilientSchema,
+  customerRoleSchema,
+  customerRoleValues,
+} from '@/schemas/contracts/customer';
+import { customerSchema as v3CustomerSchema } from '@/schemas/shapes/v3/customer';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Backend source extraction
+// ---------------------------------------------------------------------------
+
+const SET_ROLE_SOURCE_PATH = fileURLToPath(
+  new URL('../../../apps/web/auth/operations/customers/set_role.rb', import.meta.url)
+);
+
+/**
+ * Extracts VALID_ROLES from the Ruby op's source.
+ *
+ * Throws (failing the suite loudly) if the file moves or the declaration
+ * changes shape — a silent empty list would make every assertion below
+ * vacuously pass.
+ */
+function backendAssignableRoles(): string[] {
+  const source = readFileSync(SET_ROLE_SOURCE_PATH, 'utf8');
+  const match = source.match(/VALID_ROLES\s*=\s*%w\[([^\]]*)\]/);
+  if (!match) {
+    throw new Error(
+      `Could not extract VALID_ROLES from ${SET_ROLE_SOURCE_PATH}. ` +
+        'If the declaration moved or changed shape, update this test AND ' +
+        'verify customerRoleValues still covers every assignable role.'
+    );
+  }
+  return match[1].trim().split(/\s+/).filter(Boolean);
+}
+
+/** Minimal valid V3 customer record (mirrors account.spec.ts fixture). */
+const validCustomerBase = {
+  identifier: 'cust:abc123',
+  created: 1700000000,
+  updated: 1700000000,
+  objid: 'abc123',
+  extid: '',
+  role: 'customer',
+  email: 'user@example.com',
+  verified: true,
+  active: true,
+  secrets_created: 0,
+  secrets_burned: 0,
+  secrets_shared: 0,
+  emails_sent: 0,
+  last_login: null,
+  locale: 'en',
+  notify_on_reveal: false,
+  feature_flags: {},
+};
+
+// ---------------------------------------------------------------------------
+// Vocabulary sync (frontend ⊇ backend-assignable)
+// ---------------------------------------------------------------------------
+
+describe('Customer role contract (SetRole::VALID_ROLES)', () => {
+  const backendRoles = backendAssignableRoles();
+
+  it('extraction found a plausible role list', () => {
+    // Guard against regex rot: the backend list must at minimum contain the
+    // two roles the product cannot function without.
+    expect(backendRoles).toContain('colonel');
+    expect(backendRoles).toContain('customer');
+  });
+
+  it.each(backendRoles)(
+    'backend-assignable role "%s" is in customerRoleValues',
+    (role) => {
+      expect(customerRoleValues).toContain(role);
+    }
+  );
+
+  it.each(backendRoles)(
+    'backend-assignable role "%s" parses through the strict role schema',
+    (role) => {
+      expect(customerRoleSchema.parse(role)).toBe(role);
+    }
+  );
+
+  it('frontend-only roles are documented lifecycle values', () => {
+    // Values the frontend knows but the CLI cannot assign. Each is set by a
+    // backend feature rather than the SetRole op. If this list grows,
+    // document where the new value comes from.
+    const lifecycleRoles: Record<string, string> = {
+      recipient: 'Read-only secret recipient',
+      user_deleted_self: 'right_to_be_forgotten feature (lib/onetime/models/features)',
+      anonymous: 'Customer#anonymous? sentinel (lib/onetime/models/customer.rb)',
+    };
+    const frontendOnly = customerRoleValues.filter((r) => !backendRoles.includes(r));
+    expect(frontendOnly.filter((r) => !(r in lifecycleRoles))).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Degradation behavior (role must never be parse-blocking)
+// ---------------------------------------------------------------------------
+
+describe('customerRoleResilientSchema degradation', () => {
+  it('degrades an unknown role to "customer"', () => {
+    expect(customerRoleResilientSchema.parse('superuser')).toBe('customer');
+  });
+
+  it('degrades a null role (legacy Redis hash without the field) to "customer"', () => {
+    expect(customerRoleResilientSchema.parse(null)).toBe('customer');
+    expect(customerRoleResilientSchema.parse(undefined)).toBe('customer');
+  });
+
+  it('passes known roles through unchanged', () => {
+    for (const role of customerRoleValues) {
+      expect(customerRoleResilientSchema.parse(role)).toBe(role);
+    }
+  });
+
+  it('a full customer record with an unknown role parses with role degraded', () => {
+    // The #4298 failure mode: the role value must degrade the badge, never
+    // fail the record parse and take down the settings page.
+    const result = v3CustomerSchema.parse({ ...validCustomerBase, role: 'superuser' });
+    expect(result.role).toBe('customer');
+  });
+
+  it('a full customer record with a CLI-assigned role keeps it', () => {
+    const result = v3CustomerSchema.parse({ ...validCustomerBase, role: 'admin' });
+    expect(result.role).toBe('admin');
+  });
+});

--- a/src/tests/schemas/api/v3/responses/account.spec.ts
+++ b/src/tests/schemas/api/v3/responses/account.spec.ts
@@ -159,18 +159,26 @@ describe('v3CustomerSchema', () => {
   });
 
   describe('role validation', () => {
-    it.each(['customer', 'colonel', 'recipient', 'user_deleted_self'] as const)(
-      'accepts role "%s"',
-      (role) => {
-        const input = { ...validCustomerBase, role };
-        const result = v3CustomerSchema.parse(input);
-        expect(result.role).toBe(role);
-      }
-    );
+    it.each([
+      'customer',
+      'colonel',
+      'admin',
+      'staff',
+      'recipient',
+      'user_deleted_self',
+      'anonymous',
+    ] as const)('accepts role "%s"', (role) => {
+      const input = { ...validCustomerBase, role };
+      const result = v3CustomerSchema.parse(input);
+      expect(result.role).toBe(role);
+    });
 
-    it('rejects invalid role', () => {
-      const input = { ...validCustomerBase, role: 'admin' };
-      expect(() => v3CustomerSchema.parse(input)).toThrow();
+    it('degrades an unknown role to "customer" instead of rejecting (#4298)', () => {
+      // A role outside the enum must never fail the record parse — that took
+      // down /account/settings/api for CLI-promoted accounts.
+      const input = { ...validCustomerBase, role: 'superuser' };
+      const result = v3CustomerSchema.parse(input);
+      expect(result.role).toBe('customer');
     });
   });
 

--- a/src/tests/schemas/shapes/customer.compat.spec.ts
+++ b/src/tests/schemas/shapes/customer.compat.spec.ts
@@ -521,23 +521,28 @@ describe('Transform Error Handling', () => {
   });
 
   describe('role validation', () => {
-    it('rejects invalid role values', () => {
+    it('degrades invalid role values to "customer" instead of rejecting (#4298)', () => {
       const wire = createV2WireCustomer(createCanonicalCustomer());
       (wire as Record<string, unknown>).role = 'superuser';
 
       const result = v2CustomerSchema.safeParse(wire);
 
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        const roleError = result.error.issues.find((i) =>
-          i.path.includes('role')
-        );
-        expect(roleError).toBeDefined();
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.role).toBe('customer');
       }
     });
 
     it('accepts all valid role values', () => {
-      const roles = ['customer', 'colonel', 'recipient', 'user_deleted_self'];
+      const roles = [
+        'customer',
+        'colonel',
+        'admin',
+        'staff',
+        'recipient',
+        'user_deleted_self',
+        'anonymous',
+      ];
 
       for (const role of roles) {
         const wire = createV2WireCustomer(


### PR DESCRIPTION
## Summary

[#4298](https://github.com/onetimesecret/onetimesecret/issues/4298)

The frontend `customerRoleValues` enum was missing `admin` and `staff`, both assignable to live customer records via `bin/ots customers role promote --role admin|staff` (`Auth::Operations::Customers::SetRole::VALID_ROLES` is the backend authority, and the admin UI already compares against `role === 'admin'`). Any promoted account then failed the entire `AccountResponse` zod parse at `record.cust.role` (Sentry FRONTEND-19V), `accountStore.fetch()` threw (FRONTEND-1A6), and `/account/settings/api` rendered "Something went wrong".

Changes:

- **Vocabulary sync**: `customerRoleValues` / `CustomerRole` now include `admin`, `staff`, and `anonymous` (the `Customer#anonymous?` sentinel), alongside the existing lifecycle values.
- **Role is no longer parse-blocking**: customer records parse `role` through `customerRoleResilientSchema` (`.catch('customer')`, same precedent as `homepage-config.ts`). An unknown or missing role — including legacy Redis hashes where `role` was never persisted — degrades the role badge instead of taking down the page. Authorization is enforced server-side, so the fallback can only under-display, never over-grant.
- **Drift guard**: new contract test `src/tests/contracts/customer-role-contract.spec.ts` reads `VALID_ROLES` out of `set_role.rb` and asserts every backend-assignable role parses through the frontend schema, so the two vocabularies cannot silently diverge again. It also pins the degradation behavior.
- **Telemetry gap**: Sentry `normalizeDepth: 6` (default 3 collapsed `gracefulParse`'s `issues[]` extras to `"[Array]"`, which has now obstructed two schema-failure diagnoses — this one and the colonel-org one).
- Updated the two tests that asserted an out-of-enum role must *reject* the record (that expectation was the production failure mode), plus stale docs.

Not in this PR (backend/ops follow-ups from the diagnosis):
- Redis backfill scan for customers with a role outside the agreed set or a missing `role` field — `customers role reconcile` only repairs the role *index*, not out-of-vocabulary values.
- Confirming the #4298 reporter's actual stored role via `bin/ots customers show` (needs production access).

## Related Issues

Fixes #4298

## Test Plan

- New contract suite: `pnpm vitest run src/tests/contracts/customer-role-contract.spec.ts` — backend `VALID_ROLES` ⊆ frontend enum, strict parse of each assignable role, degradation of unknown/null role to `customer`, and a full v3 customer record with `role: 'admin'` (the production payload) parsing successfully.
- Updated `account.spec.ts` and `customer.compat.spec.ts` role suites to the new accept/degrade behavior.
- Full frontend unit suite: 398 files, 9031 tests passing. `pnpm run type-check` clean; `type-check:tests` error count unchanged from base (pre-existing failures, none in touched files).


---
_Generated by [Claude Code](https://claude.ai/code/session_017dSkRh8EGis3NQV6GNfYxQ)_