### PR TITLE
Preserve signup redirects through email verification

### DIFF
--- a/src/shared/composables/usePostAuthRedirect.ts
+++ b/src/shared/composables/usePostAuthRedirect.ts
@@ -157,9 +157,12 @@ export function usePostAuthRedirect() {
         requestedProduct: product,
       }
     );
-    await router.push(
-      `/billing/${orgExtid}/plans?product=${product}&interval=${interval}&change=true`
-    );
+    // Object form so vue-router encodes the values: product/interval can come
+    // straight from route.query, and raw `&`/`=`/`#` must not become URL syntax.
+    await router.push({
+      path: `/billing/${orgExtid}/plans`,
+      query: { product, interval, change: 'true' },
+    });
     return true;
   }
 
@@ -215,7 +218,10 @@ export function usePostAuthRedirect() {
         product,
         interval,
       });
-      await router.push(`/billing/${org.extid}/plans?product=${product}&interval=${interval}`);
+      await router.push({
+        path: `/billing/${org.extid}/plans`,
+        query: { product, interval },
+      });
       return true;
     } catch (err) {
       // Graceful degradation - if billing redirect fails, continue to dashboard

--- a/src/tests/composables/useAuth.billing.spec.ts
+++ b/src/tests/composables/useAuth.billing.spec.ts
@@ -243,8 +243,8 @@ describe('useAuth - Billing Redirect Safety Checks', () => {
       const org = createMockOrganization(); // Default is free plan (no paid subscription)
       axiosMock.onGet('/api/organizations').reply(200, { records: [org], count: 1 });
       await login('test@example.com', 'password123');
-      const expectedPath = `/billing/${org.extid}/plans?product=identity&interval=month`;
-      expect(router.push).toHaveBeenCalledWith(expectedPath);
+      const expected = { path: `/billing/${org.extid}/plans`, query: { product: 'identity', interval: 'month' } };
+      expect(router.push).toHaveBeenCalledWith(expected);
     */
 
     it.todo('should use the default organization for billing redirect');
@@ -255,8 +255,8 @@ describe('useAuth - Billing Redirect Safety Checks', () => {
       const orgs = { records: [otherOrg, defaultOrg], count: 2 };
       axiosMock.onGet('/api/organizations').reply(200, orgs);
       await login('test@example.com', 'password123');
-      const expectedPath = `/billing/on_default/plans?product=unlimited&interval=year`;
-      expect(router.push).toHaveBeenCalledWith(expectedPath);
+      const expected = { path: '/billing/on_default/plans', query: { product: 'unlimited', interval: 'year' } };
+      expect(router.push).toHaveBeenCalledWith(expected);
     */
   });
 
@@ -417,8 +417,8 @@ describe('useAuth - Billing Redirect Safety Checks', () => {
       const result = await login('test@example.com', 'password123');
       expect(result).toBe(true);
       expect(isLoading.value).toBe(false);
-      const expectedPath = `/billing/${org.extid}/plans?product=identity&interval=month`;
-      expect(router.push).toHaveBeenCalledWith(expectedPath);
+      const expected = { path: `/billing/${org.extid}/plans`, query: { product: 'identity', interval: 'month' } };
+      expect(router.push).toHaveBeenCalledWith(expected);
     */
   });
 });
@@ -528,9 +528,10 @@ describe('useAuth - Billing Redirect Valid Flag (Future)', () => {
     await login('test@example.com', 'password123');
 
     // Should redirect to billing plans for checkout
-    expect(router.push).toHaveBeenCalledWith(
-      `/billing/${org.extid}/plans?product=identity&interval=month`
-    );
+    expect(router.push).toHaveBeenCalledWith({
+      path: `/billing/${org.extid}/plans`,
+      query: { product: 'identity', interval: 'month' },
+    });
   });
 });
 
@@ -632,9 +633,10 @@ describe('useAuth - Subscription Status Checks', () => {
     await login('test@example.com', 'password123');
 
     // Should redirect to plan change flow
-    expect(router.push).toHaveBeenCalledWith(
-      `/billing/${org.extid}/plans?product=unlimited&interval=month&change=true`
-    );
+    expect(router.push).toHaveBeenCalledWith({
+      path: `/billing/${org.extid}/plans`,
+      query: { product: 'unlimited', interval: 'month', change: 'true' },
+    });
   });
 
   it.skip('should redirect to plan change flow when on free plan upgrading to paid', async () => {
@@ -659,9 +661,10 @@ describe('useAuth - Subscription Status Checks', () => {
     await login('test@example.com', 'password123');
 
     // Should redirect to plans with change=true (free is treated as existing plan)
-    expect(router.push).toHaveBeenCalledWith(
-      `/billing/${org.extid}/plans?product=identity&interval=month&change=true`
-    );
+    expect(router.push).toHaveBeenCalledWith({
+      path: `/billing/${org.extid}/plans`,
+      query: { product: 'identity', interval: 'month', change: 'true' },
+    });
   });
 });
 

