### PR TITLE
Prevent Sentry issue floods from malformed requests

### DIFF
--- a/apps/api/v1/controllers/helpers.rb
+++ b/apps/api/v1/controllers/helpers.rb
@@ -60,9 +60,14 @@ module V1
       # text, so the backend's message scrubbers still see it and the issue
       # title still says what failed; the endpoint alone decides the group.
       #
+      # The group key is the ROUTE TEMPLATE, not `req.path` — see
+      # #endpoint_template. On the wildcard routes (/secret/:key,
+      # /receipt/:key) the concrete path is one-per-key, which would defeat
+      # the grouping this exists for and put the key itself in Sentry.
+      #
       # Level is :warning, not :error: rejected input is the validator working.
       capture_message ex.message, :warning do |scope|
-        scope.set_fingerprint(['v1-form-error', req.path])
+        scope.set_fingerprint(['v1-form-error', endpoint_template])
       end
 
       handle_form_error ex
@@ -321,9 +326,12 @@ module V1
         end
 
         # Add searchable tags (guard req to avoid NameError if not defined)
+        # Route template, never the concrete path: an `endpoint` tag carrying
+        # a secret key is both unbounded-cardinality and a leak (see
+        # #endpoint_template).
         scope.set_tags(
           service: 'api',
-          endpoint: (defined?(req) && req&.path_info) || 'unknown',
+          endpoint: endpoint_template,
         )
 
         # Add request context: path only (never the query string) plus any
@@ -378,6 +386,60 @@ module V1
       id_str.length <= 8 ? id_str : "#{id_str[0, 8]}..."
     end
     private :truncate_id
+
+    # The endpoint identity used for the Sentry `endpoint` tag and for the
+    # FormError grouping fingerprint.
+    #
+    # NEVER the bare `req.path`. The v1 wildcard routes — /secret/:key,
+    # /receipt/:key, /receipt/:key/burn and the /private/ and /metadata/
+    # aliases — put the concrete secret or receipt key in the path, and both
+    # consumers of this value are the wrong place for it:
+    #   - CARDINALITY: one distinct fingerprint (and one distinct tag value)
+    #     per key, which is precisely the per-message issue explosion the
+    #     fingerprint was added to stop.
+    #   - DISCLOSURE: before_send's scrubbers (SetupDiagnostics.scrub_url)
+    #     reach request.url and contexts.request.url only. Tags and the
+    #     fingerprint are never scrubbed, so a raw path here ships the key to
+    #     Sentry in the clear.
+    #
+    # Otto stamps the matched route onto the env during dispatch
+    # (otto/route.rb -> env['otto.route_definition']). Its #path is the
+    # DECLARED template from routes.txt ('/secret/:key'), so it is the
+    # endpoint identity we want and structurally cannot carry request data.
+    # In the mounted stack it is always present by the time a controller
+    # runs; the fallback is for harnesses that invoke a controller without
+    # Otto's dispatch (unit specs), and it scrubs the raw path rather than
+    # trusting it.
+    #
+    # @return [String] route template, scrubbed path, or 'unknown'
+    def endpoint_template
+      return 'unknown' unless defined?(req) && req
+
+      route    = req.env['otto.route_definition'] if req.respond_to?(:env) && req.env.respond_to?(:[])
+      template = route.path if route.respond_to?(:path)
+      return template if template.is_a?(String) && !template.empty?
+
+      raw = req.path_info if req.respond_to?(:path_info)
+      raw = req.path if (raw.nil? || raw.empty?) && req.respond_to?(:path)
+      return 'unknown' if raw.nil? || raw.empty?
+
+      scrub_endpoint_path(raw)
+    rescue StandardError
+      'unknown'
+    end
+    private :endpoint_template
+
+    # Reuses the diagnostics URL scrubber so the fallback above can never
+    # emit an identifier the before_send pass would have redacted. Fails
+    # closed to 'unknown' when diagnostics are not loaded (bare unit
+    # harnesses) rather than returning the unscrubbed path.
+    def scrub_endpoint_path(raw)
+      return 'unknown' unless defined?(Onetime::Initializers::SetupDiagnostics) &&
+                              Onetime::Initializers::SetupDiagnostics.respond_to?(:scrub_url)
+
+      Onetime::Initializers::SetupDiagnostics.scrub_url(raw) || 'unknown'
+    end
+    private :scrub_endpoint_path
 
     def capture_message(message, level = :log, &)
       return unless OT.d9s_enabled # diagnostics are disabled by default

--- a/apps/api/v1/controllers/helpers.rb
+++ b/apps/api/v1/controllers/helpers.rb
@@ -397,10 +397,12 @@ module V1
     #   - CARDINALITY: one distinct fingerprint (and one distinct tag value)
     #     per key, which is precisely the per-message issue explosion the
     #     fingerprint was added to stop.
-    #   - DISCLOSURE: before_send's scrubbers (SetupDiagnostics.scrub_url)
-    #     reach request.url and contexts.request.url only. Tags and the
-    #     fingerprint are never scrubbed, so a raw path here ships the key to
-    #     Sentry in the clear.
+    #   - DISCLOSURE: NOTHING scrubs event.tags — not before_send, not the
+    #     SDK — so the tag half of this is the only thing standing between a
+    #     raw path and Sentry. The fingerprint has a backstop
+    #     (SetupDiagnostics.scrub_event_fingerprint), but a backstop is not a
+    #     licence to hand it a credential: it redacts, which loses the
+    #     endpoint identity this value exists to carry.
     #
     # Otto stamps the matched route onto the env during dispatch
     # (otto/route.rb -> env['otto.route_definition']). Its #path is the

--- a/apps/api/v1/controllers/helpers.rb
+++ b/apps/api/v1/controllers/helpers.rb
@@ -49,7 +49,21 @@ module V1
       # not surface any other way. We track as messages though since
       # they are not exceptions in the diagnostic sense. We pass only
       # the message and not fields to limit the amount of data sent.
-      capture_message ex.message, :error
+      #
+      # GROUPED BY ENDPOINT, NOT BY MESSAGE (BACKEND-AZ/AH/AD). v1 is an
+      # unauthenticated surface under constant bot traffic, and the default
+      # grouping key for a message event IS the message — so every distinct
+      # validation string anonymous input can provoke minted its own issue, at
+      # error level. Changing HOW malformed bodies fail (#4283 multipart
+      # rejection) therefore read as a brand-new escalating defect when it was
+      # the same bots failing one step earlier. The message stays the event
+      # text, so the backend's message scrubbers still see it and the issue
+      # title still says what failed; the endpoint alone decides the group.
+      #
+      # Level is :warning, not :error: rejected input is the validator working.
+      capture_message ex.message, :warning do |scope|
+        scope.set_fingerprint(['v1-form-error', req.path])
+      end
 
       handle_form_error ex
 

--- a/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
+++ b/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
@@ -260,8 +260,51 @@ RSpec.describe V1::ControllerHelpers do
           controller.capture_error(test_error)
         end
 
