### PR TITLE
Read ANTHROPIC_MODEL in the Claude workflows and pin the action to a SHA

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -75,21 +75,24 @@ jobs:
       # be related. Re-run after comment activity settles.
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Primary model precedence: the workflow_dispatch "model" input (manual
-          # runs) -> the CLAUDE_MODEL repo variable -> this built-in default. The
-          # action's frozen default (claude-sonnet-4-20250514) is retired and
-          # 404s. Fall back to Haiku on overload. The fallback default MUST differ
-          # from the primary default: the action errors with "Fallback model
-          # cannot be the same as the main model" when they resolve to the same id.
-          model: "${{ inputs.model || vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}"
-          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-haiku-4-5-20251001' }}"
+          # Model selection. The action's own default is a retired id that 404s
+          # before the run starts, so this must always resolve to something live.
+          # 'opus' is an alias the pinned CLI resolves at run time, so a model
+          # retirement needs no edit here. Set the ANTHROPIC_MODEL repo variable
+          # to override; the literal is the floor, so an unset or cleared
+          # variable stays harmless (an empty value would hand the action back
+          # its own retired default). No fallback_model: on v1 the input does not
+          # exist, and a silent downgrade under a sticky comment would replace a
+          # defect review with a weaker one that still reads as green.
+          claude_args: --model ${{ vars.ANTHROPIC_MODEL || 'opus' }}
 
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
+          # Automated review prompt (no @claude mention needed). Supplying
+          # `prompt` on a pull_request event is what puts v1 in automation mode.
+          prompt: |
             Review this PR for defects. Report only findings you can state
             as a concrete failure scenario (specific input or state leading
             to wrong output, data loss, or a security consequence), with
@@ -115,19 +118,13 @@ jobs:
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true
 
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+          # Optional: further CLI flags go on the claude_args line above, e.g.
+          #   claude_args: --model opus --allowed-tools 'Bash(pnpm run test:*)'
+          #
+          # The v0 inputs model/fallback_model/direct_prompt do not exist on v1;
+          # the action silently ignores unknown inputs, so do not reintroduce
+          # them. `direct_prompt` in particular becomes a dropped prompt, which
+          # turns the review into an unscoped default one with no visible error.
 
       - name: Remove claude-review label
         # Remove label whether success or failure - prevents getting stuck

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -16,17 +16,6 @@ on:
     # PR still triggers (paths-ignore skips only when every file matches).
     paths-ignore:
       - 'locales/content/**'
-  workflow_dispatch:
-    inputs:
-      model:
-        description: "Claude model for this run (overrides the CLAUDE_MODEL repo variable)"
-        type: choice
-        required: false
-        default: claude-sonnet-4-6
-        options:
-          - claude-sonnet-4-6
-          - claude-opus-4-6
-          - claude-haiku-4-5-20251001
 
 jobs:
   claude-review:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,24 +64,23 @@ jobs:
       # be related. Re-run after comment activity settles.
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7 # v1
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Model selection. The action's own default is a retired id that 404s
-          # before the run starts, so this must always resolve to something live.
-          # 'opus' is an alias the pinned CLI resolves at run time, so a model
-          # retirement needs no edit here. Set the ANTHROPIC_MODEL repo variable
-          # to override; the literal is the floor, so an unset or cleared
-          # variable stays harmless (an empty value would hand the action back
-          # its own retired default). No fallback_model: on v1 the input does not
-          # exist, and a silent downgrade under a sticky comment would replace a
-          # defect review with a weaker one that still reads as green.
-          claude_args: --model ${{ vars.ANTHROPIC_MODEL || 'opus' }}
+          # Model selection. The action's own default (claude-sonnet-4-20250514)
+          # is retired and 404s before the run starts, so this must always
+          # resolve to something live. Set the ANTHROPIC_MODEL repo variable to
+          # change models without a PR; the literal is the floor, so an unset or
+          # cleared variable stays harmless (an empty value would hand the action
+          # back its own retired default). Spelled out rather than passed as the
+          # 'opus' alias: this ref bundles Claude Code 1.0.88, which resolves
+          # aliases against its own build-time table, itself naming retired ids.
+          model: "${{ vars.ANTHROPIC_MODEL || 'claude-opus-5' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-haiku-4-5-20251001' }}"
 
-          # Automated review prompt (no @claude mention needed). Supplying
-          # `prompt` on a pull_request event is what puts v1 in automation mode.
-          prompt: |
+          # Direct prompt for automated review (no @claude mention needed)
+          direct_prompt: |
             Review this PR for defects. Report only findings you can state
             as a concrete failure scenario (specific input or state leading
             to wrong output, data loss, or a security consequence), with
@@ -107,13 +106,8 @@ jobs:
           # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true
 
-          # Optional: further CLI flags go on the claude_args line above, e.g.
-          #   claude_args: --model opus --allowed-tools 'Bash(pnpm run test:*)'
-          #
-          # The v0 inputs model/fallback_model/direct_prompt do not exist on v1;
-          # the action silently ignores unknown inputs, so do not reintroduce
-          # them. `direct_prompt` in particular becomes a dropped prompt, which
-          # turns the review into an unscoped default one with no visible error.
+          # Optional: Add specific tools for running tests or linting
+          # allowed_tools: "Bash(pnpm run test),Bash(pnpm run lint)"
 
       - name: Remove claude-review label
         # Remove label whether success or failure - prevents getting stuck

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -57,14 +57,14 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Primary model: set the CLAUDE_MODEL repo variable to override without
-          # editing this file. Pinning a current id avoids the action's frozen
-          # default (claude-sonnet-4-20250514), which is retired and 404s. Fall
-          # back to Haiku if the primary is unavailable or overloaded. The fallback
-          # default MUST differ from the primary default: the action errors with
-          # "Fallback model cannot be the same as the main model" otherwise.
-          model: "${{ vars.CLAUDE_MODEL || 'claude-sonnet-4-6' }}"
-          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-haiku-4-5-20251001' }}"
+          # Model selection. The action's own default is a retired id that 404s
+          # before the run starts, so this must always resolve to something live.
+          # 'opus' is an alias the pinned CLI resolves at run time, so a model
+          # retirement needs no edit here. Set the ANTHROPIC_MODEL repo variable
+          # to override; the literal is the floor, so an unset or cleared
+          # variable stays harmless (an empty value would hand the action back
+          # its own retired default).
+          claude_args: --model ${{ vars.ANTHROPIC_MODEL || 'opus' }}
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
@@ -72,15 +72,10 @@ jobs:
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
 
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
+          # Optional: further CLI flags go on the claude_args line above, e.g.
+          #   claude_args: --model opus --allowed-tools 'Bash(pnpm run test:*)'
+          # See https://code.claude.com/docs/en/cli-reference
+          #
+          # The v0 inputs model/fallback_model/custom_instructions/claude_env
+          # do not exist on v1; the action silently ignores unknown inputs, so
+          # do not reintroduce them.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@70fec183852c4f82f3f1969faed7dd60c5149ca7 # v1
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -57,14 +57,16 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Model selection. The action's own default is a retired id that 404s
-          # before the run starts, so this must always resolve to something live.
-          # 'opus' is an alias the pinned CLI resolves at run time, so a model
-          # retirement needs no edit here. Set the ANTHROPIC_MODEL repo variable
-          # to override; the literal is the floor, so an unset or cleared
-          # variable stays harmless (an empty value would hand the action back
-          # its own retired default).
-          claude_args: --model ${{ vars.ANTHROPIC_MODEL || 'opus' }}
+          # Model selection. The action's own default (claude-sonnet-4-20250514)
+          # is retired and 404s before the run starts, so this must always
+          # resolve to something live. Set the ANTHROPIC_MODEL repo variable to
+          # change models without a PR; the literal is the floor, so an unset or
+          # cleared variable stays harmless (an empty value would hand the action
+          # back its own retired default). Spelled out rather than passed as the
+          # 'opus' alias: this ref bundles Claude Code 1.0.88, which resolves
+          # aliases against its own build-time table, itself naming retired ids.
+          model: "${{ vars.ANTHROPIC_MODEL || 'claude-opus-5' }}"
+          fallback_model: "${{ vars.CLAUDE_FALLBACK_MODEL || 'claude-haiku-4-5-20251001' }}"
 
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
@@ -72,10 +74,13 @@ jobs:
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
 
-          # Optional: further CLI flags go on the claude_args line above, e.g.
-          #   claude_args: --model opus --allowed-tools 'Bash(pnpm run test:*)'
-          # See https://code.claude.com/docs/en/cli-reference
-          #
-          # The v0 inputs model/fallback_model/custom_instructions/claude_env
-          # do not exist on v1; the action silently ignores unknown inputs, so
-          # do not reintroduce them.
+          # Optional: Allow Claude to run specific commands
+          # allowed_tools: "Bash(pnpm install),Bash(pnpm run test:*),Bash(pnpm run lint:*)"
+
+          # Optional: Add custom instructions for Claude
+          # custom_instructions: |
+          #   Follow our coding standards
+
+          # Optional: Custom environment variables for Claude
+          # claude_env: |
+          #   NODE_ENV: test


### PR DESCRIPTION
Stays on `claude-code-action` beta. Three commits, and the middle of the series
detours through v1 before returning — read the net diff, not the intermediate states.

## The defect

`ANTHROPIC_MODEL=claude-opus-5` has been set on this repo since 2026-08-24, but both
workflows read `vars.CLAUDE_MODEL`, which was never set. Every review since has run the
`claude-sonnet-4-6` literal instead. Same variable name is already in use in
`onetimesecret/macos` and `onetime/monorepo`, so an org-level variable can move all
three at once.

The `|| 'claude-opus-5'` literal is load-bearing: an unset variable evaluates to the
empty string, which hands the action back its own default — the retired
`claude-sonnet-4-20250514`, which 404s about four seconds in.

## Net change

- `model:` reads `ANTHROPIC_MODEL` and floors at `claude-opus-5`, in both workflows.
- Action pinned to `28f8362` (`beta`, currently v0.0.63, tagged 2025-08-22). It was the
  last floating action ref in these files, on a job with `id-token: write`.
- The review workflow's `workflow_dispatch` trigger is removed. It was unreachable: the
  job's `if:` gates on `github.event.action` values only a `pull_request` event
  produces, so a manual run always skipped — and carries no PR to review regardless.
  Its `type: choice` model picker had also gone stale (offered `claude-opus-4-6`, no
  Opus 5). `claude-review` remains the working manual trigger.

`fallback_model`, `direct_prompt` and `use_sticky_comment: true` are unchanged.

## Why a dated id and not the `opus` alias

This ref bundles Claude Code 1.0.88, which resolves aliases against its own build-time
table — one that can itself name a retired id. That is why `onetime/monorepo@d3c3248`
spelled out a dated id too.

## Verification

- Both files parse; `scripts/check-ci-secrets.sh` passes (26 consumed, 2 ignored).
- **Expect this PR's own Claude review to fail.** The action requires
  `claude-code-review.yml` to be byte-for-byte identical to the default branch before it
  can obtain a token — already noted in `scripts/ci-secrets-ignore.txt`. Clears on merge.