### PR TITLE
fix(billing): require org owner for Stripe invoice URLs

### DIFF
--- a/apps/web/billing/controllers/billing.rb
+++ b/apps/web/billing/controllers/billing.rb
@@ -288,7 +288,7 @@ module Billing
       #
       # @return [Hash] List of invoices
       def list_invoices
-        org = load_organization(req.params['extid'])
+        org = load_organization(req.params['extid'], require_owner: true)
 
         unless org.stripe_customer_id
           return json_response({ invoices: [] })

--- a/apps/web/billing/spec/controllers/billing_controller_spec.rb
+++ b/apps/web/billing/spec/controllers/billing_controller_spec.rb
@@ -663,6 +663,31 @@ RSpec.describe 'Billing::Controllers::BillingController', :integration, :stripe_
       expect(last_response.status).to eq(403)
     end
 
+    it 'requires owner permissions (not just member)' do
+      # Regression (F-03): invoice URLs (invoice_pdf / hosted_invoice_url) are
+      # bearer links to billing documents. A non-owner member must not be able
+      # to fetch them; only owners may, matching the checkout/change-plan/
+      # migrate-currency/cancel/reactivate sibling endpoints.
+      organization.stripe_customer_id = 'cus_test_invoices_owner_only'
+      organization.save
+
+      member_customer = Onetime::Customer.create!(email: deterministic_email('member-invoice'))
+      created_customers << member_customer
+      member_customer.save
+
+      organization.add_members_instance(member_customer)
+
+      env 'rack.session', {
+        'authenticated' => true,
+        'external_id' => member_customer.extid,
+      }
+
+      get "/billing/api/org/#{organization.extid}/invoices"
+
+      expect(last_response.status).to eq(403)
+      expect(last_response.body).to include('Owner access required')
+    end
+
     it 'requires authentication' do
       env 'rack.session', {}
 


### PR DESCRIPTION
## Summary

Broken access control (finding F-03): the `list_invoices` endpoint (`GET /billing/api/org/:extid/invoices`) returned Stripe `invoice_pdf` and `hosted_invoice_url` values — bearer links to an organization's billing documents — to any organization **member**, not just an **owner**.

The endpoint called `load_organization(req.params['extid'])` in `apps/web/billing/controllers/billing.rb` (line 291) without `require_owner: true`. The default in `base.rb` (`load_organization(extid, require_owner: false)`) is member-level access, so any non-owner member could fetch these links.

Its four sibling endpoints in the same file already pass `require_owner: true`:
- `create_checkout_session` (line 77)
- `change_plan` (line 592)
- `migrate_currency` (line 976)
- `validate_subscription_management` (line 1136), backing `cancel_subscription` / `reactivate_subscription`

**Fix** — one keyword argument, bringing the invoice endpoint in line with its siblings:

```ruby
-        org = load_organization(req.params['extid'])
+        org = load_organization(req.params['extid'], require_owner: true)
```

When the caller is a non-owner, `load_organization` raises `Onetime::Forbidden` ("Owner access required"). `list_invoices` only rescues `Stripe::StripeError`, so the exception propagates to the OttoHooks Forbidden handler (ADR-013) and renders a proper 403 — not a 500.

## Related Issues

Fixes internal finding F-03 (broken access control, open since 2026-08-20). No public issue number.

## Test Plan

Added a regression spec in `apps/web/billing/spec/controllers/billing_controller_spec.rb`, mirroring the existing owner-only test for `change-plan`:

- New: a non-owner member requesting `/billing/api/org/:extid/invoices` gets `403` with `Owner access required`.
- Existing (unchanged): the owner (default session) still receives the invoice list including `invoice_pdf` and `hosted_invoice_url`, and a non-member still gets `403`.

Run with the lane runner:

```console
tests/lanes/run simple --only apps/web/billing/spec/controllers/billing_controller_spec.rb
```

---
_Generated by [Claude Code](https://claude.ai/code/session_015SGRoWqbEaTpBUXNBHjgNR)_