-        # Tags are not scrubbed by before_send either, and a per-key tag value
-        # is unbounded cardinality on top of the disclosure.
+        # Nothing anywhere scrubs event.tags, so the tag is the one sink with
+        # no second line of defence.
+        it 'scrubs the identifier out of the tag when no route was recorded' do
+          keyed_path = "/api/v1/secret/#{'a' * 62}"
+          keyed_req  = double(
+            'Request',
+            url: "https://example.com#{keyed_path}",
+            path: keyed_path,
+            request_method: 'POST',
+            ip: '192.168.1.100',
+            path_info: keyed_path,
+            env: {}
+          )
+
+          expect(mock_scope).to receive(:set_tags).with(
+            hash_including(endpoint: '/api/v1/secret/[REDACTED]')
+          )
+
+          controller_class.new(request: keyed_req).capture_error(test_error)
+        end
+
+        # Fail closed: with no scrubber reachable, emit nothing rather than
+        # the raw path.
+        it 'falls back to unknown when the scrubber is unavailable' do
+          allow(Onetime::Initializers::SetupDiagnostics)
+            .to receive(:respond_to?).with(:scrub_url).and_return(false)
+
+          keyed_path = "/api/v1/secret/#{'a' * 62}"
+          keyed_req  = double(
+            'Request',
+            url: "https://example.com#{keyed_path}",
+            path: keyed_path,
+            request_method: 'POST',
+            ip: '192.168.1.100',
+            path_info: keyed_path,
+            env: {}
+          )
+
+          expect(mock_scope).to receive(:set_tags).with(
+            hash_including(endpoint: 'unknown')
+          )
+
+          controller_class.new(request: keyed_req).capture_error(test_error)
+        end
+
         it 'tags the endpoint with the route template when Otto recorded one' do
           route      = double('RouteDefinition', path: '/secret/:key')
           keyed_path = "/api/v1/secret/#{'a' * 62}"
@@ -606,6 +649,19 @@ RSpec.describe V1::ControllerHelpers do
         expect(OT).to receive(:le).with(/capture_message.*StandardError.*Sentry unavailable/)
 
         controller.capture_message(test_message)
+      end
+    end
+  end
+
+  # Otto maps PUBLIC controller methods to routes, so every helper here has to
+  # stay private or it becomes a reachable endpoint.
+  describe 'helper visibility' do
+    let(:controller_instance) { controller_class.new }
+
+    %i[truncate_id endpoint_template scrub_endpoint_path].each do |helper|
+      it "keeps #{helper} private (not exposed as a controller action)" do
+        expect(controller_instance.public_methods).not_to include(helper)
+        expect(controller_instance.private_methods).to include(helper)
       end
     end
   end

--- a/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
+++ b/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
@@ -162,6 +162,65 @@ RSpec.describe V1::ControllerHelpers do
       expect(form_controller.carefully { raise OT::FormError, 'nope' }).to eq(:handled)
       expect(form_controller.handled_error.message).to eq('nope')
     end
+
+    # The fingerprint is NOT scrubbed by before_send (which only reaches
+    # request.url / contexts.request.url), and a wildcard v1 path carries the
+    # concrete secret key. Grouping on the raw path would therefore both mint
+    # one issue per key and ship the key to Sentry.
+    context 'on a wildcard route' do
+      # 62-char base-36 verifiable identifier, the real shape of a secret key.
+      let(:secret_key) { 'a' * 62 }
+
+      let(:wildcard_request) do
+        double(
+          'Request',
+          url: "https://example.com/api/v1/secret/#{secret_key}",
+          path: "/api/v1/secret/#{secret_key}",
+          request_method: 'POST',
+          ip: '192.168.1.100',
+          path_info: "/api/v1/secret/#{secret_key}",
+          env: env
+        )
+      end
+
+      let(:wildcard_controller) do
+        form_controller_class.new(request: wildcard_request).tap do |instance|
+          allow(instance).to receive(:add_response_headers)
+          allow(instance).to receive(:log_customer_activity)
+        end
+      end
+
+      context 'when Otto recorded the matched route' do
+        # Otto stamps env['otto.route_definition'] during dispatch; #path is
+        # the declared template from routes.txt.
+        let(:env) { { 'otto.route_definition' => double('RouteDefinition', path: '/secret/:key') } }
+
+        it 'fingerprints on the route template, not the concrete key' do
+          expect(Sentry).to receive(:capture_message).and_yield(mock_scope)
+          expect(mock_scope).to receive(:set_fingerprint)
+            .with(['v1-form-error', '/secret/:key'])
+
+          wildcard_controller.carefully { raise OT::FormError, 'Double check that passphrase' }
+        end
+      end
+
+      context 'when no route was recorded (bare harness)' do
+        let(:env) { {} }
+
+        it 'falls back to a scrubbed path and never emits the key' do
+          fingerprint = nil
+          allow(Sentry).to receive(:capture_message) do |_message, **_opts, &block|
+            allow(mock_scope).to receive(:set_fingerprint) { |value| fingerprint = value }
+            block&.call(mock_scope)
+          end
+
+          wildcard_controller.carefully { raise OT::FormError, 'Double check that passphrase' }
+
+          expect(fingerprint).to eq(['v1-form-error', '/api/v1/secret/[REDACTED]'])
+          expect(fingerprint.last).not_to include(secret_key)
+        end
+      end
+    end
   end
 
   describe '#capture_error' do
@@ -199,6 +258,28 @@ RSpec.describe V1::ControllerHelpers do
           )
 
           controller.capture_error(test_error)
+        end
+
+        # Tags are not scrubbed by before_send either, and a per-key tag value
+        # is unbounded cardinality on top of the disclosure.
+        it 'tags the endpoint with the route template when Otto recorded one' do
+          route      = double('RouteDefinition', path: '/secret/:key')
+          keyed_path = "/api/v1/secret/#{'a' * 62}"
+          keyed_req  = double(
+            'Request',
+            url: "https://example.com#{keyed_path}",
+            path: keyed_path,
+            request_method: 'POST',
+            ip: '192.168.1.100',
+            path_info: keyed_path,
+            env: { 'otto.route_definition' => route }
+          )
+
+          expect(mock_scope).to receive(:set_tags).with(
+            hash_including(endpoint: '/secret/:key')
+          )
+
+          controller_class.new(request: keyed_req).capture_error(test_error)
         end
 
         it 'sets request context with path (never the query string), method, and ip' do

--- a/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
+++ b/apps/api/v1/spec/controllers/helpers_sentry_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe V1::ControllerHelpers do
     allow(scope).to receive(:set_context)
     allow(scope).to receive(:set_tags)
     allow(scope).to receive(:set_tag)
+    allow(scope).to receive(:set_fingerprint)
     scope
   end
 
@@ -98,6 +99,68 @@ RSpec.describe V1::ControllerHelpers do
           true
         end
       end)
+    end
+  end
+
+  # v1 is unauthenticated and bot-hammered. The default grouping key for a
+  # message event IS the message, so every distinct validation string anonymous
+  # input can provoke used to mint its own Sentry issue — a change in HOW
+  # malformed bodies fail read as a brand-new escalating defect (BACKEND-AZ).
+  describe 'FormError capture' do
+    # `handle_form_error` lives on the concrete v1 controller base, not in the
+    # helpers module under test, so the harness supplies it.
+    let(:form_controller_class) do
+      Class.new(controller_class) do
+        attr_reader :handled_error
+
+        def handle_form_error(ex)
+          @handled_error = ex
+          :handled
+        end
+      end
+    end
+
+    let(:form_controller) do
+      form_controller_class.new(request: mock_request).tap do |instance|
+        allow(instance).to receive(:add_response_headers)
+        allow(instance).to receive(:log_customer_activity)
+      end
+    end
+
+    before do
+      allow(OT).to receive(:d9s_enabled).and_return(true)
+      allow(OT).to receive(:ld)
+    end
+
+    it 'groups by endpoint, not by validation message' do
+      expect(Sentry).to receive(:capture_message)
+        .with('You did not provide anything to share', hash_including(level: :warning))
+        .and_yield(mock_scope)
+      expect(mock_scope).to receive(:set_fingerprint)
+        .with(['v1-form-error', '/api/v1/secrets'])
+
+      form_controller.carefully do
+        raise OT::FormError, 'You did not provide anything to share'
+      end
+    end
+
+    it 'keeps the message as the event text, so the backend scrubbers still see it' do
+      captured = nil
+      allow(Sentry).to receive(:capture_message) do |message, **_opts, &block|
+        captured = message
+        block&.call(mock_scope)
+      end
+
+      form_controller.carefully { raise OT::FormError, 'Passphrase must be at least 4 characters long' }
+
+      expect(captured).to eq('Passphrase must be at least 4 characters long')
+    end
+
+    it 'still delegates to handle_form_error' do
+      allow(Sentry).to receive(:capture_message)
+
+      expect(form_controller.carefully { raise OT::FormError, 'nope' }).to eq(:handled)
+      expect(form_controller.handled_error.message).to eq('nope')
     end
   end
 

