### PR TITLE
Show the capped caveat on the users admin list

### DIFF
--- a/locales/content/en/admin-customers.json
+++ b/locales/content/en/admin-customers.json
@@ -27,6 +27,10 @@
     "text": "No customers match this search",
     "content_hash": "ea7e7012"
   },
+  "web.admin.customers.list.capped": {
+    "text": "Results are capped: the count shown is a floor, not the total. Narrow the search or filter to see everything.",
+    "content_hash": "27537844"
+  },
   "web.admin.customers.roles.colonel": {
     "text": "Colonel",
     "content_hash": "02577777"

--- a/src/apps/admin/composables/usePaginatedFetch.ts
+++ b/src/apps/admin/composables/usePaginatedFetch.ts
@@ -20,6 +20,13 @@ export interface PageMeta {
   per_page: number;
   total_count: number;
   total_pages: number;
+  /**
+   * True when a bounded server-side scan/window stopped early, making
+   * total_count a FLOOR rather than the population. Optional — only the
+   * endpoints with bounded filter scans (domains, users, billing) emit it;
+   * views should render a caveat when it is true.
+   */
+  capped?: boolean;
 }
 
 /**

--- a/src/apps/admin/views/AdminCustomers.vue
+++ b/src/apps/admin/views/AdminCustomers.vue
@@ -419,6 +419,18 @@
         @submit="onSearchSubmit" />
     </div>
 
+    <!-- The server's index scan is bounded: when it caps (search hit its
+         match/round limits, or the role filter exceeded its scan window),
+         total_count is a FLOOR. Say so rather than letting the count and
+         pager read as the population (mirrors StripeOrganizationsSection). -->
+    <div
+      v-if="pagination?.capped"
+      class="mb-4 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-900/20 dark:text-amber-200"
+      role="status"
+      data-testid="customers-capped-caveat">
+      {{ t('web.admin.customers.list.capped') }}
+    </div>
+
     <!-- Table -->
     <div
       class="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900">

--- a/src/tests/apps/admin/AdminCustomers.spec.ts
+++ b/src/tests/apps/admin/AdminCustomers.spec.ts
@@ -76,6 +76,7 @@ function usersPayload(
     per_page?: number;
     role?: string | null;
     suspended?: boolean;
+    capped?: boolean;
   } = {}
 ) {
   return {
@@ -103,6 +104,9 @@ function usersPayload(
         per_page: overrides.per_page ?? 50,
         total_count: 1,
         total_pages: 1,
+        // The wire signal is optional: only capped responses carry it, so the
+        // uncapped fixture omits it entirely (like the unfiltered endpoint).
+        ...(overrides.capped !== undefined ? { capped: overrides.capped } : {}),
         role_filter: overrides.role ?? null,
       },
     },
@@ -359,6 +363,27 @@ describe('AdminCustomers (list view — ticket #22)', () => {
 
     // KitPagination shows the range summary string.
     expect(wrapper.text()).toContain('web.colonel.pagination.showing');
+  });
+
+  it('renders the capped caveat when the server marks the scan as capped', async () => {
+    mockApi.get.mockResolvedValue({ data: usersPayload({ capped: true }) });
+    wrapper = mountView();
+    await flushPromises();
+
+    const caveat = wrapper.find('[data-testid="customers-capped-caveat"]');
+    expect(caveat.exists()).toBe(true);
+    expect(caveat.attributes('role')).toBe('status');
+    expect(caveat.text()).toContain('web.admin.customers.list.capped');
+  });
+
+  it('does not render the capped caveat on an uncapped response', async () => {
+    // The endpoint always emits the flag (false on the unbounded paths), so
+    // exercise the real wire shape; fixture omission is covered elsewhere.
+    mockApi.get.mockResolvedValue({ data: usersPayload({ capped: false }) });
+    wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="customers-capped-caveat"]').exists()).toBe(false);
   });
 
   it('shows the error banner + retry on a network failure', async () => {

--- a/src/tests/apps/admin/AdminCustomers.spec.ts
+++ b/src/tests/apps/admin/AdminCustomers.spec.ts
@@ -104,9 +104,9 @@ function usersPayload(
         per_page: overrides.per_page ?? 50,
         total_count: 1,
         total_pages: 1,
-        // The wire signal is optional: only capped responses carry it, so the
-        // uncapped fixture omits it entirely (like the unfiltered endpoint).
-        ...(overrides.capped !== undefined ? { capped: overrides.capped } : {}),
+        // The endpoint always emits the flag (false on the unbounded paths) —
+        // see Colonel::ListUsers#success_data — so the fixture does too.
+        capped: overrides.capped ?? false,
         role_filter: overrides.role ?? null,
       },
     },
@@ -377,8 +377,6 @@ describe('AdminCustomers (list view — ticket #22)', () => {
   });
 
   it('does not render the capped caveat on an uncapped response', async () => {
-    // The endpoint always emits the flag (false on the unbounded paths), so
-    // exercise the real wire shape; fixture omission is covered elsewhere.
     mockApi.get.mockResolvedValue({ data: usersPayload({ capped: false }) });
     wrapper = mountView();
     await flushPromises();


### PR DESCRIPTION
## Summary

The colonel users endpoint (`Auth::Operations::Customers::List`) emits `pagination.capped: true` when its bounded email-index HSCAN or role-filter scan window stops early (epic #20 / #2211 CONTRACT 8), but the users admin view rendered `total_count` as if it were the population. This adds the same amber `role="status"` caveat the billing (`StripeOrganizationsSection`) and sessions lists already show, so a capped count reads as a floor.

- `PageMeta` in `usePaginatedFetch.ts` gains the optional `capped` field — byte-identical to the change in #4312 so the two branches merge cleanly whichever lands first
- Caveat block in `AdminCustomers.vue` (`data-testid="customers-capped-caveat"`), keyed `web.admin.customers.list.capped`
- The locale entry reuses #4312's exact caveat string, so the `content_hash` (`27537844`) matches and translators see one string, not two

## Notes for review

- The Zod `paginationSchema` already accepted the optional `capped` field on `main`, and the store hands `details.pagination` straight through — the only missing links were the `PageMeta` type and the view.
- #4312 is not merged yet; this PR is intentionally independent of it (no shared-component extraction across the four caveat call sites — billing is a two-signal variant and sessions a different inline shape, so that refactor is a follow-up once #4312 lands).

## Related Issues

Part of epic #20 / #2211 (bounded index scans surface their early-stop honestly).

## Test Plan

- `pnpm vitest run src/tests/apps/admin` — 64 files, 769 passed (includes the two new cases: capped response renders the notice with `role="status"`; `capped: false` — the real uncapped wire shape — does not)
- `python3 locales/scripts/i18n validate hashes` — 4099 en keys, 0 stale
- `vue-tsc --noEmit` — no errors in touched files