### PR TITLE
Fix TypeScript type-check warnings in test code

### DIFF
--- a/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
@@ -29,7 +29,10 @@ vi.mock('@/shared/components/icons/OIcon.vue', () => ({
 }));
 
 import AdminCustomerSessionsSection from '@/apps/admin/components/AdminCustomerSessionsSection.vue';
-import { colonelCustomerSessionsResponseSchema } from '@/schemas/api/internal/responses/colonel-customer-sessions';
+import {
+  colonelCustomerSessionsResponseSchema,
+  type AdminCustomerSession,
+} from '@/schemas/api/internal/responses/colonel-customer-sessions';
 import { createTestI18n } from '@tests/setup';
 
 const i18n = createTestI18n();
@@ -40,7 +43,7 @@ const USER_ID = 'ur_abc123';
 const COUNTRY_HEADER = 'web.admin.customers.detail.sessions.columns.country';
 const UNKNOWN = 'web.admin.customers.detail.sessions.unknown';
 
-function sessionRow(overrides: Record<string, unknown> = {}) {
+function sessionRow(overrides: Partial<AdminCustomerSession> = {}): AdminCustomerSession {
   return {
     session_id: 'sid_1',
     user_id: USER_ID,
@@ -59,16 +62,20 @@ function sessionRow(overrides: Record<string, unknown> = {}) {
 /**
  * A row from a backend that predates the geo join: the key is ABSENT, not null.
  * `{ geo_country: undefined }` would not exercise the same thing — the property
- * would still exist — so it is deleted outright.
+ * would still exist — so it is deleted outright. `geo_country` is declared
+ * `.optional()` on the schema (see adminCustomerSessionSchema), so deleting it
+ * still yields a valid AdminCustomerSession — no cast needed.
  */
-function sessionRowWithoutCountry(overrides: Record<string, unknown> = {}) {
-  const row = sessionRow(overrides) as Record<string, unknown>;
+function sessionRowWithoutCountry(
+  overrides: Partial<AdminCustomerSession> = {}
+): AdminCustomerSession {
+  const row = sessionRow(overrides);
   delete row.geo_country;
   return row;
 }
 
 function sessionsPayload(
-  rows = [sessionRow(), sessionRow({ session_id: 'sid_2' })],
+  rows: AdminCustomerSession[] = [sessionRow(), sessionRow({ session_id: 'sid_2' })],
   currentSessionId: string | null = null
 ) {
   return {

--- a/src/tests/apps/admin/AdminDomainsTable.spec.ts
+++ b/src/tests/apps/admin/AdminDomainsTable.spec.ts
@@ -253,7 +253,9 @@ describe('AdminDomains — table, filters and drawer', () => {
     // The drawer renders from the row already in hand — no second fetch.
     expect(mockApi.get).toHaveBeenCalledTimes(1);
 
-    const fullPage = wrapper.findComponent('[data-testid="domain-open-full-page"]');
+    const fullPage = wrapper.findComponent<typeof RouterLinkStub>(
+      '[data-testid="domain-open-full-page"]'
+    );
     expect(fullPage.exists()).toBe(true);
     expect(fullPage.props('to')).toEqual({
       name: 'AdminDomainDetail',

--- a/src/tests/apps/admin/AdminSessions.spec.ts
+++ b/src/tests/apps/admin/AdminSessions.spec.ts
@@ -59,6 +59,7 @@ vi.mock('@headlessui/vue', () => ({
 }));
 
 import AdminSessions from '@/apps/admin/views/AdminSessions.vue';
+import type { ColonelSession } from '@/schemas/api/internal/responses/colonel-sessions';
 import { createTestI18n } from '@tests/setup';
 
 const i18n = createTestI18n();
@@ -70,7 +71,7 @@ const SID = 'sid_auth_1';
 const COUNTRY_HEADER = 'web.admin.sessions.columns.country';
 const UNKNOWN = 'web.admin.sessions.detail.unknown';
 
-function sessionsPayload(rows = [sessionRow()]) {
+function sessionsPayload(rows: ColonelSession[] = [sessionRow()]) {
   return {
     shrimp: '',
     record: {},
@@ -82,7 +83,7 @@ function sessionsPayload(rows = [sessionRow()]) {
   };
 }
 
-function sessionRow(overrides: Record<string, unknown> = {}) {
+function sessionRow(overrides: Partial<ColonelSession> = {}): ColonelSession {
   return {
     session_id: SID,
     key: `session:${SID}`,
@@ -101,10 +102,12 @@ function sessionRow(overrides: Record<string, unknown> = {}) {
 /**
  * A row from a backend that predates the geo join: the key is ABSENT, not null.
  * `{ geo_country: undefined }` would not exercise the same thing — the property
- * would still exist — so it is deleted outright.
+ * would still exist — so it is deleted outright. `geo_country` is declared
+ * `.optional()` on the schema (see colonelSessionSchema), so deleting it still
+ * yields a valid ColonelSession — no cast needed.
  */
-function sessionRowWithoutCountry(overrides: Record<string, unknown> = {}) {
-  const row = sessionRow(overrides) as Record<string, unknown>;
+function sessionRowWithoutCountry(overrides: Partial<ColonelSession> = {}): ColonelSession {
+  const row = sessionRow(overrides);
   delete row.geo_country;
   return row;
 }

--- a/src/tests/apps/admin/bannerSchemas.spec.ts
+++ b/src/tests/apps/admin/bannerSchemas.spec.ts
@@ -67,7 +67,7 @@ describe('colonelBannerSetResponseSchema (SetBanner ack)', () => {
     const result = colonelBannerSetResponseSchema.safeParse(payload);
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(result.data.details.message).toBe('Broadcast banner published');
+    expect(result.data.details?.message).toBe('Broadcast banner published');
   });
 
   it('rejects a set ack missing details.message', () => {

--- a/src/tests/apps/admin/checkoutLinkSchemas.spec.ts
+++ b/src/tests/apps/admin/checkoutLinkSchemas.spec.ts
@@ -42,7 +42,7 @@ describe('colonelCheckoutLinkResponseSchema (CreateCheckoutLink)', () => {
       'https://checkout.stripe.com/c/pay/cs_test_a1b2c3'
     );
     expect(result.data.record.expires_at).toBe(1783464864);
-    expect(result.data.details.region).toBe('eu');
+    expect(result.data.details?.region).toBe('eu');
   });
 
   it('rejects a 2xx ack missing the checkout_url (the deliverable)', () => {
@@ -64,7 +64,7 @@ describe('colonelCheckoutLinkResponseSchema (CreateCheckoutLink)', () => {
     const result = colonelCheckoutLinkResponseSchema.safeParse(payload);
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(result.data.details.region).toBe('global');
+    expect(result.data.details?.region).toBe('global');
   });
 
   // The backend must never send null here (BillingConfig#region is nil when

--- a/src/tests/apps/admin/customerDetailSchemas.spec.ts
+++ b/src/tests/apps/admin/customerDetailSchemas.spec.ts
@@ -1,9 +1,12 @@
 // src/tests/apps/admin/customerDetailSchemas.spec.ts
 
 import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
 
 import {
+  colonelUserDetailRecordSchema,
   colonelUserDetailResponseSchema,
+  colonelUserDetailsSchema,
   colonelUserMutationResponseSchema,
 } from '@/schemas/api/internal/responses/colonel';
 import { responseSchemas } from '@/schemas/api/internal/responses/registry';
@@ -17,7 +20,18 @@ import { responseSchemas } from '@/schemas/api/internal/responses/registry';
  */
 
 // GetUserDetails `success_data`, on the wire (numbers for date fields).
-function detailPayload() {
+//
+// Typed against the schema's wire (pre-transform) shape — record/details kept
+// required (unlike the wrapped response schema, which makes `details`
+// optional for endpoints that may omit it) since every fixture below always
+// supplies both. This lets later tests swap `details.billing` between its
+// null and populated variants without TypeScript pinning the field to
+// whichever literal shape appears here first.
+function detailPayload(): {
+  shrimp: string;
+  record: z.input<typeof colonelUserDetailRecordSchema>;
+  details: z.input<typeof colonelUserDetailsSchema>;
+} {
   return {
     shrimp: '',
     record: {

--- a/src/tests/apps/admin/useAdminBilling.spec.ts
+++ b/src/tests/apps/admin/useAdminBilling.spec.ts
@@ -15,6 +15,7 @@ vi.mock('@/shared/composables/useApi', () => ({
 }));
 
 import { STRIPE_ORGANIZATIONS_URL, useAdminBilling } from '@/apps/admin/stores/useAdminBilling';
+import type { ColonelStripeOrganization } from '@/schemas/api/internal/responses/colonel-billing';
 
 /** Build a real AxiosError so the store can read `response.status`. */
 function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
@@ -23,7 +24,7 @@ function axiosError(status: number, data: unknown, message = 'Request failed'): 
   return err;
 }
 
-function orgRow(overrides: Record<string, unknown> = {}) {
+function orgRow(overrides: Partial<ColonelStripeOrganization> = {}): ColonelStripeOrganization {
   return {
     org_id: 'org1',
     extid: 'og_abc123',
@@ -40,7 +41,10 @@ function orgRow(overrides: Record<string, unknown> = {}) {
   };
 }
 
-function payload(rows = [orgRow()]) {
+// Only `extid` + `stripe_customer_id` are required on the wire (see
+// colonelStripeOrganizationSchema); every other field is nullish, so a row
+// array may legitimately mix full rows with sparse ones.
+function payload(rows: ColonelStripeOrganization[] = [orgRow()]) {
   return {
     shrimp: '',
     record: {},

--- a/src/tests/apps/secret/components/SecretReceiptTableItem.spec.ts
+++ b/src/tests/apps/secret/components/SecretReceiptTableItem.spec.ts
@@ -3,6 +3,8 @@
 import { mount, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ComponentPublicInstance } from 'vue';
+import { ReceiptState } from '@/schemas/shapes/v3/receipt';
+import type { ReceiptList } from '@/schemas/shapes/v3/receipt';
 
 // Mock vue-i18n
 vi.mock('vue-i18n', () => ({
@@ -56,7 +58,7 @@ const OIconStub = {
   props: ['collection', 'name', 'size', 'class'],
 };
 
-function createMockReceipt(overrides = {}) {
+function createMockReceipt(overrides: Partial<ReceiptList> = {}): ReceiptList {
   return {
     identifier: 'test-receipt-id',
     shortid: 'rcpt123',
@@ -66,7 +68,7 @@ function createMockReceipt(overrides = {}) {
     secret_ttl: 604800,
     receipt_ttl: 604800,
     lifespan: 604800,
-    state: 'new',
+    state: ReceiptState.NEW,
     created: new Date(),
     updated: new Date(),
     shared: null,
@@ -88,8 +90,11 @@ function createMockReceipt(overrides = {}) {
   };
 }
 
+type SecretReceiptTableItemModule =
+  typeof import('@/apps/secret/components/SecretReceiptTableItem.vue');
+
 describe('SecretReceiptTableItem', () => {
-  let SecretReceiptTableItem: ReturnType<typeof import('@/apps/secret/components/SecretReceiptTableItem.vue')>['default'];
+  let SecretReceiptTableItem: SecretReceiptTableItemModule['default'];
 
   beforeEach(async () => {
     vi.resetModules();
@@ -337,7 +342,10 @@ describe('SecretReceiptTableItem', () => {
     it('shows recipients when show_recipients is true', () => {
       const wrapper = mountComponent({
         show_recipients: true,
-        recipients: 'user@example.com',
+        // recipients is string[] | null post-parse (V3 normalizes the wire's
+        // comma-joined string server-side; see v3Recipients in the schema).
+        // A single-entry array stringifies identically in the template.
+        recipients: ['user@example.com'],
       });
       expect(wrapper.text()).toContain('to:');
       expect(wrapper.text()).toContain('user@example.com');

--- a/src/tests/apps/secret/routes/secret.spec.ts
+++ b/src/tests/apps/secret/routes/secret.spec.ts
@@ -3,6 +3,15 @@
 import routes from '@/apps/secret/routes/secret';
 import ShowSecretContainer from '@/apps/secret/reveal/ShowSecret.vue';
 import { describe, expect, it } from 'vitest';
+import type { RouteLocationNormalized } from 'vue-router';
+
+// The route spreads `beforeEnter` from a `NavigationGuardWithThis` union (it
+// can also be an array of guards) into an object typed as `RouteRecordRaw`,
+// so reading it back widens to that union and loses the concrete single-arg
+// signature `withValidatedSecretKey` actually defines. Cast to what the
+// production guard really is (mirrors ShowSecretCapabilities.spec.ts, which
+// tests this same guard).
+type SecretBeforeEnterGuard = (to: RouteLocationNormalized) => { name: string } | undefined;
 
 describe('Secret Routes', () => {
   const secretRoute = routes.find((route) => route.path === '/secret/:secretIdentifier');
@@ -18,7 +27,7 @@ describe('Secret Routes', () => {
 
   describe('secretIdentifier validation', () => {
     it('should allow valid secret keys', () => {
-      const guard = secretRoute?.beforeEnter;
+      const guard = secretRoute?.beforeEnter as SecretBeforeEnterGuard | undefined;
       if (!guard) throw new Error('beforeEnter guard not defined');
 
       const mockRoute = {
@@ -30,7 +39,7 @@ describe('Secret Routes', () => {
     });
 
     it('should redirect to Not Found for invalid secret keys', () => {
-      const guard = secretRoute?.beforeEnter;
+      const guard = secretRoute?.beforeEnter as SecretBeforeEnterGuard | undefined;
       if (!guard) throw new Error('beforeEnter guard not defined');
 
       const invalidKeys = ['abc 123', 'abc@123', '', 'abc/123'];

--- a/src/tests/apps/secret/views/disabled/DisabledVariantsLogo.spec.ts
+++ b/src/tests/apps/secret/views/disabled/DisabledVariantsLogo.spec.ts
@@ -25,6 +25,11 @@ const baseProps = {
   workspaceName: 'Acme',
   monogramInitial: 'A',
   primaryColor: '#3B82F6',
+  // Unset by default (no domain has chosen a font/corner), matching the
+  // "operator never configured this" case documented on DisabledHomepageProps.
+  fontFamilyClass: null as string | null,
+  headingFontClass: null as string | null,
+  cornerClass: null as string | null,
   logoUri: null as string | null,
   logoDarkUri: null as string | null,
   logoAlt: null as string | null,

--- a/src/tests/apps/secret/views/useDisabledConfig.spec.ts
+++ b/src/tests/apps/secret/views/useDisabledConfig.spec.ts
@@ -34,7 +34,6 @@ interface SetupOptions {
   displayDomain?: string;
   brandDescription?: string | null;
   primaryColor?: string;
-  logoUri?: string | null;
   /** Brand font_family as saved in the raw domain_branding hash. Omitted =
    *  key absent (operator never chose a font). */
   fontFamily?: FontFamily;
@@ -174,7 +173,9 @@ function setup(opts: SetupOptions = {}) {
     domainStrategy: opts.domainStrategy ?? 'canonical',
     displayDomain: opts.displayDomain ?? 'onetimesecret.com',
     primaryColor: opts.primaryColor ?? '#dc4a22',
-    logoUri: opts.logoUri ?? null,
+    // logoUri is NOT set here: identityStore.logoUri is a computed derived
+    // from bootstrapStore.domain_logo, not writable state, so it can't be
+    // $patch'd — it's driven above via `tenantLogo` -> bootstrap.domain_logo.
     siteHost: opts.siteHost ?? 'onetimesecret.com',
     brand:
       opts.brandDescription === undefined

--- a/src/tests/apps/session/views/CheckEmail.spec.ts
+++ b/src/tests/apps/session/views/CheckEmail.spec.ts
@@ -18,7 +18,7 @@
 
 import { mount, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { createRouter, createMemoryHistory, Router } from 'vue-router';
+import { createRouter, createMemoryHistory, Router, RouterLink } from 'vue-router';
 import { defineComponent } from 'vue';
 import CheckEmail from '@/apps/session/views/CheckEmail.vue';
 import { CHECK_EMAIL_STATE_KEY } from '@/shared/constants/checkEmail';
@@ -185,7 +185,9 @@ describe('CheckEmail.vue', () => {
       query: { product: 'identity', interval: 'month' },
     });
 
-    const to = wrapper.findComponent('[data-testid="check-email-start-over-link"]').props('to');
+    const to = wrapper
+      .findComponent<typeof RouterLink>('[data-testid="check-email-start-over-link"]')
+      .props('to');
     // Billing context is preserved; the email is deliberately dropped so the
     // corrected address is retyped and no PII returns to a URL.
     expect(to).toEqual({
@@ -197,7 +199,9 @@ describe('CheckEmail.vue', () => {
   it('points "start over" to a bare /signup when there are no billing params', async () => {
     wrapper = await createWrapper({ email: 'tom@myspace.com' });
 
-    const to = wrapper.findComponent('[data-testid="check-email-start-over-link"]').props('to');
+    const to = wrapper
+      .findComponent<typeof RouterLink>('[data-testid="check-email-start-over-link"]')
+      .props('to');
     expect(to).toBe('/signup');
   });
 
@@ -209,7 +213,9 @@ describe('CheckEmail.vue', () => {
       query: { redirect: '/secret/abc?view=raw#content' },
     });
 
-    const to = wrapper.findComponent('[data-testid="check-email-start-over-link"]').props('to');
+    const to = wrapper
+      .findComponent<typeof RouterLink>('[data-testid="check-email-start-over-link"]')
+      .props('to');
     expect(to).toEqual({
       path: '/signup',
       query: { redirect: '/secret/abc?view=raw#content' },
@@ -222,7 +228,9 @@ describe('CheckEmail.vue', () => {
       query: { redirect: '/workspace/domains', product: 'identity', interval: 'month' },
     });
 
-    const to = wrapper.findComponent('[data-testid="check-email-start-over-link"]').props('to');
+    const to = wrapper
+      .findComponent<typeof RouterLink>('[data-testid="check-email-start-over-link"]')
+      .props('to');
     expect(to).toEqual({
       path: '/signup',
       query: { redirect: '/workspace/domains', product: 'identity', interval: 'month' },

--- a/src/tests/apps/workspace/account/settings/CautionZone.spec.ts
+++ b/src/tests/apps/workspace/account/settings/CautionZone.spec.ts
@@ -5,7 +5,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { nextTick } from 'vue';
 import CautionZone from '@/apps/workspace/account/settings/CautionZone.vue';
+import type { CustomerCanonical } from '@/schemas/contracts/customer';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import { mockCustomer } from '@tests/fixtures/bootstrap.fixture';
 import { createTestI18n } from '@tests/setup';
 
 // Mock vue-router
@@ -71,13 +73,30 @@ describe('CautionZone', () => {
     }
   });
 
-  const mountComponent = (custValue: { objid: string | null; extid: string } | null = null) => {
+  const mountComponent = (
+    custOverrides: { objid: string | null; extid: string } | null = null
+  ) => {
     const pinia = createTestingPinia({
       createSpy: vi.fn,
       stubActions: false,
     });
 
     const store = useBootstrapStore(pinia);
+    // The real cust record (CustomerCanonical) requires many more fields than
+    // objid/extid, so build a full valid record from the shared fixture and
+    // only vary what each scenario below cares about. `objid` is typed as a
+    // non-nullable string in the schema; the "anonymous user" scenarios still
+    // exercise the component's `cust?.objid` falsy-check defensively with a
+    // null value, which the cast below allows while keeping the field's
+    // declared type intact everywhere else.
+    const custValue: CustomerCanonical | null =
+      custOverrides === null
+        ? null
+        : {
+            ...mockCustomer,
+            extid: custOverrides.extid,
+            objid: custOverrides.objid as unknown as string,
+          };
     store.$patch({ cust: custValue });
 
     return mount(CautionZone, {

--- a/src/tests/apps/workspace/billing/PlanSelector.spec.ts
+++ b/src/tests/apps/workspace/billing/PlanSelector.spec.ts
@@ -83,6 +83,7 @@ function deduplicatePlans(
 // Test fixtures
 const createMockPlan = (overrides: Partial<BillingPlan> = {}): BillingPlan => ({
   id: 'plan_test_123',
+  stripe_price_id: 'price_test_123',
   name: 'Test Plan',
   tier: 'single_team',
   interval: 'month',

--- a/src/tests/apps/workspace/components/billing/EntitlementUpgradePrompt.spec.ts
+++ b/src/tests/apps/workspace/components/billing/EntitlementUpgradePrompt.spec.ts
@@ -47,7 +47,6 @@ function createError(overrides: Partial<ApplicationError> = {}): ApplicationErro
   return {
     code: 'entitlement_required',
     message: 'Homepage secrets require Identity Plus plan',
-    status: 403,
     ...overrides,
   } as ApplicationError;
 }
@@ -176,7 +175,6 @@ describe('EntitlementUpgradePrompt', () => {
           code: 'entitlement_required',
           message:
             'Custom homepage secrets require an Identity Plus subscription',
-          status: 403,
         }),
         resourceType: 'homepage_secrets',
       });
@@ -194,7 +192,6 @@ describe('EntitlementUpgradePrompt', () => {
           code: 'entitlement_required',
           message:
             'Custom homepage secrets require an Identity Plus subscription',
-          status: 403,
         }),
         resourceType: 'homepage_secrets',
       });

--- a/src/tests/apps/workspace/components/dashboard/DomainsTableActionsCell.spec.ts
+++ b/src/tests/apps/workspace/components/dashboard/DomainsTableActionsCell.spec.ts
@@ -70,6 +70,8 @@ const mockDomain = {
   sld: 'example',
   is_apex: false,
   verified: false,
+  resolving: false,
+  status: 'pending',
   txt_validation_host: '_challenge.test',
   txt_validation_value: 'verify123',
   vhost: null,

--- a/src/tests/apps/workspace/components/dashboard/DomainsTableDomainCell.spec.ts
+++ b/src/tests/apps/workspace/components/dashboard/DomainsTableDomainCell.spec.ts
@@ -62,6 +62,8 @@ const mockDomain = {
   sld: 'example',
   is_apex: false,
   verified: false,
+  resolving: false,
+  status: 'pending',
   txt_validation_host: '_challenge.test',
   txt_validation_value: 'verify123',
   vhost: null,

--- a/src/tests/apps/workspace/components/domains/DomainEmailConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainEmailConfigForm.spec.ts
@@ -16,6 +16,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { createTestI18n } from '@tests/setup';
 import DomainEmailConfigForm from '@/apps/workspace/components/domains/DomainEmailConfigForm.vue';
 import type { EmailConfigFormState } from '@/shared/composables/useEmailConfig';
+import type { TestEmailConfigResponse } from '@/schemas/api/domains/responses/test-email-config';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mocks
@@ -91,7 +92,7 @@ describe('DomainEmailConfigForm', () => {
     isTesting: boolean;
     hasUnsavedChanges: boolean;
     provider: string;
-    testResult: Record<string, unknown> | null;
+    testResult: TestEmailConfigResponse | null;
     testError: string;
     error: string;
     displayDomain: string;

--- a/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainSigninConfigForm.spec.ts
@@ -113,17 +113,37 @@ const realEn = JSON.parse(
   readFileSync(resolve(process.cwd(), 'generated/locales/en.json'), 'utf-8')
 );
 
+// `as never` on the messages value (same escape hatch as
+// admin-message-compile.spec.ts): the generated i18n-keys augmentation types
+// DefineLocaleMessage to the full app key schema, and Composer['t'] derives
+// its key-path union by recursing through whatever schema this instance's
+// `messages` resolves to. realEn's static type is JSON.parse's `any`, and
+// recursing an `any` through that path-building conditional never bottoms
+// out (TS2589 "excessively deep and possibly infinite"). `never` short-
+// circuits the recursion instead, leaving t() typed against the global
+// augmented key schema (still real key-checked) while accepting the actual
+// parsed bundle at runtime, unchanged.
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
-  messages: { en: realEn },
+  messages: { en: realEn as never },
 });
 
+// Calling `i18n.global.t` directly still forces TS to materialize the same
+// exploding Composer['t'] overload set (the `as never` above only changes
+// what's *in* the schema, not that resolving `.global.t`'s type walks it).
+// Reading `.global` through an `unknown` cast first, into the minimal shape
+// actually used below, sidesteps that resolution entirely — `i18n` itself is
+// untouched and still mounts as a real i18n plugin.
+const i18nGlobal = i18n as unknown as {
+  global: { t: (key: string, params?: Record<string, string>) => string };
+};
+
 /** Resolve a key against the real bundle. */
-const t = (key: string) => i18n.global.t(key);
+const t = (key: string) => i18nGlobal.global.t(key);
 
 /** Resolve a key with named interpolation, as the component does. */
-const tp = (key: string, params: Record<string, string>) => i18n.global.t(key, params);
+const tp = (key: string, params: Record<string, string>) => i18nGlobal.global.t(key, params);
 
 /**
  * Copy the component renders, sourced from the bundle — never hand-typed here.

--- a/src/tests/apps/workspace/components/domains/DomainSsoConfigForm.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainSsoConfigForm.spec.ts
@@ -129,6 +129,8 @@ const mockEnforceSsoOnlyFormState: SsoConfigFormState = {
 
 interface MountOptions {
   domainExtId?: string;
+  domainHost?: string;
+  orgId?: string;
   formState?: SsoConfigFormState;
   ssoConfig?: CustomDomainSsoConfig | null;
   isLoading?: boolean;
@@ -166,6 +168,8 @@ describe('DomainSsoConfigForm', () => {
 
   const defaultMountOptions: Required<MountOptions> = {
     domainExtId: 'dm_123',
+    domainHost: 'secrets.example.com',
+    orgId: 'org_ext_123',
     formState: createDefaultFormState(),
     ssoConfig: null,
     isLoading: false,
@@ -464,6 +468,7 @@ describe('DomainSsoConfigForm', () => {
       wrapper = await mountComponent({
         formState: mockExistingFormState,
         testResult: {
+          user_id: 'cust_456',
           success: true,
           message: 'Connection successful',
           provider_type: 'entra_id',
@@ -480,6 +485,7 @@ describe('DomainSsoConfigForm', () => {
       wrapper = await mountComponent({
         formState: mockExistingFormState,
         testResult: {
+          user_id: 'cust_456',
           success: false,
           message: 'Invalid tenant ID',
           provider_type: 'entra_id',

--- a/src/tests/apps/workspace/components/domains/DomainsTable.spec.ts
+++ b/src/tests/apps/workspace/components/domains/DomainsTable.spec.ts
@@ -3,6 +3,8 @@
 import { mount } from '@vue/test-utils';
 import { describe, it, expect, vi } from 'vitest';
 import DomainsTable from '@/apps/workspace/components/domains/DomainsTable.vue';
+import type { CustomDomain } from '@/schemas/shapes/v3/custom-domain';
+import type { HomepageConfigCanonical } from '@/schemas/contracts';
 
 // Mock vue-i18n
 vi.mock('vue-i18n', () => ({
@@ -91,13 +93,40 @@ vi.mock('@/shared/components/icons/OIcon.vue', () => ({
   default: { name: 'OIcon', template: '<span />', props: ['collection', 'name', 'class'] },
 }));
 
-const baseDomain = {
-  extid: 'dm-test-extid',
-  display_domain: 'test.example.com',
-  verified: true,
+const baseHomepageConfig: HomepageConfigCanonical = {
+  domain_id: 'dom_123',
+  enabled: false,
+  secrets_mode: 'create',
+  signup_enabled: false,
+  signin_enabled: false,
+  disabled_homepage_variant: null,
+  created_at: null,
+  updated_at: null,
 };
 
-function mountTable(domains: object[]) {
+const baseDomain: CustomDomain = {
+  domainid: 'dom_123',
+  extid: 'dm-test-extid',
+  custid: 'cust_123',
+  display_domain: 'test.example.com',
+  base_domain: 'example.com',
+  subdomain: 'test',
+  trd: 'test',
+  tld: 'com',
+  sld: 'example',
+  is_apex: false,
+  txt_validation_host: '_challenge.test',
+  txt_validation_value: 'verify123',
+  status: 'pending',
+  verified: true,
+  resolving: false,
+  vhost: null,
+  brand: null,
+  created: new Date('2024-01-01'),
+  updated: new Date('2024-01-01'),
+};
+
+function mountTable(domains: CustomDomain[]) {
   return mount(DomainsTable, {
     props: {
       domains,
@@ -110,7 +139,10 @@ function mountTable(domains: object[]) {
 describe('DomainsTable - homepage incoming badge', () => {
   it('shows the badge when the homepage is enabled in incoming mode', () => {
     const wrapper = mountTable([
-      { ...baseDomain, homepage_config: { enabled: true, secrets_mode: 'incoming' } },
+      {
+        ...baseDomain,
+        homepage_config: { ...baseHomepageConfig, enabled: true, secrets_mode: 'incoming' },
+      },
     ]);
     expect(wrapper.find('[data-testid="homepage-incoming-badge"]').exists()).toBe(true);
   });
@@ -120,14 +152,20 @@ describe('DomainsTable - homepage incoming badge', () => {
     // domain can carry secrets_mode='incoming' with enabled=false. The badge
     // must not render for what is effectively a private homepage.
     const wrapper = mountTable([
-      { ...baseDomain, homepage_config: { enabled: false, secrets_mode: 'incoming' } },
+      {
+        ...baseDomain,
+        homepage_config: { ...baseHomepageConfig, enabled: false, secrets_mode: 'incoming' },
+      },
     ]);
     expect(wrapper.find('[data-testid="homepage-incoming-badge"]').exists()).toBe(false);
   });
 
   it('hides the badge when the homepage is enabled in create mode', () => {
     const wrapper = mountTable([
-      { ...baseDomain, homepage_config: { enabled: true, secrets_mode: 'create' } },
+      {
+        ...baseDomain,
+        homepage_config: { ...baseHomepageConfig, enabled: true, secrets_mode: 'create' },
+      },
     ]);
     expect(wrapper.find('[data-testid="homepage-incoming-badge"]').exists()).toBe(false);
   });

--- a/src/tests/apps/workspace/components/members/MembersTable.spec.ts
+++ b/src/tests/apps/workspace/components/members/MembersTable.spec.ts
@@ -1,6 +1,7 @@
 // src/tests/apps/workspace/components/members/MembersTable.spec.ts
 
 import MembersTable from '@/apps/workspace/components/members/MembersTable.vue';
+import { lenientExtIdSchema } from '@/types/identifiers';
 import type { OrganizationMember, OrganizationRole } from '@/types/organization';
 import { createTestI18n } from '@tests/setup';
 import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
@@ -83,9 +84,14 @@ vi.mock('@vueuse/core', () => ({
   }),
 }));
 
+// Branded-ID helper: OrganizationMember.extid is the lenientExtIdSchema output
+// type, not a plain string — parsing through the real schema (rather than
+// asserting) mints a properly-typed ExtId from a raw test literal.
+const extid = (raw: string) => lenientExtIdSchema.parse(raw);
+
 // Test data factory
 const createMember = (overrides: Partial<OrganizationMember> = {}): OrganizationMember => ({
-  extid: 'mem_abc123',
+  extid: extid('mem_abc123'),
   email: 'member@example.com',
   role: 'member' as OrganizationRole,
   joined_at: 1704067200, // 2024-01-01
@@ -99,9 +105,9 @@ describe('MembersTable', () => {
 
   const defaultProps = {
     members: [
-      createMember({ extid: 'mem_owner', email: 'owner@example.com', role: 'owner', is_owner: true }),
-      createMember({ extid: 'mem_admin', email: 'admin@example.com', role: 'admin' }),
-      createMember({ extid: 'mem_member', email: 'member@example.com', role: 'member' }),
+      createMember({ extid: extid('mem_owner'), email: 'owner@example.com', role: 'owner', is_owner: true }),
+      createMember({ extid: extid('mem_admin'), email: 'admin@example.com', role: 'admin' }),
+      createMember({ extid: extid('mem_member'), email: 'member@example.com', role: 'member' }),
     ],
     orgExtid: 'on1abc123',
     isLoading: false,
@@ -337,11 +343,11 @@ describe('MembersTable', () => {
 
     it('emits member-updated when role is changed', async () => {
       mockCanChangeRole.mockReturnValue(true);
-      const updatedMember = createMember({ extid: 'mem_admin', role: 'member' });
+      const updatedMember = createMember({ extid: extid('mem_admin'), role: 'member' });
       mockUpdateMemberRole.mockResolvedValue(updatedMember);
 
       mountComponent({
-        members: [createMember({ extid: 'mem_admin', role: 'admin' })],
+        members: [createMember({ extid: extid('mem_admin'), role: 'admin' })],
       });
 
       const selector = wrapper.find('[data-testid="role-selector"]');
@@ -360,7 +366,7 @@ describe('MembersTable', () => {
       mockCanChangeRole.mockReturnValue(true);
 
       mountComponent({
-        members: [createMember({ extid: 'mem_admin', role: 'admin' })],
+        members: [createMember({ extid: extid('mem_admin'), role: 'admin' })],
       });
 
       const selector = wrapper.find('[data-testid="role-selector"]');
@@ -446,7 +452,7 @@ describe('MembersTable', () => {
       mockReveal.mockResolvedValue({ isCanceled: true }); // User cancels
 
       mountComponent({
-        members: [createMember({ extid: 'mem_admin', email: 'admin@example.com', role: 'admin' })],
+        members: [createMember({ extid: extid('mem_admin'), email: 'admin@example.com', role: 'admin' })],
       });
 
       const removeButton = wrapper.find('button[aria-label="web.organizations.members.remove_member_title"]');
@@ -469,7 +475,7 @@ describe('MembersTable', () => {
       });
 
       mountComponent({
-        members: [createMember({ extid: 'mem_admin', email: 'admin@example.com', role: 'admin' })],
+        members: [createMember({ extid: extid('mem_admin'), email: 'admin@example.com', role: 'admin' })],
       });
 
       const removeButton = wrapper.find('button[aria-label="web.organizations.members.remove_member_title"]');
@@ -498,7 +504,7 @@ describe('MembersTable', () => {
       mockReveal.mockResolvedValue({ isCanceled: false }); // User confirms
 
       mountComponent({
-        members: [createMember({ extid: 'mem_admin', email: 'admin@example.com', role: 'admin' })],
+        members: [createMember({ extid: extid('mem_admin'), email: 'admin@example.com', role: 'admin' })],
       });
 
       const removeButton = wrapper.find('button[aria-label="web.organizations.members.remove_member_title"]');
@@ -518,7 +524,7 @@ describe('MembersTable', () => {
       mockReveal.mockResolvedValue({ isCanceled: true }); // User cancels
 
       mountComponent({
-        members: [createMember({ extid: 'mem_admin', email: 'admin@example.com', role: 'admin' })],
+        members: [createMember({ extid: extid('mem_admin'), email: 'admin@example.com', role: 'admin' })],
       });
 
       const removeButton = wrapper.find('button[aria-label="web.organizations.members.remove_member_title"]');
@@ -537,7 +543,7 @@ describe('MembersTable', () => {
       mockReveal.mockResolvedValue({ isCanceled: false });
 
       mountComponent({
-        members: [createMember({ extid: 'mem_admin', role: 'admin' })],
+        members: [createMember({ extid: extid('mem_admin'), role: 'admin' })],
       });
 
       const removeButton = wrapper.find('button[aria-label="web.organizations.members.remove_member_title"]');
@@ -563,7 +569,7 @@ describe('MembersTable', () => {
       });
 
       mountComponent({
-        members: [createMember({ extid: 'mem_admin', role: 'admin' })],
+        members: [createMember({ extid: extid('mem_admin'), role: 'admin' })],
       });
 
       const removeButton = wrapper.find('button[aria-label="web.organizations.members.remove_member_title"]');

--- a/src/tests/apps/workspace/components/organizations/OrganizationCard.spec.ts
+++ b/src/tests/apps/workspace/components/organizations/OrganizationCard.spec.ts
@@ -45,6 +45,7 @@ describe('OrganizationCard', () => {
     contact_email: null,
     is_default: false,
     planid: 'free',
+    active_subscription: false,
     created: new Date(),
     updated: new Date(),
     ...overrides,

--- a/src/tests/apps/workspace/domains/DomainIncoming.spec.ts
+++ b/src/tests/apps/workspace/domains/DomainIncoming.spec.ts
@@ -14,6 +14,8 @@ import { createTestingPinia } from '@pinia/testing';
 import { ref } from 'vue';
 import { createTestI18n } from '@tests/setup';
 import DomainIncoming from '@/apps/workspace/domains/DomainIncoming.vue';
+import type { ApplicationError } from '@/schemas/errors';
+import { wrapError } from '@/schemas/errors';
 import {
   emptyFormState,
   singleRecipientFormState,
@@ -64,7 +66,7 @@ vi.mock('@/shared/composables/useIncomingConfig', () => ({
 const mockDomainState = {
   domain: ref({ display_domain: 'example.com', extid: 'dm-ext-123' }),
   isLoading: ref(false),
-  error: ref(null),
+  error: ref<ApplicationError | null>(null),
   initialize: mockInitializeDomain,
 };
 
@@ -257,7 +259,7 @@ describe('DomainIncoming', () => {
     });
 
     it('PG-LOAD-004: shows error state on domain API failure', async () => {
-      mockDomainState.error.value = { message: 'Domain not found' };
+      mockDomainState.error.value = wrapError('Domain not found', 'technical', 'error', null);
 
       wrapper = mountComponent();
       await flushPromises();

--- a/src/tests/apps/workspace/domains/DomainSignup.spec.ts
+++ b/src/tests/apps/workspace/domains/DomainSignup.spec.ts
@@ -12,7 +12,7 @@ import { mount, flushPromises, VueWrapper } from '@vue/test-utils';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createI18n } from 'vue-i18n';
 import { createPinia, setActivePinia } from 'pinia';
-import { ref } from 'vue';
+import { defineComponent, ref } from 'vue';
 import DomainSignup from '@/apps/workspace/domains/DomainSignup.vue';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -50,7 +50,10 @@ vi.mock('@/shared/components/forms/BasicFormAlerts.vue', () => ({
 }));
 
 vi.mock('@/apps/workspace/components/domains/DomainSignupConfigForm.vue', () => ({
-  default: {
+  // defineComponent (rather than a bare object literal) gives `this` inside
+  // `mounted()` the Options API instance typing — including `$emit` — derived
+  // from the declared `emits` list below.
+  default: defineComponent({
     name: 'DomainSignupConfigForm',
     template: '<div class="domain-signup-config-form" data-testid="domain-signup-config-form" :data-domain-ext-id="domainExtId" />',
     props: ['domainExtId'],
@@ -61,7 +64,7 @@ vi.mock('@/apps/workspace/components/domains/DomainSignupConfigForm.vue', () => 
     mounted() {
       this.$emit('can-save', true);
     },
-  },
+  }),
 }));
 
 // Domain composable mock

--- a/src/tests/apps/workspace/layouts/SettingsLayout.reactivity.spec.ts
+++ b/src/tests/apps/workspace/layouts/SettingsLayout.reactivity.spec.ts
@@ -82,7 +82,7 @@ describe('SettingsLayout — reactive tab visibility', () => {
 
   it('shows Security section in full-auth mode even without a password', async () => {
     mounted = await mountLayout({
-      authentication: { mode: 'full' },
+      authentication: { ...authenticatedBootstrap.authentication, mode: 'full' },
       features: { mfa: true, webauthn: true, sso: { enabled: true }, restrict_to: null } as never,
       has_password: false,
     });
@@ -95,7 +95,7 @@ describe('SettingsLayout — reactive tab visibility', () => {
 
   it('hides Security section when auth mode is not full', async () => {
     mounted = await mountLayout({
-      authentication: { mode: 'simple' },
+      authentication: { ...authenticatedBootstrap.authentication, mode: 'simple' },
       features: { mfa: true, webauthn: true, sso: { enabled: true }, restrict_to: null } as never,
       has_password: false,
     });
@@ -107,14 +107,16 @@ describe('SettingsLayout — reactive tab visibility', () => {
 
   it('reacts to auth mode change without re-mounting', async () => {
     mounted = await mountLayout({
-      authentication: { mode: 'simple' },
+      authentication: { ...authenticatedBootstrap.authentication, mode: 'simple' },
       features: { mfa: true, webauthn: true, sso: { enabled: true }, restrict_to: null } as never,
       has_password: false,
     });
 
     expect(visibleTabIds(mounted.wrapper)).not.toContain('/account/settings/security');
 
-    mounted.store.update({ authentication: { mode: 'full' } });
+    mounted.store.update({
+      authentication: { ...authenticatedBootstrap.authentication, mode: 'full' },
+    });
     await nextTick();
 
     expect(visibleTabIds(mounted.wrapper)).toContain('/account/settings/security');

--- a/src/tests/apps/workspace/routes/account.guards.spec.ts
+++ b/src/tests/apps/workspace/routes/account.guards.spec.ts
@@ -50,7 +50,12 @@ function invokeGuard(path: string): ReturnType<NavigationGuardWithThis<undefined
   // Account route guards are synchronous (no async/await needed).
   // They take (to, from, next) but use the return-value form, not next().
   // We can call with minimal args since the guards only read feature flags.
-  return guard(
+  // Invoked via `.call(undefined, ...)` rather than a bare `guard(...)`: the
+  // guard's type declares `this: undefined`, and a bare call would instead
+  // check this enclosing (non-method) function's own inferred `this` type
+  // (`void`) against it, which isn't assignable.
+  return guard.call(
+    undefined,
     {} as any, // to (unused by these guards)
     {} as any, // from (unused)
     undefined as any, // next (unused, return-value form)

--- a/src/tests/apps/workspace/routes/dashboard.spec.ts
+++ b/src/tests/apps/workspace/routes/dashboard.spec.ts
@@ -19,7 +19,11 @@ const findRoute = (name: string) =>
 const runGuard = (name: string, params: Record<string, string>) => {
   const guard = findRoute(name)?.beforeEnter;
   if (typeof guard !== 'function') throw new Error(`no beforeEnter on ${name}`);
-  return guard({ params } as never, {} as never, (() => {}) as never);
+  // Invoked via `.call(undefined, ...)` rather than a bare `guard(...)`: the
+  // guard's type declares `this: undefined`, and a bare call would instead
+  // check this enclosing (non-method) function's own inferred `this` type
+  // (`void`) against it, which isn't assignable.
+  return guard.call(undefined, { params } as never, {} as never, (() => {}) as never);
 };
 
 describe('Dashboard Routes', () => {

--- a/src/tests/components/DomainHeader.spec.ts
+++ b/src/tests/components/DomainHeader.spec.ts
@@ -44,6 +44,7 @@ vi.mock('vue-i18n', () => ({
 
 describe('DomainHeader', () => {
   const createMockDomain = (overrides: Partial<CustomDomain> = {}): CustomDomain => ({
+    domainid: 'domain-uuid-123',
     extid: 'domain-123',
     custid: 'cust-456',
     display_domain: 'example.com',
@@ -53,11 +54,17 @@ describe('DomainHeader', () => {
     tld: 'com',
     sld: 'example',
     is_apex: true,
-    created: 1700000000,
-    updated: 1700000000,
+    txt_validation_host: '_onetime-challenge.example.com',
+    txt_validation_value: 'validation-value-123',
+    status: 'active',
+    verified: true,
+    resolving: true,
+    brand: null,
+    created: new Date(1700000000 * 1000),
+    updated: new Date(1700000000 * 1000),
     vhost: {
       status: 'ACTIVE',
-      last_monitored_unix: 123,
+      last_monitored_unix: new Date(123 * 1000),
     },
     vhost_fetch_failed_at: null,
     ...overrides,

--- a/src/tests/components/ScopeSwitcherNavigation.spec.ts
+++ b/src/tests/components/ScopeSwitcherNavigation.spec.ts
@@ -13,6 +13,8 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { reactive } from 'vue';
+import type { ScopesAvailable } from '@/types/router';
+import type { Organization } from '@/types/organization';
 
 // Mock router
 const mockPush = vi.fn();
@@ -20,12 +22,7 @@ const mockRoute = reactive<{
   path: string;
   matched: Array<{ path: string }>;
   meta: {
-    scopesAvailable?: {
-      organization?: 'show' | 'locked' | 'hide';
-      domain?: 'show' | 'locked' | 'hide';
-      onOrgSwitch?: string;
-      onDomainSwitch?: string;
-    };
+    scopesAvailable?: ScopesAvailable;
   };
 }>({
   path: '/org/abc123',
@@ -40,8 +37,8 @@ vi.mock('vue-router', () => ({
 
 // Mock organization store
 const mockOrganizationStore = {
-  organizations: [],
-  currentOrganization: null,
+  organizations: [] as Organization[],
+  currentOrganization: null as Organization | null,
   hasOrganizations: true,
   setCurrentOrganization: vi.fn(),
   fetchOrganizations: vi.fn(),
@@ -236,7 +233,19 @@ describe('ScopeSwitcher Navigation', () => {
       // Regression test: switching domains on /org/:orgid/domains/:extid/brand
       // previously left :orgid as a literal string in the navigated URL,
       // causing downstream API calls to request /api/organizations/:orgid (404).
-      mockOrganizationStore.currentOrganization = { extid: 'org-abc', objid: 'org-obj-1' } as any;
+      mockOrganizationStore.currentOrganization = {
+        objid: 'org-obj-1',
+        extid: 'org-abc',
+        display_name: 'Test Org',
+        description: null,
+        owner_id: 'cust-1',
+        contact_email: null,
+        is_default: false,
+        planid: 'free',
+        active_subscription: false,
+        created: new Date('2024-01-01'),
+        updated: new Date('2024-01-01'),
+      };
       mockRoute.matched = [{ path: '/org/:orgid/domains/:extid/brand' }];
 
       simulateDomainSwitch('test.example.com', 'same');
@@ -429,9 +438,9 @@ describe('ScopeSwitcher Navigation', () => {
   describe('real route configurations', () => {
     it('domain detail pages have correct scope config for domain switching', () => {
       // Simulating /domains/:extid/brand route config
-      const domainBrandConfig = {
-        organization: 'show' as const,
-        domain: 'show' as const,
+      const domainBrandConfig: ScopesAvailable = {
+        organization: 'show',
+        domain: 'show',
         onOrgSwitch: '/dashboard',
         onDomainSwitch: 'same',
       };
@@ -442,9 +451,9 @@ describe('ScopeSwitcher Navigation', () => {
 
     it('org settings page has correct scope config for org switching', () => {
       // Simulating /org/:extid route config
-      const orgSettingsConfig = {
-        organization: 'show' as const,
-        domain: 'hide' as const,
+      const orgSettingsConfig: ScopesAvailable = {
+        organization: 'show',
+        domain: 'hide',
         onOrgSwitch: 'same',
       };
 
@@ -454,9 +463,9 @@ describe('ScopeSwitcher Navigation', () => {
 
     it('dashboard page has no navigation config (backwards compatible)', () => {
       // Simulating /dashboard route config using SCOPE_PRESETS.showBoth
-      const dashboardConfig = {
-        organization: 'show' as const,
-        domain: 'show' as const,
+      const dashboardConfig: ScopesAvailable = {
+        organization: 'show',
+        domain: 'show',
       };
 
       expect(dashboardConfig.onOrgSwitch).toBeUndefined();

--- a/src/tests/components/SecretFormDomainContext.spec.ts
+++ b/src/tests/components/SecretFormDomainContext.spec.ts
@@ -4,7 +4,7 @@ import { mount } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import SecretForm from '@/apps/secret/components/form/SecretForm.vue';
-import { nextTick } from 'vue';
+import { nextTick, reactive, ref } from 'vue';
 
 // Mock composables
 const mockCurrentContext = {
@@ -346,12 +346,16 @@ describe('SecretForm - Domain Context Integration', () => {
         await import('@/shared/composables/useSecretConcealer')
       ).useSecretConcealer.mockReturnValue({
         form: { secret: '', passphrase: '', ttl: 300, share_domain: '' },
-        validation: { errors: new Map() },
+        validation: {
+          errors: reactive(new Map()),
+          validate: vi.fn(() => true),
+          validateRecipient: vi.fn(() => true),
+        },
         operations: {
           updateField: mockUpdateField,
           reset: vi.fn(),
         },
-        isSubmitting: false,
+        isSubmitting: ref(false),
         submit: vi.fn(),
       });
 
@@ -383,12 +387,16 @@ describe('SecretForm - Domain Context Integration', () => {
         await import('@/shared/composables/useSecretConcealer')
       ).useSecretConcealer.mockReturnValue({
         form: { secret: '', passphrase: '', ttl: 300, share_domain: '' },
-        validation: { errors: new Map() },
+        validation: {
+          errors: reactive(new Map()),
+          validate: vi.fn(() => true),
+          validateRecipient: vi.fn(() => true),
+        },
         operations: {
           updateField: mockUpdateField,
           reset: vi.fn(),
         },
-        isSubmitting: false,
+        isSubmitting: ref(false),
         submit: vi.fn(),
       });
 

--- a/src/tests/components/WorkspaceSecretForm.spec.ts
+++ b/src/tests/components/WorkspaceSecretForm.spec.ts
@@ -466,7 +466,7 @@ describe('WorkspaceSecretForm Logic', () => {
     });
 
     it('falls back to 604800 when secret_options is null', () => {
-      const secretOptions = null;
+      const secretOptions = null as { default_ttl?: number } | null;
       const defaultTtl = secretOptions?.default_ttl ?? 604800;
 
       expect(defaultTtl).toBe(604800);

--- a/src/tests/components/identifier-navigation.spec.ts
+++ b/src/tests/components/identifier-navigation.spec.ts
@@ -29,6 +29,7 @@ const mockOrganization: Organization = {
   contact_email: null,
   is_default: false,
   planid: 'free',
+  active_subscription: false,
   created: new Date('2024-01-01'),
   updated: new Date('2024-01-01'),
 };
@@ -44,6 +45,7 @@ const mockOrganizations: Organization[] = [
     contact_email: null,
     is_default: true,
     planid: 'free',
+    active_subscription: false,
     created: new Date('2024-02-01'),
     updated: new Date('2024-02-01'),
   },

--- a/src/tests/composables/useAuth.billing.spec.ts
+++ b/src/tests/composables/useAuth.billing.spec.ts
@@ -225,8 +225,11 @@ describe('useAuth - Billing Redirect Safety Checks', () => {
     });
 
     it('should not redirect when billing_enabled is undefined', async () => {
-      // Set billing_enabled to undefined via bootstrapStore
-      bootstrapStore.billing_enabled = undefined;
+      // Set billing_enabled to undefined via bootstrapStore. $patch (not direct
+      // assignment) because the state type's billing_enabled is a non-optional
+      // boolean (schema default(false)) — $patch's _DeepPartial widens it to
+      // accept undefined for this "field absent from response" scenario.
+      bootstrapStore.$patch({ billing_enabled: undefined });
       disableBillingOnRefetch(undefined);
 
       setRouteQuery({ product: 'identity', interval: 'month' });

--- a/src/tests/composables/useAuth.logout.spec.ts
+++ b/src/tests/composables/useAuth.logout.spec.ts
@@ -164,11 +164,11 @@ describe('useAuth logout flow — no brand flash', () => {
     });
 
     it('logoutMinimal does not reset domain_branding', async () => {
-      expect(bootstrapStore.domain_branding.primary_color).toBe('#ff6600');
+      expect(bootstrapStore.domain_branding?.primary_color).toBe('#ff6600');
 
       await authStore.logoutMinimal();
 
-      expect(bootstrapStore.domain_branding.primary_color).toBe('#ff6600');
+      expect(bootstrapStore.domain_branding?.primary_color).toBe('#ff6600');
     });
 
     it('logoutMinimal does not reset display_domain', async () => {

--- a/src/tests/composables/useDomainContext.spec.ts
+++ b/src/tests/composables/useDomainContext.spec.ts
@@ -158,6 +158,8 @@ describe('useDomainContext', () => {
      */
     link_domains?: string[];
     domain_strategy?: 'canonical' | 'subdomain' | 'custom' | 'invalid';
+    /** Server-side preferred domain (sess['domain_context']). Schema default is null. */
+    domain_context?: string | null;
   }) {
     const pinia = createTestingPinia({
       createSpy: vi.fn,
@@ -175,6 +177,7 @@ describe('useDomainContext', () => {
     // Schema default is [] (pre-#4063 payloads omit it) - see the knob doc above
     bootstrapStore.link_domains = config.link_domains ?? [];
     bootstrapStore.domain_strategy = config.domain_strategy ?? 'canonical';
+    bootstrapStore.domain_context = config.domain_context ?? null;
 
     return { pinia, bootstrapStore };
   }

--- a/src/tests/composables/useDomainStatus.spec.ts
+++ b/src/tests/composables/useDomainStatus.spec.ts
@@ -20,7 +20,12 @@ vi.mock('vue-i18n', () => ({
 }));
 
 describe('useDomainStatus', () => {
+  // CustomDomain (V3 shape) carries parsed values, not wire primitives:
+  // created/updated and vhost.last_monitored_unix are Date, not epoch numbers.
+  const MOCK_DATE = new Date(1700000000000);
+
   const createMockDomain = (overrides: Partial<CustomDomain> = {}): CustomDomain => ({
+    domainid: 'domain-uuid-123',
     extid: 'domain-123',
     custid: 'cust-456',
     display_domain: 'example.com',
@@ -30,11 +35,14 @@ describe('useDomainStatus', () => {
     tld: 'com',
     sld: 'example',
     is_apex: true,
-    created: 1700000000,
-    updated: 1700000000,
+    txt_validation_host: '_onetime-challenge.example.com',
+    txt_validation_value: 'validation-value-abc123',
+    verified: true,
+    brand: null,
+    created: MOCK_DATE,
+    updated: MOCK_DATE,
     vhost: {
       status: 'PENDING',
-      last_monitored_unix: null,
     },
     vhost_fetch_failed_at: null,
     ...overrides,
@@ -48,25 +56,25 @@ describe('useDomainStatus', () => {
 
   describe('isActive', () => {
     it('returns true for ACTIVE status', () => {
-      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE', last_monitored_unix: 123 } }));
+      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE', last_monitored_unix: MOCK_DATE } }));
       const { isActive } = useDomainStatus(domain);
       expect(isActive.value).toBe(true);
     });
 
     it('returns true for ACTIVE_SSL status', () => {
-      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE_SSL', last_monitored_unix: 123 } }));
+      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE_SSL', last_monitored_unix: MOCK_DATE } }));
       const { isActive } = useDomainStatus(domain);
       expect(isActive.value).toBe(true);
     });
 
     it('returns true for ACTIVE_SSL_PROXIED status', () => {
-      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE_SSL_PROXIED', last_monitored_unix: 123 } }));
+      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE_SSL_PROXIED', last_monitored_unix: MOCK_DATE } }));
       const { isActive } = useDomainStatus(domain);
       expect(isActive.value).toBe(true);
     });
 
     it('returns false for PENDING status', () => {
-      const domain = ref(createMockDomain({ vhost: { status: 'PENDING', last_monitored_unix: null } }));
+      const domain = ref(createMockDomain({ vhost: { status: 'PENDING' } }));
       const { isActive } = useDomainStatus(domain);
       expect(isActive.value).toBe(false);
     });
@@ -80,13 +88,13 @@ describe('useDomainStatus', () => {
 
   describe('isWarning', () => {
     it('returns true for DNS_INCORRECT status', () => {
-      const domain = ref(createMockDomain({ vhost: { status: 'DNS_INCORRECT', last_monitored_unix: null } }));
+      const domain = ref(createMockDomain({ vhost: { status: 'DNS_INCORRECT' } }));
       const { isWarning } = useDomainStatus(domain);
       expect(isWarning.value).toBe(true);
     });
 
     it('returns false for other statuses', () => {
-      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE', last_monitored_unix: 123 } }));
+      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE', last_monitored_unix: MOCK_DATE } }));
       const { isWarning } = useDomainStatus(domain);
       expect(isWarning.value).toBe(false);
     });
@@ -94,13 +102,13 @@ describe('useDomainStatus', () => {
 
   describe('isError', () => {
     it('returns true when domain exists but is neither active nor warning', () => {
-      const domain = ref(createMockDomain({ vhost: { status: 'PENDING', last_monitored_unix: null } }));
+      const domain = ref(createMockDomain({ vhost: { status: 'PENDING' } }));
       const { isError } = useDomainStatus(domain);
       expect(isError.value).toBe(true);
     });
 
     it('returns false when domain is active', () => {
-      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE', last_monitored_unix: 123 } }));
+      const domain = ref(createMockDomain({ vhost: { status: 'ACTIVE', last_monitored_unix: MOCK_DATE } }));
       const { isError } = useDomainStatus(domain);
       expect(isError.value).toBe(false);
     });
@@ -156,7 +164,7 @@ describe('useDomainStatus', () => {
     it('returns "Unverified" when stale', () => {
       const now = Date.now() / 1000;
       const domain = ref(createMockDomain({
-        vhost: { status: 'ACTIVE', last_monitored_unix: 123 },
+        vhost: { status: 'ACTIVE', last_monitored_unix: MOCK_DATE },
         vhost_fetch_failed_at: now - 60,
       }));
       const { displayStatus } = useDomainStatus(domain);
@@ -165,7 +173,7 @@ describe('useDomainStatus', () => {
 
     it('returns "Active" for active domain', () => {
       const domain = ref(createMockDomain({
-        vhost: { status: 'ACTIVE', last_monitored_unix: 123 },
+        vhost: { status: 'ACTIVE', last_monitored_unix: MOCK_DATE },
         vhost_fetch_failed_at: null,
       }));
       const { displayStatus } = useDomainStatus(domain);
@@ -174,7 +182,7 @@ describe('useDomainStatus', () => {
 
     it('returns "DNS Incorrect" for warning status', () => {
       const domain = ref(createMockDomain({
-        vhost: { status: 'DNS_INCORRECT', last_monitored_unix: null },
+        vhost: { status: 'DNS_INCORRECT' },
         vhost_fetch_failed_at: null,
       }));
       const { displayStatus } = useDomainStatus(domain);
@@ -183,7 +191,7 @@ describe('useDomainStatus', () => {
 
     it('returns "Inactive" for error status', () => {
       const domain = ref(createMockDomain({
-        vhost: { status: 'PENDING', last_monitored_unix: null },
+        vhost: { status: 'PENDING' },
         vhost_fetch_failed_at: null,
       }));
       const { displayStatus } = useDomainStatus(domain);
@@ -201,7 +209,7 @@ describe('useDomainStatus', () => {
 
     it('returns check-circle for active domain', () => {
       const domain = ref(createMockDomain({
-        vhost: { status: 'ACTIVE', last_monitored_unix: 123 },
+        vhost: { status: 'ACTIVE', last_monitored_unix: MOCK_DATE },
         vhost_fetch_failed_at: null,
       }));
       const { statusIcon } = useDomainStatus(domain);
@@ -210,7 +218,7 @@ describe('useDomainStatus', () => {
 
     it('returns alert-circle for warning status', () => {
       const domain = ref(createMockDomain({
-        vhost: { status: 'DNS_INCORRECT', last_monitored_unix: null },
+        vhost: { status: 'DNS_INCORRECT' },
         vhost_fetch_failed_at: null,
       }));
       const { statusIcon } = useDomainStatus(domain);
@@ -219,7 +227,7 @@ describe('useDomainStatus', () => {
 
     it('returns close-circle for error status', () => {
       const domain = ref(createMockDomain({
-        vhost: { status: 'PENDING', last_monitored_unix: null },
+        vhost: { status: 'PENDING' },
         vhost_fetch_failed_at: null,
       }));
       const { statusIcon } = useDomainStatus(domain);
@@ -237,7 +245,7 @@ describe('useDomainStatus', () => {
 
     it('returns emerald classes for active domain', () => {
       const domain = ref(createMockDomain({
-        vhost: { status: 'ACTIVE', last_monitored_unix: 123 },
+        vhost: { status: 'ACTIVE', last_monitored_unix: MOCK_DATE },
         vhost_fetch_failed_at: null,
       }));
       const { statusColor } = useDomainStatus(domain);
@@ -246,7 +254,7 @@ describe('useDomainStatus', () => {
 
     it('returns amber classes for warning status', () => {
       const domain = ref(createMockDomain({
-        vhost: { status: 'DNS_INCORRECT', last_monitored_unix: null },
+        vhost: { status: 'DNS_INCORRECT' },
         vhost_fetch_failed_at: null,
       }));
       const { statusColor } = useDomainStatus(domain);
@@ -255,7 +263,7 @@ describe('useDomainStatus', () => {
 
     it('returns rose classes for error status', () => {
       const domain = ref(createMockDomain({
-        vhost: { status: 'PENDING', last_monitored_unix: null },
+        vhost: { status: 'PENDING' },
         vhost_fetch_failed_at: null,
       }));
       const { statusColor } = useDomainStatus(domain);
@@ -266,7 +274,7 @@ describe('useDomainStatus', () => {
   describe('reactivity', () => {
     it('updates computed values when domain changes', async () => {
       const domain = ref<CustomDomain | null>(createMockDomain({
-        vhost: { status: 'PENDING', last_monitored_unix: null },
+        vhost: { status: 'PENDING' },
       }));
       const { isActive, displayStatus, statusColor } = useDomainStatus(domain);
 
@@ -276,7 +284,7 @@ describe('useDomainStatus', () => {
 
       // Update domain status
       domain.value = createMockDomain({
-        vhost: { status: 'ACTIVE', last_monitored_unix: 123 },
+        vhost: { status: 'ACTIVE', last_monitored_unix: MOCK_DATE },
       });
       await nextTick();
 
@@ -287,7 +295,7 @@ describe('useDomainStatus', () => {
 
     it('handles domain becoming null', async () => {
       const domain = ref<CustomDomain | null>(createMockDomain({
-        vhost: { status: 'ACTIVE', last_monitored_unix: 123 },
+        vhost: { status: 'ACTIVE', last_monitored_unix: MOCK_DATE },
       }));
       const { isActive, displayStatus, isError } = useDomainStatus(domain);
 

--- a/src/tests/composables/useDomainStatus.spec.ts
+++ b/src/tests/composables/useDomainStatus.spec.ts
@@ -24,29 +24,38 @@ describe('useDomainStatus', () => {
   // created/updated and vhost.last_monitored_unix are Date, not epoch numbers.
   const MOCK_DATE = new Date(1700000000000);
 
-  const createMockDomain = (overrides: Partial<CustomDomain> = {}): CustomDomain => ({
-    domainid: 'domain-uuid-123',
-    extid: 'domain-123',
-    custid: 'cust-456',
-    display_domain: 'example.com',
-    base_domain: 'example.com',
-    subdomain: '',
-    trd: '',
-    tld: 'com',
-    sld: 'example',
-    is_apex: true,
-    txt_validation_host: '_onetime-challenge.example.com',
-    txt_validation_value: 'validation-value-abc123',
-    verified: true,
-    brand: null,
-    created: MOCK_DATE,
-    updated: MOCK_DATE,
-    vhost: {
-      status: 'PENDING',
-    },
-    vhost_fetch_failed_at: null,
-    ...overrides,
-  });
+  // Built as a fully-typed base object (no spread) so TS checks it directly
+  // against CustomDomain; merging `overrides` on a separately-typed variable
+  // avoids a spurious TS2719 "unrelated types" error that vue-tsc raises when
+  // an inline object literal spreads Partial<CustomDomain> directly into a
+  // return position typed as CustomDomain.
+  const createMockDomain = (overrides: Partial<CustomDomain> = {}): CustomDomain => {
+    const base: CustomDomain = {
+      domainid: 'domain-uuid-123',
+      extid: 'domain-123',
+      custid: 'cust-456',
+      display_domain: 'example.com',
+      base_domain: 'example.com',
+      subdomain: '',
+      trd: '',
+      tld: 'com',
+      sld: 'example',
+      is_apex: true,
+      txt_validation_host: '_onetime-challenge.example.com',
+      txt_validation_value: 'validation-value-abc123',
+      verified: true,
+      resolving: true,
+      status: 'pending',
+      brand: null,
+      created: MOCK_DATE,
+      updated: MOCK_DATE,
+      vhost: {
+        status: 'PENDING',
+      },
+      vhost_fetch_failed_at: null,
+    };
+    return { ...base, ...overrides };
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/tests/composables/useEmailConfig.spec.ts
+++ b/src/tests/composables/useEmailConfig.spec.ts
@@ -20,7 +20,11 @@ import { flushPromises } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { CustomDomainEmailConfig } from '@/schemas/shapes/domains/email-config';
-import enWorkspaceDomains from '@locales/content/en/workspace-domains.json';
+// Relative path (not the `@locales` alias): the alias is wired for vitest's
+// runtime resolver (vitest.config.ts) but has no matching tsconfig "paths"
+// entry, so vue-tsc can't resolve it. Matches the precedent in
+// src/tests/i18n/security-messages.spec.ts.
+import enWorkspaceDomains from '../../../locales/content/en/workspace-domains.json';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mock Setup

--- a/src/tests/composables/useEntitlements.spec.ts
+++ b/src/tests/composables/useEntitlements.spec.ts
@@ -5,8 +5,13 @@ import { ref, nextTick } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import { organizationSchema } from '@/schemas/shapes/organizations/organization';
 import type { Organization } from '@/types/organization';
-import { createMockOrganization, mockOrganizations } from '../fixtures/billing.fixture';
+import {
+  createMockOrganization as createWireOrganization,
+  mockOrganizations,
+  type OrganizationWire,
+} from '../fixtures/billing.fixture';
 
 const { mockGet } = vi.hoisted(() => ({
   mockGet: vi.fn(),
@@ -14,6 +19,15 @@ const { mockGet } = vi.hoisted(() => ({
 
 vi.mock('@/api', () => ({ createApi: () => ({ get: mockGet }) }));
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => `translated:${key}` }) }));
+
+// useEntitlements takes the parsed `Organization` shape (Date timestamps),
+// but the billing fixtures return wire format (epoch-second numbers) meant
+// for mocking API responses. Parse through the production schema so tests
+// feed the composable the same shape the real store produces.
+const mockOrg = (overrides: Partial<OrganizationWire> = {}): Organization =>
+  organizationSchema.parse(createWireOrganization(overrides));
+
+const freeOrg = organizationSchema.parse(mockOrganizations.free);
 
 describe('useEntitlements', () => {
   beforeEach(() => {
@@ -62,7 +76,7 @@ describe('useEntitlements', () => {
     it('loads entitlement definitions from API', async () => {
       mockGet.mockResolvedValueOnce(mockApiResponse);
       const useEntitlements = await importFresh();
-      const org = ref<Organization | null>(createMockOrganization());
+      const org = ref<Organization | null>(mockOrg());
       const { initDefinitions, hasDefinitions, isLoadingDefinitions } = useEntitlements(org);
 
       expect(hasDefinitions.value).toBe(false);
@@ -79,7 +93,7 @@ describe('useEntitlements', () => {
       mockGet.mockReturnValueOnce(new Promise((resolve) => { resolveApi = resolve; }));
 
       const useEntitlements = await importFresh();
-      const org = ref<Organization | null>(createMockOrganization());
+      const org = ref<Organization | null>(mockOrg());
       const { initDefinitions, isLoadingDefinitions } = useEntitlements(org);
 
       const initPromise = initDefinitions();
@@ -95,7 +109,7 @@ describe('useEntitlements', () => {
     it('does not fetch again if already initialized', async () => {
       mockGet.mockResolvedValue({ data: { entitlements: [], plans: [] } });
       const useEntitlements = await importFresh();
-      const { initDefinitions } = useEntitlements(ref(createMockOrganization()));
+      const { initDefinitions } = useEntitlements(ref(mockOrg()));
 
       await initDefinitions();
       await initDefinitions();
@@ -107,7 +121,7 @@ describe('useEntitlements', () => {
     it('returns translated i18n key from store when available', async () => {
       mockGet.mockResolvedValueOnce(mockApiResponse);
       const useEntitlements = await importFresh();
-      const { initDefinitions, formatEntitlement } = useEntitlements(ref(createMockOrganization()));
+      const { initDefinitions, formatEntitlement } = useEntitlements(ref(mockOrg()));
 
       await initDefinitions();
       await nextTick();
@@ -116,13 +130,13 @@ describe('useEntitlements', () => {
 
     it('falls back to hardcoded i18n keys when store has no data', async () => {
       const useEntitlements = await importFresh();
-      const { formatEntitlement } = useEntitlements(ref(createMockOrganization()));
+      const { formatEntitlement } = useEntitlements(ref(mockOrg()));
       expect(formatEntitlement('api_access')).toBe('translated:web.billing.overview.entitlements.api_access');
     });
 
     it('returns raw key when no mapping exists', async () => {
       const useEntitlements = await importFresh();
-      const { formatEntitlement } = useEntitlements(ref(createMockOrganization()));
+      const { formatEntitlement } = useEntitlements(ref(mockOrg()));
       expect(formatEntitlement('unknown_entitlement')).toBe('unknown_entitlement');
     });
   });
@@ -143,14 +157,14 @@ describe('useEntitlements', () => {
   describe('entitlements reactivity', () => {
     it('entitlements derived from organization reactively', async () => {
       const useEntitlements = await importFresh();
-      const org = ref<Organization | null>(mockOrganizations.free);
+      const org = ref<Organization | null>(freeOrg);
       const { entitlements, can, planId } = useEntitlements(org);
 
       expect(entitlements.value).toEqual([]);
       expect(can('api_access')).toBe(false);
       expect(planId.value).toBe('free_v1');
 
-      org.value = createMockOrganization({ entitlements: ['api_access'], planid: 'team_plus_v1' });
+      org.value = mockOrg({ entitlements: ['api_access'], planid: 'team_plus_v1' });
       await nextTick();
 
       expect(entitlements.value).toContain('api_access');
@@ -163,7 +177,7 @@ describe('useEntitlements', () => {
     it('captures API failures', async () => {
       mockGet.mockRejectedValueOnce(new Error('Network error'));
       const useEntitlements = await importFresh();
-      const { initDefinitions, definitionsError } = useEntitlements(ref(createMockOrganization()));
+      const { initDefinitions, definitionsError } = useEntitlements(ref(mockOrg()));
 
       await initDefinitions();
       await nextTick();
@@ -173,7 +187,7 @@ describe('useEntitlements', () => {
     it('error is null on successful load', async () => {
       mockGet.mockResolvedValueOnce({ data: { entitlements: [], plans: [] } });
       const useEntitlements = await importFresh();
-      const { initDefinitions, definitionsError } = useEntitlements(ref(createMockOrganization()));
+      const { initDefinitions, definitionsError } = useEntitlements(ref(mockOrg()));
 
       await initDefinitions();
       await nextTick();
@@ -183,7 +197,7 @@ describe('useEntitlements', () => {
     it('falls back gracefully when API fails', async () => {
       mockGet.mockRejectedValueOnce(new Error('API unavailable'));
       const useEntitlements = await importFresh();
-      const org = ref<Organization | null>(createMockOrganization({ entitlements: ['api_access'] }));
+      const org = ref<Organization | null>(mockOrg({ entitlements: ['api_access'] }));
       const { initDefinitions, can, formatEntitlement } = useEntitlements(org);
 
       await initDefinitions();
@@ -198,7 +212,7 @@ describe('useEntitlements', () => {
       vi.resetModules();
       setupBootstrapStore({ billing_enabled: false });
       const { useEntitlements } = await import('@/shared/composables/useEntitlements');
-      const { can, isStandaloneMode } = useEntitlements(ref(mockOrganizations.free));
+      const { can, isStandaloneMode } = useEntitlements(ref(freeOrg));
 
       expect(isStandaloneMode.value).toBe(true);
       expect(can('api_access')).toBe(true);
@@ -209,7 +223,7 @@ describe('useEntitlements', () => {
       vi.resetModules();
       setupBootstrapStore({ billing_enabled: true });
       const { useEntitlements } = await import('@/shared/composables/useEntitlements');
-      const { can, isStandaloneMode } = useEntitlements(ref(mockOrganizations.free));
+      const { can, isStandaloneMode } = useEntitlements(ref(freeOrg));
 
       expect(isStandaloneMode.value).toBe(false);
       expect(can('api_access')).toBe(false);
@@ -219,7 +233,7 @@ describe('useEntitlements', () => {
   describe('upgradePath', () => {
     it('returns null when organization already has entitlement', async () => {
       const useEntitlements = await importFresh();
-      const { upgradePath } = useEntitlements(ref(createMockOrganization({ entitlements: ['api_access'] })));
+      const { upgradePath } = useEntitlements(ref(mockOrg({ entitlements: ['api_access'] })));
       expect(upgradePath('api_access')).toBeNull();
     });
 
@@ -231,7 +245,7 @@ describe('useEntitlements', () => {
         },
       });
       const useEntitlements = await importFresh();
-      const org = ref(createMockOrganization({ entitlements: [] }));
+      const org = ref(mockOrg({ entitlements: [] }));
       const { initDefinitions, upgradePath } = useEntitlements(org);
 
       await initDefinitions();
@@ -241,7 +255,7 @@ describe('useEntitlements', () => {
 
     it('returns null when store not initialized (no fallback)', async () => {
       const useEntitlements = await importFresh();
-      const { upgradePath } = useEntitlements(ref(createMockOrganization({ entitlements: [] })));
+      const { upgradePath } = useEntitlements(ref(mockOrg({ entitlements: [] })));
       // No fallback - callers must ensure initDefinitions() runs first
       expect(upgradePath('audit_logs')).toBeNull();
     });
@@ -250,7 +264,7 @@ describe('useEntitlements', () => {
   describe('hasReachedLimit', () => {
     it('returns true when current equals or exceeds limit', async () => {
       const useEntitlements = await importFresh();
-      const org = ref(createMockOrganization({ limits: { teams: 5 } }));
+      const org = ref(mockOrg({ limits: { teams: 5 } }));
       const { hasReachedLimit } = useEntitlements(org);
 
       expect(hasReachedLimit('teams', 5)).toBe(true);
@@ -259,13 +273,13 @@ describe('useEntitlements', () => {
 
     it('returns false when current is below limit or limit is 0', async () => {
       const useEntitlements = await importFresh();
-      const org = ref(createMockOrganization({ limits: { teams: 5 } }));
+      const org = ref(mockOrg({ limits: { teams: 5 } }));
       const { hasReachedLimit } = useEntitlements(org);
       expect(hasReachedLimit('teams', 3)).toBe(false);
 
       const useEntitlements2 = await importFresh();
       const { hasReachedLimit: hasReachedLimit2 } = useEntitlements2(
-        ref(createMockOrganization({ limits: { teams: 0 } }))
+        ref(mockOrg({ limits: { teams: 0 } }))
       );
       expect(hasReachedLimit2('teams', 100)).toBe(false);
     });

--- a/src/tests/composables/useEntitlements.spec.ts
+++ b/src/tests/composables/useEntitlements.spec.ts
@@ -8,7 +8,7 @@ import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { organizationSchema } from '@/schemas/shapes/organizations/organization';
 import type { Organization } from '@/types/organization';
 import {
-  createMockOrganization as createWireOrganization,
+  createMockOrganization as createMockOrganizationWire,
   mockOrganizations,
   type OrganizationWire,
 } from '../fixtures/billing.fixture';
@@ -25,7 +25,7 @@ vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key: string) => `translated:$
 // for mocking API responses. Parse through the production schema so tests
 // feed the composable the same shape the real store produces.
 const mockOrg = (overrides: Partial<OrganizationWire> = {}): Organization =>
-  organizationSchema.parse(createWireOrganization(overrides));
+  organizationSchema.parse(createMockOrganizationWire(overrides));
 
 const freeOrg = organizationSchema.parse(mockOrganizations.free);
 

--- a/src/tests/composables/useReceipt.spec.ts
+++ b/src/tests/composables/useReceipt.spec.ts
@@ -1,6 +1,7 @@
 // src/tests/composables/useReceipt.spec.ts
 
 import { useReceipt } from '@/shared/composables/useReceipt';
+import type { Receipt, ReceiptDetails } from '@/schemas/shapes/v3/receipt';
 import { AxiosError } from 'axios';
 import { useAuthStore } from '@/shared/stores/authStore';
 import { useReceiptStore } from '@/shared/stores/receiptStore';
@@ -61,6 +62,12 @@ describe('useReceipt', () => {
   });
 
   describe('lifecycle', () => {
+    // record/details/canBurn are real `ref()`s here (not the unwrapped values
+    // Pinia's Store<> type presents) so storeToRefs(store) - which special-
+    // cases "already a ref" (see Pinia's storeToRefs source) and otherwise
+    // DROPS plain-value keys entirely - actually returns live, mutable refs
+    // for these tests to read/assert against. That intentional shape doesn't
+    // structurally match Store<"receipt", ...>, hence the `unknown` bridge.
     const store = {
       init: vi.fn(),
       fetch: vi.fn().mockResolvedValue(mockReceiptRecord),
@@ -73,7 +80,9 @@ describe('useReceipt', () => {
     };
 
     beforeEach(() => {
-      vi.mocked(useReceiptStore).mockReturnValue(store as ReturnType<typeof useReceiptStore>);
+      vi.mocked(useReceiptStore).mockReturnValue(
+        store as unknown as ReturnType<typeof useReceiptStore>
+      );
     });
 
     it('should initialize with empty state', () => {
@@ -122,33 +131,40 @@ describe('useReceipt', () => {
   });
 
   describe('router integration', () => {
-    // More idiomatic router mock
+    // Only `push` is exercised by these tests (see assertions below). Cast via
+    // `unknown`, matching the pattern used elsewhere in this file (e.g. the
+    // 'burning secrets' describe block): a real Router has many more required
+    // members (resolve, addRoute, currentRoute as a full RouteLocationNormalizedLoaded,
+    // etc.) that a hand-rolled mock has no need to implement.
     const routerMock = {
       push: vi.fn(),
-      currentRoute: ref({
-        name: 'Test',
-        params: {},
-        query: {},
-      }),
       replace: vi.fn(),
       back: vi.fn(),
       forward: vi.fn(),
       go: vi.fn(),
-    } satisfies Partial<Router>;
+    } as unknown as Router;
 
     beforeEach(() => {
       vi.mocked(useRouter).mockReturnValue(routerMock);
+      // Note: `isLoading` is NOT part of ReceiptStore's shape - it's a local
+      // ref inside useReceipt() itself (driven by useAsyncHandler's wrap()),
+      // never read from the store. Omitted here accordingly.
+      //
+      // record/details/canBurn are real `ref()`s (see the 'lifecycle' describe
+      // block above for why), so this bridges through `unknown` rather than
+      // matching Store<"receipt", ...>'s unwrapped shape directly.
       const storeMock = {
         burn: vi.fn().mockResolvedValue(undefined),
         canBurn: ref(true),
         fetch: vi.fn(),
         record: ref(null),
         details: ref(null),
-        isLoading: ref(false),
         setApiMode: vi.fn(),
         $reset: vi.fn(),
       };
-      vi.mocked(useReceiptStore).mockReturnValue(storeMock as ReturnType<typeof useReceiptStore>);
+      vi.mocked(useReceiptStore).mockReturnValue(
+        storeMock as unknown as ReturnType<typeof useReceiptStore>
+      );
     });
 
     it('should redirect after burn with correct params', async () => {
@@ -183,23 +199,28 @@ describe('useReceipt', () => {
   });
 
   describe('fetching receipt', () => {
+    // record/details are real `ref()`s (see the 'lifecycle' describe block
+    // above for why: storeToRefs(store) needs an actual ref to pass through)
+    // so the fetch mock can write through them like the real store does.
+    // `isLoading` is NOT part of ReceiptStore - it's useReceipt()'s own local
+    // ref (see composable) - so it's intentionally absent here.
     const store = {
       fetch: vi.fn().mockImplementation(async () => {
         store.record.value = mockReceiptRecord;
         store.details.value = mockReceiptDetails;
         return;
       }),
-      record: ref(null),
-      details: ref(null),
-      isLoading: ref(false),
+      record: ref<Receipt | null>(null),
+      details: ref<ReceiptDetails | null>(null),
       setApiMode: vi.fn(),
     };
 
     beforeEach(() => {
-      vi.mocked(useReceiptStore).mockReturnValue(store);
+      vi.mocked(useReceiptStore).mockReturnValue(
+        store as unknown as ReturnType<typeof useReceiptStore>
+      );
       store.record.value = null;
       store.details.value = null;
-      store.isLoading.value = false;
     });
 
     it('should handle successful receipt fetch', async () => {
@@ -219,8 +240,10 @@ describe('useReceipt', () => {
       // Setup
       const networkError = new Error('Network error');
       store.fetch.mockRejectedValueOnce(networkError);
-      const notifications = { show: vi.fn() };
-      vi.mocked(useNotificationsStore).mockReturnValue(notifications);
+      const notifications: Partial<ReturnType<typeof useNotificationsStore>> = { show: vi.fn() };
+      vi.mocked(useNotificationsStore).mockReturnValue(
+        notifications as ReturnType<typeof useNotificationsStore>
+      );
 
       // Execute
       const { fetch, isLoading, error } = useReceipt('test-key');
@@ -249,8 +272,10 @@ describe('useReceipt', () => {
       );
 
       store.fetch.mockRejectedValueOnce(notFoundError);
-      const notifications = { show: vi.fn() };
-      vi.mocked(useNotificationsStore).mockReturnValue(notifications);
+      const notifications: Partial<ReturnType<typeof useNotificationsStore>> = { show: vi.fn() };
+      vi.mocked(useNotificationsStore).mockReturnValue(
+        notifications as ReturnType<typeof useNotificationsStore>
+      );
 
       // Execute
       const { fetch, isLoading, error } = useReceipt('test-key');
@@ -283,13 +308,18 @@ describe('useReceipt', () => {
         details: ref(mockReceiptDetails),
         setApiMode: vi.fn(),
       };
-      const notifications = { show: vi.fn() };
+      const notifications: Partial<ReturnType<typeof useNotificationsStore>> = { show: vi.fn() };
       const mockRouter = {
         push: vi.fn().mockResolvedValue(undefined), // Router push returns a promise
       } as unknown as Router;
 
-      vi.mocked(useReceiptStore).mockReturnValue(store);
-      vi.mocked(useNotificationsStore).mockReturnValue(notifications);
+      // record/details/canBurn are real `ref()`s (see 'lifecycle' above for why).
+      vi.mocked(useReceiptStore).mockReturnValue(
+        store as unknown as ReturnType<typeof useReceiptStore>
+      );
+      vi.mocked(useNotificationsStore).mockReturnValue(
+        notifications as ReturnType<typeof useNotificationsStore>
+      );
       vi.mocked(useRouter).mockReturnValue(mockRouter);
 
       const { burn, passphrase } = useReceipt('test-key');
@@ -318,11 +348,16 @@ describe('useReceipt', () => {
         record: ref(mockReceiptRecord),
         setApiMode: vi.fn(),
       };
-      const notifications = { show: vi.fn() };
-      const router = { push: vi.fn() };
+      const notifications: Partial<ReturnType<typeof useNotificationsStore>> = { show: vi.fn() };
+      const router = { push: vi.fn() } as unknown as Router;
 
-      vi.mocked(useReceiptStore).mockReturnValue(store);
-      vi.mocked(useNotificationsStore).mockReturnValue(notifications);
+      // canBurn/record are real `ref()`s (see 'lifecycle' above for why).
+      vi.mocked(useReceiptStore).mockReturnValue(
+        store as unknown as ReturnType<typeof useReceiptStore>
+      );
+      vi.mocked(useNotificationsStore).mockReturnValue(
+        notifications as ReturnType<typeof useNotificationsStore>
+      );
       vi.mocked(useRouter).mockReturnValue(router);
 
       // Execute
@@ -341,6 +376,7 @@ describe('useReceipt', () => {
   });
 
   describe('API mode selection', () => {
+    // record/details/canBurn are real `ref()`s (see 'lifecycle' above for why).
     const store = {
       fetch: vi.fn().mockResolvedValue(mockReceiptRecord),
       burn: vi.fn(),
@@ -352,7 +388,9 @@ describe('useReceipt', () => {
     };
 
     beforeEach(() => {
-      vi.mocked(useReceiptStore).mockReturnValue(store as ReturnType<typeof useReceiptStore>);
+      vi.mocked(useReceiptStore).mockReturnValue(
+        store as unknown as ReturnType<typeof useReceiptStore>
+      );
       store.setApiMode.mockClear();
     });
 

--- a/src/tests/composables/useSecretConcealer.spec.ts
+++ b/src/tests/composables/useSecretConcealer.spec.ts
@@ -1,7 +1,7 @@
 // src/tests/composables/useSecretConcealer.spec.ts
 
 import { useSecretConcealer } from '@/shared/composables/useSecretConcealer';
-import { useSecretStore } from '@/shared/stores/secretStore';
+import { useSecretStore, type ApiMode } from '@/shared/stores/secretStore';
 import { Router, useRouter } from 'vue-router';
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -21,8 +21,10 @@ const mockRouter = {
 } as unknown as Router; // Use `unknown` as an intermediate type to bypass
 vi.mocked(useRouter).mockReturnValue(mockRouter);
 
-// Mock authStore to control authentication state
-const mockAuthStore = {
+// Mock authStore to control authentication state. Typed boolean | null to
+// match the real authStore.isAuthenticated (see authStore.ts) - null is the
+// genuine "uncertain/initial" state, exercised below.
+const mockAuthStore: { isAuthenticated: boolean | null } = {
   isAuthenticated: true,
 };
 vi.mock('@/shared/stores/authStore', () => ({
@@ -39,12 +41,17 @@ describe('useSecretConcealer', () => {
 
   describe('lifecycle', () => {
     beforeEach(() => {
-      const store = {
+      // Partial<ReturnType<...>>, not a bare literal: useSecretStore is a
+      // Pinia setup store, so its real return type carries every state ref,
+      // getter and action plus Pinia's own instance methods. Typing the mock
+      // this way lets the object literal include just what each test needs
+      // while still keeping the mockReturnValue() call itself checked below.
+      const store: Partial<ReturnType<typeof useSecretStore>> = {
         conceal: vi.fn().mockResolvedValue({ record: { receipt: { key: 'test' } } }),
         generate: vi.fn().mockResolvedValue({ record: { receipt: { key: 'test' } } }),
         setApiMode: vi.fn(),
       };
-      vi.mocked(useSecretStore).mockReturnValue(store);
+      vi.mocked(useSecretStore).mockReturnValue(store as ReturnType<typeof useSecretStore>);
     });
 
     it('initializes with empty state', () => {
@@ -65,12 +72,12 @@ describe('useSecretConcealer', () => {
     };
 
     beforeEach(() => {
-      const store = {
+      const store: Partial<ReturnType<typeof useSecretStore>> = {
         conceal: vi.fn().mockResolvedValue(mockResponse),
         generate: vi.fn().mockResolvedValue(mockResponse),
         setApiMode: vi.fn(),
       };
-      vi.mocked(useSecretStore).mockReturnValue(store);
+      vi.mocked(useSecretStore).mockReturnValue(store as ReturnType<typeof useSecretStore>);
     });
 
     it.skip('handles successful secret sharing', async () => {
@@ -95,12 +102,12 @@ describe('useSecretConcealer', () => {
     });
 
     it('handles validation errors', async () => {
-      const store = {
+      const store: Partial<ReturnType<typeof useSecretStore>> = {
         conceal: vi.fn().mockRejectedValue(new Error('Validation failed')),
         generate: vi.fn().mockRejectedValue(new Error('Validation failed')),
         setApiMode: vi.fn(),
       };
-      vi.mocked(useSecretStore).mockReturnValue(store);
+      vi.mocked(useSecretStore).mockReturnValue(store as ReturnType<typeof useSecretStore>);
 
       const { submit, isSubmitting } = useSecretConcealer();
 
@@ -113,12 +120,12 @@ describe('useSecretConcealer', () => {
 
   describe('form mode handling', () => {
     beforeEach(() => {
-      const store = {
+      const store: Partial<ReturnType<typeof useSecretStore>> = {
         conceal: vi.fn().mockResolvedValue({ record: { receipt: { key: 'test' } } }),
         generate: vi.fn().mockResolvedValue({ record: { receipt: { key: 'test' } } }),
         setApiMode: vi.fn(),
       };
-      vi.mocked(useSecretStore).mockReturnValue(store);
+      vi.mocked(useSecretStore).mockReturnValue(store as ReturnType<typeof useSecretStore>);
     });
 
     it('can submit in generate mode', async () => {
@@ -138,12 +145,12 @@ describe('useSecretConcealer', () => {
     });
 
     it('rejects generate submission with a malformed recipient email', async () => {
-      const store = {
+      const store: Partial<ReturnType<typeof useSecretStore>> = {
         conceal: vi.fn(),
         generate: vi.fn(),
         setApiMode: vi.fn(),
       };
-      vi.mocked(useSecretStore).mockReturnValue(store);
+      vi.mocked(useSecretStore).mockReturnValue(store as ReturnType<typeof useSecretStore>);
 
       const { form, operations, submit } = useSecretConcealer();
       operations.updateField('recipient', 'not-an-email');
@@ -156,16 +163,16 @@ describe('useSecretConcealer', () => {
   });
 
   describe('API mode selection', () => {
-    let mockSetApiMode: ReturnType<typeof vi.fn>;
+    let mockSetApiMode: ReturnType<typeof vi.fn<(mode: ApiMode) => void>>;
 
     beforeEach(() => {
-      mockSetApiMode = vi.fn();
-      const store = {
+      mockSetApiMode = vi.fn<(mode: ApiMode) => void>();
+      const store: Partial<ReturnType<typeof useSecretStore>> = {
         conceal: vi.fn().mockResolvedValue({ record: { receipt: { key: 'test' } } }),
         generate: vi.fn().mockResolvedValue({ record: { receipt: { key: 'test' } } }),
         setApiMode: mockSetApiMode,
       };
-      vi.mocked(useSecretStore).mockReturnValue(store);
+      vi.mocked(useSecretStore).mockReturnValue(store as ReturnType<typeof useSecretStore>);
     });
 
     describe('default behavior (usePublicApi not specified)', () => {

--- a/src/tests/composables/useSsoConfig.spec.ts
+++ b/src/tests/composables/useSsoConfig.spec.ts
@@ -340,6 +340,8 @@ describe('useSsoConfig', () => {
         issuer: '',
         allowed_domains: [],
         enabled: true,
+        enforce_sso_only: false,
+        grant_org_scope: false,
       };
 
       await composable.saveConfig();
@@ -372,6 +374,8 @@ describe('useSsoConfig', () => {
         issuer: '',
         allowed_domains: [],
         enabled: true,
+        enforce_sso_only: false,
+        grant_org_scope: false,
       };
 
       await composable.saveConfig();
@@ -395,6 +399,8 @@ describe('useSsoConfig', () => {
         issuer: '',
         allowed_domains: [],
         enabled: true,
+        enforce_sso_only: false,
+        grant_org_scope: false,
       };
 
       expect(composable.hasUnsavedChanges.value).toBe(true);
@@ -418,6 +424,8 @@ describe('useSsoConfig', () => {
         issuer: '',
         allowed_domains: [],
         enabled: true,
+        enforce_sso_only: false,
+        grant_org_scope: false,
       };
 
       await composable.saveConfig();
@@ -449,6 +457,8 @@ describe('useSsoConfig', () => {
         issuer: '',
         allowed_domains: [],
         enabled: true,
+        enforce_sso_only: false,
+        grant_org_scope: false,
       };
 
       // Should not throw
@@ -479,6 +489,8 @@ describe('useSsoConfig', () => {
         issuer: '',
         allowed_domains: [],
         enabled: true,
+        enforce_sso_only: false,
+        grant_org_scope: false,
       };
 
       const savePromise = composable.saveConfig();
@@ -934,6 +946,8 @@ describe('useSsoConfig', () => {
         issuer: 'https://changed.example.com',
         allowed_domains: ['changed.com'],
         enabled: false,
+        enforce_sso_only: false,
+        grant_org_scope: false,
       };
 
       expect(composable.hasUnsavedChanges.value).toBe(true);

--- a/src/tests/composables/useTheme.spec.ts
+++ b/src/tests/composables/useTheme.spec.ts
@@ -2,7 +2,7 @@
 
 import { useTheme } from '@/shared/composables/useTheme';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { nextTick } from 'vue';
+import { defineComponent, nextTick } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 
 describe('useTheme', () => {
@@ -72,13 +72,13 @@ describe('useTheme', () => {
   });
 
   it('themeListeners should start empty and be empty after unmount', async () => {
-    const comp = {
+    const comp = defineComponent({
       template: '<div>test comp</div>',
       setup() {
         const theme = useTheme();
         return { theme };
       },
-    };
+    });
     const wrapper = shallowMount(comp);
     // After beforeEach clears listeners, size starts at 0
     expect(wrapper.vm.theme.getThemeListenersSize()).toBe(0);

--- a/src/tests/composables/useWorkspacePrivacyDefaults.spec.ts
+++ b/src/tests/composables/useWorkspacePrivacyDefaults.spec.ts
@@ -5,7 +5,14 @@ import { ref, computed, nextTick } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
-import type { BrandSettingsCanonical as BrandSettings } from '@/schemas/contracts/custom-domain';
+// The composable's UseWorkspacePrivacyDefaultsOptions.brandSettings is typed
+// against the V3 wire shape (brandSettingsSchema), not the base contract:
+// button_text_light/passphrase_required/notify_enabled are non-optional there
+// (the V3 schema overrides them with `.default()`), while the contract's
+// BrandSettingsCanonical leaves every field optional (`.partial()`). Import
+// the type actually used by the composable so overrides here type-check the
+// same way real callers do.
+import type { BrandSettings } from '@/schemas/shapes/v3/custom-domain';
 
 // Mock formatDuration
 const mockFormatDuration = vi.fn((seconds: number) => {
@@ -46,7 +53,14 @@ describe('useWorkspacePrivacyDefaults', () => {
     const bootstrapStore = useBootstrapStore();
     bootstrapStore.secret_options = {
       default_ttl: config.default_ttl ?? 604800,
-      passphrase: { required: config.passphrase_required ?? false },
+      // passphraseSchema fields all carry `.default()`, so the parsed type
+      // requires all four even though the option itself is optional.
+      passphrase: {
+        required: config.passphrase_required ?? false,
+        minimum_length: 4,
+        maximum_length: 128,
+        enforce_complexity: false,
+      },
       ttl_options: [60, 3600, 86400, 604800, 1209600, 2592000],
     };
 
@@ -65,7 +79,10 @@ describe('useWorkspacePrivacyDefaults', () => {
 
   function createOptions(
     overrides: Partial<{
-      brandSettings: BrandSettings;
+      // Partial, not BrandSettings: callers pass a patch merged over
+      // defaultBrandSettings below (which supplies the 3 fields the real
+      // schema requires: button_text_light/passphrase_required/notify_enabled).
+      brandSettings: Partial<BrandSettings>;
       isCanonical: boolean;
       isLoading: boolean;
     }> = {}
@@ -336,6 +353,7 @@ describe('useWorkspacePrivacyDefaults', () => {
   describe('reactivity', () => {
     it('updates when brand settings change', async () => {
       const brandSettings = ref<BrandSettings>({
+        button_text_light: true,
         default_ttl: undefined,
         passphrase_required: false,
         notify_enabled: false,
@@ -362,7 +380,12 @@ describe('useWorkspacePrivacyDefaults', () => {
       const isCanonicalRef = ref(false);
 
       const { privacyDefaults } = useWorkspacePrivacyDefaults({
-        brandSettings: ref({ default_ttl: 3600 }),
+        brandSettings: ref<BrandSettings>({
+          button_text_light: true,
+          default_ttl: 3600,
+          passphrase_required: false,
+          notify_enabled: false,
+        }),
         isCanonical: computed(() => isCanonicalRef.value),
       });
 

--- a/src/tests/contracts/bootstrap-test-schema.ts
+++ b/src/tests/contracts/bootstrap-test-schema.ts
@@ -17,9 +17,22 @@ import {
  * Used by contract tests to verify sub-schema behavior.
  */
 export const bootstrapUiSchema = z.object({
-  ui: uiInterfaceSchema.default({ enabled: true }),
+  // zod v4's `.default()` substitutes this value verbatim when the key is
+  // absent from the input — unlike `.parse()`, it does NOT run the value
+  // back through uiInterfaceSchema, so nested defaults (e.g. show_version)
+  // never cascade in (see $ZodDefault in zod/v4/core/schemas.js). TypeScript
+  // therefore requires the literal to already match the schema's full
+  // OUTPUT type, even though only `enabled` is set on purpose here — the
+  // cast records that this is intentional, not a truncated UiInterface.
+  // bootstrap-schema-contract.spec.ts's "provides sensible defaults for
+  // empty input" pins this exact partial shape, so don't "complete" it via
+  // uiInterfaceSchema.parse({...}) (that would add show_version and break
+  // the assertion).
+  ui: uiInterfaceSchema.default({ enabled: true } as z.output<typeof uiInterfaceSchema>),
   messages: z.array(messageSchema).default([]),
-  features: featuresSchema.default({ markdown: false }),
+  // Same verbatim-substitution caveat as `ui` above: organizations/
+  // secret_activity are deliberately not cascaded into this literal.
+  features: featuresSchema.default({ markdown: false } as z.output<typeof featuresSchema>),
   // Ruby always emits development; organization is conditional
   development: developmentConfigSchema.default(developmentConfigSchema.parse({})),
   organization: organizationSchema.optional(),

--- a/src/tests/contracts/v3-schema-null-safety.spec.ts
+++ b/src/tests/contracts/v3-schema-null-safety.spec.ts
@@ -542,8 +542,14 @@ describe('V3 schema null-safety audit', () => {
     /** Resolve a `record.<field>` schema from a V3 response schema. */
     function recordFieldSchema(responseSchema: AnySchema, field: string): AnySchema {
       const root = unwrapSchema(responseSchema) as z.ZodObject<z.ZodRawShape>;
-      const record = unwrapSchema(root.shape.record) as z.ZodObject<z.ZodRawShape>;
-      return record.shape[field];
+      // Zod v4: `ZodObject<ZodRawShape>.shape` entries are typed with the core
+      // $ZodType, not the classic ZodType that AnySchema aliases, even though
+      // they're classic schema instances at runtime. Cast through `any` for
+      // these introspection helpers, same as unwrapSchema/isBooleanSchema above.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const record = unwrapSchema(root.shape.record as any) as z.ZodObject<z.ZodRawShape>;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return record.shape[field] as any;
     }
 
     it.each(['secret_ttl', 'lifespan'])(

--- a/src/tests/fixtures/bootstrap.fixture.ts
+++ b/src/tests/fixtures/bootstrap.fixture.ts
@@ -23,7 +23,6 @@ export const schemaDefaults: BootstrapPayload = bootstrapSchema.parse({});
  * Customer fixture for authenticated states.
  */
 export const mockCustomer: CustomerCanonical = {
-  identifier: 'cust_ext_123',
   objid: 'cust_obj_123',
   extid: 'cust_ext_123',
   email: 'test@example.com',
@@ -125,8 +124,14 @@ export const baseBootstrap: BootstrapPayload = {
 
   // Explicitly include optional fields for test key enumeration
   // These are undefined but need to be present for Object.keys() in tests
+  //
+  // `development` is NOT listed here (unlike below): the schema always
+  // emits it via `.default(...)`, so BootstrapPayload['development'] is a
+  // required `{ enabled; domain_context_enabled }` object, never undefined.
+  // It's already present with its real default value via the schemaDefaults
+  // spread above — this list is only for genuinely `.optional()`/`.nullish()`
+  // fields (see the matching `DEFAULTS` comment in bootstrapStore.ts).
   customer_since: undefined,
-  development: undefined,
   organization: undefined,
   entitlement_preview_planid: undefined,
   entitlement_preview_plan_name: undefined,

--- a/src/tests/fixtures/domains.fixture.ts
+++ b/src/tests/fixtures/domains.fixture.ts
@@ -1,6 +1,6 @@
 // src/tests/fixtures/domains.fixture.ts
 
-import type { CustomDomain } from '@/schemas/shapes/v2';
+import type { CustomDomain } from '@/schemas/shapes/v3';
 
 const BASE_DOMAIN = {
   domainid: '',
@@ -11,6 +11,9 @@ const BASE_DOMAIN = {
   is_apex: false,
   verified: false,
   resolving: false,
+  // V3 schema default (customDomainSchema.status) — matches the wire shape
+  // these fixtures otherwise represent (see mockDomainsRaw comment below).
+  status: 'pending',
 } as const;
 
 const BRAND_DOMAIN1 = {
@@ -71,7 +74,17 @@ export const mockDomainsRaw: Record<string, Record<string, unknown>> = {
 };
 
 // Transformed format (after V3 Zod parse) — used for assertions
-export const mockDomains: Record<string, CustomDomain> = {
+//
+// `satisfies` (not `: Record<string, CustomDomain>`) validates every entry
+// against the real V3 shape — catching missing/renamed fields — while
+// keeping the inferred type as narrow literals rather than widening to V3's
+// CustomDomain (whose `brand` fields are nullable). useDomainsManager.spec.ts
+// (src/tests/types.d.ts) still types its store mock against the older V2
+// CustomDomain, whose BrandSettings fields are non-nullable-optional; a
+// direct V3 annotation here would make `brand.primary_color` etc.
+// `string | null | undefined`, which V2's `string | undefined` rejects. The
+// narrow literal inference stays assignable to both.
+export const mockDomains = {
   'domain-1': {
     ...BASE_DOMAIN,
     domainid: 'domain-1',
@@ -105,7 +118,7 @@ export const mockDomains: Record<string, CustomDomain> = {
     brand: { ...BRAND_DOMAIN2 },
     vhost: {},
   },
-};
+} satisfies Record<string, CustomDomain>;
 
 export const newDomainDataRaw = {
   ...BASE_DOMAIN,
@@ -123,7 +136,9 @@ export const newDomainDataRaw = {
   vhost: {},
 };
 
-export const newDomainData: CustomDomain = {
+// See the `mockDomains` comment above re: `satisfies` vs a direct type
+// annotation — same V2/V3 BrandSettings nullability conflict applies here.
+export const newDomainData = {
   ...BASE_DOMAIN,
   domainid: 'domain-3',
   extid: 'dm-ext-3',
@@ -137,4 +152,4 @@ export const newDomainData: CustomDomain = {
   updated: new Date(1704240000 * 1000),
   brand: { ...BRAND_DOMAIN2 },
   vhost: {},
-};
+} satisfies CustomDomain;

--- a/src/tests/fixtures/receipt.fixture.ts
+++ b/src/tests/fixtures/receipt.fixture.ts
@@ -1,8 +1,14 @@
 // src/tests/fixtures/receipt.fixture.ts
 
-import { ReceiptState } from '@/schemas/shapes/v2/receipt';
-import { Secret, SecretState } from '@/schemas/shapes/v2/secret';
-import type { Receipt, ReceiptDetails } from '@/schemas/shapes/v2/receipt';
+// Receipt/ReceiptDetails and ReceiptState come from the V3 shape — this is the
+// authoritative shape the production store (src/shared/stores/receiptStore.ts)
+// actually parses responses into and operates on. V2 kept these fields
+// nullish/string-typed for Redis-string backward compatibility, which no
+// longer matches what `useReceiptStore` exposes to consumers.
+import { ReceiptState } from '@/schemas/shapes/v3/receipt';
+import { SecretState } from '@/schemas/shapes/v2/secret';
+import type { Receipt, ReceiptDetails } from '@/schemas/shapes/v3/receipt';
+import type { Secret } from '@/schemas/shapes/v3/secret';
 
 // =============================================================================
 // NEW TERMINOLOGY FIXTURES (previewed/revealed)
@@ -502,7 +508,19 @@ export const mockSecretRecord: Secret = {
 
 export const mockBurnedSecretRecord: Secret | null = null;
 
-export const mockReceivedSecretRecord: Secret = {
+/**
+ * Legacy-state secret mock type.
+ *
+ * Mirrors the canonical V3 `Secret` shape but widens `state` to also accept
+ * the deprecated V2 aliases ('received', 'viewed') — contracts/secret.ts
+ * dropped those from `secretStateValues`, so they no longer satisfy `Secret`
+ * itself. The mocks below are kept exactly as-is (including the deprecated
+ * state strings) for backward-compat fixture consumers that still assert
+ * against them (see receipt.fixture.spec.ts).
+ */
+type LegacySecret = Omit<Secret, 'state'> & { state: Secret['state'] | 'received' | 'viewed' };
+
+export const mockReceivedSecretRecord: LegacySecret = {
   key: 'secret-received-key-123',
   shortid: 'secret-received-abc123',
   state: SecretState.RECEIVED,
@@ -511,12 +529,14 @@ export const mockReceivedSecretRecord: Secret = {
   updated: new Date(1735204014 * 1000),
   has_passphrase: false,
   verification: true,
+  is_previewed: true,
+  is_revealed: true,
   secret_value: 'received test secret',
   secret_ttl: 86400,
   lifespan: 86400,
 };
 
-export const mockOrphanedSecretRecord: Secret = {
+export const mockOrphanedSecretRecord: LegacySecret = {
   key: 'secret-orphaned-key-123',
   shortid: 'secret-orphaned-abc123',
   state: SecretState.VIEWED,
@@ -525,12 +545,14 @@ export const mockOrphanedSecretRecord: Secret = {
   updated: new Date(1735204014 * 1000),
   has_passphrase: false,
   verification: true,
+  is_previewed: true,
+  is_revealed: false,
   secret_value: 'orphaned test secret',
   secret_ttl: 0,
   lifespan: 0,
 };
 
-export const mockReceivedSecretRecord1: Secret = {
+export const mockReceivedSecretRecord1: LegacySecret = {
   key: 'secret-received-1',
   shortid: 'sec-rcv1',
   state: SecretState.RECEIVED,
@@ -539,12 +561,14 @@ export const mockReceivedSecretRecord1: Secret = {
   updated: new Date(1735204014 * 1000),
   has_passphrase: false,
   verification: true,
+  is_previewed: true,
+  is_revealed: true,
   secret_value: 'received-test-secret-1',
   secret_ttl: 3600,
   lifespan: 3600,
 };
 
-export const mockReceivedSecretRecord2: Secret = {
+export const mockReceivedSecretRecord2: LegacySecret = {
   key: 'secret-received-2',
   shortid: 'sec-rcv2',
   state: SecretState.RECEIVED,
@@ -553,6 +577,8 @@ export const mockReceivedSecretRecord2: Secret = {
   updated: new Date(1735204014 * 1000),
   has_passphrase: false,
   verification: true,
+  is_previewed: true,
+  is_revealed: true,
   secret_value: 'received-test-secret-2',
   secret_ttl: 7200,
   lifespan: 7200,
@@ -567,6 +593,8 @@ export const mockNotReceivedSecretRecord1: Secret = {
   updated: new Date(1735204014 * 1000),
   has_passphrase: false,
   verification: true,
+  is_previewed: false,
+  is_revealed: false,
   secret_value: 'not-received-test-secret-1',
   secret_ttl: 1800,
   lifespan: 1800,

--- a/src/tests/plugins/core/diagnostics/beforeBreadcrumb.spec.ts
+++ b/src/tests/plugins/core/diagnostics/beforeBreadcrumb.spec.ts
@@ -104,6 +104,9 @@ import type { RouteMeta } from '@/types/router';
 const baseConfig = {
   sentry: {
     dsn: 'https://key@sentry.io/123',
+    enabled: true,
+    logErrors: true,
+    trackComponents: true,
     environment: 'test',
     release: '1.0.0',
   },

--- a/src/tests/plugins/core/diagnostics/beforeSend.spec.ts
+++ b/src/tests/plugins/core/diagnostics/beforeSend.spec.ts
@@ -12,6 +12,12 @@
 // would obscure the mock-to-test-pairing for no structural benefit, so the
 // file-level max-classes-per-file rule is disabled here.
 /* eslint-disable max-classes-per-file */
+//
+// Every `ErrorEvent` fixture below carries `type: undefined` even though
+// nothing reads it: @sentry/core types `ErrorEvent` as `Event & { type:
+// undefined }` (required, not optional) so it can be structurally
+// discriminated from `TransactionEvent` (`type: 'transaction'`). Omitting the
+// key fails the type check with "Property 'type' is missing".
 
 import type { RouteMeta } from '@/types/router';
 import type { ErrorEvent, TransactionEvent } from '@sentry/core';
@@ -107,6 +113,9 @@ import { createDiagnostics } from '@/plugins/core/enableDiagnostics';
 const baseConfig = {
   sentry: {
     dsn: 'https://key@sentry.io/123',
+    enabled: true,
+    logErrors: true,
+    trackComponents: true,
     environment: 'test',
     release: '1.0.0',
   },
@@ -199,6 +208,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: [{ value: 'Failed for user@example.com' }],
         },
@@ -215,6 +225,7 @@ describe('beforeSend handler', () => {
 
       const handler = getBeforeSend();
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: [{ value: `Error processing ${id62}` }],
         },
@@ -230,6 +241,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: [{ value: 'Not found: /secret/abc123' }],
         },
@@ -245,6 +257,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: [{ value: 'Error for user@example.com' }, { value: 'At path /private/xyz789' }],
         },
@@ -263,6 +276,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         message: 'User user@example.com logged out',
       };
 
@@ -284,6 +298,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: [
             {
@@ -313,6 +328,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: [
             {
@@ -342,6 +358,7 @@ describe('beforeSend handler', () => {
 
       const bundleUrl = 'https://eu.onetimesecret.com/dist/assets/main.BbCc7LVY.js';
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: [
             {
@@ -366,6 +383,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: { values: [{ value: 'no stack' }] },
       };
 
@@ -406,6 +424,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: {
           url: 'https://example.com/secret/abc123/view',
         },
@@ -424,6 +443,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         transaction: 'https://example.com/private/xyz789',
       };
 
@@ -440,6 +460,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         breadcrumbs: [
           {
             category: 'navigation',
@@ -471,6 +492,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: {
           url: 'https://example.com/colonel/admin123',
         },
@@ -490,6 +512,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: [{ value: 'Error for user@example.com' }],
         },
@@ -514,6 +537,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: {
           url: 'https://example.com/user/john/token/secret123',
         },
@@ -532,6 +556,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: {
           url: 'https://example.com/about',
         },
@@ -553,6 +578,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: { url: 'https://example.com/check-email?email=user@example.com' },
       };
 
@@ -566,6 +592,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: { url: 'https://example.com/pricing?email=user@example.com' },
         transaction: '/pricing?email=user@example.com',
       };
@@ -581,6 +608,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: { url: 'https://example.com/check-email?product=identity&interval=month' },
       };
 
@@ -601,6 +629,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: {
           headers: { Referer: 'https://example.com/secret/abc123def456' },
         },
@@ -616,6 +645,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: {
           headers: { referer: 'https://example.com/reveal?token=abc123' },
         },
@@ -634,6 +664,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         request: {
           headers: { Referer: 'https://example.com/page/abc123' },
         },
@@ -652,6 +683,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent & { secret?: string } = {
+        type: undefined, // see file-header note on ErrorEvent.type
         secret: 'should-be-removed',
         message: 'Test event',
       };
@@ -671,6 +703,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: undefined,
         },
@@ -689,6 +722,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         exception: {
           values: [{ type: 'Error' }],
         },
@@ -707,6 +741,7 @@ describe('beforeSend handler', () => {
       const handler = getBeforeSend();
 
       const event: ErrorEvent = {
+        type: undefined, // see file-header note on ErrorEvent.type
         breadcrumbs: [
           {
             category: 'console',

--- a/src/tests/plugins/core/diagnostics/createDiagnostics.spec.ts
+++ b/src/tests/plugins/core/diagnostics/createDiagnostics.spec.ts
@@ -8,6 +8,7 @@
 /* eslint-disable max-classes-per-file */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { App, Plugin } from 'vue';
 import type { Router } from 'vue-router';
 
 // ---------------------------------------------------------------------------
@@ -132,9 +133,24 @@ function createMockRouter(): Router {
   } as unknown as Router;
 }
 
+/**
+ * `createDiagnostics()` is typed to return Vue's `Plugin` union
+ * (`ObjectPlugin | FunctionPlugin`), under which `.install` types as possibly
+ * undefined because the callable `FunctionPlugin` variant makes it optional.
+ * The production implementation always returns an object plugin
+ * (`{ install(app) { ... } }`), so this narrows to the shape it actually
+ * produces instead of asserting `!` at the call site.
+ */
+function installPlugin(plugin: Plugin, app: App): void {
+  (plugin as { install: (app: App) => void }).install(app);
+}
+
 const baseConfig = {
   sentry: {
     dsn: 'https://key@sentry.io/123',
+    enabled: true,
+    logErrors: true,
+    trackComponents: true,
     environment: 'test',
     release: '1.0.0',
   },
@@ -413,9 +429,9 @@ describe('createDiagnostics jurisdiction tagging', () => {
     const app = {
       provide: vi.fn(),
       unmount: originalUnmount,
-    } as unknown as import('vue').App;
+    } as unknown as App;
 
-    plugin.install(app);
+    installPlugin(plugin, app);
 
     expect(unregisterAfterEach).not.toHaveBeenCalled();
 

--- a/src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts
+++ b/src/tests/plugins/core/diagnostics/expectedOutcomes.spec.ts
@@ -311,7 +311,14 @@ describe('beforeSend integration', () => {
     createDiagnostics({
       host: TEST_HOST,
       config: {
-        sentry: { dsn: 'https://key@example.com/123', environment: 'test', release: '1.0.0' },
+        sentry: {
+          dsn: 'https://key@example.com/123',
+          enabled: true,
+          logErrors: true,
+          trackComponents: true,
+          environment: 'test',
+          release: '1.0.0',
+        },
       },
       router: createMockRouter(),
     });
@@ -336,6 +343,7 @@ describe('beforeSend integration', () => {
 
     const result = handler(
       {
+        type: undefined,
         exception: {
           values: [{ type: 'AxiosError', value: 'Request failed with status code 404' }],
         },
@@ -350,7 +358,7 @@ describe('beforeSend integration', () => {
     const handler = getBeforeSend();
 
     const result = handler(
-      { exception: { values: [{ type: 'AxiosError', value: 'Request aborted' }] } },
+      { type: undefined, exception: { values: [{ type: 'AxiosError', value: 'Request aborted' }] } },
       hintFor({
         url: `/api/v3/guest/secret/${SECRET_ID}`,
         method: 'get',
@@ -367,7 +375,7 @@ describe('beforeSend integration', () => {
     const handler = getBeforeSend();
 
     const result = handler(
-      { exception: { values: [{ type: 'AxiosError', value: 'Network Error' }] } },
+      { type: undefined, exception: { values: [{ type: 'AxiosError', value: 'Network Error' }] } },
       hintFor({
         url: `/api/v3/guest/secret/${SECRET_ID}`,
         method: 'get',
@@ -384,7 +392,7 @@ describe('beforeSend integration', () => {
     const handler = getBeforeSend();
 
     const result = handler(
-      { exception: { values: [{ type: 'AxiosError', value: 'Network Error' }] } },
+      { type: undefined, exception: { values: [{ type: 'AxiosError', value: 'Network Error' }] } },
       hintFor({
         url: `/api/v3/guest/secret/${SECRET_ID}`,
         method: 'get',
@@ -407,6 +415,7 @@ describe('beforeSend integration', () => {
 
     const result = handler(
       {
+        type: undefined,
         exception: {
           values: [{ type: 'AxiosError', value: 'Request failed with status code 404' }],
         },
@@ -427,7 +436,10 @@ describe('beforeSend integration', () => {
     const handler = getBeforeSend();
 
     const result = handler(
-      { exception: { values: [{ type: 'AxiosError', value: 'timeout exceeded' }] } },
+      {
+        type: undefined,
+        exception: { values: [{ type: 'AxiosError', value: 'timeout exceeded' }] },
+      },
       hintFor({
         url: `/api/v3/guest/secret/${SECRET_ID}`,
         method: 'get',
@@ -450,6 +462,7 @@ describe('beforeSend integration', () => {
 
     const result = handler(
       {
+        type: undefined,
         exception: {
           values: [{ type: 'AxiosError', value: 'Request failed with status code 503' }],
         },
@@ -470,7 +483,7 @@ describe('beforeSend integration', () => {
     const handler = getBeforeSend();
 
     const result = handler(
-      { exception: { values: [{ type: 'TypeError', value: 'boom' }] } },
+      { type: undefined, exception: { values: [{ type: 'TypeError', value: 'boom' }] } },
       { originalException: new TypeError('boom') }
     );
 

--- a/src/tests/plugins/core/diagnostics/grouping.spec.ts
+++ b/src/tests/plugins/core/diagnostics/grouping.spec.ts
@@ -53,6 +53,7 @@ function requestError(overrides: {
 describe('applyGroupingRules — schema validation (Rule A)', () => {
   it('groups by schema name extracted from the message', () => {
     const event: ErrorEvent = {
+      type: undefined,
       exception: { values: [{ type: 'Error', value: SCHEMA_MESSAGE }] },
     };
 
@@ -65,8 +66,12 @@ describe('applyGroupingRules — schema validation (Rule A)', () => {
     // The deploy-fragmentation case: same defect, two deploys, two bundle
     // hashes. Default grouping keys on the frames and splits them; the
     // explicit rule must not.
+    // `culprit` (a server-side Sentry issue field, not part of the outbound
+    // SDK `ErrorEvent` type) is deliberately omitted here — the differing
+    // minified bundle is represented instead by each frame's own
+    // filename/function, which is what the rule must ignore.
     const eventDeployA: ErrorEvent = {
-      culprit: 'main.Ccws7ZEL',
+      type: undefined,
       exception: {
         values: [
           {
@@ -78,7 +83,7 @@ describe('applyGroupingRules — schema validation (Rule A)', () => {
       },
     };
     const eventDeployB: ErrorEvent = {
-      culprit: 'main.DZXtQ8Fc',
+      type: undefined,
       exception: {
         values: [
           {
@@ -99,6 +104,7 @@ describe('applyGroupingRules — schema validation (Rule A)', () => {
 
   it('reads a standalone message as well as exception values', () => {
     const event: ErrorEvent = {
+      type: undefined,
       message: 'Schema validation failed for MembersResponse — 1 issue(s) [(root)]: …',
     };
 
@@ -109,9 +115,11 @@ describe('applyGroupingRules — schema validation (Rule A)', () => {
 
   it('does not key on issue counts or field paths — only the schema name', () => {
     const oneIssue: ErrorEvent = {
+      type: undefined,
       message: 'Schema validation failed for BrandSettings — 1 issue(s) [font_family]: …',
     };
     const threeIssues: ErrorEvent = {
+      type: undefined,
       message:
         'Schema validation failed for BrandSettings — 3 issue(s) [corner_style, primary_color, locale]: …',
     };
@@ -125,7 +133,10 @@ describe('applyGroupingRules — schema validation (Rule A)', () => {
   it('leaves the context-less message family to default grouping', () => {
     // gracefulParse without a context argument emits no "for <SchemaName>"
     // clause — there is no stable name to key on.
-    const event: ErrorEvent = { message: 'Schema validation failed — 1 issue(s) [(root)]: …' };
+    const event: ErrorEvent = {
+      type: undefined,
+      message: 'Schema validation failed — 1 issue(s) [(root)]: …',
+    };
 
     applyGroupingRules(event);
 
@@ -136,6 +147,7 @@ describe('applyGroupingRules — schema validation (Rule A)', () => {
 describe('applyGroupingRules — API request errors (Rule B)', () => {
   it('groups by method, parameterized path, and HTTP status', () => {
     const event: ErrorEvent = {
+      type: undefined,
       exception: { values: [{ type: 'AxiosError', value: 'Request failed with status code 404' }] },
     };
     const hint: EventHint = {
@@ -153,8 +165,8 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
     const idA = 'a'.repeat(62);
     const idB = 'b'.repeat(62);
 
-    const eventA: ErrorEvent = {};
-    const eventB: ErrorEvent = {};
+    const eventA: ErrorEvent = { type: undefined };
+    const eventB: ErrorEvent = { type: undefined };
     applyGroupingRules(eventA, {
       originalException: requestError({ url: `/api/v2/secret/${idA}`, method: 'get', status: 404 }),
     });
@@ -167,7 +179,7 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
   });
 
   it('parameterizes receipt endpoints the same way', () => {
-    const event: ErrorEvent = {};
+    const event: ErrorEvent = { type: undefined };
     applyGroupingRules(event, {
       originalException: requestError({
         url: `/api/v2/receipt/${'c'.repeat(62)}`,
@@ -180,7 +192,7 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
   });
 
   it('drops the query string from the grouping path', () => {
-    const event: ErrorEvent = {};
+    const event: ErrorEvent = { type: undefined };
     applyGroupingRules(event, {
       originalException: requestError({
         url: '/api/v2/status?cb=1755859200',
@@ -198,7 +210,7 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
       { code: 'ECONNABORTED' },
       { name: 'AbortError' },
     ]) {
-      const event: ErrorEvent = {};
+      const event: ErrorEvent = { type: undefined };
       applyGroupingRules(event, {
         originalException: requestError({ url: '/api/v2/status', method: 'get', ...shape }),
       });
@@ -207,7 +219,7 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
   });
 
   it("keys no-response failures as 'network'", () => {
-    const event: ErrorEvent = {};
+    const event: ErrorEvent = { type: undefined };
     applyGroupingRules(event, {
       originalException: requestError({
         url: '/api/v2/status',
@@ -230,7 +242,7 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
       // They share code ECONNABORTED on the wire unless the client asks
       // otherwise (src/api/index.ts sets transitional.clarifyTimeoutError),
       // and only this split lets the noise filter drop one without the other.
-      const event: ErrorEvent = {};
+      const event: ErrorEvent = { type: undefined };
       applyGroupingRules(event, {
         originalException: requestError({ url: '/api/v2/status', method: 'get', ...shape }),
       });
@@ -240,7 +252,7 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
   );
 
   it('falls back to the error class name when there is no status and no known code', () => {
-    const event: ErrorEvent = {};
+    const event: ErrorEvent = { type: undefined };
     applyGroupingRules(event, {
       originalException: requestError({
         url: '/api/v2/status',
@@ -253,7 +265,7 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
   });
 
   it('defaults the method to GET when the config omits it', () => {
-    const event: ErrorEvent = {};
+    const event: ErrorEvent = { type: undefined };
     applyGroupingRules(event, {
       originalException: requestError({ url: '/api/v2/status', status: 404 }),
     });
@@ -265,6 +277,7 @@ describe('applyGroupingRules — API request errors (Rule B)', () => {
 describe('applyGroupingRules — pass-through', () => {
   it('leaves events matching neither rule untouched (default grouping preserved)', () => {
     const event: ErrorEvent = {
+      type: undefined,
       exception: {
         values: [
           { type: 'TypeError', value: "Cannot read properties of undefined (reading 'foo')" },
@@ -278,7 +291,11 @@ describe('applyGroupingRules — pass-through', () => {
   });
 
   it('respects a grouping array already set upstream', () => {
-    const event: ErrorEvent = { message: SCHEMA_MESSAGE, fingerprint: ['custom-upstream-group'] };
+    const event: ErrorEvent = {
+      type: undefined,
+      message: SCHEMA_MESSAGE,
+      fingerprint: ['custom-upstream-group'],
+    };
 
     applyGroupingRules(event);
 
@@ -288,7 +305,7 @@ describe('applyGroupingRules — pass-through', () => {
   it('prefers the schema rule when an event matches both families', () => {
     // A schema failure captured off the back of an API response: the defect
     // is the contract drift, not the transport, so it groups by schema.
-    const event: ErrorEvent = { message: SCHEMA_MESSAGE };
+    const event: ErrorEvent = { type: undefined, message: SCHEMA_MESSAGE };
 
     applyGroupingRules(event, {
       originalException: requestError({ url: '/api/v2/secret/abc', method: 'get', status: 200 }),
@@ -299,7 +316,7 @@ describe('applyGroupingRules — pass-through', () => {
 
   it('ignores hints whose originalException is not request-shaped', () => {
     for (const originalException of [undefined, null, 'a string', new Error('plain')]) {
-      const event: ErrorEvent = {};
+      const event: ErrorEvent = { type: undefined };
       applyGroupingRules(event, { originalException } as EventHint);
       expect(event.fingerprint).toBeUndefined();
     }
@@ -387,7 +404,14 @@ describe('beforeSend integration', () => {
     createDiagnostics({
       host: 'example.com',
       config: {
-        sentry: { dsn: 'https://key@sentry.io/123', environment: 'test', release: '1.0.0' },
+        sentry: {
+          dsn: 'https://key@sentry.io/123',
+          enabled: true,
+          logErrors: true,
+          trackComponents: true,
+          environment: 'test',
+          release: '1.0.0',
+        },
       },
       router: createMockRouter(),
     });
@@ -415,6 +439,7 @@ describe('beforeSend integration', () => {
     // pipeline for an event that IS reported, so it needs an outcome that
     // survives the drop filter.
     const event: ErrorEvent = {
+      type: undefined,
       exception: {
         values: [
           {
@@ -442,7 +467,7 @@ describe('beforeSend integration', () => {
     const handler = getBeforeSend();
 
     const result = handler(
-      { exception: { values: [{ type: 'TypeError', value: 'boom' }] } },
+      { type: undefined, exception: { values: [{ type: 'TypeError', value: 'boom' }] } },
       { originalException: new TypeError('boom') }
     ) as ErrorEvent;
 

--- a/src/tests/plugins/core/globalErrorBoundary.errorHandler.spec.ts
+++ b/src/tests/plugins/core/globalErrorBoundary.errorHandler.spec.ts
@@ -63,7 +63,7 @@ vi.mock('@/services/logging.service', () => ({
 // Import after mocks
 // ---------------------------------------------------------------------------
 import { createErrorBoundary } from '@/plugins/core/globalErrorBoundary';
-import type { App } from 'vue';
+import type { App, ComponentPublicInstance, Plugin } from 'vue';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -79,6 +79,18 @@ function createMockApp(): App {
     mount: vi.fn(),
     unmount: vi.fn(),
   } as unknown as App;
+}
+
+/**
+ * `createErrorBoundary()` is typed to return Vue's `Plugin` union
+ * (`ObjectPlugin | FunctionPlugin`), under which `.install` types as possibly
+ * undefined because the callable `FunctionPlugin` variant makes it optional.
+ * The production implementation always returns an object plugin
+ * (`{ install(app) { ... } }`), so this narrows to the shape it actually
+ * produces instead of asserting `!` at every call site.
+ */
+function installErrorBoundary(plugin: Plugin, app: App): void {
+  (plugin as { install: (app: App) => void }).install(app);
 }
 
 // ---------------------------------------------------------------------------
@@ -113,7 +125,7 @@ describe('createErrorBoundary', () => {
   describe('plugin installation', () => {
     it('installs error handler on app.config', () => {
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       expect(mockApp.config.errorHandler).toBeInstanceOf(Function);
     });
@@ -122,10 +134,14 @@ describe('createErrorBoundary', () => {
   describe('error handler Sentry capture', () => {
     it('calls captureException when diagnostics is enabled', () => {
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       const error = new Error('Test error');
-      const instance = { $options: { name: 'TestComponent' } };
+      // Partial fixture: only $options.name is read (getComponentName), but
+      // the errorHandler's real signature expects a full ComponentPublicInstance.
+      const instance = {
+        $options: { name: 'TestComponent' },
+      } as unknown as ComponentPublicInstance;
 
       mockApp.config.errorHandler?.(error, instance, 'setup function');
 
@@ -137,7 +153,7 @@ describe('createErrorBoundary', () => {
       mockIsDiagnosticsEnabled.mockReturnValue(false);
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       const error = new Error('Test error');
       mockApp.config.errorHandler?.(error, null, 'setup function');
@@ -147,7 +163,7 @@ describe('createErrorBoundary', () => {
 
     it('normalizes non-Error throwables to Error instances', () => {
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.('string error', null, 'setup function');
 
@@ -169,7 +185,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(
         new Error('Request failed with status code 404'),
@@ -189,7 +205,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('boom'), null, 'setup function');
 
@@ -200,9 +216,13 @@ describe('createErrorBoundary', () => {
   describe('context tags', () => {
     it('passes componentName from getComponentName()', () => {
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
-      const instance = { $options: { name: 'SecretForm' } };
+      // Partial fixture: only $options.name is read (getComponentName), but
+      // the errorHandler's real signature expects a full ComponentPublicInstance.
+      const instance = {
+        $options: { name: 'SecretForm' },
+      } as unknown as ComponentPublicInstance;
       mockApp.config.errorHandler?.(new Error('test'), instance, 'mounted hook');
 
       expect(mockCaptureException).toHaveBeenCalledWith(
@@ -215,7 +235,7 @@ describe('createErrorBoundary', () => {
 
     it('passes componentInfo from Vue error info', () => {
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'mounted hook');
 
@@ -235,7 +255,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -255,7 +275,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -275,7 +295,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -295,7 +315,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -311,7 +331,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -331,7 +351,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -347,7 +367,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -367,7 +387,7 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -388,9 +408,13 @@ describe('createErrorBoundary', () => {
       });
 
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
-      const instance = { $options: { name: 'CreateSecret' } };
+      // Partial fixture: only $options.name is read (getComponentName), but
+      // the errorHandler's real signature expects a full ComponentPublicInstance.
+      const instance = {
+        $options: { name: 'CreateSecret' },
+      } as unknown as ComponentPublicInstance;
       mockApp.config.errorHandler?.(new Error('test'), instance, 'render function');
 
       expect(mockCaptureException).toHaveBeenCalledWith(
@@ -417,7 +441,7 @@ describe('createErrorBoundary', () => {
 
     it('does not explicitly pass service tag (scope-level tag from enableDiagnostics)', () => {
       const plugin = createErrorBoundary();
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -439,7 +463,7 @@ describe('createErrorBoundary', () => {
 
       const mockNotify = vi.fn();
       const plugin = createErrorBoundary({ notify: mockNotify });
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 
@@ -456,7 +480,7 @@ describe('createErrorBoundary', () => {
 
       const mockNotify = vi.fn();
       const plugin = createErrorBoundary({ notify: mockNotify });
-      plugin.install(mockApp);
+      installErrorBoundary(plugin, mockApp);
 
       mockApp.config.errorHandler?.(new Error('test'), null, 'setup');
 

--- a/src/tests/router/guards.routes.spec.ts
+++ b/src/tests/router/guards.routes.spec.ts
@@ -2,7 +2,7 @@
 
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
-import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, Mocked, test, vi } from 'vitest';
 import {
   NavigationGuardReturn,
   RouteLocationNormalized,
@@ -681,7 +681,10 @@ describe('Router Guards', () => {
   });
 
   describe('validateAuthentication', () => {
-    let mockValidator: AuthValidator;
+    // Mocked<AuthValidator> (not plain AuthValidator) so checkWindowStatus
+    // keeps its vi.fn() mock methods (e.g. mockResolvedValueOnce) at the type
+    // level, matching what vi.fn() actually returns at runtime.
+    let mockValidator: Mocked<AuthValidator>;
     let protectedRoute: RouteLocationNormalized;
 
     beforeEach(() => {
@@ -690,7 +693,7 @@ describe('Router Guards', () => {
         needsCheck: true,
         isAuthenticated: null,
         checkWindowStatus: vi.fn().mockImplementation(async () => true),
-      } satisfies AuthValidator;
+      } satisfies Mocked<AuthValidator>;
 
       protectedRoute = {
         meta: { requiresAuth: true },

--- a/src/tests/schemas/shapes/custom-domain.compat.spec.ts
+++ b/src/tests/schemas/shapes/custom-domain.compat.spec.ts
@@ -645,7 +645,11 @@ describe.skip('V3 CustomDomain Default Values', () => {
   });
 
   it('applies pending status default when missing', () => {
-    const wire = createV3WireCustomDomain(createCanonicalCustomDomain());
+    // V3WireCustomDomain doesn't declare `status` (it's not part of the
+    // serializer's wire type), so widen locally to destructure it off —
+    // matches the `as Record<string, unknown>` pattern used above for the
+    // same field.
+    const wire = createV3WireCustomDomain(createCanonicalCustomDomain()) as Record<string, unknown>;
     const { status, ...wireWithoutStatus } = wire;
 
     const parsed = v3CustomDomainSchema.parse(wireWithoutStatus);

--- a/src/tests/schemas/shapes/fixtures/receipt.fixtures.ts
+++ b/src/tests/schemas/shapes/fixtures/receipt.fixtures.ts
@@ -68,8 +68,6 @@ export function createCanonicalReceiptBase(
     created: BASE_TIMESTAMP,
     updated: BASE_TIMESTAMP,
     shared: null,
-    received: null,
-    viewed: null,
     previewed: null,
     revealed: null,
     burned: null,
@@ -89,8 +87,6 @@ export function createCanonicalReceiptBase(
 
     // Boolean status flags
     has_passphrase: false,
-    is_viewed: false,
-    is_received: false,
     is_previewed: false,
     is_revealed: false,
     is_burned: false,
@@ -183,9 +179,6 @@ export function createPreviewedReceipt(
     shared: ONE_HOUR_LATER,
     previewed: TWO_HOURS_LATER,
     is_previewed: true,
-    // Legacy fields
-    viewed: TWO_HOURS_LATER,
-    is_viewed: true,
     ...overrides,
   });
 }
@@ -203,11 +196,6 @@ export function createRevealedReceipt(
     revealed: TWO_HOURS_LATER,
     is_previewed: true,
     is_revealed: true,
-    // Legacy fields
-    viewed: TWO_HOURS_LATER,
-    received: TWO_HOURS_LATER,
-    is_viewed: true,
-    is_received: true,
     secret_state: 'revealed' as ReceiptState,
     ...overrides,
   });
@@ -359,7 +347,7 @@ export function compareCanonicalReceiptBase(
     'identifier', 'key', 'shortid', 'state', 'custid', 'owner_id',
     'secret_ttl', 'receipt_ttl', 'lifespan', 'secret_shortid',
     'secret_identifier', 'share_domain', 'has_passphrase',
-    'is_viewed', 'is_received', 'is_previewed', 'is_revealed',
+    'is_previewed', 'is_revealed',
     'is_burned', 'is_destroyed', 'is_expired', 'is_orphaned',
     'memo', 'kind',
   ] as const;
@@ -372,7 +360,7 @@ export function compareCanonicalReceiptBase(
 
   // Date fields (compare as timestamps)
   const dateFields = [
-    'created', 'updated', 'shared', 'received', 'viewed',
+    'created', 'updated', 'shared',
     'previewed', 'revealed', 'burned',
   ] as const;
 

--- a/src/tests/schemas/shapes/helpers/roundtrip.harness.ts
+++ b/src/tests/schemas/shapes/helpers/roundtrip.harness.ts
@@ -30,11 +30,16 @@ export interface RoundTripHarness<TCanonical, TV2Wire, TV3Wire> {
   /** Converts canonical to V3 wire format */
   toV3Wire: (canonical: TCanonical) => TV3Wire;
 
-  /** V2 Zod schema for parsing V2 wire data */
-  v2Schema: z.ZodType<TCanonical, z.ZodTypeDef, TV2Wire>;
+  /**
+   * V2 Zod schema for parsing V2 wire data.
+   *
+   * Zod v4 dropped the middle `Def` type parameter that v3's `ZodType` used —
+   * the generic signature is now `ZodType<Output, Input>`.
+   */
+  v2Schema: z.ZodType<TCanonical, TV2Wire>;
 
   /** V3 Zod schema for parsing V3 wire data */
-  v3Schema: z.ZodType<TCanonical, z.ZodTypeDef, TV3Wire>;
+  v3Schema: z.ZodType<TCanonical, TV3Wire>;
 
   /**
    * Compares two canonical objects for equality.

--- a/src/tests/schemas/shapes/helpers/serializers.ts
+++ b/src/tests/schemas/shapes/helpers/serializers.ts
@@ -27,7 +27,6 @@ import type { receiptBaseSchema, receiptSchema, receiptDetailsSchema } from '@/s
 import type { receiptBaseSchema as v3ReceiptBaseSchema, receiptSchema as v3ReceiptSchema, receiptDetailsSchema as v3ReceiptDetailsSchema, receiptListSchema as v3ReceiptListSchema } from '@/schemas/shapes/v3/receipt';
 import type { secretResponsesSchema, secretSchema, secretDetailsSchema } from '@/schemas/shapes/v2/secret';
 import type { secretBaseSchema as v3SecretBaseSchema, secretSchema as v3SecretSchema, secretDetailsSchema as v3SecretDetailsSchema } from '@/schemas/shapes/v3/secret';
-import type { feedbackSchema, feedbackDetailsSchema } from '@/schemas/shapes/v2/feedback';
 import type { feedbackSchema as v3FeedbackSchema, feedbackDetailsSchema as v3FeedbackDetailsSchema } from '@/schemas/shapes/v3/feedback';
 import type { customerSchema } from '@/schemas/shapes/v2/customer';
 import type { CustomerCanonical } from '@/schemas/contracts';
@@ -43,7 +42,7 @@ export type V2WireReceiptDetails = z.input<typeof receiptDetailsSchema>;
 export type V3WireReceiptBase = z.input<typeof v3ReceiptBaseSchema>;
 export type V3WireReceipt = z.input<typeof v3ReceiptSchema>;
 export type V3WireReceiptDetails = z.input<typeof v3ReceiptDetailsSchema>;
-export type V3WireReceiptList = z.input<typeof v3ReceiptListSchema>;
+export type V3WireReceiptListRecord = z.input<typeof v3ReceiptListSchema>;
 
 // Secret wire format types
 export type V2WireSecretBase = z.input<typeof secretResponsesSchema>;
@@ -55,8 +54,13 @@ export type V3WireSecret = z.input<typeof v3SecretSchema>;
 export type V3WireSecretDetails = z.input<typeof v3SecretDetailsSchema>;
 
 // Feedback wire format types
-export type V2WireFeedback = z.input<typeof feedbackSchema>;
-export type V2WireFeedbackDetails = z.input<typeof feedbackDetailsSchema>;
+//
+// There is no production `@/schemas/shapes/v2/feedback` module — V2 feedback
+// support was removed (see feedback.compat.spec.ts). These types are defined
+// directly to describe the historical V2 wire shape that the serializer
+// functions below still produce, for test coverage of that legacy format.
+export type V2WireFeedback = { msg: string; stamp: string };
+export type V2WireFeedbackDetails = { received?: string };
 
 export type V3WireFeedback = z.input<typeof v3FeedbackSchema>;
 export type V3WireFeedbackDetails = z.input<typeof v3FeedbackDetailsSchema>;
@@ -148,8 +152,12 @@ export function toV2WireReceiptBase(canonical: ReceiptBaseCanonical): V2WireRece
     created: dateToEpochSeconds(canonical.created)!,
     updated: dateToEpochSeconds(canonical.updated)!,
     shared: dateToISOString(canonical.shared),
-    received: dateToISOString(canonical.received),
-    viewed: dateToISOString(canonical.viewed),
+    // Deprecated V2 aliases: the canonical contract dropped 'received'/'viewed'
+    // in favor of 'revealed'/'previewed' (see contracts/receipt.ts state
+    // migration notes), but the V2 wire schema still accepts both old and new
+    // field names for backward compatibility, so mirror the current fields.
+    received: dateToISOString(canonical.revealed),
+    viewed: dateToISOString(canonical.previewed),
     previewed: dateToISOString(canonical.previewed),
     revealed: dateToISOString(canonical.revealed),
     burned: dateToISOString(canonical.burned),
@@ -169,8 +177,10 @@ export function toV2WireReceiptBase(canonical: ReceiptBaseCanonical): V2WireRece
 
     // Boolean status flags: string
     has_passphrase: canonical.has_passphrase,
-    is_viewed: booleanToString(canonical.is_viewed),
-    is_received: booleanToString(canonical.is_received),
+    // Deprecated V2 aliases: mirror the current is_previewed/is_revealed
+    // fields (see the timestamp aliases above).
+    is_viewed: booleanToString(canonical.is_previewed),
+    is_received: booleanToString(canonical.is_revealed),
     is_previewed: canonical.is_previewed !== undefined ? booleanToString(canonical.is_previewed) : undefined,
     is_revealed: canonical.is_revealed !== undefined ? booleanToString(canonical.is_revealed) : undefined,
     is_burned: booleanToString(canonical.is_burned),
@@ -214,7 +224,7 @@ export function toV2WireReceiptDetails(canonical: ReceiptDetailsCanonical): V2Wi
     no_cache: booleanToString(canonical.no_cache),
     // secret_realttl is NOT transformed in V2 schema — keeps native number
     secret_realttl: canonical.secret_realttl,
-    view_count: canonical.view_count !== null ? numberToString(canonical.view_count) : null,
+    view_count: canonical.view_count == null ? canonical.view_count : numberToString(canonical.view_count),
     has_passphrase: canonical.has_passphrase !== null ? booleanToString(canonical.has_passphrase) : null,
     can_decrypt: canonical.can_decrypt !== null ? booleanToString(canonical.can_decrypt) : null,
     secret_value: canonical.secret_value,
@@ -256,11 +266,11 @@ export function toV3WireReceiptBase(canonical: ReceiptBaseCanonical): V3WireRece
     owner_id: canonical.owner_id,
 
     // Timestamps: ALL are numbers
+    // Note: no 'received'/'viewed' aliases here — V3 is the clean API and
+    // drops the deprecated field names entirely (see shapes/v3/receipt.ts).
     created: dateToEpochSeconds(canonical.created)!,
     updated: dateToEpochSeconds(canonical.updated)!,
     shared: dateToEpochSeconds(canonical.shared),
-    received: dateToEpochSeconds(canonical.received),
-    viewed: dateToEpochSeconds(canonical.viewed),
     previewed: dateToEpochSeconds(canonical.previewed),
     revealed: dateToEpochSeconds(canonical.revealed),
     burned: dateToEpochSeconds(canonical.burned),
@@ -279,9 +289,9 @@ export function toV3WireReceiptBase(canonical: ReceiptBaseCanonical): V3WireRece
     share_domain: canonical.share_domain,
 
     // Boolean status flags: native booleans
+    // Note: no 'is_viewed'/'is_received' aliases — V3 drops the deprecated
+    // field names entirely (see shapes/v3/receipt.ts).
     has_passphrase: canonical.has_passphrase,
-    is_viewed: canonical.is_viewed,
-    is_received: canonical.is_received,
     is_previewed: canonical.is_previewed,
     is_revealed: canonical.is_revealed,
     is_burned: canonical.is_burned,
@@ -685,12 +695,11 @@ import type { OrganizationCanonical } from '@/schemas/contracts';
  *   - nullable strings: null preserved
  */
 export type V2WireOrganization = {
-  identifier: string;
   objid: string;
   extid: string;
   display_name: string;
   description: string | null;
-  owner_id: string;
+  owner_id?: string | null;
   contact_email: string | null;
   is_default: string;
   planid: string;
@@ -707,12 +716,11 @@ export type V2WireOrganization = {
  *   - nullable strings: null preserved
  */
 export type V3WireOrganization = {
-  identifier: string;
   objid: string;
   extid: string;
   display_name: string;
   description: string | null;
-  owner_id: string;
+  owner_id?: string | null;
   contact_email: string | null;
   is_default: boolean;
   planid: string;
@@ -735,7 +743,6 @@ export function toV2WireOrganization(
   canonical: OrganizationCanonical
 ): V2WireOrganization {
   return {
-    identifier: canonical.identifier,
     objid: canonical.objid,
     extid: canonical.extid,
     display_name: canonical.display_name,
@@ -749,9 +756,11 @@ export function toV2WireOrganization(
     // Plan
     planid: canonical.planid,
 
-    // Timestamps: strings (Unix epoch seconds as string)
-    created: numberToString(dateToEpochSeconds(canonical.created)!),
-    updated: numberToString(dateToEpochSeconds(canonical.updated)!),
+    // Timestamps: strings. Unlike receipts/secrets/customers, the
+    // organization CONTRACT already stores Unix epoch seconds as a plain
+    // number (see contracts/organization.ts) — no Date round-trip needed.
+    created: numberToString(canonical.created),
+    updated: numberToString(canonical.updated),
   };
 }
 
@@ -770,7 +779,6 @@ export function toV3WireOrganization(
   canonical: OrganizationCanonical
 ): V3WireOrganization {
   return {
-    identifier: canonical.identifier,
     objid: canonical.objid,
     extid: canonical.extid,
     display_name: canonical.display_name,
@@ -784,9 +792,11 @@ export function toV3WireOrganization(
     // Plan
     planid: canonical.planid,
 
-    // Timestamps: numbers
-    created: dateToEpochSeconds(canonical.created)!,
-    updated: dateToEpochSeconds(canonical.updated)!,
+    // Timestamps: numbers. The organization CONTRACT already stores Unix
+    // epoch seconds as a plain number (see contracts/organization.ts) —
+    // no Date round-trip needed, unlike receipts/secrets/customers.
+    created: canonical.created,
+    updated: canonical.updated,
   };
 }
 
@@ -941,7 +951,9 @@ export type V2WireVHost = {
   is_resolving?: string;
   status_message?: string;
   created_at?: string;
-  last_monitored_unix?: string;
+  // V2 schema uses fromNumber.secondsToDate for this one field — number,
+  // not string, despite the rest of V2 VHost being string-encoded.
+  last_monitored_unix?: number;
   ssl_active_from?: string | null;
   ssl_active_until?: string | null;
 };

--- a/src/tests/schemas/shapes/receipt.compat.spec.ts
+++ b/src/tests/schemas/shapes/receipt.compat.spec.ts
@@ -58,8 +58,6 @@ describe('V2 Wire → V3 Schema (Forward Compatibility)', () => {
       // Even when nullable timestamps are null, V2 still sends booleans/numbers as strings
       const canonical = createCanonicalReceiptBase({
         shared: null,
-        received: null,
-        viewed: null,
         previewed: null,
         revealed: null,
         burned: null,
@@ -91,12 +89,13 @@ describe('V2 Wire → V3 Schema (Forward Compatibility)', () => {
 
     it('FAILS: V3 boolean fields reject V2 string booleans', () => {
       const canonical = createCanonicalReceiptBase({
-        is_viewed: true,
+        is_previewed: true,
         is_burned: true,
       });
       const v2Wire = createV2WireReceiptBase(canonical);
 
-      // V2 sends booleans as strings ("true"/"false")
+      // V2 sends booleans as strings ("true"/"false"), including the
+      // deprecated is_viewed alias mirrored from is_previewed.
       expect(typeof v2Wire.is_viewed).toBe('string');
       expect(typeof v2Wire.is_burned).toBe('string');
 
@@ -106,7 +105,7 @@ describe('V2 Wire → V3 Schema (Forward Compatibility)', () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         const boolError = result.error.issues.find(
-          (i) => i.path.includes('is_viewed') || i.path.includes('is_burned')
+          (i) => i.path.includes('is_previewed') || i.path.includes('is_burned')
         );
         expect(boolError).toBeDefined();
       }
@@ -176,12 +175,13 @@ describe('V3 Wire → V2 Schema (Backward Compatibility)', () => {
     it('SUCCEEDS: V2 transforms.fromString.boolean handles native booleans', () => {
       // V2's parseBoolean function handles both strings AND booleans
       const canonical = createCanonicalReceiptBase({
-        is_viewed: true,
+        is_previewed: true,
         is_burned: false,
       });
       const v3Wire = createV3WireReceiptBase(canonical);
 
-      expect(typeof v3Wire.is_viewed).toBe('boolean');
+      // V3 drops the deprecated is_viewed alias entirely — only is_previewed exists.
+      expect(typeof v3Wire.is_previewed).toBe('boolean');
       expect(typeof v3Wire.is_burned).toBe('boolean');
 
       const result = v2ReceiptBaseSchema.safeParse(v3Wire);
@@ -267,7 +267,7 @@ describe('Edge Case Compatibility', () => {
     it('V2 and V3 both handle null timestamps identically', () => {
       const canonical = createCanonicalReceiptBase({
         shared: null,
-        received: null,
+        revealed: null,
       });
 
       const v2Wire = createV2WireReceiptBase(canonical);
@@ -287,8 +287,11 @@ describe('Edge Case Compatibility', () => {
       const v2Wire = createV2WireReceiptBase(canonical);
       const v3Wire = createV3WireReceiptBase(canonical);
 
+      // V3 drops custid from the wire entirely (2026-07-29 API audit, item 5;
+      // see shapes/v3/receipt.ts v3DroppedFields) — only V2 still carries it.
       expect(v2Wire.custid).toBeUndefined();
-      expect(v3Wire.custid).toBeUndefined();
+      expect(v2Wire.memo).toBeUndefined();
+      expect(v3Wire.memo).toBeUndefined();
     });
   });
 

--- a/src/tests/schemas/shapes/receipt.roundtrip.spec.ts
+++ b/src/tests/schemas/shapes/receipt.roundtrip.spec.ts
@@ -51,9 +51,18 @@ import type { ReceiptState } from '@/schemas/shapes/v2/receipt';
 /**
  * Asserts that two dates are equal by timestamp.
  */
-function expectDatesEqual(actual: Date | null, expected: Date | null, fieldName: string) {
-  if (expected === null) {
-    expect(actual, `${fieldName} should be null`).toBeNull();
+function expectDatesEqual(
+  actual: Date | null | undefined,
+  expected: Date | null | undefined,
+  fieldName: string
+) {
+  if (expected == null) {
+    // V2's deprecated timestamp aliases (received/viewed/shared, etc.) are
+    // declared with `.optional()` on top of the nullable transform, so the
+    // parsed type is `Date | null | undefined` even though every fixture in
+    // this file always sends an explicit `null` on the wire — undefined is
+    // never actually produced at runtime, just permitted by the type.
+    expect(actual == null, `${fieldName} should be null/undefined, got ${actual}`).toBe(true);
   } else {
     expect(actual, `${fieldName} should be a Date`).toBeInstanceOf(Date);
     expect(actual!.getTime(), `${fieldName} timestamp mismatch`).toBe(expected.getTime());
@@ -95,9 +104,10 @@ describe('V2 Receipt Round-Trip', () => {
       expectDatesEqual(parsed.updated, canonical.updated, 'updated');
       expectDatesEqual(parsed.shared, canonical.shared, 'shared');
 
-      // Booleans
-      expect(parsed.is_viewed).toBe(canonical.is_viewed);
-      expect(parsed.is_received).toBe(canonical.is_received);
+      // Booleans (parsed.is_viewed/is_received are V2's deprecated aliases,
+      // mirrored from the canonical is_previewed/is_revealed fields)
+      expect(parsed.is_viewed).toBe(canonical.is_previewed);
+      expect(parsed.is_received).toBe(canonical.is_revealed);
       expect(parsed.is_burned).toBe(canonical.is_burned);
 
       // Numbers
@@ -121,7 +131,7 @@ describe('V2 Receipt Round-Trip', () => {
     it('preserves null timestamps', () => {
       const canonical = createCanonicalReceiptBase({
         shared: null,
-        received: null,
+        revealed: null,
         burned: null,
       });
       const wire = createV2WireReceiptBase(canonical);
@@ -134,7 +144,7 @@ describe('V2 Receipt Round-Trip', () => {
 
     it('preserves boolean false values', () => {
       const canonical = createCanonicalReceiptBase({
-        is_viewed: false,
+        is_previewed: false,
         is_burned: false,
         is_expired: false,
       });
@@ -148,7 +158,7 @@ describe('V2 Receipt Round-Trip', () => {
 
     it('preserves boolean true values', () => {
       const canonical = createCanonicalReceiptBase({
-        is_viewed: true,
+        is_previewed: true,
         is_burned: true,
         is_expired: true,
       });
@@ -376,7 +386,7 @@ describe('Deprecated Field Aliasing', () => {
 
       // Both should be set to the same value for backward compatibility
       expectDatesEqual(parsed.revealed, canonical.revealed, 'revealed');
-      expectDatesEqual(parsed.received, canonical.received, 'received');
+      expectDatesEqual(parsed.received, canonical.revealed, 'received');
       // They should be equal timestamps
       expect(parsed.revealed?.getTime()).toBe(parsed.received?.getTime());
     });
@@ -388,7 +398,7 @@ describe('Deprecated Field Aliasing', () => {
 
       // Both should be set to the same value for backward compatibility
       expectDatesEqual(parsed.previewed, canonical.previewed, 'previewed');
-      expectDatesEqual(parsed.viewed, canonical.viewed, 'viewed');
+      expectDatesEqual(parsed.viewed, canonical.previewed, 'viewed');
       // They should be equal timestamps
       expect(parsed.previewed?.getTime()).toBe(parsed.viewed?.getTime());
     });
@@ -445,11 +455,13 @@ describe('Deprecated Field Aliasing', () => {
       ['is_revealed', 'is_received', false],
       ['is_previewed', 'is_viewed', true],
       ['is_previewed', 'is_viewed', false],
-    ])('%s and %s should both be %s', (newField, oldField, value) => {
-      const overrides =
-        newField === 'is_revealed'
-          ? { is_revealed: value, is_received: value }
-          : { is_previewed: value, is_viewed: value };
+    ] as const)('%s and %s should both be %s', (newField, oldField, value) => {
+      // Only the canonical field is settable — is_received/is_viewed are V2
+      // wire-only aliases mirrored from is_revealed/is_previewed, not real
+      // ReceiptCanonical properties (see contracts/receipt.ts).
+      const overrides = newField === 'is_revealed'
+        ? { is_revealed: value }
+        : { is_previewed: value };
       const canonical = createCanonicalReceipt(overrides);
       const wire = createV2WireReceipt(canonical);
       const parsed = receiptSchema.parse(wire);
@@ -822,8 +834,11 @@ describe('Edge Cases', () => {
       const wire = createV3WireReceiptBase(canonical);
       const parsed = v3ReceiptBaseSchema.parse(wire);
 
-      // These should remain undefined/absent
-      expect(parsed.custid).toBeUndefined();
+      // custid is dropped from the V3 schema entirely (2026-07-29 API audit,
+      // item 5) rather than merely optional, so it's absent from the parsed
+      // object altogether — not just undefined. owner_id is the canonical
+      // creator identifier and remains a genuinely optional field.
+      expect('custid' in parsed).toBe(false);
       expect(parsed.owner_id).toBeUndefined();
     });
 

--- a/src/tests/services/billing.service.currency-migration.spec.ts
+++ b/src/tests/services/billing.service.currency-migration.spec.ts
@@ -53,18 +53,22 @@ describe('Currency migration service methods', () => {
       );
       expect(result.success).toBe(true);
       expect(result.migration.mode).toBe('graceful');
+      if (result.migration.mode !== 'graceful') throw new Error('expected graceful mode');
       expect(result.migration.cancel_at).toBe(1704067200);
     });
 
     it('calls correct endpoint with immediate mode', async () => {
+      // Live shape (currency_migration_service.rb): checkout_url/refund_* —
+      // see the migrateCurrency() comment in billing.service.ts.
       const mockResponse = {
         data: {
           success: true,
           migration: {
             mode: 'immediate',
-            checkout_session_url: 'https://checkout.stripe.com/c/pay/cs_test_123',
-            prorated_credit_amount: 1500,
-            prorated_credit_formatted: 'EUR 15.00',
+            checkout_url: 'https://checkout.stripe.com/c/pay/cs_test_123',
+            refund_amount: 1500,
+            refund_formatted: 'EUR 15.00',
+            refund_failed: false,
           },
         },
       };
@@ -81,7 +85,8 @@ describe('Currency migration service methods', () => {
       );
       expect(result.success).toBe(true);
       expect(result.migration.mode).toBe('immediate');
-      expect(result.migration.checkout_session_url).toContain('stripe.com');
+      if (result.migration.mode !== 'immediate') throw new Error('expected immediate mode');
+      expect(result.migration.checkout_url).toContain('stripe.com');
     });
 
     it('propagates API errors', async () => {
@@ -135,19 +140,34 @@ describe('Currency migration service methods', () => {
     it('extracts conflict details from 409 response', () => {
       // Build an error-like object matching what axios produces at runtime.
       // The extractCurrencyConflict function checks 'response' in error,
-      // then data.code === 'currency_conflict'.
+      // then data.code === 'currency_conflict'. Shape verified against the
+      // live billing controller (checkout 409 branch): { error, code,
+      // details: { existing_currency, requested_currency, current_plan,
+      // requested_plan, warnings } } — not a flat payload.
       const conflictData = {
+        error: true,
         code: 'currency_conflict',
-        error: 'currency_conflict',
         message: 'A currency change is required.',
-        current_currency: 'eur',
-        requested_currency: 'cad',
-        current_plan_name: 'Identity Plus',
-        current_period_end: 1704067200,
-        new_plan_name: 'Team Plus',
-        new_plan_amount: 9900,
-        new_plan_interval: 'month',
-        new_price_id: 'price_cad_456',
+        details: {
+          existing_currency: 'eur',
+          requested_currency: 'cad',
+          current_plan: {
+            name: 'Identity Plus',
+            price_formatted: '€9.00',
+            current_period_end: 1704067200,
+          },
+          requested_plan: {
+            name: 'Team Plus',
+            price_formatted: 'CA$99.00',
+            price_id: 'price_cad_456',
+          },
+          warnings: {
+            has_credit_balance: false,
+            credit_balance_amount: 0,
+            has_pending_invoice_items: false,
+            has_incompatible_coupons: false,
+          },
+        },
       };
 
       // Simulate axios-shaped error with response property
@@ -161,9 +181,9 @@ describe('Currency migration service methods', () => {
       const result = extractCurrencyConflict(error);
 
       expect(result).not.toBeNull();
-      expect(result?.current_currency).toBe('eur');
-      expect(result?.requested_currency).toBe('cad');
-      expect(result?.new_price_id).toBe('price_cad_456');
+      expect(result?.details.existing_currency).toBe('eur');
+      expect(result?.details.requested_currency).toBe('cad');
+      expect(result?.details.requested_plan?.price_id).toBe('price_cad_456');
     });
 
     it('returns null for non-409 errors', () => {

--- a/src/tests/services/diagnostics.service.spec.ts
+++ b/src/tests/services/diagnostics.service.spec.ts
@@ -15,27 +15,40 @@
  *   pnpm test src/tests/services/diagnostics.service.spec.ts
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mock Scope class that tracks method calls and supports clone()
 // ---------------------------------------------------------------------------
-function createMockScope() {
-  const scope: Record<string, ReturnType<typeof vi.fn>> & {
-    _extras: Record<string, unknown>;
-    _tags: Record<string, string>;
-  } = {
+// An explicit interface (rather than `Record<string, ReturnType<typeof
+// vi.fn>> & {...}`) is required here: that index-signature form made every
+// method's Mock<T> generic parameter widen to `Mock<Procedure | Constructable>`,
+// which the concrete `this: typeof scope`-typed mock implementations below are
+// not assignable to (TS2322). Naming the shape up front avoids the self-
+// referential inference that produced the mismatch.
+interface MockScope {
+  _extras: Record<string, unknown>;
+  _tags: Record<string, string>;
+  setExtras: Mock<(extras: Record<string, unknown>) => MockScope>;
+  setTag: Mock<(key: string, value: string) => MockScope>;
+  clone: Mock<() => MockScope>;
+  captureException: Mock<(...args: unknown[]) => unknown>;
+  captureMessage: Mock<(...args: unknown[]) => unknown>;
+}
+
+function createMockScope(): MockScope {
+  const scope: MockScope = {
     _extras: {},
     _tags: {},
-    setExtras: vi.fn(function (this: typeof scope, extras: Record<string, unknown>) {
+    setExtras: vi.fn(function (this: MockScope, extras: Record<string, unknown>) {
       Object.assign(this._extras, extras);
       return this;
     }),
-    setTag: vi.fn(function (this: typeof scope, key: string, value: string) {
+    setTag: vi.fn(function (this: MockScope, key: string, value: string) {
       this._tags[key] = value;
       return this;
     }),
-    clone: vi.fn(function (this: typeof scope) {
+    clone: vi.fn(function (this: MockScope) {
       const cloned = createMockScope();
       // Simulate copying existing extras and tags from the base scope
       cloned._extras = { ...this._extras };

--- a/src/tests/services/sso.service.org-level.deprecated.spec.ts
+++ b/src/tests/services/sso.service.org-level.deprecated.spec.ts
@@ -34,6 +34,43 @@ vi.mock('@/api', () => ({
 // Import after mocking
 import { SsoService } from '@/services/sso.service';
 
+/**
+ * The org-level methods this file exercises (getConfig/putConfig/patchConfig/
+ * saveConfig/deleteConfig/testConnection) were removed from SsoService in
+ * #2786 — the real service now exposes only the *ForDomain methods (see
+ * sso.service.ts). This whole suite is `describe.skip`-ped and kept solely as
+ * a historical reference of the old contract (no test here ever executes), so
+ * this cast — not a production change — exists only to let the reference file
+ * still type-check against the CURRENT SsoService shape.
+ */
+interface DeprecatedOrgLevelSsoService {
+  getConfig(orgExtId: string): Promise<Record<string, unknown>>;
+  putConfig(
+    orgExtId: string,
+    payload: Record<string, unknown>
+  ): Promise<Record<string, unknown>>;
+  patchConfig(
+    orgExtId: string,
+    payload: Record<string, unknown>
+  ): Promise<Record<string, unknown>>;
+  saveConfig(
+    orgExtId: string,
+    payload: Record<string, unknown>
+  ): Promise<Record<string, unknown>>;
+  deleteConfig(orgExtId: string): Promise<Record<string, unknown>>;
+  testConnection(
+    orgExtId: string,
+    payload: Record<string, unknown>
+  ): Promise<{
+    success: boolean;
+    provider_type: string;
+    message?: string;
+    details: Record<string, unknown>;
+  }>;
+}
+
+const DeprecatedSsoService = SsoService as unknown as DeprecatedOrgLevelSsoService;
+
 describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,7 +96,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       };
       mockGet.mockResolvedValueOnce(mockResponse);
 
-      const result = await SsoService.getConfig('org_abc123');
+      const result = await DeprecatedSsoService.getConfig('org_abc123');
 
       expect(mockGet).toHaveBeenCalledWith('/api/organizations/org_abc123/sso');
       expect(result).toEqual(mockResponse.data);
@@ -72,7 +109,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       };
       mockGet.mockRejectedValueOnce(axiosError);
 
-      const result = await SsoService.getConfig('org_no_sso');
+      const result = await DeprecatedSsoService.getConfig('org_no_sso');
 
       expect(mockGet).toHaveBeenCalledWith('/api/organizations/org_no_sso/sso');
       expect(result).toEqual({ record: null });
@@ -86,14 +123,14 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       };
       mockGet.mockRejectedValueOnce(axiosError);
 
-      await expect(SsoService.getConfig('org_error')).rejects.toEqual(axiosError);
+      await expect(DeprecatedSsoService.getConfig('org_error')).rejects.toEqual(axiosError);
     });
 
     it('propagates network errors without response', async () => {
       const networkError = new Error('Network Error');
       mockGet.mockRejectedValueOnce(networkError);
 
-      await expect(SsoService.getConfig('org_network_error')).rejects.toThrow('Network Error');
+      await expect(DeprecatedSsoService.getConfig('org_network_error')).rejects.toThrow('Network Error');
     });
   });
 
@@ -120,7 +157,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
         tenant_id: 'tenant-123',
       };
 
-      const result = await SsoService.putConfig('org_abc', payload);
+      const result = await DeprecatedSsoService.putConfig('org_abc', payload);
 
       expect(mockPut).toHaveBeenCalledWith('/api/organizations/org_abc/sso', payload);
       expect(result).toEqual(mockResponse.data);
@@ -130,7 +167,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       const mockResponse = { data: { record: { id: 'sso_123' } } };
       mockPut.mockResolvedValueOnce(mockResponse);
 
-      await SsoService.putConfig('org_test', {
+      await DeprecatedSsoService.putConfig('org_test', {
         provider_type: 'entra_id' as const,
         client_id: 'entra-client',
         client_secret: 'entra-secret',
@@ -162,7 +199,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
         display_name: 'Updated Name',
       };
 
-      const result = await SsoService.patchConfig('org_abc', payload);
+      const result = await DeprecatedSsoService.patchConfig('org_abc', payload);
 
       expect(mockPatch).toHaveBeenCalledWith('/api/organizations/org_abc/sso', payload);
       expect(result).toEqual(mockResponse.data);
@@ -172,7 +209,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       const mockResponse = { data: { record: { id: 'sso_123' } } };
       mockPatch.mockResolvedValueOnce(mockResponse);
 
-      await SsoService.patchConfig('org_test', {
+      await DeprecatedSsoService.patchConfig('org_test', {
         enabled: false,
       });
 
@@ -191,7 +228,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
         // No client_secret - preserves existing
       };
 
-      await SsoService.patchConfig('org_abc', payload);
+      await DeprecatedSsoService.patchConfig('org_abc', payload);
 
       expect(mockPatch).toHaveBeenCalledWith('/api/organizations/org_abc/sso', payload);
     });
@@ -210,7 +247,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
         tenant_id: 'tenant-123',
       };
 
-      await SsoService.saveConfig('org_abc', payload);
+      await DeprecatedSsoService.saveConfig('org_abc', payload);
 
       expect(mockPut).toHaveBeenCalledWith('/api/organizations/org_abc/sso', payload);
       expect(mockPatch).not.toHaveBeenCalled();
@@ -228,7 +265,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
         // No client_secret
       };
 
-      await SsoService.saveConfig('org_abc', payload);
+      await DeprecatedSsoService.saveConfig('org_abc', payload);
 
       expect(mockPatch).toHaveBeenCalledWith('/api/organizations/org_abc/sso', payload);
       expect(mockPut).not.toHaveBeenCalled();
@@ -246,7 +283,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
         tenant_id: 'tenant-123',
       };
 
-      await SsoService.saveConfig('org_abc', payload);
+      await DeprecatedSsoService.saveConfig('org_abc', payload);
 
       expect(mockPatch).toHaveBeenCalledWith('/api/organizations/org_abc/sso', payload);
       expect(mockPut).not.toHaveBeenCalled();
@@ -258,7 +295,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       mockPut.mockResolvedValueOnce(putResponse);
       mockPatch.mockResolvedValueOnce(patchResponse);
 
-      const putResult = await SsoService.saveConfig('org_1', {
+      const putResult = await DeprecatedSsoService.saveConfig('org_1', {
         provider_type: 'entra_id' as const,
         client_id: 'id',
         client_secret: 'secret',
@@ -266,7 +303,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
         tenant_id: 'tenant-123',
       });
 
-      const patchResult = await SsoService.saveConfig('org_2', {
+      const patchResult = await DeprecatedSsoService.saveConfig('org_2', {
         display_name: 'Updated',
       });
 
@@ -285,7 +322,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       };
       mockDelete.mockResolvedValueOnce(mockResponse);
 
-      const result = await SsoService.deleteConfig('org_abc');
+      const result = await DeprecatedSsoService.deleteConfig('org_abc');
 
       expect(mockDelete).toHaveBeenCalledWith('/api/organizations/org_abc/sso');
       expect(result).toEqual(mockResponse.data);
@@ -294,7 +331,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
     it('propagates API errors', async () => {
       mockDelete.mockRejectedValueOnce(new Error('Not found'));
 
-      await expect(SsoService.deleteConfig('org_no_sso')).rejects.toThrow('Not found');
+      await expect(DeprecatedSsoService.deleteConfig('org_no_sso')).rejects.toThrow('Not found');
     });
   });
 
@@ -321,7 +358,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
         tenant_id: 'test-tenant-id',
       };
 
-      const result = await SsoService.testConnection('org_abc', payload);
+      const result = await DeprecatedSsoService.testConnection('org_abc', payload);
 
       expect(mockPost).toHaveBeenCalledWith('/api/organizations/org_abc/sso/test', payload);
       expect(result).toEqual(mockResponse.data);
@@ -343,7 +380,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       };
       mockPost.mockResolvedValueOnce(mockResponse);
 
-      const result = await SsoService.testConnection('org_abc', {
+      const result = await DeprecatedSsoService.testConnection('org_abc', {
         provider_type: 'entra_id' as const,
         client_id: 'test-client',
         tenant_id: 'invalid-tenant',
@@ -371,7 +408,7 @@ describe.skip('SsoService (DEPRECATED: org-level API removed in #2786)', () => {
       };
       mockPost.mockResolvedValueOnce(mockResponse);
 
-      const result = await SsoService.testConnection('org_abc', {
+      const result = await DeprecatedSsoService.testConnection('org_abc', {
         provider_type: 'oidc' as const,
         client_id: 'oidc-client-id',
         issuer: 'https://idp.example.com',

--- a/src/tests/setup-env.ts
+++ b/src/tests/setup-env.ts
@@ -18,13 +18,27 @@ if (typeof process !== 'undefined') {
   });
 }
 
-(window as BootstrapPayload).__BOOTSTRAP_ME__ = {
+// `window.__BOOTSTRAP_ME__` is declared as `BootstrapPayload | undefined` in
+// src/types/declarations/global.d.ts, so no cast is needed to reach the
+// property itself. The value below only seeds the handful of fields tests
+// actually rely on (locale/auth state), not a full BootstrapPayload, so it
+// is asserted through `Pick<...>` first: that keeps every field name/type
+// checked against the real contract, and only the final widening to the
+// (necessarily fuller) BootstrapPayload type is an assertion.
+type MinimalBootstrap = Pick<
+  BootstrapPayload,
+  'supported_locales' | 'fallback_locale' | 'default_locale' | 'locale' | 'authenticated'
+>;
+
+const bootstrapMock: MinimalBootstrap = {
   supported_locales: ['en', 'fr_CA', 'de_AT'],
   fallback_locale: 'en',
   default_locale: 'en',
   locale: 'en',
   authenticated: false,
 };
+
+window.__BOOTSTRAP_ME__ = bootstrapMock as BootstrapPayload;
 
 // Mock __SENTRY_RELEASE__ global that Vite defines at build time
 // This value is replaced by the actual git commit hash during production builds

--- a/src/tests/shared/components/forms/FeedbackModalForm.spec.ts
+++ b/src/tests/shared/components/forms/FeedbackModalForm.spec.ts
@@ -31,11 +31,24 @@ vi.mock('@vueuse/core', () => ({
 
 const i18n = createTestI18n();
 
+// Minimal customer shape the component actually reads (cust?.objid, cust?.email)
+// via storeToRefs(bootstrapStore). Deliberately looser than the production
+// CustomerCanonical contract (@/schemas/contracts/customer) so the "Edge Cases"
+// fixtures below (e.g. objid present but email null) can be expressed without
+// widening the real cust contract to permit a nullable email.
+type TestCustomer = {
+  objid: string | null;
+  extid: string | null;
+  email: string | null;
+  role: string;
+  verified: boolean;
+};
+
 describe('FeedbackModalForm', () => {
   let wrapper: VueWrapper;
 
   // Authenticated customer with objid present
-  const authenticatedCustomer = {
+  const authenticatedCustomer: TestCustomer = {
     objid: 'cust_obj_123',
     extid: 'cust_ext_123',
     email: 'test@example.com',
@@ -44,7 +57,7 @@ describe('FeedbackModalForm', () => {
   };
 
   // Edge case: object with null fields (defensive test, backend now sends null)
-  const anonymousCustomer = {
+  const anonymousCustomer: TestCustomer = {
     objid: null,
     extid: null,
     email: null,
@@ -64,7 +77,7 @@ describe('FeedbackModalForm', () => {
 
   const mountComponent = (
     storeState: {
-      cust?: typeof authenticatedCustomer | typeof anonymousCustomer | null;
+      cust?: TestCustomer | null;
     } = {}
   ) => {
     const pinia = createTestingPinia({

--- a/src/tests/shared/components/navigation/UserMenu.spec.ts
+++ b/src/tests/shared/components/navigation/UserMenu.spec.ts
@@ -2,6 +2,7 @@
 
 import UserMenu from '@/shared/components/navigation/UserMenu.vue';
 import { createTestingPinia } from '@pinia/testing';
+import { mockCustomer } from '@tests/fixtures/bootstrap.fixture';
 import { createTestI18n } from '@tests/setup';
 import { mount, VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -166,13 +167,6 @@ const i18n = createTestI18n();
 
 describe('UserMenu', () => {
   let wrapper: VueWrapper;
-
-  const mockCustomer = {
-    custid: '123',
-    email: 'test@example.com',
-    extid: 'ext_123',
-    objid: 'obj_123',
-  };
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/tests/shared/layouts/BaseLayout.spec.ts
+++ b/src/tests/shared/layouts/BaseLayout.spec.ts
@@ -46,8 +46,6 @@ const i18n = createTestI18n();
  * - Provides named slots for header, main, footer, and status areas
  */
 describe('BaseLayout', () => {
-  let wrapper: VueWrapper;
-
   // BaseLayout component stub representing the expected interface
   const BaseLayoutStub = defineComponent({
     name: 'BaseLayout',
@@ -118,6 +116,10 @@ describe('BaseLayout', () => {
         ]);
     },
   });
+
+  // Typed against the stub's own instance (not the bare default VueWrapper,
+  // whose $props resolves to {}) so wrapper.vm.$props.<prop> below type-checks.
+  let wrapper: VueWrapper<InstanceType<typeof BaseLayoutStub>>;
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/tests/stores/authStore.logoutMinimal.spec.ts
+++ b/src/tests/stores/authStore.logoutMinimal.spec.ts
@@ -109,11 +109,11 @@ describe('authStore.logoutMinimal', () => {
   });
 
   it('does NOT reset bootstrapStore reactive state (domain_branding preserved)', async () => {
-    expect(bootstrapStore.domain_branding.primary_color).toBe('#ff6600');
+    expect(bootstrapStore.domain_branding?.primary_color).toBe('#ff6600');
 
     await store.logoutMinimal();
 
-    expect(bootstrapStore.domain_branding.primary_color).toBe('#ff6600');
+    expect(bootstrapStore.domain_branding?.primary_color).toBe('#ff6600');
   });
 
   it('does NOT reset bootstrapStore reactive state (display_domain preserved)', async () => {

--- a/src/tests/stores/authStore.spec.ts
+++ b/src/tests/stores/authStore.spec.ts
@@ -21,8 +21,9 @@ vi.mock('@/services/diagnostics.service', async (importOriginal) => ({
 
 // Create a mock Customer object that matches the actual Customer type
 const mockCustomer: Customer = {
-  identifier: 'cust-1',
-  custid: '1',
+  objid: 'cust-1',
+  extid: 'cust-ext-1',
+  email: 'john@example.com',
   role: 'customer',
   verified: true,
   secrets_burned: 0,
@@ -35,9 +36,7 @@ const mockCustomer: Customer = {
   secrets_created: 0,
   active: true,
   locale: 'en-US',
-  stripe_checkout_email: 'john@example.com',
-  stripe_subscription_id: 'sub_123456',
-  stripe_customer_id: 'cus_123456',
+  notify_on_reveal: false,
 };
 
 describe('authStore', () => {
@@ -413,7 +412,9 @@ describe('authStore', () => {
 
     it('does not sync store authenticated to window state', () => {
       expect(store.isAuthenticated).toBe(true);
-      expect(window.authenticated).toBeUndefined();
+      // `authenticated` is deliberately NOT part of the Window interface — this
+      // asserts the legacy global-sync anti-pattern hasn't crept back in.
+      expect((window as unknown as Record<string, unknown>).authenticated).toBeUndefined();
     });
 
     it('initializes correctly from window state', () => {
@@ -550,24 +551,33 @@ describe('authStore', () => {
       vi.useRealTimers();
     });
 
-    it('applies jitter within configured bounds', () => {
-      vi.useFakeTimers();
+    it('applies jitter within configured bounds', async () => {
       store.$patch({ isAuthenticated: true });
 
       const samples = 100;
       const delays: number[] = [];
 
-      // Spy on setTimeout to capture the actual delays
-      const setTimeoutSpy = vi.spyOn(vi, 'setSystemTime');
+      // Capture each scheduled delay by wrapping the global setTimeout by
+      // hand rather than vi.spyOn(globalThis, 'setTimeout'): in this
+      // environment vi.spyOn's restore does not fully undo the wrap, leaving
+      // globalThis.setTimeout broken for every later test in the file (they
+      // then hang on setupTestPinia's own use of it). A plain save/restore of
+      // the reference sidesteps that. Real timers throughout: each loop
+      // iteration is superseded by $scheduleNextCheck()'s own leading
+      // $stopAuthCheck() call, so no scheduled callback ever actually runs,
+      // and the last one is cancelled explicitly below.
+      const originalSetTimeout = globalThis.setTimeout;
+      globalThis.setTimeout = ((handler: TimerHandler, delay?: number, ...args: unknown[]) => {
+        delays.push(delay ?? 0);
+        return originalSetTimeout(handler, delay, ...args);
+      }) as typeof globalThis.setTimeout;
 
-      for (let i = 0; i < samples; i++) {
-        store.$scheduleNextCheck();
-        // Get the delay from the last setTimeout call
-        const lastCall = setTimeoutSpy.mock.calls[setTimeoutSpy.mock.calls.length - 1];
-        if (lastCall) {
-          delays.push(lastCall[1] as number);
+      try {
+        for (let i = 0; i < samples; i++) {
+          store.$scheduleNextCheck();
         }
-        vi.clearAllTimers(); // Clear timer before next iteration
+      } finally {
+        globalThis.setTimeout = originalSetTimeout;
       }
 
       const minExpected = AUTH_CHECK_CONFIG.INTERVAL - AUTH_CHECK_CONFIG.JITTER; // 810_000
@@ -578,8 +588,8 @@ describe('authStore', () => {
         expect(delay).toBeLessThanOrEqual(maxExpected);
       });
 
-      vi.useRealTimers();
-      setTimeoutSpy.mockRestore();
+      // Cancel the real timer left pending by the final loop iteration.
+      await store.$stopAuthCheck();
     });
 
     it('stops existing auth check before scheduling a new one', () => {
@@ -699,7 +709,8 @@ describe('authStore', () => {
       bootstrapStore.update({
         authenticated: true,
         had_valid_session: true,
-        cust: mockCustomer,
+        cust: fixtureCustomer,
+        email: fixtureCustomer.email,
       });
 
       store.init();

--- a/src/tests/stores/bootstrapStore.spec.ts
+++ b/src/tests/stores/bootstrapStore.spec.ts
@@ -14,6 +14,7 @@ import {
   standaloneBootstrap,
   baseBootstrap,
   mockCustomer,
+  schemaDefaults,
 } from '@/tests/fixtures/bootstrap.fixture';
 import type { BootstrapPayload } from '@/schemas/contracts/bootstrap';
 
@@ -260,10 +261,9 @@ describe('bootstrapStore', () => {
       store.update({
         locale: 'es',
         i18n_enabled: true,
-        supported_locales: [
-          { code: 'en', name: 'English', enabled: true },
-          { code: 'es', name: 'Spanish', enabled: true },
-        ],
+        // Production shape: BootstrapPayload.supported_locales is a flat
+        // array of locale codes (z.array(z.string())), not LocaleInfo objects.
+        supported_locales: ['en', 'es'],
         fallback_locale: 'en',
       });
 
@@ -319,6 +319,7 @@ describe('bootstrapStore', () => {
 
     it('updates UI configuration', () => {
       const newUi = {
+        ...schemaDefaults.ui,
         enabled: true,
         header: {
           enabled: true,
@@ -359,7 +360,13 @@ describe('bootstrapStore', () => {
 
     it('updates organization data', () => {
       store.update({
-        organization: { planid: 'pro-plan' },
+        organization: {
+          objid: 'org_obj_1',
+          extid: 'org_ext_1',
+          display_name: 'Acme Inc',
+          is_default: true,
+          planid: 'pro-plan',
+        },
       });
 
       expect(store.organization?.planid).toBe('pro-plan');
@@ -528,14 +535,14 @@ describe('bootstrapStore', () => {
 
     it('resets all server config fields to defaults (unlike resetForLogout)', () => {
       store.update({
-        authentication: { enabled: false, signup: false },
-        ui: { enabled: false },
-        features: { markdown: true },
+        authentication: { ...schemaDefaults.authentication, enabled: false, signup: false },
+        ui: { ...schemaDefaults.ui, enabled: false },
+        features: { ...schemaDefaults.features, markdown: true },
         regions: {
           identifier: 'EU',
           enabled: true,
           current_jurisdiction: 'EU',
-          jurisdictions: [{ identifier: 'EU', display_name: 'Europe', domain: 'eu.example.com', icon: { collection: 'flags', name: 'eu' }, enabled: true }],
+          jurisdictions: [{ identifier: 'EU', display_name_i18n_key: 'web.regions.eu', domain: 'eu.example.com', icon: { collection: 'flags', name: 'eu' }, enabled: true }],
         },
       });
 
@@ -571,7 +578,15 @@ describe('bootstrapStore', () => {
     });
 
     it('resets organization data to defaults', () => {
-      store.update({ organization: { planid: 'pro' } });
+      store.update({
+        organization: {
+          objid: 'org_obj_2',
+          extid: 'org_ext_2',
+          display_name: 'Acme Inc',
+          is_default: true,
+          planid: 'pro',
+        },
+      });
 
       store.$reset();
 
@@ -623,8 +638,8 @@ describe('bootstrapStore', () => {
 
     it('preserves regions configuration through reset (server config)', () => {
       const jurisdictions = [
-        { identifier: 'EU', display_name: 'Europe', domain: 'eu.example.com', icon: { collection: 'flags', name: 'eu' }, enabled: true },
-        { identifier: 'US', display_name: 'United States', domain: 'us.example.com', icon: { collection: 'flags', name: 'us' }, enabled: true },
+        { identifier: 'EU', display_name_i18n_key: 'web.regions.eu', domain: 'eu.example.com', icon: { collection: 'flags', name: 'eu' }, enabled: true },
+        { identifier: 'US', display_name_i18n_key: 'web.regions.us', domain: 'us.example.com', icon: { collection: 'flags', name: 'us' }, enabled: true },
       ];
       store.update({
         regions: {
@@ -682,6 +697,7 @@ describe('bootstrapStore', () => {
     it('preserves UI configuration through reset (server config)', () => {
       store.update({
         ui: {
+          ...schemaDefaults.ui,
           enabled: false,
           header: { enabled: false },
           footer_links: { enabled: true, groups: [] },
@@ -698,7 +714,7 @@ describe('bootstrapStore', () => {
 
     it('preserves features configuration through reset (server config)', () => {
       store.update({
-        features: { markdown: false },
+        features: { ...schemaDefaults.features, markdown: false },
       });
 
       store.resetForLogout();
@@ -762,6 +778,7 @@ describe('bootstrapStore', () => {
       it('returns header configuration from UI (logo layout knobs pass through)', () => {
         store.update({
           ui: {
+            ...schemaDefaults.ui,
             enabled: true,
             header: {
               enabled: true,
@@ -779,6 +796,7 @@ describe('bootstrapStore', () => {
       it('returns undefined when header not configured', () => {
         store.update({
           ui: {
+            ...schemaDefaults.ui,
             enabled: true,
           },
         });
@@ -791,6 +809,7 @@ describe('bootstrapStore', () => {
       it('returns footer links configuration from UI', () => {
         store.update({
           ui: {
+            ...schemaDefaults.ui,
             enabled: true,
             footer_links: {
               enabled: true,
@@ -815,6 +834,7 @@ describe('bootstrapStore', () => {
       it('returns undefined when footer links not configured', () => {
         store.update({
           ui: {
+            ...schemaDefaults.ui,
             enabled: true,
           },
         });
@@ -881,6 +901,7 @@ describe('bootstrapStore', () => {
       // Update UI
       store.update({
         ui: {
+          ...schemaDefaults.ui,
           enabled: true,
           header: { enabled: true },
         },
@@ -965,6 +986,7 @@ describe('bootstrapStore', () => {
       store.init();
 
       const complexUi = {
+        ...schemaDefaults.ui,
         enabled: true,
         header: {
           enabled: true,
@@ -1197,6 +1219,7 @@ describe('bootstrapStore', () => {
     it('preserves features configuration through resetForLogout', () => {
       store.update({
         features: {
+          ...schemaDefaults.features,
           markdown: false,
         },
       });
@@ -1208,12 +1231,16 @@ describe('bootstrapStore', () => {
     });
 
     it('preserves diagnostics configuration through resetForLogout', () => {
+      // Production shape: DiagnosticsConfig is `{ sentry: SentryConfig } | null`
+      // (see bootstrap.ts sentryConfigSchema/diagnosticsSchema), not a flat
+      // set of feature-area booleans.
       const diagnosticsConfig = {
-        enabled: true,
-        domains: true,
-        regions: true,
-        entitlements: true,
-        locales: true,
+        sentry: {
+          dsn: 'https://test@sentry.io/123',
+          enabled: true,
+          logErrors: true,
+          trackComponents: true,
+        },
       };
 
       store.update({ diagnostics: diagnosticsConfig });
@@ -1252,14 +1279,14 @@ describe('bootstrapStore', () => {
         trackComponents: true,
       };
       store.update({
-        authentication: { enabled: false, signup: false, signin: true },
-        ui: { enabled: false, header: { enabled: false } },
-        features: { markdown: false },
+        authentication: { ...schemaDefaults.authentication, enabled: false, signup: false, signin: true },
+        ui: { ...schemaDefaults.ui, enabled: false, header: { enabled: false } },
+        features: { ...schemaDefaults.features, markdown: false },
         regions: {
           identifier: 'EU',
           enabled: true,
           current_jurisdiction: 'EU',
-          jurisdictions: [{ identifier: 'EU', display_name: 'Europe', domain: 'eu.example.com', icon: { collection: 'flags', name: 'eu' }, enabled: true }],
+          jurisdictions: [{ identifier: 'EU', display_name_i18n_key: 'web.regions.eu', domain: 'eu.example.com', icon: { collection: 'flags', name: 'eu' }, enabled: true }],
         },
         secret_options: { default_ttl: 7200, ttl_options: [300, 600] },
         diagnostics: { sentry: sentryConfig },
@@ -1285,8 +1312,8 @@ describe('bootstrapStore', () => {
         cust: mockCustomer,
         stripe_customer: { id: 'cus_123' } as any,
         // Server config
-        authentication: { enabled: false },
-        features: { markdown: false },
+        authentication: { ...schemaDefaults.authentication, enabled: false },
+        features: { ...schemaDefaults.features, markdown: false },
       });
 
       store.resetForLogout();
@@ -1392,9 +1419,11 @@ describe('bootstrapStore', () => {
     });
 
     it('updates messages array', () => {
+      // Production shape: messageSchema.type is 'success' | 'error' | 'info'
+      // (bootstrap.ts) — there is no 'warning' variant.
       const messages = [
         { type: 'info' as const, content: 'Welcome message' },
-        { type: 'warning' as const, content: 'Maintenance soon' },
+        { type: 'error' as const, content: 'Maintenance soon' },
       ];
 
       store.update({ messages });
@@ -1496,17 +1525,18 @@ describe('bootstrapStore', () => {
     });
 
     it('updates deeply nested UI header navigation', () => {
+      // Production shape: headerNavigationSchema (bootstrap.ts) is just
+      // `{ enabled: boolean }` — navigation has no `links` array. Deep-nested
+      // link arrays are covered separately by footer_links.groups[].links
+      // (see 'preserves complex nested objects on update' above).
       const uiWithNavigation = {
+        ...schemaDefaults.ui,
         enabled: true,
         header: {
           enabled: true,
           logo: { href: '/', show_name: true, prominent: false },
           navigation: {
             enabled: true,
-            links: [
-              { text: 'Home', url: '/' },
-              { text: 'About', url: '/about', external: false },
-            ],
           },
         },
       };
@@ -1514,14 +1544,13 @@ describe('bootstrapStore', () => {
       store.update({ ui: uiWithNavigation });
 
       expect(store.ui.header?.navigation?.enabled).toBe(true);
-      expect(store.ui.header?.navigation?.links).toHaveLength(2);
     });
 
     it('updates deeply nested regions configuration', () => {
       const jurisdictions = [
-        { identifier: 'EU', display_name: 'Europe', domain: 'eu.example.com', icon: { collection: 'flags', name: 'eu' }, enabled: true },
-        { identifier: 'US', display_name: 'United States', domain: 'us.example.com', icon: { collection: 'flags', name: 'us' }, enabled: true },
-        { identifier: 'CA', display_name: 'Canada', domain: 'ca.example.com', icon: { collection: 'flags', name: 'ca' }, enabled: true },
+        { identifier: 'EU', display_name_i18n_key: 'web.regions.eu', domain: 'eu.example.com', icon: { collection: 'flags', name: 'eu' }, enabled: true },
+        { identifier: 'US', display_name_i18n_key: 'web.regions.us', domain: 'us.example.com', icon: { collection: 'flags', name: 'us' }, enabled: true },
+        { identifier: 'CA', display_name_i18n_key: 'web.regions.ca', domain: 'ca.example.com', icon: { collection: 'flags', name: 'ca' }, enabled: true },
       ];
       const regionsConfig = {
         identifier: 'EU',
@@ -1541,6 +1570,7 @@ describe('bootstrapStore', () => {
       // First update with full UI
       store.update({
         ui: {
+          ...schemaDefaults.ui,
           enabled: true,
           header: { enabled: true },
           footer_links: { enabled: true, groups: [] },
@@ -1550,6 +1580,7 @@ describe('bootstrapStore', () => {
       // Second update with partial UI replaces the whole object
       store.update({
         ui: {
+          ...schemaDefaults.ui,
           enabled: false,
         },
       });

--- a/src/tests/stores/domainsStore.spec.ts
+++ b/src/tests/stores/domainsStore.spec.ts
@@ -121,7 +121,7 @@ describe('domainsStore', () => {
         },
       });
 
-      store.domains = [domain];
+      store.records = [domain];
 
       await store.updateDomainBrand(domain.extid, brandUpdate);
     });
@@ -142,7 +142,7 @@ describe('domainsStore', () => {
       const newSettings = {
         primary_color: '#ff0000',
         font_family: 'sans',
-      };
+      } as const;
 
       // Mock the exact response format expected by the brandSettings schema
       axiosMock.onPut(`/api/domains/${domain.extid}/brand`).reply(200, {
@@ -183,9 +183,9 @@ describe('domainsStore', () => {
       const newSettings = {
         primary_color: '#ff0000',
         font_family: 'sans',
-      };
+      } as const;
 
-      store.domains = [domain]; // Set initial state
+      store.records = [domain]; // Set initial state
 
       axiosMock.onPut(`/api/domains/${domain.extid}/brand`).reply(200, {
         record: {

--- a/src/tests/stores/incomingStore.spec.ts
+++ b/src/tests/stores/incomingStore.spec.ts
@@ -433,6 +433,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       const result = await store.createIncomingSecret(payload);
@@ -446,6 +447,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       const result = await store.createIncomingSecret(payload);
@@ -462,6 +464,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       await expect(store.createIncomingSecret(payload)).rejects.toThrow(
@@ -478,6 +481,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       await expect(store.createIncomingSecret(payload)).rejects.toThrow(
@@ -489,6 +493,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       try {
@@ -516,6 +521,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       await expect(store.createIncomingSecret(payload)).rejects.toThrow();
@@ -529,6 +535,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'invalid-hash',
+        memo: '',
       };
 
       await expect(store.createIncomingSecret(payload)).rejects.toThrow();
@@ -542,6 +549,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       await expect(store.createIncomingSecret(payload)).rejects.toThrow();
@@ -556,6 +564,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       // Unlike loadConfig, createIncomingSecret does not capture entitlement errors
@@ -574,6 +583,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       await expect(store.createIncomingSecret(payload)).rejects.toThrow();
@@ -587,6 +597,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       await expect(store.createIncomingSecret(payload)).rejects.toThrow();
@@ -605,6 +616,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'abc123hash',
+        memo: '',
       };
 
       await expect(store.createIncomingSecret(payload)).rejects.toThrow();
@@ -963,6 +975,7 @@ describe('incomingStore', () => {
       const payload = {
         secret: 'my secret value',
         recipient: 'test-hash',
+        memo: '',
       };
 
       await expect(store.createIncomingSecret(payload)).rejects.toThrow(

--- a/src/tests/stores/jurisdictionStore.spec.ts
+++ b/src/tests/stores/jurisdictionStore.spec.ts
@@ -1,6 +1,6 @@
 // src/tests/stores/jurisdictionStore.spec.ts
 
-import { ApiError, ApplicationError } from '@/schemas';
+import { ApplicationError } from '@/schemas';
 import type { Jurisdiction, RegionsConfig } from '@/schemas/shapes/v2';
 import { useJurisdictionStore } from '@/shared/stores/jurisdictionStore';
 import { createTestingPinia } from '@pinia/testing';
@@ -11,16 +11,16 @@ import { createApp } from 'vue';
 const mockJurisdictions: Jurisdiction[] = [
   {
     identifier: 'us-east',
-    display_name: 'US East',
+    display_name_i18n_key: 'web.regions.jurisdictions.us-east.name',
     domain: 'us-east.example.com',
-    icon: 'us-flag',
+    icon: { collection: 'fa6-solid', name: 'earth-americas' },
     enabled: true,
   },
   {
     identifier: 'eu-west',
-    display_name: 'EU West',
+    display_name_i18n_key: 'web.regions.jurisdictions.eu-west.name',
     domain: 'eu-west.example.com',
-    icon: 'eu-flag',
+    icon: { collection: 'fa6-solid', name: 'earth-europe' },
     enabled: true,
   },
 ];
@@ -47,13 +47,7 @@ describe('jurisdictionStore', () => {
       store.init({ regions: mockRegionConfig });
 
       // Test full jurisdiction object structure
-      expect(store.currentJurisdiction).toEqual({
-        identifier: 'us-east',
-        display_name: 'US East',
-        domain: 'us-east.example.com',
-        icon: 'us-flag',
-        enabled: true,
-      });
+      expect(store.currentJurisdiction).toEqual(mockJurisdictions[0]);
 
       // Verify array contents explicitly
       expect(store.jurisdictions).toEqual([mockJurisdictions[0], mockJurisdictions[1]]);
@@ -100,13 +94,13 @@ describe('jurisdictionStore', () => {
     it.skip('throws ApiError for non-existent jurisdiction', () => {
       expect(() => {
         store.findJurisdiction('non-existent');
-      }).toThrow(ApiError);
+      }).toThrow(/Jurisdiction "non-existent" not found/i);
     });
 
     it('finds jurisdiction with case-sensitive match', () => {
       expect(() => {
         store.findJurisdiction('EU-WEST');
-      }).toThrow(ApiError);
+      }).toThrow(/Jurisdiction "EU-WEST" not found/i);
     });
 
     it('throws descriptive ApplicationError for non-existent jurisdiction', () => {

--- a/src/tests/stores/languageStore-locale-detection.spec.ts
+++ b/src/tests/stores/languageStore-locale-detection.spec.ts
@@ -18,6 +18,7 @@
 
 import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { DEFAULT_LOCALE, useLanguageStore } from '@/shared/stores/languageStore';
+import { mockCustomer } from '@/tests/fixtures/bootstrap.fixture';
 import type AxiosMockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupTestPinia } from '../setup';
@@ -196,7 +197,7 @@ describe('Language Store - Browser Locale Detection (#2668)', () => {
     it('user preference takes priority over deviceLocale', () => {
       bootstrapStore.update({
         supported_locales: fullSupportedLocales,
-        cust: { locale: 'ja' },
+        cust: { ...mockCustomer, locale: 'ja' },
       });
 
       const store = useLanguageStore();

--- a/src/tests/stores/languageStore.spec.ts
+++ b/src/tests/stores/languageStore.spec.ts
@@ -36,7 +36,7 @@ describe('Language Store', () => {
   });
 
   afterEach(() => {
-    if (axiosMock) axiosMock.reset();
+    if (axiosMock) axiosMock?.reset();
     vi.restoreAllMocks();
     vi.useRealTimers();
     vi.unstubAllGlobals();
@@ -152,10 +152,10 @@ describe('Language Store', () => {
     });
 
     it('should handle updateLanguage correctly', async () => {
-      axiosMock.onPost('/api/account/update-locale').reply(200, {});
+      axiosMock?.onPost('/api/account/update-locale').reply(200, {});
 
       await store.updateLanguage('fr');
-      expect(axiosMock.history.post[0].data).toBe(JSON.stringify({ locale: 'fr' }));
+      expect(axiosMock?.history.post[0].data).toBe(JSON.stringify({ locale: 'fr' }));
     });
 
     describe('Error Handling', () => {
@@ -163,7 +163,7 @@ describe('Language Store', () => {
         const locale = 'en-US';
 
         // Setup axiosMock with 404 response
-        axiosMock.onPost('/api/account/update-locale', { locale }).reply(400); // TODO: Not correct
+        axiosMock?.onPost('/api/account/update-locale', { locale }).reply(400); // TODO: Not correct
 
         let caughtError: ApplicationError;
         try {
@@ -179,24 +179,24 @@ describe('Language Store', () => {
         expect(caughtError.severity).toBe('error');
 
         // Verify API was called with correct parameters
-        expect(axiosMock.history.post).toHaveLength(1);
-        expect(axiosMock.history.post[0].url).toBe('/api/account/update-locale');
-        expect(JSON.parse(axiosMock.history.post[0].data)).toEqual({ locale });
+        expect(axiosMock?.history.post).toHaveLength(1);
+        expect(axiosMock?.history.post[0].url).toBe('/api/account/update-locale');
+        expect(JSON.parse(axiosMock?.history.post[0].data)).toEqual({ locale });
       });
 
       it('should handle network errors in updateLanguage', async () => {
         const locale = 'fr';
 
         // Setup axiosMock
-        axiosMock.onPost('/api/account/update-locale', { locale }).networkError();
+        axiosMock?.onPost('/api/account/update-locale', { locale }).networkError();
 
         // Expect raw AxiosError, not ApplicationError
         await expect(store.updateLanguage(locale)).rejects.toThrow();
 
         // Verify API was called with correct parameters
-        expect(axiosMock.history.post).toHaveLength(1);
-        expect(axiosMock.history.post[0].url).toBe('/api/account/update-locale');
-        expect(JSON.parse(axiosMock.history.post[0].data)).toEqual({ locale });
+        expect(axiosMock?.history.post).toHaveLength(1);
+        expect(axiosMock?.history.post[0].url).toBe('/api/account/update-locale');
+        expect(JSON.parse(axiosMock?.history.post[0].data)).toEqual({ locale });
       });
 
       it('should handle server errors in updateLanguage', async () => {
@@ -204,16 +204,16 @@ describe('Language Store', () => {
 
         // Setup axiosMock with 500 response
         axiosMock
-          .onPost('/api/account/update-locale', { locale })
+          ?.onPost('/api/account/update-locale', { locale })
           .reply(500, { message: 'Internal Server Error' });
 
         // Expect raw AxiosError, not ApplicationError
         await expect(store.updateLanguage(locale)).rejects.toThrow();
 
         // Verify API was called correctly
-        expect(axiosMock.history.post).toHaveLength(1);
-        expect(axiosMock.history.post[0].url).toBe('/api/account/update-locale');
-        expect(JSON.parse(axiosMock.history.post[0].data)).toEqual({ locale });
+        expect(axiosMock?.history.post).toHaveLength(1);
+        expect(axiosMock?.history.post[0].url).toBe('/api/account/update-locale');
+        expect(JSON.parse(axiosMock?.history.post[0].data)).toEqual({ locale });
       });
 
       it('should handle invalid locale validation', async () => {
@@ -223,7 +223,7 @@ describe('Language Store', () => {
         await expect(store.updateLanguage(locale)).rejects.toThrow();
 
         // Verify no API call was made
-        expect(axiosMock.history.post).toHaveLength(0);
+        expect(axiosMock?.history.post).toHaveLength(0);
       });
     });
   });
@@ -279,18 +279,18 @@ describe('Language Store', () => {
     });
 
     it('should handle updateLanguage with region locales', async () => {
-      axiosMock.onPost('/api/account/update-locale').reply(200, {});
+      axiosMock?.onPost('/api/account/update-locale').reply(200, {});
 
       await store.updateLanguage('it_IT');
-      expect(axiosMock.history.post[0].data).toBe(JSON.stringify({ locale: 'it_IT' }));
+      expect(axiosMock?.history.post[0].data).toBe(JSON.stringify({ locale: 'it_IT' }));
     });
 
     it('should handle updateLanguage with hyphenated input (it-IT -> it_IT)', async () => {
-      axiosMock.onPost('/api/account/update-locale').reply(200, {});
+      axiosMock?.onPost('/api/account/update-locale').reply(200, {});
 
       await store.updateLanguage('it-IT');
       // Should normalize to it_IT before sending to server
-      expect(axiosMock.history.post[0].data).toBe(JSON.stringify({ locale: 'it_IT' }));
+      expect(axiosMock?.history.post[0].data).toBe(JSON.stringify({ locale: 'it_IT' }));
     });
 
     it('should reject unsupported locale', async () => {

--- a/src/tests/stores/membersStore.spec.ts
+++ b/src/tests/stores/membersStore.spec.ts
@@ -1,17 +1,23 @@
 // src/tests/stores/membersStore.spec.ts
 
 import { useMembersStore } from '@/shared/stores/membersStore';
+import { lenientExtIdSchema } from '@/types/identifiers';
 import AxiosMockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { setupTestPinia } from '../setup';
+
+// Branded-ID helper: OrganizationMember.extid is the lenientExtIdSchema output
+// type, not a plain string — parsing through the real schema (rather than
+// asserting) mints a properly-typed ExtId from a raw test literal.
+const extid = (raw: string) => lenientExtIdSchema.parse(raw);
 
 // Mock member data matching the organizationMemberSchema
 // Fields match backend response from apps/api/organizations/logic/members/list_members.rb
 // Note: Schema requires 'extid' (external identifier), not 'id'
 const mockMembers = [
   {
-    extid: 'member-1',
+    extid: extid('member-1'),
     email: 'owner@example.com',
     role: 'owner' as const,
     joined_at: 1704067200, // Unix timestamp
@@ -19,7 +25,7 @@ const mockMembers = [
     is_current_user: true,
   },
   {
-    extid: 'member-2',
+    extid: extid('member-2'),
     email: 'admin@example.com',
     role: 'admin' as const,
     joined_at: 1704153600,
@@ -27,7 +33,7 @@ const mockMembers = [
     is_current_user: false,
   },
   {
-    extid: 'member-3',
+    extid: extid('member-3'),
     email: 'member@example.com',
     role: 'member' as const,
     joined_at: 1704240000,

--- a/src/tests/stores/organizationStore.spec.ts
+++ b/src/tests/stores/organizationStore.spec.ts
@@ -6,8 +6,16 @@ import { baseBootstrap } from '@/tests/fixtures/bootstrap.fixture';
 
 import { useOrganizationStore } from '@/shared/stores/organizationStore';
 import type { Organization } from '@/types/organization';
+import { lenientExtIdSchema, lenientObjIdSchema } from '@/types/identifiers';
 import type AxiosMockAdapter from 'axios-mock-adapter';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Branded-ID helpers: OrganizationInvitation.id/invited_by and
+// .organization_id are lenientObjIdSchema/lenientExtIdSchema output
+// (see contracts/organization.ts) — plain strings/toObjId/toExtId are a
+// structurally-identical but nominally distinct brand and won't assign.
+const objId = (raw: string) => lenientObjIdSchema.parse(raw);
+const extId = (raw: string) => lenientExtIdSchema.parse(raw);
 
 describe('Organization Store', () => {
   let axiosMock: AxiosMockAdapter | null;
@@ -406,12 +414,12 @@ describe('Organization Store', () => {
         // Pre-populate with existing invitation
         store.invitations = [
           {
-            id: 'inv-existing',
-            organization_id: 'org-123',
+            id: objId('inv-existing'),
+            organization_id: extId('org-123'),
             email: 'existing@example.com',
             role: 'member',
             status: 'pending',
-            invited_by: 'owner@example.com',
+            invited_by: objId('owner@example.com'),
             invited_at: Date.now() / 1000,
             expires_at: Date.now() / 1000 + 604800,
             resend_count: 0,
@@ -472,12 +480,12 @@ describe('Organization Store', () => {
         // Pre-populate with invitation
         store.invitations = [
           {
-            id: 'inv-123',
-            organization_id: 'org-123',
+            id: objId('inv-123'),
+            organization_id: extId('org-123'),
             email: 'invitee@example.com',
             role: 'member',
             status: 'pending',
-            invited_by: 'owner@example.com',
+            invited_by: objId('owner@example.com'),
             invited_at: Date.now() / 1000,
             expires_at: Date.now() / 1000 + 604800,
             resend_count: 0,
@@ -535,24 +543,24 @@ describe('Organization Store', () => {
         // Pre-populate with invitations
         store.invitations = [
           {
-            id: 'inv-123',
-            organization_id: 'org-123',
+            id: objId('inv-123'),
+            organization_id: extId('org-123'),
             email: 'invitee@example.com',
             role: 'member',
             status: 'pending',
-            invited_by: 'owner@example.com',
+            invited_by: objId('owner@example.com'),
             invited_at: Date.now() / 1000,
             expires_at: Date.now() / 1000 + 604800,
             resend_count: 0,
             token: 'token-to-revoke',
           },
           {
-            id: 'inv-456',
-            organization_id: 'org-123',
+            id: objId('inv-456'),
+            organization_id: extId('org-123'),
             email: 'another@example.com',
             role: 'admin',
             status: 'pending',
-            invited_by: 'owner@example.com',
+            invited_by: objId('owner@example.com'),
             invited_at: Date.now() / 1000,
             expires_at: Date.now() / 1000 + 604800,
             resend_count: 0,
@@ -611,12 +619,12 @@ describe('Organization Store', () => {
       it('clears invitations on store reset', () => {
         store.invitations = [
           {
-            id: 'inv-123',
-            organization_id: 'org-123',
+            id: objId('inv-123'),
+            organization_id: extId('org-123'),
             email: 'test@example.com',
             role: 'member',
             status: 'pending',
-            invited_by: 'owner@example.com',
+            invited_by: objId('owner@example.com'),
             invited_at: Date.now() / 1000,
             expires_at: Date.now() / 1000 + 604800,
             resend_count: 0,

--- a/src/tests/stores/receiptStore.spec.ts
+++ b/src/tests/stores/receiptStore.spec.ts
@@ -149,7 +149,7 @@ describe('receiptStore', () => {
       store.details = details;
 
       axiosMock
-        .onPost(`/api/v3/receipt/${testKey}/burn`, {
+        ?.onPost(`/api/v3/receipt/${testKey}/burn`, {
           passphrase,
           continue: true,
         })

--- a/src/tests/stores/secretStore-alt.spec.ts
+++ b/src/tests/stores/secretStore-alt.spec.ts
@@ -17,14 +17,24 @@ import { baseBootstrap } from '@/tests/fixtures/bootstrap.fixture';
 import AxiosMockAdapter from 'axios-mock-adapter';
 
 /**
+ * Loosely-typed state shape for the hand-rolled store double below. The real
+ * `useSecretStore` types its state as `Secret | null` / `SecretDetails | null`
+ * (see src/shared/stores/secretStore.ts), but this test double intentionally
+ * starts from `{}` rather than `null` and gets fed a mix of raw fixture
+ * shapes (mockSecretResponse.record/.details) and ad hoc overrides, so an
+ * index signature is used here instead of the production schema types.
+ */
+type MockState = Record<string, unknown> | null;
+
+/**
  * Create a test implementation of the secrets store
  * This approach bypasses axios mocking complexity by directly
  * implementing the store functionality with mock data
  */
 const createTestStore = () => defineStore('secrets', () => {
     // Internal reactive state - initialize with empty objects to avoid null reference errors
-    const record = ref({});
-    const details = ref({});
+    const record = ref<MockState>({});
+    const details = ref<MockState>({});
 
     // Mock implementations
     const fetch = vi.fn().mockImplementation(async (id) => {
@@ -102,8 +112,8 @@ describe('secretStore', () => {
   let api;
   let app;
   let appInstance;
-  let store;
-  let useSecretStore;
+  let useSecretStore: ReturnType<typeof createTestStore>;
+  let store: ReturnType<typeof useSecretStore>;
 
   beforeEach(async () => {
     // Setup bootstrap state with modern fixture (minimal state for this test)
@@ -146,7 +156,7 @@ describe('secretStore', () => {
       await store.fetch('abc123');
 
       // Test everything except lifespan
-      const { lifespan: _, ...recordWithoutLifespan } = store.record;
+      const { lifespan: _, ...recordWithoutLifespan } = store.record!;
       const { lifespan: __, ...expectedWithoutLifespan } = mockSecretResponse.record;
 
       expect(recordWithoutLifespan).toEqual(expectedWithoutLifespan);
@@ -171,7 +181,7 @@ describe('secretStore', () => {
       await store.fetch('abc123');
 
       // Check record shape and transformed fields separately
-      const { lifespan: _, ...recordWithoutLifespan } = store.record;
+      const { lifespan: _, ...recordWithoutLifespan } = store.record!;
       const { lifespan: __, ...expectedWithoutLifespan } = mockSecretResponse.record;
 
       expect(recordWithoutLifespan).toEqual(expectedWithoutLifespan);
@@ -242,56 +252,63 @@ describe('secretStore', () => {
   describe('field handling', () => {
     describe('is_owner field', () => {
       beforeEach(async () => {
-        // Mock implementation for this specific test group
+        // Mock implementation for this specific test group.
+        // Note: this override is never actually exercised below -- each
+        // `it()` in this describe builds its own standalone `testStore`
+        // rather than calling `store.fetch()`. Written against `store.record`
+        // / `store.details` (not `.value`) because that's how Pinia
+        // setup-store state is read/written from outside the store; unlike
+        // `createTestStore`'s own closure, there is no local `record`/
+        // `details` ref binding in this outer describe scope.
         store.fetch = vi.fn().mockImplementation(async (id) => {
           if (id === 'owner-true') {
-            record.value = mockSecretResponse.record;
-            details.value = { ...mockSecretResponse.details, is_owner: true };
+            store.record = mockSecretResponse.record;
+            store.details = { ...mockSecretResponse.details, is_owner: true };
           } else if (id === 'owner-false') {
-            record.value = mockSecretResponse.record;
-            details.value = { ...mockSecretResponse.details, is_owner: false };
+            store.record = mockSecretResponse.record;
+            store.details = { ...mockSecretResponse.details, is_owner: false };
           } else if (id === 'owner-undefined') {
-            record.value = mockSecretResponse.record;
-            details.value = { ...mockSecretResponse.details, is_owner: undefined };
+            store.record = mockSecretResponse.record;
+            store.details = { ...mockSecretResponse.details, is_owner: undefined };
           } else {
-            record.value = mockSecretResponse.record;
-            details.value = mockSecretResponse.details;
+            store.record = mockSecretResponse.record;
+            store.details = mockSecretResponse.details;
           }
-          return { record: record.value, details: details.value };
+          return { record: store.record, details: store.details };
         });
       });
 
       it('handles is_owner true from API', async () => {
         // Create a dynamic store for this specific test
         const testStore = createTestStore()();
-        testStore.details.value = {
+        testStore.details = {
           ...mockSecretResponse.details,
           is_owner: true,
         };
 
-        expect(testStore.details.value.is_owner).toBe(true);
+        expect(testStore.details!.is_owner).toBe(true);
       });
 
       it('handles is_owner false from API', async () => {
         // Create a dynamic store for this specific test
         const testStore = createTestStore()();
-        testStore.details.value = {
+        testStore.details = {
           ...mockSecretResponse.details,
           is_owner: false,
         };
 
-        expect(testStore.details.value.is_owner).toBe(false);
+        expect(testStore.details!.is_owner).toBe(false);
       });
 
       it('handles missing is_owner field from API', async () => {
         // Create a dynamic store for this specific test
         const testStore = createTestStore()();
-        testStore.details.value = {
+        testStore.details = {
           ...mockSecretResponse.details,
           is_owner: false, // Schema should default undefined to false
         };
 
-        expect(testStore.details.value.is_owner).toBe(false);
+        expect(testStore.details!.is_owner).toBe(false);
       });
     });
 
@@ -299,50 +316,50 @@ describe('secretStore', () => {
       it('makes TTL value available as lifespan', async () => {
         // Create a dynamic store for this specific test
         const testStore = createTestStore()();
-        testStore.record.value = {
+        testStore.record = {
           ...mockSecretResponse.record,
           secret_ttl: 86400, // 24 hours in seconds
           lifespan: 86400,
         };
 
-        expect(testStore.record.value.lifespan).toBeDefined();
-        expect(typeof testStore.record.value.lifespan).toBe('number');
-        expect(testStore.record.value.lifespan).toBe(86400);
+        expect(testStore.record!.lifespan).toBeDefined();
+        expect(typeof testStore.record!.lifespan).toBe('number');
+        expect(testStore.record!.lifespan).toBe(86400);
       });
 
       it('handles zero TTL values', async () => {
         // Create a dynamic store for this specific test
         const testStore = createTestStore()();
-        testStore.record.value = {
+        testStore.record = {
           ...mockSecretResponse.record,
           secret_ttl: 0,
           lifespan: 0,
         };
 
-        expect(testStore.record.value.lifespan).toBe(0);
+        expect(testStore.record!.lifespan).toBe(0);
       });
 
       it('handles numeric lifespan from API', async () => {
         // Create a dynamic store for this specific test
         const testStore = createTestStore()();
-        testStore.record.value = {
+        testStore.record = {
           ...mockSecretResponse.record,
           lifespan: 86400,
         };
 
-        expect(typeof testStore.record.value.lifespan).toBe('number');
-        expect(testStore.record.value.lifespan).toBe(86400);
+        expect(typeof testStore.record!.lifespan).toBe('number');
+        expect(testStore.record!.lifespan).toBe(86400);
       });
 
       it('handles zero lifespan from API', async () => {
         // Create a dynamic store for this specific test
         const testStore = createTestStore()();
-        testStore.record.value = {
+        testStore.record = {
           ...mockSecretResponse.record,
           lifespan: 0,
         };
 
-        expect(testStore.record.value.lifespan).toBe(0);
+        expect(testStore.record!.lifespan).toBe(0);
       });
 
       it('should fail if lifespan is undefined', async () => {

--- a/src/tests/stores/secretStore.spec.ts
+++ b/src/tests/stores/secretStore.spec.ts
@@ -113,7 +113,7 @@ describe('secretStore', () => {
       it('conceal() uses /api/v3/secret/conceal in authenticated mode', async () => {
         axiosMock?.onPost('/api/v3/secret/conceal').reply(200, mockConcealResponse);
 
-        await store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal' });
+        await store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal', share_domain: '' });
 
         expect(axiosMock?.history.post.length).toBe(1);
         expect(axiosMock?.history.post[0].url).toBe('/api/v3/secret/conceal');
@@ -123,7 +123,7 @@ describe('secretStore', () => {
         store.setApiMode('public');
         axiosMock?.onPost('/api/v3/guest/secret/conceal').reply(200, mockConcealResponse);
 
-        await store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal' });
+        await store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal', share_domain: '' });
 
         expect(axiosMock?.history.post.length).toBe(1);
         expect(axiosMock?.history.post[0].url).toBe('/api/v3/guest/secret/conceal');
@@ -132,7 +132,7 @@ describe('secretStore', () => {
       it('generate() uses /api/v3/secret/generate in authenticated mode', async () => {
         axiosMock?.onPost('/api/v3/secret/generate').reply(200, mockConcealResponse);
 
-        await store.generate({ ttl: 3600, kind: 'generate' });
+        await store.generate({ ttl: 3600, kind: 'generate', share_domain: '' });
 
         expect(axiosMock?.history.post.length).toBe(1);
         expect(axiosMock?.history.post[0].url).toBe('/api/v3/secret/generate');
@@ -142,7 +142,7 @@ describe('secretStore', () => {
         store.setApiMode('public');
         axiosMock?.onPost('/api/v3/guest/secret/generate').reply(200, mockConcealResponse);
 
-        await store.generate({ ttl: 3600, kind: 'generate' });
+        await store.generate({ ttl: 3600, kind: 'generate', share_domain: '' });
 
         expect(axiosMock?.history.post.length).toBe(1);
         expect(axiosMock?.history.post[0].url).toBe('/api/v3/guest/secret/generate');
@@ -494,7 +494,7 @@ describe('secretStore', () => {
         axiosMock?.onPost('/api/v3/guest/secret/conceal').reply(403, guestRoutesDisabledResponse);
 
         await expect(
-          store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal' })
+          store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal', share_domain: '' })
         ).rejects.toThrow();
       });
 
@@ -502,7 +502,9 @@ describe('secretStore', () => {
         store.setApiMode('public');
         axiosMock?.onPost('/api/v3/guest/secret/generate').reply(403, guestRoutesDisabledResponse);
 
-        await expect(store.generate({ ttl: 3600, kind: 'generate' })).rejects.toThrow();
+        await expect(
+          store.generate({ ttl: 3600, kind: 'generate', share_domain: '' })
+        ).rejects.toThrow();
       });
 
       it('fetch() rejects with 403 when guest routes globally disabled', async () => {
@@ -529,7 +531,7 @@ describe('secretStore', () => {
         const initialDetails = store.details;
 
         await expect(
-          store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal' })
+          store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal', share_domain: '' })
         ).rejects.toThrow();
 
         expect(store.record).toBe(initialRecord);
@@ -547,7 +549,7 @@ describe('secretStore', () => {
         });
 
         await expect(
-          store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal' })
+          store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal', share_domain: '' })
         ).rejects.toThrow();
       });
 
@@ -559,7 +561,9 @@ describe('secretStore', () => {
           code: 'GUEST_GENERATE_DISABLED',
         });
 
-        await expect(store.generate({ ttl: 3600, kind: 'generate' })).rejects.toThrow();
+        await expect(
+          store.generate({ ttl: 3600, kind: 'generate', share_domain: '' })
+        ).rejects.toThrow();
       });
 
       it('reveal() rejects with GUEST_REVEAL_DISABLED code', async () => {
@@ -600,7 +604,12 @@ describe('secretStore', () => {
 
         axiosMock?.onPost('/api/v3/secret/conceal').reply(200, mockConcealResponse);
 
-        const result = await store.conceal({ secret: 'test', ttl: 3600, kind: 'conceal' });
+        const result = await store.conceal({
+          secret: 'test',
+          ttl: 3600,
+          kind: 'conceal',
+          share_domain: '',
+        });
 
         expect(result).toBeDefined();
         expect(axiosMock?.history.post[0].url).toBe('/api/v3/secret/conceal');

--- a/src/tests/support/axe.ts
+++ b/src/tests/support/axe.ts
@@ -11,17 +11,39 @@
 //   vitest-axe ships an `extend-expect` entry, but in this installed version
 //   `dist/extend-expect.js` is EMPTY (0 bytes), so importing it registers
 //   nothing. We therefore wire the matcher explicitly via `expect.extend`
-//   using the `toHaveNoViolations` export from `vitest-axe/matchers`.
+//   using the `toHaveNoViolations` export from `vitest-axe/dist/matchers`
+//   (see the import comment below for why `dist/matchers` specifically),
+//   and declare it on vitest's `Matchers` interface ourselves for typing.
 //
 
 import { axe } from 'vitest-axe';
-import { toHaveNoViolations } from 'vitest-axe/matchers';
+// Import from the `dist/matchers` entry point rather than the public
+// `vitest-axe/matchers` subpath: in this installed version (0.1.0), the
+// public entry's declaration file re-exports everything as type-only
+// (`export type * from './dist/matchers'`), so under `isolatedModules`
+// `toHaveNoViolations` cannot be used as a value from there (TS1362) even
+// though the runtime export is a real function. `dist/matchers` is the same
+// underlying module (the public entry just re-exports it) with a correct,
+// value-preserving declaration, so this changes nothing at runtime.
+import { toHaveNoViolations } from 'vitest-axe/dist/matchers';
 import { expect } from 'vitest';
 import type { VueWrapper } from '@vue/test-utils';
 
 // Register the custom matcher once for the whole test process. Any spec that
 // imports from this module gets `expect(...).toHaveNoViolations()` wired up.
 expect.extend({ toHaveNoViolations });
+
+// vitest-axe also ships a `vitest-axe/extend-expect` entry that declares this
+// matcher on `Assertion`/`AsymmetricMatchersContaining`, but it augments an
+// old `Vi.Assertion` namespace that no longer exists in the installed vitest
+// (4.x moved these interfaces into the `vitest`/`@vitest/expect` module
+// directly), so importing it would not actually type `expect(...).toHaveNoViolations()`.
+// Augment the current extension point directly instead.
+declare module 'vitest' {
+  interface Matchers<T = any> {
+    toHaveNoViolations(): void;
+  }
+}
 
 /**
  * axe-core rules that cannot be meaningfully evaluated for an isolated

--- a/src/tests/utils/features.spec.ts
+++ b/src/tests/utils/features.spec.ts
@@ -36,6 +36,7 @@ import {
   configuredProviderLabel,
   getSsoProviders,
 } from '@/utils/features';
+import { authenticationSettingsSchema } from '@/schemas/contracts/bootstrap';
 import { _resetForTesting } from '@/services/bootstrap.service';
 
 // Mock the bootstrap service
@@ -1374,11 +1375,21 @@ describe('features utility', () => {
 
   describe('isFullAuthModeOf', () => {
     it('returns true when authentication mode is full', () => {
-      expect(isFullAuthModeOf({ authentication: { mode: 'full' } })).toBe(true);
+      // isFullAuthModeOf only reads .mode, but its state param requires a full
+      // AuthenticationSettings object — derive one from the schema (rather
+      // than hand-rolling the enabled/signup/signin/etc. defaults) so this
+      // stays in sync with the real contract.
+      expect(
+        isFullAuthModeOf({ authentication: authenticationSettingsSchema.parse({ mode: 'full' }) })
+      ).toBe(true);
     });
 
     it('returns false when authentication mode is simple', () => {
-      expect(isFullAuthModeOf({ authentication: { mode: 'simple' } })).toBe(false);
+      expect(
+        isFullAuthModeOf({
+          authentication: authenticationSettingsSchema.parse({ mode: 'simple' }),
+        })
+      ).toBe(false);
     });
 
     it('returns false when authentication is undefined', () => {
@@ -1547,7 +1558,9 @@ describe('features utility', () => {
     const originalWindow = globalThis.window;
 
     beforeEach(() => {
-      // @ts-expect-error - intentionally setting to undefined for SSR simulation
+      // Cast through Record<string, unknown> (rather than @ts-expect-error) to
+      // simulate SSR: deleting via an index signature doesn't need suppression,
+      // unlike `delete globalThis.window` against the DOM lib's typed property.
       delete (globalThis as Record<string, unknown>).window;
     });
 

--- a/src/tests/views/session/AcceptInvite.spec.ts
+++ b/src/tests/views/session/AcceptInvite.spec.ts
@@ -3,6 +3,8 @@
 import InviteSignUpForm from '@/apps/session/components/InviteSignUpForm.vue';
 import AcceptInvite from '@/apps/session/views/AcceptInvite.vue';
 import { useAuthStore } from '@/shared/stores/authStore';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+import { mockCustomer } from '@tests/fixtures/bootstrap.fixture';
 import { createTestI18n } from '@tests/setup';
 import { flushPromises, mount } from '@vue/test-utils';
 import { createPinia, setActivePinia } from 'pinia';
@@ -44,6 +46,7 @@ const i18n = createTestI18n();
 describe('AcceptInvite', () => {
   let pinia: ReturnType<typeof createPinia>;
   let authStore: ReturnType<typeof useAuthStore>;
+  let bootstrapStore: ReturnType<typeof useBootstrapStore>;
   let router: ReturnType<typeof createRouter>;
 
   const mockInvitation = {
@@ -95,6 +98,7 @@ describe('AcceptInvite', () => {
     pinia = createPinia();
     setActivePinia(pinia);
     authStore = useAuthStore();
+    bootstrapStore = useBootstrapStore();
 
     // Reset axios mock
     const axiosMock = getGlobalAxiosMock();
@@ -175,15 +179,14 @@ describe('AcceptInvite', () => {
 
     it('shows accept and decline buttons for authenticated user with pending invitation', async () => {
       // Must be authenticated to see direct Accept/Decline buttons
-      authStore.$patch({
-        isAuthenticated: true,
-        cust: {
-          custid: 'cust-123',
-          email: 'invitee@example.com',
-          verified: true,
-          created: new Date(),
-          updated: new Date(),
-        },
+      // isAuthenticated lives on authStore; the customer record and current
+      // email live on bootstrapStore (see authStore.ts's CUSTOMER OBJECT
+      // STATE notes) — emailMismatch in AcceptInvite.vue reads
+      // bootstrapStore.email, not authStore, so both must be set here.
+      authStore.$patch({ isAuthenticated: true });
+      bootstrapStore.$patch({
+        email: 'invitee@example.com',
+        cust: { ...mockCustomer, email: 'invitee@example.com' },
       });
 
       const axiosMock = getGlobalAxiosMock();
@@ -256,7 +259,10 @@ describe('AcceptInvite', () => {
     it('shows signup form by default when user is not authenticated', async () => {
       // The show endpoint deliberately carries no account_exists signal (AZ7),
       // so unauthenticated users always start in the signup flow.
-      authStore.$patch({ cust: null });
+      // cust lives on bootstrapStore, not authStore (see CUSTOMER OBJECT
+      // STATE notes in authStore.ts) — it already defaults to null, this is
+      // an explicit reset in case an earlier test in this file left it set.
+      bootstrapStore.$patch({ cust: null });
       const axiosMock = getGlobalAxiosMock();
       axiosMock.onGet('/api/invite/test-token-123').reply(200, {
         record: mockInvitation,
@@ -269,7 +275,10 @@ describe('AcceptInvite', () => {
     });
 
     it('switches to sign-in notice after signup reports signup unavailable', async () => {
-      authStore.$patch({ cust: null });
+      // cust lives on bootstrapStore, not authStore (see CUSTOMER OBJECT
+      // STATE notes in authStore.ts) — it already defaults to null, this is
+      // an explicit reset in case an earlier test in this file left it set.
+      bootstrapStore.$patch({ cust: null });
       const axiosMock = getGlobalAxiosMock();
       axiosMock.onGet('/api/invite/test-token-123').reply(200, {
         record: mockInvitation,
@@ -296,7 +305,8 @@ describe('AcceptInvite', () => {
    */
   describe('Host sign-in restriction (ADR-034#invite-signup-is-gated)', () => {
     beforeEach(() => {
-      authStore.$patch({ isAuthenticated: false, cust: null });
+      authStore.$patch({ isAuthenticated: false });
+      bootstrapStore.$patch({ cust: null });
     });
 
     const replyWith = (record: Record<string, unknown>, token = 'test-token-123') => {
@@ -534,15 +544,10 @@ describe('AcceptInvite', () => {
         // the restriction is spent once a session exists. This is what lets
         // the ADR-034#invite-signup-is-gated flow terminate: SSO signs them in,
         // they return here, they join.
-        authStore.$patch({
-          isAuthenticated: true,
-          cust: {
-            custid: 'cust-123',
-            email: 'invitee@example.com',
-            verified: true,
-            created: new Date(),
-            updated: new Date(),
-          },
+        authStore.$patch({ isAuthenticated: true });
+        bootstrapStore.$patch({
+          email: 'invitee@example.com',
+          cust: { ...mockCustomer, email: 'invitee@example.com' },
         });
         replyWith({
           ...mockInvitation,
@@ -589,15 +594,14 @@ describe('AcceptInvite', () => {
 
   describe('Authenticated User - Accept Flow', () => {
     beforeEach(() => {
-      authStore.$patch({
-        isAuthenticated: true,
-        cust: {
-          custid: 'cust-123',
-          email: 'invitee@example.com',
-          verified: true,
-          created: new Date(),
-          updated: new Date(),
-        },
+      // isAuthenticated lives on authStore; the customer record and current
+      // email live on bootstrapStore (see authStore.ts's CUSTOMER OBJECT
+      // STATE notes) — emailMismatch in AcceptInvite.vue reads
+      // bootstrapStore.email, not authStore, so both must be set here.
+      authStore.$patch({ isAuthenticated: true });
+      bootstrapStore.$patch({
+        email: 'invitee@example.com',
+        cust: { ...mockCustomer, email: 'invitee@example.com' },
       });
     });
 
@@ -643,15 +647,14 @@ describe('AcceptInvite', () => {
 
   describe('Authenticated User - Decline Flow', () => {
     beforeEach(() => {
-      authStore.$patch({
-        isAuthenticated: true,
-        cust: {
-          custid: 'cust-123',
-          email: 'invitee@example.com',
-          verified: true,
-          created: new Date(),
-          updated: new Date(),
-        },
+      // isAuthenticated lives on authStore; the customer record and current
+      // email live on bootstrapStore (see authStore.ts's CUSTOMER OBJECT
+      // STATE notes) — emailMismatch in AcceptInvite.vue reads
+      // bootstrapStore.email, not authStore, so both must be set here.
+      authStore.$patch({ isAuthenticated: true });
+      bootstrapStore.$patch({
+        email: 'invitee@example.com',
+        cust: { ...mockCustomer, email: 'invitee@example.com' },
       });
     });
 
@@ -698,15 +701,14 @@ describe('AcceptInvite', () => {
   describe('UI Layout', () => {
     it('renders invitation header correctly for authenticated user', async () => {
       // Authenticated user sees "Invitation Details" header in direct_accept state
-      authStore.$patch({
-        isAuthenticated: true,
-        cust: {
-          custid: 'cust-123',
-          email: 'invitee@example.com',
-          verified: true,
-          created: new Date(),
-          updated: new Date(),
-        },
+      // isAuthenticated lives on authStore; the customer record and current
+      // email live on bootstrapStore (see authStore.ts's CUSTOMER OBJECT
+      // STATE notes) — emailMismatch in AcceptInvite.vue reads
+      // bootstrapStore.email, not authStore, so both must be set here.
+      authStore.$patch({ isAuthenticated: true });
+      bootstrapStore.$patch({
+        email: 'invitee@example.com',
+        cust: { ...mockCustomer, email: 'invitee@example.com' },
       });
 
       const axiosMock = getGlobalAxiosMock();
@@ -736,15 +738,14 @@ describe('AcceptInvite', () => {
   describe('Accessibility', () => {
     it('has accessible buttons with type attributes', async () => {
       // Use authenticated user to see direct Accept/Decline buttons (type="button")
-      authStore.$patch({
-        isAuthenticated: true,
-        cust: {
-          custid: 'cust-123',
-          email: 'invitee@example.com',
-          verified: true,
-          created: new Date(),
-          updated: new Date(),
-        },
+      // isAuthenticated lives on authStore; the customer record and current
+      // email live on bootstrapStore (see authStore.ts's CUSTOMER OBJECT
+      // STATE notes) — emailMismatch in AcceptInvite.vue reads
+      // bootstrapStore.email, not authStore, so both must be set here.
+      authStore.$patch({ isAuthenticated: true });
+      bootstrapStore.$patch({
+        email: 'invitee@example.com',
+        cust: { ...mockCustomer, email: 'invitee@example.com' },
       });
 
       const axiosMock = getGlobalAxiosMock();


### PR DESCRIPTION
## Summary

`pnpm run type-check:tests` (the `typescript-unit` CI job) was failing with
638 TypeScript errors across 87 test files — see the
[failing run on #4311](https://github.com/onetimesecret/onetimesecret/actions/runs/33294368641/job/99211502453?pr=4311).
That check isn't required for merge, so it had gone unaddressed for a while.

This PR fixes the underlying type mismatches — mostly test fixtures/mocks
that had drifted from the real v3 schema shapes and component/composable
APIs that production code now uses — rather than suppressing errors with
`any` or `@ts-expect-error`. No production runtime behavior is changed.

**Result: `pnpm run type-check:tests` now passes clean (0 errors, was 638).**
Full suite re-run after all fixes: **403 test files passed / 1 pre-existing
skip, 9227 tests passed / 86 skipped / 9 todo, 0 failures.**

Along the way, one genuine (pre-existing, unrelated to types) runtime test
bug was found and fixed in `authStore.spec.ts`: a timer spy was targeting
`vi.setSystemTime` instead of `setTimeout`, which also masked a
`vi.spyOn`/`mockRestore` interaction that left `globalThis.setTimeout`
broken for later tests once corrected naively — fixed by manually
saving/restoring the timer reference instead.

### Two production-code observations (not changed here, flagged for a maintainer)

Both were found while fixing test types; neither is a behavior bug today,
and fixing either is a production change outside this PR's scope:

1. `src/schemas/api/incoming/requests/incoming-secret.ts`: `memo` is
   `z.string().optional().default('')`, so zod's output type makes it
   *required* — contradicting the field's own docstring, which says it's
   optional. Harmless today (the one real caller always populates it), but
   a latent trap for the next caller.
2. `ObjId`/`ExtId` are declared via two independent `unique symbol` brands —
   one in `src/schemas/utils/identifiers.ts` (backs `lenientObjIdSchema`/
   `lenientExtIdSchema`) and one in `src/types/identifiers.ts` (backs
   `toObjId`/`toExtId`). They're nominally incompatible despite identical
   shape/name (deliberate, per that file's own comment, to avoid a circular
   import), so a value built with `toObjId()`/`toExtId()` won't type-check
   against a field typed through the `lenient*` schemas. Worth consolidating
   or documenting more prominently.

## Related Issues

None filed — this addresses the CI failure linked above directly.

## Test Plan

- `pnpm run type-check:tests` — 0 errors (was 638).
- `pnpm exec vitest run src/tests/` — 403 passed / 1 skipped test files,
  9227 passed / 86 skipped / 9 todo tests, 0 failures.
- Each changed file/group was also re-run individually against its
  "must stay green" consumers during development to catch regressions
  early (see commit messages for per-group detail).