--- a/apps/web/auth/config/hooks/login.rb
+++ b/apps/web/auth/config/hooks/login.rb
@@ -92,12 +92,13 @@ module Auth::Config::Hooks
         # verifies with the internal request but establishes the session with its
         # own `rodauth.login('password')` on the actual route.
         #
-        # respond_to? takes the include_all argument because internal_request?
-        # is PRIVATE on the Rodauth instance; the one-argument form returns
-        # false for it and the guard would never fire. The feature is enabled
-        # unconditionally today (config/base.rb), so the guard is for a future
-        # conditional enablement — same defensive shape as
-        # hooks/create_account.rb.
+        # The include_all argument is MANDATORY, not stylistic:
+        # internal_request? is private on the Rodauth instance (base.rb
+        # defines it after its `private`, and the internal-request subclass
+        # overrides it the same way), so the one-argument respond_to? returns
+        # false and the guard would silently never fire. The respond_to? is
+        # house style — it is defined on Rodauth::Base, so it is always there
+        # regardless of which features are enabled.
         next if respond_to?(:internal_request?, true) && internal_request?
 
         correlation_id = session[:auth_correlation_id]

--- a/apps/web/auth/config/hooks/login.rb
+++ b/apps/web/auth/config/hooks/login.rb
@@ -91,7 +91,14 @@ module Auth::Config::Hooks
         # The real logins that need this hook are real requests: /auth/link-sso
         # verifies with the internal request but establishes the session with its
         # own `rodauth.login('password')` on the actual route.
-        next if internal_request?
+        #
+        # respond_to? takes the include_all argument because internal_request?
+        # is PRIVATE on the Rodauth instance; the one-argument form returns
+        # false for it and the guard would never fire. The feature is enabled
+        # unconditionally today (config/base.rb), so the guard is for a future
+        # conditional enablement — same defensive shape as
+        # hooks/create_account.rb.
+        next if respond_to?(:internal_request?, true) && internal_request?
 
         correlation_id = session[:auth_correlation_id]
 

--- a/apps/web/auth/config/hooks/login.rb
+++ b/apps/web/auth/config/hooks/login.rb
@@ -76,6 +76,23 @@ module Auth::Config::Hooks
       # 3. Either prepare session for MFA flow OR sync full session
       #
       auth.after_login do