--- a/src/tests/composables/usePostAuthRedirect.spec.ts
+++ b/src/tests/composables/usePostAuthRedirect.spec.ts
@@ -1,0 +1,125 @@
+// src/tests/composables/usePostAuthRedirect.spec.ts
+
+/**
+ * Tests for the billing branch of usePostAuthRedirect.
+ *
+ * The route-query fallback means `product`/`interval` are user-controlled.
+ * These tests pin that both billing destinations are pushed in vue-router's
+ * object form ({ path, query }) so reserved characters in those values are
+ * encoded by the router instead of being interpreted as URL syntax — a raw
+ * `product=x&change=true` must stay ONE query value, not become two.
+ */
+
+import { usePostAuthRedirect } from '@/shared/composables/usePostAuthRedirect';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import { useOrganizationStore } from '@/shared/stores/organizationStore';
+import { createWireOrganization, type OrganizationWire } from '@/tests/fixtures/billing.fixture';
+import type AxiosMockAdapter from 'axios-mock-adapter';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useRoute, useRouter } from 'vue-router';
+import { getRouter } from 'vue-router-mock';
+import { setupTestPinia } from '../setup';
+
+// Mock vue-router - must be before any imports that use it
+vi.mock('vue-router');
+
+// Mock vue-i18n to provide translation function
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => key,
+    locale: { value: 'en' },
+  }),
+}));
+
+// Mock logging service to suppress debug output during tests
+vi.mock('@/services/logging.service', () => ({
+  loggingService: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+function createMockOrganization(overrides: Partial<OrganizationWire> = {}): OrganizationWire {
+  const now = Math.floor(Date.now() / 1000);
+  return createWireOrganization({
+    objid: 'org_obj_123',
+    extid: 'on1234abc',
+    owner_id: 'cust_obj_456',
+    display_name: 'Test Organization',
+    description: null,
+    contact_email: 'contact@example.com',
+    is_default: true,
+    planid: 'free_v1',
+    created: now,
+    updated: now,
+    entitlements: [],
+    limits: { teams: 0, total_members_per_org: 0, custom_domains: 0 },
+    ...overrides,
+  });
+}
+
+describe('usePostAuthRedirect - billing destination encoding', () => {
+  let axiosMock: AxiosMockAdapter;
+  let router: ReturnType<typeof getRouter>;
+  let mockRoute: { query: Record<string, string> };
+
+  beforeEach(async () => {
+    const setup = await setupTestPinia();
+    axiosMock = setup.axiosMock!;
+    router = getRouter();
+
+    const bootstrapStore = useBootstrapStore();
+    bootstrapStore.authenticated = true;
+    bootstrapStore.billing_enabled = true;
+
+    mockRoute = { query: {} };
+    vi.mocked(useRouter).mockReturnValue(router);
+    vi.mocked(useRoute).mockReturnValue(mockRoute as any);
+  });
+
+  afterEach(() => {
+    axiosMock.restore();
+    vi.clearAllMocks();
+    router.reset();
+  });
+
+  it('pushes the checkout destination in object form, reserved characters intact', async () => {
+    mockRoute.query = { product: 'x&change=true', interval: 'month#frag' };
+    // planid is required-canonical in the org schema, so a validated response
+    // can never carry a falsy one; stub the store to reach the checkout branch.
+    const orgStore = useOrganizationStore();
+    vi.spyOn(orgStore, 'fetchOrganizations').mockResolvedValue([]);
+    vi.spyOn(orgStore, 'restorePersistedSelection').mockReturnValue({
+      extid: 'on1234abc',
+      planid: undefined,
+    } as any);
+
+    const { handleBillingRedirect } = usePostAuthRedirect();
+    const redirected = await handleBillingRedirect();
+
+    expect(redirected).toBe(true);
+    // Object form: the router encodes these values; string interpolation would
+    // have let `&change=true` split into a second query parameter.
+    expect(router.push).toHaveBeenCalledWith({
+      path: '/billing/on1234abc/plans',
+      query: { product: 'x&change=true', interval: 'month#frag' },
+    });
+  });
+
+  it('pushes the plan-change destination in object form, reserved characters intact', async () => {
+    mockRoute.query = { product: 'x&change=true', interval: 'year' };
+    const org = createMockOrganization({ planid: 'identity_plus_v1' });
+    axiosMock.onGet('/api/organizations').reply(200, { records: [org], count: 1 });
+
+    const { handleBillingRedirect } = usePostAuthRedirect();
+    const redirected = await handleBillingRedirect();
+
+    expect(redirected).toBe(true);
+    expect(router.push).toHaveBeenCalledWith({
+      path: `/billing/${org.extid}/plans`,
+      query: { product: 'x&change=true', interval: 'year', change: 'true' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve validated internal redirect targets from signup through email verification and every subsequent sign-in path, including verification links opened in a fresh browser session.
- Keep paid-plan checkout intents ahead of ordinary redirects, correct checkout URLs to the router query-string contract, and consume stored navigation targets after use.
- Share and fixture-test redirect validation across Ruby and TypeScript, and add browser coverage plus a dedicated real-SMTP full-auth CI lane.

## Review guide
- Start with apps/web/auth/config/hooks/account.rb and apps/web/auth/config/features/account_management.rb; verify capture, re-validation, one-time consumption, and plan-intent precedence for JSON and form clients.
- Review lib/onetime/utils/redirect_paths.rb, src/utils/redirect.ts, and tests/fixtures/redirect_path_cases.json for the cross-runtime safe-path rules. The new full-auth workflow requires Valkey, RabbitMQ, and Mailpit to exercise the queued verification-email journey.

## Validation
- Pre-commit, pre-push, and CI checks will validate this change.

Resolves #4305