+        # INTERNAL REQUESTS ARE NOT LOGINS. `Auth::Config.valid_login_and_password?`
+        # (account destroy, change email, change password, /auth/link-sso) is a
+        # Rodauth internal request: it runs the real login route to check a
+        # password, then throws the result away. It has no web session — Rodauth
+        # hands the internal instance a bare Hash — and no user-visible sign-in
+        # happened, so every side effect below is wrong for it:
+        #   - `session.id` raises NoMethodError on a Hash (BACKEND-B0/B1/B3/B4,
+        #     one Sentry issue per confirmation endpoint);
+        #   - a password CONFIRMATION was logging `login_success` into the auth
+        #     audit stream and could fire the new-sign-in security alert;
+        #   - SyncSession and the deferred SSO bind would act on a session that
+        #     is discarded microseconds later.
+        # The real logins that need this hook are real requests: /auth/link-sso
+        # verifies with the internal request but establishes the session with its
+        # own `rodauth.login('password')` on the actual route.
+        next if internal_request?
+
         correlation_id = session[:auth_correlation_id]
 
         Auth::Logging.log_auth_event(

--- a/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
+++ b/apps/web/auth/spec/integration/full/omniauth_signin_interstitial_spec.rb
@@ -206,6 +206,7 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
       email      = "ok-#{SecureRandom.hex(6)}@company.example.com"
       uid        = "sub-#{SecureRandom.hex(8)}"
       account_id = seed_account_with_password(email)
+      allow(Auth::Logging).to receive(:log_auth_event).and_call_original
 
       begin
         response = sso_callback(email: email, uid: uid)
@@ -218,6 +219,11 @@ RSpec.describe 'OmniAuth sign-in interstitial (#3840 Phase 3)', type: :integrati
           "Expected a Rodauth login response, got #{result.status}: #{result.body}"
         body = JSON.parse(result.body)
         expect(body).to have_key('success')
+
+        # The password check is a Rodauth internal request; only the actual
+        # login that establishes this session may be recorded as a login.
+        expect(Auth::Logging).to have_received(:log_auth_event)
+          .with(:login_success, hash_including(account_id: account_id)).once
 
         # The bind: exactly one (provider, uid) row, on the proven account.
         rows = identities.where(provider: 'oidc', uid: uid).all

--- a/changelog.d/20260827_133000_claude_sentry_issue_flood.rst
+++ b/changelog.d/20260827_133000_claude_sentry_issue_flood.rst
@@ -1,0 +1,52 @@
+Fixed
+-----
+
+- Frontend diagnostics: every capture the app makes now reaches ``beforeSend``
+  with the hint Sentry expects. ``diagnostics.service`` calls
+  ``Client.captureException`` directly (to capture against an isolated scope),
+  and that method does not build a hint — it forwards the one it is given. It
+  was given ``undefined``, so ``hint.originalException`` was never present and
+  BOTH rules that read it were silently inert in production: the
+  expected-transport-outcome drop (#4286) dropped nothing, and the API-error
+  grouping (#4287) fingerprinted nothing, leaving axios failures to fragment
+  into a fresh issue per call site per deploy.
+
+- Confirming a password no longer runs the login hook.
+  ``Auth::Config.valid_login_and_password?`` (account destroy, change email,
+  change password, ``/auth/link-sso``) is a Rodauth *internal request*: it runs
+  the real login route to check a credential and discards the result. Its
+  session is a bare Hash, so ``session.id`` raised ``NoMethodError``; worse, a
+  password *confirmation* was recording ``login_success`` in the auth audit
+  stream, attempting a deferred SSO bind, and could fire the new-sign-in
+  security alert. ``after_login`` now returns early for internal requests.
+
+- A session cookie carrying bytes that are not valid UTF-8 is rejected instead
+  of raising ``ArgumentError`` from ``String#match?`` — that raise reached the
+  client as a 500 before any handler ran.
+
+- The custom-domain list no longer fails to parse when a domain's proxy
+  ``vhost.keep_host`` arrives as a boolean. It is a third-party passthrough
+  field and Approximated documents it as a boolean; the schema declared it
+  string-only.
+
+Changed
+-------
+
+- v1 API form errors group by endpoint rather than by validation message.
+  v1 is unauthenticated and under constant bot traffic, and the default
+  grouping key for a message event is the message — so every distinct
+  validation string anonymous input could provoke minted its own Sentry issue
+  at error level. The message stays the event text (the backend scrubbers still
+  see it); the endpoint alone decides the group, and the level drops to
+  ``warning``.
+
+- Errors from in-app browsers whose injected bridge never loaded
+  (``xbrowser``/``swbrowser is not defined``) join the third-party ignore list.
+
+AI Assistance
+-------------
+
+- AI assistance was used to correlate the post-release Sentry issue spike
+  against the deployed code, isolate the dead capture-hint contract as the
+  cause of the frontend fragmentation, and read the four backend crash
+  signatures back to their call sites.

--- a/changelog.d/20260827_133000_claude_sentry_issue_flood.rst
+++ b/changelog.d/20260827_133000_claude_sentry_issue_flood.rst
@@ -1,52 +1,21 @@
 Fixed
 -----
 
-- Frontend diagnostics: every capture the app makes now reaches ``beforeSend``
-  with the hint Sentry expects. ``diagnostics.service`` calls
-  ``Client.captureException`` directly (to capture against an isolated scope),
-  and that method does not build a hint — it forwards the one it is given. It
-  was given ``undefined``, so ``hint.originalException`` was never present and
-  BOTH rules that read it were silently inert in production: the
-  expected-transport-outcome drop (#4286) dropped nothing, and the API-error
-  grouping (#4287) fingerprinted nothing, leaving axios failures to fragment
-  into a fresh issue per call site per deploy.
+- Frontend diagnostics now apply configured filtering and grouping to manually
+  captured errors.
 
-- Confirming a password no longer runs the login hook.
-  ``Auth::Config.valid_login_and_password?`` (account destroy, change email,
-  change password, ``/auth/link-sso``) is a Rodauth *internal request*: it runs
-  the real login route to check a credential and discards the result. Its
-  session is a bare Hash, so ``session.id`` raised ``NoMethodError``; worse, a
-  password *confirmation* was recording ``login_success`` in the auth audit
-  stream, attempting a deferred SSO bind, and could fire the new-sign-in
-  security alert. ``after_login`` now returns early for internal requests.
+- Password confirmation flows no longer record a login or run login-session
+  side effects.
 
-- A session cookie carrying bytes that are not valid UTF-8 is rejected instead
-  of raising ``ArgumentError`` from ``String#match?`` — that raise reached the
-  client as a 500 before any handler ran.
+- Invalid UTF-8 session-cookie values are rejected instead of causing a server
+  error.
 
-- The custom-domain list no longer fails to parse when a domain's proxy
-  ``vhost.keep_host`` arrives as a boolean. It is a third-party passthrough
-  field and Approximated documents it as a boolean; the schema declared it
-  string-only.
+- Custom-domain lists accept proxy ``vhost.keep_host`` values provided as
+  booleans.
 
 Changed
 -------
 
-- v1 API form errors group by endpoint rather than by validation message.
-  v1 is unauthenticated and under constant bot traffic, and the default
-  grouping key for a message event is the message — so every distinct
-  validation string anonymous input could provoke minted its own Sentry issue
-  at error level. The message stays the event text (the backend scrubbers still
-  see it); the endpoint alone decides the group, and the level drops to
-  ``warning``.
+- v1 API form errors now group by endpoint and are reported at warning level.
 
-- Errors from in-app browsers whose injected bridge never loaded
-  (``xbrowser``/``swbrowser is not defined``) join the third-party ignore list.
-
-AI Assistance
--------------
-
-- AI assistance was used to correlate the post-release Sentry issue spike
-  against the deployed code, isolate the dead capture-hint contract as the
-  cause of the frontend fragmentation, and read the four backend crash
-  signatures back to their call sites.
+- Errors from in-app browsers whose injected bridge did not load are ignored.

--- a/changelog.d/20260827_133000_claude_sentry_issue_flood.rst
+++ b/changelog.d/20260827_133000_claude_sentry_issue_flood.rst
@@ -13,6 +13,9 @@ Fixed
 - Custom-domain lists accept proxy ``vhost.keep_host`` values provided as
   booleans.
 
+- Diagnostic reports no longer carry secret or receipt identifiers in event
+  grouping keys or in the request-context path.
+
 Changed
 -------
 

--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -304,9 +304,10 @@ module Onetime
           # Handles five URL locations:
           # 1. event.request.url - Standard Sentry request data
           # 2. event.contexts['request']['url'] - Custom context set by error middleware
-          # 3. event.contexts['request']['path'] - Same context, query-less path
+          # 3. event.contexts['request'][:path] - Same context, query-less path
           #    (Onetime::ErrorHandler.safe_request_context); on /secret/<id>
-          #    the path alone is the credential
+          #    the path alone is the credential. Symbol- and string-keyed
+          #    producers both exist — see #scrub_request_context
           # 4. event.transaction - Set from raw PATH_INFO by Sentry::Rack::CaptureExceptions
           # 5. event.request.headers['Referer'] - Referer carries the previous URL,
           #    which can embed a secret identifier (e.g. /secret/<id>)
@@ -337,24 +338,8 @@ module Onetime
               end
             end
 
-            # Scrub custom request context URL and path (set via
-            # scope.set_context in error middleware). Onetime::ErrorHandler
-            # .safe_request_context deliberately drops the query string but
-            # keeps the raw path, and on /secret/<key> or /receipt/<key> that
-            # path IS the bearer credential — nothing else in this pipeline
-            # looks at the ['path'] key.
-            if event.contexts.is_a?(Hash) && event.contexts['request'].is_a?(Hash)
-              %w[url path].each do |key|
-                original = event.contexts['request'][key]
-                next unless original
-
-                scrubbed = scrub_url(original)
-                next if scrubbed == original
-
-                event.contexts['request'][key] = scrubbed
-                OT.ld "[sentry] Scrubbed contexts.request.#{key}"
-              end
-            end
+            # Scrub the custom request context set via scope.set_context.
+            scrub_request_context(event.contexts)
 
             # Scrub URL-bearing request headers (Referer). The Referer carries
             # the previous page URL, which on OTS can embed a secret identifier
@@ -378,6 +363,47 @@ module Onetime
             end
             redact_url_bearing_headers(event.request&.headers)
             event
+          end
+
+          # Scrub the 'request' context a caller attached with
+          # scope.set_context('request', ...).
+          #
+          # KEY TYPES ARE NOT NORMALIZED anywhere in this path.
+          # Sentry::Scope#set_context merges the caller's Hash verbatim, and
+          # before_send runs on the live event, so whatever the producer wrote
+          # is what is here. The producers disagree:
+          # Onetime::ErrorHandler.safe_request_context returns SYMBOL keys
+          # (:path, :method, :ip) under the STRING outer key 'request', and
+          # apps/web/core/controllers/welcome.rb hand-builds the same shape.
+          # A string-only reader therefore matched nothing in production. Both
+          # spellings are checked on both levels rather than picking one,
+          # because the producers are free to change independently.
+          #
+          # :path is the one that matters. safe_request_context deliberately
+          # drops the query string and keeps the bare path — and on
+          # /secret/<id> or /receipt/<id> that path IS the bearer credential,
+          # so it is the last unscrubbed copy of it in the payload.
+          #
+          # @param contexts [Hash, nil] event.contexts
+          # @return [void]
+          def scrub_request_context(contexts)
+            return unless contexts.is_a?(Hash)
+
+            request_ctx = contexts['request'] || contexts[:request]
+            return unless request_ctx.is_a?(Hash)
+
+            %w[url path].each do |name|
+              [name, name.to_sym].each do |key|
+                original = request_ctx[key]
+                next unless original.is_a?(String)
+
+                scrubbed = scrub_url(original)
+                next if scrubbed == original
+
+                request_ctx[key] = scrubbed
+                OT.ld "[sentry] Scrubbed contexts.request.#{key}"
+              end
+            end
           end
 
           # Scrub URL-bearing request headers (e.g. Referer) in place through

--- a/lib/onetime/initializers/setup_diagnostics.rb
+++ b/lib/onetime/initializers/setup_diagnostics.rb
@@ -133,6 +133,13 @@ module Onetime
             # frontend's scrubEventMessages in enableDiagnostics.ts.
             Onetime::Initializers::SetupDiagnostics.scrub_event_messages(event)
 
+            # Scrub the grouping fingerprint. Sentry serializes it verbatim and
+            # no other pass reaches it, so a call site that fingerprints on a
+            # request path (see V1::ControllerHelpers#endpoint_template) would
+            # ship a secret/receipt key in the clear. Belt to that braces: the
+            # call site should never hand us one, and if it does, this catches it.
+            Onetime::Initializers::SetupDiagnostics.scrub_event_fingerprint(event)
+
             # Return the event if it passes validation
             event
           end
@@ -294,11 +301,14 @@ module Onetime
 
           # Scrub sensitive data from URLs in Sentry events
           #
-          # Handles four URL locations:
+          # Handles five URL locations:
           # 1. event.request.url - Standard Sentry request data
           # 2. event.contexts['request']['url'] - Custom context set by error middleware
-          # 3. event.transaction - Set from raw PATH_INFO by Sentry::Rack::CaptureExceptions
-          # 4. event.request.headers['Referer'] - Referer carries the previous URL,
+          # 3. event.contexts['request']['path'] - Same context, query-less path
+          #    (Onetime::ErrorHandler.safe_request_context); on /secret/<id>
+          #    the path alone is the credential
+          # 4. event.transaction - Set from raw PATH_INFO by Sentry::Rack::CaptureExceptions
+          # 5. event.request.headers['Referer'] - Referer carries the previous URL,
           #    which can embed a secret identifier (e.g. /secret/<id>)
           #
           # @param event [Sentry::Event] The event to scrub
@@ -327,15 +337,22 @@ module Onetime
               end
             end
 
-            # Scrub custom request context URL (set via scope.set_context in error middleware)
-            if event.contexts.is_a?(Hash) &&
-               event.contexts['request'].is_a?(Hash) &&
-               event.contexts['request']['url']
-              original_url = event.contexts['request']['url']
-              scrubbed_url = scrub_url(original_url)
-              if scrubbed_url != original_url
-                event.contexts['request']['url'] = scrubbed_url
-                OT.ld '[sentry] Scrubbed contexts.request.url'
+            # Scrub custom request context URL and path (set via
+            # scope.set_context in error middleware). Onetime::ErrorHandler
+            # .safe_request_context deliberately drops the query string but
+            # keeps the raw path, and on /secret/<key> or /receipt/<key> that
+            # path IS the bearer credential — nothing else in this pipeline
+            # looks at the ['path'] key.
+            if event.contexts.is_a?(Hash) && event.contexts['request'].is_a?(Hash)
+              %w[url path].each do |key|
+                original = event.contexts['request'][key]
+                next unless original
+
+                scrubbed = scrub_url(original)
+                next if scrubbed == original
+
+                event.contexts['request'][key] = scrubbed
+                OT.ld "[sentry] Scrubbed contexts.request.#{key}"
               end
             end
 
@@ -480,6 +497,42 @@ module Onetime
           rescue StandardError
             # Fail-closed: return redacted placeholder to prevent leaking sensitive data
             '[SCRUBBING_FAILED]'
+          end
+
+          # Scrub the grouping fingerprint.
+          #
+          # `event.fingerprint` is an Array of Strings the SDK serializes
+          # verbatim: no other before_send pass touches it, and neither do
+          # tags. A fingerprint component built from a request path therefore
+          # reaches Sentry unredacted — on OTS that path can be the 62-char
+          # bearer identifier that reads a secret or burns a receipt.
+          #
+          # Components are run through scrub_text (paths, named query params,
+          # emails, exact-length identifiers). Static components ('v1-form-
+          # error', an endpoint TEMPLATE like '/secret/:key', Sentry's
+          # '{{ default }}' token) contain none of those patterns and pass
+          # through byte-identical, so grouping is unchanged for every
+          # well-behaved call site.
+          #
+          # @param event [Sentry::Event] The event to scrub
+          # @return [Sentry::Event] The scrubbed event
+          def scrub_event_fingerprint(event)
+            return event unless event.respond_to?(:fingerprint)
+
+            fingerprint = event.fingerprint
+            return event unless fingerprint.is_a?(Array) && !fingerprint.empty?
+
+            scrubbed = fingerprint.map do |component|
+              component.is_a?(String) ? scrub_text(component) : component
+            end
+            return event if scrubbed == fingerprint
+
+            event.fingerprint = scrubbed
+            OT.ld '[sentry] Scrubbed fingerprint'
+            event
+          rescue StandardError => ex
+            OT.ld "[sentry] Fingerprint scrubbing failed: #{ex.class}"
+            event
           end
 
           # Scrub sensitive data from free text (exception messages,

--- a/lib/onetime/session.rb
+++ b/lib/onetime/session.rb
@@ -302,7 +302,14 @@ module Onetime
     #
     # This is just format validation - doesn't check if session exists in Redis
     def valid_session_id?(sid)
-      return false if sid.to_s.empty?
+      sid = sid.to_s
+      return false if sid.empty?
+
+      # A cookie value is client-controlled bytes, not a String the app made.
+      # `match?` RAISES ArgumentError on invalid UTF-8 (BACKEND-B5: a request
+      # carrying a binary session cookie 500s here before any handler runs),
+      # and an unmatchable byte sequence is by definition not a valid sid.
+      return false unless sid.valid_encoding?
       return false unless sid.match?(/\A[a-f0-9]{64,}\z/)
 
       # Additional security checks could go here

--- a/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
+++ b/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
@@ -1266,6 +1266,23 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
         expect(result.request.url).to eq('https://example.com/api/v1/status')
       end
 
+      # Onetime::ErrorHandler.safe_request_context drops the query string but
+      # keeps the bare path, and on /secret/<id> or /receipt/<id> the path IS
+      # the bearer credential. Nothing else in the pipeline reads this key.
+      it 'scrubs the query-less path in contexts.request' do
+        identifier = 'a' * 62
+        event = mock_event_class.new(
+          request: nil,
+          contexts: { 'request' => { 'path' => "/api/v1/receipt/#{identifier}/burn", 'method' => 'POST' } }
+        )
+
+        result = described_class.scrub_event_urls(event)
+
+        expect(result.contexts['request']['path']).to eq('/api/v1/receipt/[REDACTED]/burn')
+        expect(result.contexts['request']['path']).not_to include(identifier)
+        expect(result.contexts['request']['method']).to eq('POST')
+      end
+
       it 'scrubs context URLs when request is nil (non-HTTP events)' do
         identifier = 'a' * 25
         contexts = { 'request' => { 'url' => "https://example.com/secret/#{identifier}" } }
@@ -1422,6 +1439,69 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
 
           expect(result.request.headers['Referer']).to eq('[SCRUBBING_FAILED]')
         end
+      end
+    end
+
+    # Sentry serializes event.fingerprint verbatim and no other before_send
+    # pass (nor the tag pipeline) touches it, so a call site that fingerprints
+    # on a request path would leak the identifier in that path.
+    describe '.scrub_event_fingerprint' do
+      let(:fingerprint_event_class) do
+        Class.new do
+          attr_accessor :fingerprint
+
+          def initialize(fingerprint = nil)
+            @fingerprint = fingerprint
+          end
+        end
+      end
+
+      it 'redacts an identifier carried in a fingerprint component' do
+        identifier = 'a' * 62
+        event = fingerprint_event_class.new(['v1-form-error', "/api/v1/secret/#{identifier}"])
+
+        described_class.scrub_event_fingerprint(event)
+
+        expect(event.fingerprint).to eq(['v1-form-error', '/api/v1/secret/[REDACTED]'])
+      end
+
+      it 'leaves route templates and static components byte-identical' do
+        original = ['v1-form-error', '/secret/:key']
+        event = fingerprint_event_class.new(original.dup)
+
+        described_class.scrub_event_fingerprint(event)
+
+        expect(event.fingerprint).to eq(original)
+      end
+
+      it "leaves Sentry's {{ default }} token alone" do
+        event = fingerprint_event_class.new(['{{ default }}', 'api-error'])
+
+        described_class.scrub_event_fingerprint(event)
+
+        expect(event.fingerprint).to eq(['{{ default }}', 'api-error'])
+      end
+
+      it 'passes non-string components through untouched' do
+        event = fingerprint_event_class.new(['v1-form-error', 42, nil])
+
+        described_class.scrub_event_fingerprint(event)
+
+        expect(event.fingerprint).to eq(['v1-form-error', 42, nil])
+      end
+
+      it 'is a no-op for an absent or empty fingerprint' do
+        expect { described_class.scrub_event_fingerprint(fingerprint_event_class.new(nil)) }.not_to raise_error
+        expect { described_class.scrub_event_fingerprint(fingerprint_event_class.new([])) }.not_to raise_error
+        expect { described_class.scrub_event_fingerprint(Object.new) }.not_to raise_error
+      end
+
+      it 'returns the event unchanged when scrubbing itself raises' do
+        allow(described_class).to receive(:scrub_text).and_raise(StandardError, 'boom')
+        event = fingerprint_event_class.new(['v1-form-error', '/api/v1/secret/x'])
+
+        expect { described_class.scrub_event_fingerprint(event) }.not_to raise_error
+        expect(event.fingerprint).to eq(['v1-form-error', '/api/v1/secret/x'])
       end
     end
 

--- a/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
+++ b/spec/unit/onetime/initializers/setup_diagnostics_spec.rb
@@ -1335,18 +1335,46 @@ RSpec.describe Onetime::Initializers::SetupDiagnostics do
       # Onetime::ErrorHandler.safe_request_context drops the query string but
       # keeps the bare path, and on /secret/<id> or /receipt/<id> the path IS
       # the bearer credential. Nothing else in the pipeline reads this key.
-      it 'scrubs the query-less path in contexts.request' do
+      #
+      # THE KEY TYPE IS THE POINT. safe_request_context and welcome.rb both
+      # write SYMBOL keys under the string outer key 'request'; a
+      # string-keyed fixture here passes against a reader that matches
+      # nothing in production. The symbol case is the real one.
+      it 'scrubs the symbol-keyed path safe_request_context actually writes' do
         identifier = 'a' * 62
         event = mock_event_class.new(
           request: nil,
-          contexts: { 'request' => { 'path' => "/api/v1/receipt/#{identifier}/burn", 'method' => 'POST' } }
+          contexts: { 'request' => { path: "/api/v1/receipt/#{identifier}/burn", method: 'POST' } }
         )
 
         result = described_class.scrub_event_urls(event)
 
-        expect(result.contexts['request']['path']).to eq('/api/v1/receipt/[REDACTED]/burn')
-        expect(result.contexts['request']['path']).not_to include(identifier)
-        expect(result.contexts['request']['method']).to eq('POST')
+        expect(result.contexts['request'][:path]).to eq('/api/v1/receipt/[REDACTED]/burn')
+        expect(result.contexts['request'][:method]).to eq('POST')
+      end
+
+      it 'scrubs a string-keyed path too' do
+        identifier = 'a' * 62
+        event = mock_event_class.new(
+          request: nil,
+          contexts: { 'request' => { 'path' => "/api/v1/secret/#{identifier}" } }
+        )
+
+        result = described_class.scrub_event_urls(event)
+
+        expect(result.contexts['request']['path']).to eq('/api/v1/secret/[REDACTED]')
+      end
+
+      it 'scrubs a symbol-keyed outer request context' do
+        identifier = 'a' * 62
+        event = mock_event_class.new(
+          request: nil,
+          contexts: { request: { path: "/api/v1/secret/#{identifier}" } }
+        )
+
+        result = described_class.scrub_event_urls(event)
+
+        expect(result.contexts[:request][:path]).to eq('/api/v1/secret/[REDACTED]')
       end
 
       it 'scrubs context URLs when request is nil (non-HTTP events)' do

--- a/src/plugins/core/enableDiagnostics.ts
+++ b/src/plugins/core/enableDiagnostics.ts
@@ -80,6 +80,12 @@ export const THIRD_PARTY_IGNORE_ERRORS: (string | RegExp)[] = [
   // Extensions redefining built-ins (e.g. Symbol.hasInstance); wording varies
   // by browser, so match the invariant middle
   /redefine non-configurable property/,
+  // In-app browsers whose injected bridge object never loaded. Observed on
+  // secret-link views as `xbrowser`/`swbrowser is not defined`; the prefix
+  // identifies the host app, so the list grows one app at a time rather than
+  // matching a bare `browser is not defined` that would also swallow our own.
+  'xbrowser is not defined',
+  'swbrowser is not defined',
 ];
 
 /**

--- a/src/schemas/contracts/custom-domain/index.ts
+++ b/src/schemas/contracts/custom-domain/index.ts
@@ -127,8 +127,12 @@ export const vhostCanonical = z
     /** Where DNS currently points. */
     dns_pointed_at: z.string().optional(),
 
-    /** Keep-host header setting. */
-    keep_host: z.string().nullable(),
+    /**
+     * Keep-host header setting. Boolean upstream (Approximated), but older
+     * stored blobs carry it as a string — accept both rather than fail the
+     * whole response on a passthrough field (FRONTEND-18E/197).
+     */
+    keep_host: z.union([z.string(), z.boolean()]).nullable(),
 
     /** Human-readable last monitored time. */
     last_monitored_humanized: z.string().optional(),

--- a/src/schemas/shapes/v2/custom-domain/vhost.ts
+++ b/src/schemas/shapes/v2/custom-domain/vhost.ts
@@ -46,7 +46,13 @@ export const vhostSchema = z
 
     // Optional string fields
     dns_pointed_at: z.string().optional(),
-    keep_host: z.string().nullable(),
+    // Third-party passthrough: the vhost blob is Approximated's response
+    // stored verbatim, and their API documents keep_host as a BOOLEAN
+    // (approximated_client.rb sends `keep_host: true|false|nil`). Declaring it
+    // string-only rejected the whole CustomDomainListResponse on every
+    // dashboard load for any domain that carries the flag (FRONTEND-18E/197).
+    // Accept both readings — this field is not ours to normalize.
+    keep_host: z.union([z.string(), z.boolean()]).nullable(),
     last_monitored_humanized: z.string().optional(),
     status_message: z.string().optional(),
     user_message: z.string().optional(),

--- a/src/services/diagnostics.service.ts
+++ b/src/services/diagnostics.service.ts
@@ -42,7 +42,17 @@ let diagnosticsClient: DiagnosticsClient | null = null;
  *
  * @see https://github.com/onetimesecret/onetimesecret/issues/2964
  */
-const TAG_FIELDS = ['componentName', 'errorType', 'errorSeverity', 'schema', 'schemaField', 'service', 'jurisdiction', 'planid', 'role'] as const;
+const TAG_FIELDS = [
+  'componentName',
+  'errorType',
+  'errorSeverity',
+  'schema',
+  'schemaField',
+  'service',
+  'jurisdiction',
+  'planid',
+  'role',
+] as const;
 type _TagField = (typeof TAG_FIELDS)[number]; // Used for documentation; lookup via Set<string>
 const TAG_FIELDS_SET = new Set<string>(TAG_FIELDS);
 
@@ -112,10 +122,7 @@ export function isDiagnosticsEnabled(): boolean {
  * });
  * ```
  */
-export function captureException(
-  error: Error,
-  context?: Record<string, unknown>
-): void {
+export function captureException(error: Error, context?: Record<string, unknown>): void {
   if (diagnosticsClient) {
     const { client, scope: baseScope } = diagnosticsClient;
     const eventScope = baseScope.clone();
@@ -127,7 +134,24 @@ export function captureException(
       }
     }
 
-    client.captureException(error, undefined, eventScope);
+    // HINT — hand the client the same hint Sentry's own `Scope.captureException`
+    // builds. `Client.captureException` does NOT build one: it stamps an
+    // `event_id` onto whatever it is given and passes that straight to
+    // `beforeSend`. Calling the client directly (which this facade must, to
+    // capture against an isolated scope) therefore delivered a hint with no
+    // `originalException` — so every beforeSend rule that reads it was inert
+    // for every capture the app itself makes:
+    //   - the expected-transport-outcome drop (#4286) never dropped anything;
+    //   - the api-error grouping (#4287) never fingerprinted anything, leaving
+    //     axios failures to fragment on minified stack frames — one new issue
+    //     per call site per deploy.
+    // The synthetic exception is the other half: it is what gives a non-Error
+    // input a usable stack instead of a bare, unfingerprintable `Error`.
+    client.captureException(
+      error,
+      { originalException: error, syntheticException: new Error('Sentry syntheticException') },
+      eventScope
+    );
   } else {
     // Sentry not available, log to console as fallback
     console.error('[Diagnostics] Exception captured (Sentry unavailable):', error);
@@ -144,10 +168,7 @@ export function captureException(
  * Tag fields (errorType, schema, service, jurisdiction, planid, role) are
  * extracted and set via setTag() for Sentry indexing. Remaining fields use setExtras().
  */
-export function captureMessage(
-  message: string,
-  context?: Record<string, unknown>
-): void {
+export function captureMessage(message: string, context?: Record<string, unknown>): void {
   if (diagnosticsClient) {
     const { client, scope: baseScope } = diagnosticsClient;
     const eventScope = baseScope.clone();
@@ -159,7 +180,16 @@ export function captureMessage(
       }
     }
 
-    client.captureMessage(message, undefined, undefined, eventScope);
+    // Same hint contract as captureException above; see the note there.
+    client.captureMessage(
+      message,
+      undefined,
+      {
+        originalException: message,
+        syntheticException: new Error('Sentry syntheticException'),
+      },
+      eventScope
+    );
   } else {
     console.warn('[Diagnostics] Message captured (Sentry unavailable):', message);
     if (context) {

--- a/src/services/diagnostics.service.ts
+++ b/src/services/diagnostics.service.ts
@@ -180,7 +180,14 @@ export function captureMessage(message: string, context?: Record<string, unknown
       }
     }
 
-    // Same hint contract as captureException above; see the note there.
+    // Same hint contract as captureException above; see the note there — with
+    // one caveat. `originalException` is what the beforeSend rules read, and
+    // it is the half that matters here. `syntheticException` is NOT: Sentry's
+    // `eventFromMessage` consults it only when `attachStacktrace` is enabled,
+    // and this app never enables it, so the message path produces no stack
+    // from it today. It is passed anyway so the two capture paths hand the
+    // client the same hint shape and turning `attachStacktrace` on is a
+    // one-line config change rather than a hunt for missing hints.
     client.captureMessage(
       message,
       undefined,

--- a/src/tests/contracts/custom-domain-schema-contract.spec.ts
+++ b/src/tests/contracts/custom-domain-schema-contract.spec.ts
@@ -3,7 +3,8 @@
 // Contract snapshot tests that verify the frontend Zod schema declares
 // all fields the backend sends. Prevents silent field stripping (issue #2685).
 
-import { domainIconMetaCanonical } from '@/schemas/contracts/custom-domain';
+import { domainIconMetaCanonical, vhostCanonical } from '@/schemas/contracts/custom-domain';
+import { vhostSchema } from '@/schemas/shapes/v2/custom-domain/vhost';
 import { customDomainSchema } from '@/schemas/shapes/v3/custom-domain';
 import { describe, expect, it } from 'vitest';
 
@@ -33,20 +34,15 @@ describe('CustomDomain schema contract (safe_dump_fields)', () => {
       (f) => !(f in INTENTIONAL_EXCLUSIONS)
     );
 
-    it.each(backendFields)(
-      'customDomainSchema declares backend field "%s"',
-      (field) => {
-        expect(schemaKeys).toContain(field);
-      }
-    );
+    it.each(backendFields)('customDomainSchema declares backend field "%s"', (field) => {
+      expect(schemaKeys).toContain(field);
+    });
 
     it('all intentional exclusions reference real backend fields', () => {
       // Guard against stale exclusions: every key in INTENTIONAL_EXCLUSIONS
       // must actually exist in the backend field list.
       for (const excluded of Object.keys(INTENTIONAL_EXCLUSIONS)) {
-        expect(
-          CUSTOM_DOMAIN_SAFE_DUMP_FIELDS as readonly string[]
-        ).toContain(excluded);
+        expect(CUSTOM_DOMAIN_SAFE_DUMP_FIELDS as readonly string[]).toContain(excluded);
       }
     });
 
@@ -137,6 +133,15 @@ describe('CustomDomain schema contract (safe_dump_fields)', () => {
         expect(result.error.issues).toEqual([]);
       }
       expect(result.success).toBe(true);
+    });
+  });
+
+  describe('vhost keep_host compatibility', () => {
+    it('accepts the upstream boolean and legacy string encodings', () => {
+      for (const keep_host of [true, false, 'true', 'false']) {
+        expect(vhostCanonical.safeParse({ keep_host }).success).toBe(true);
+        expect(vhostSchema.safeParse({ keep_host }).success).toBe(true);
+      }
     });
   });
 

--- a/src/tests/contracts/custom-domain-schema-contract.spec.ts
+++ b/src/tests/contracts/custom-domain-schema-contract.spec.ts
@@ -143,6 +143,18 @@ describe('CustomDomain schema contract (safe_dump_fields)', () => {
         expect(vhostSchema.safeParse({ keep_host }).success).toBe(true);
       }
     });
+
+    // The union is `.nullable()` and not `.optional()`, which reads like a
+    // blob predating the field would be rejected. It is not: both shapes end
+    // in `.partial()`, so an absent key is already accepted. Pinned so a
+    // future de-partial() cannot silently reintroduce the whole-response
+    // failure this change fixed.
+    it('accepts null and an absent key', () => {
+      for (const vhost of [{ keep_host: null }, {}]) {
+        expect(vhostCanonical.safeParse(vhost).success).toBe(true);
+        expect(vhostSchema.safeParse(vhost).success).toBe(true);
+      }
+    });
   });
 
   // #3780: the workspace "Refresh favicon" gate reads

--- a/src/tests/services/diagnostics.service.spec.ts
+++ b/src/tests/services/diagnostics.service.spec.ts
@@ -140,7 +140,11 @@ describe('diagnostics.service', () => {
       expect(clonedScope.setExtras).toHaveBeenCalledWith(context);
 
       // Client should be called with the cloned scope, not the base scope
-      expect(client.captureException).toHaveBeenCalledWith(error, undefined, clonedScope);
+      expect(client.captureException).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ originalException: error }),
+        clonedScope
+      );
     });
 
     it('without context: captures without setting extras', async () => {
@@ -157,7 +161,11 @@ describe('diagnostics.service', () => {
 
       const clonedScope = baseScope.clone.mock.results[0].value;
       expect(clonedScope.setExtras).not.toHaveBeenCalled();
-      expect(client.captureException).toHaveBeenCalledWith(error, undefined, clonedScope);
+      expect(client.captureException).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({ originalException: error }),
+        clonedScope
+      );
     });
 
     it('without Sentry: falls back to console.error', async () => {
@@ -173,12 +181,67 @@ describe('diagnostics.service', () => {
         '[Diagnostics] Exception captured (Sentry unavailable):',
         error
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        '[Diagnostics] Context:',
-        context
-      );
+      expect(consoleSpy).toHaveBeenCalledWith('[Diagnostics] Context:', context);
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  // ========================================================================
+  // CAPTURE HINT — the contract beforeSend depends on
+  // ========================================================================
+  //
+  // `Client.captureException` does not build a hint; it forwards whatever it is
+  // given. Passing `undefined` (as this facade did) meant `beforeSend` received
+  // a hint with no `originalException`, which silently disabled BOTH
+  // beforeSend rules that read it — the expected-transport-outcome drop (#4286)
+  // and the api-error grouping (#4287). Nothing failed loudly; issue volume
+  // just kept climbing. These tests pin the hint so it cannot regress again.
+  describe('capture hint', () => {
+    it('captureException hands beforeSend the original error to inspect', async () => {
+      const { initDiagnostics, captureException } = await importFresh();
+      const client = createMockClient();
+      const baseScope = createMockScope();
+
+      initDiagnostics(client as never, baseScope as never);
+
+      // The shape the grouping/expected-outcome rules narrow on: an axios-like
+      // error is only recognizable through `hint.originalException.config`.
+      const axiosLike = Object.assign(new Error('Network Error'), {
+        config: { url: '/api/v2/dashboard', method: 'get' },
+        code: 'ERR_NETWORK',
+      });
+
+      captureException(axiosLike);
+
+      const [, hint] = client.captureException.mock.calls[0];
+      expect(hint.originalException).toBe(axiosLike);
+      expect((hint.originalException as typeof axiosLike).config.url).toBe('/api/v2/dashboard');
+    });
+
+    it('captureException supplies a synthetic exception for stackless inputs', async () => {
+      const { initDiagnostics, captureException } = await importFresh();
+      const client = createMockClient();
+      const baseScope = createMockScope();
+
+      initDiagnostics(client as never, baseScope as never);
+      captureException(new Error('boom'));
+
+      const [, hint] = client.captureException.mock.calls[0];
+      expect(hint.syntheticException).toBeInstanceOf(Error);
+    });
+
+    it('captureMessage hands beforeSend the same hint shape', async () => {
+      const { initDiagnostics, captureMessage } = await importFresh();
+      const client = createMockClient();
+      const baseScope = createMockScope();
+
+      initDiagnostics(client as never, baseScope as never);
+      captureMessage('hello');
+
+      const [, , hint] = client.captureMessage.mock.calls[0];
+      expect(hint.originalException).toBe('hello');
+      expect(hint.syntheticException).toBeInstanceOf(Error);
     });
   });
 
@@ -201,7 +264,12 @@ describe('diagnostics.service', () => {
 
       const clonedScope = baseScope.clone.mock.results[0].value;
       expect(clonedScope.setExtras).toHaveBeenCalledWith(context);
-      expect(client.captureMessage).toHaveBeenCalledWith('test message', undefined, undefined, clonedScope);
+      expect(client.captureMessage).toHaveBeenCalledWith(
+        'test message',
+        undefined,
+        expect.objectContaining({ originalException: 'test message' }),
+        clonedScope
+      );
     });
 
     it('without context: captures without setting extras', async () => {
@@ -215,7 +283,12 @@ describe('diagnostics.service', () => {
 
       const clonedScope = baseScope.clone.mock.results[0].value;
       expect(clonedScope.setExtras).not.toHaveBeenCalled();
-      expect(client.captureMessage).toHaveBeenCalledWith('bare message', undefined, undefined, clonedScope);
+      expect(client.captureMessage).toHaveBeenCalledWith(
+        'bare message',
+        undefined,
+        expect.objectContaining({ originalException: 'bare message' }),
+        clonedScope
+      );
     });
 
     it('without Sentry: falls back to console.warn', async () => {
@@ -228,10 +301,7 @@ describe('diagnostics.service', () => {
         '[Diagnostics] Message captured (Sentry unavailable):',
         'fallback message'
       );
-      expect(consoleSpy).toHaveBeenCalledWith(
-        '[Diagnostics] Context:',
-        { key: 'val' }
-      );
+      expect(consoleSpy).toHaveBeenCalledWith('[Diagnostics] Context:', { key: 'val' });
 
       consoleSpy.mockRestore();
     });

--- a/try/unit/session_try.rb
+++ b/try/unit/session_try.rb
@@ -115,6 +115,19 @@ invalid_sids.all? do |sid|
 end
 #=> true
 
+## [BACKEND-B5] Reject a cookie whose bytes are not valid UTF-8, rather than
+## raising. The value comes off the wire, so `match?` on it would raise
+## ArgumentError and 500 the request before any handler ran.
+binary_sid = (+"\xC3\x28").force_encoding(Encoding::UTF_8)
+call_private_method(@session, :valid_session_id?, binary_sid)
+#=> false
+
+## [BACKEND-B5] ...including when the invalid bytes are appended to an
+## otherwise well-formed 64-char hex sid
+tainted_sid = (+(SecureRandom.hex(32) + "\xFF")).force_encoding(Encoding::UTF_8)
+call_private_method(@session, :valid_session_id?, tainted_sid)
+#=> false
+
 
 
 ## Derive consistent keys for different purposes


### PR DESCRIPTION
## Summary
- Restore Sentry capture hints so frontend before-send filters can drop expected transport failures and group API errors reliably; ignore two known in-app browser bridge failures.
- Prevent backend error noise and invalid side effects by grouping unauthenticated v1 form rejections by endpoint at warning level, skipping login hooks for Rodauth internal password checks, and rejecting invalidly encoded session-cookie values.
- Accept boolean custom-domain vhost keep_host values returned by the proxy API, while retaining compatibility with existing string values.

## Review guide
- Start with src/services/diagnostics.service.ts and its tests: direct client captures now provide originalException and syntheticException to the isolated event scope.
- Review the Ruby request-path guards in apps/api/v1/controllers/helpers.rb, apps/web/auth/config/hooks/login.rb, and lib/onetime/session.rb for the intended handling of untrusted or internal requests.
- The custom-domain schemas intentionally accept both string and boolean keep_host values because the stored upstream response is a passthrough field.

## Validation
- Added targeted RSpec, TypeScript, and session try coverage for the changed capture and input-handling behavior.
- Pre-commit, pre-push, and CI checks will validate this change.