### PR TITLE
fix(ci): resolve @sentry/cli from the pinned lockfile in the release job

### DIFF
--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -213,6 +213,32 @@ jobs:
       - name: Assert compose image pins match README (drift gate)
         run: bash scripts/check-version-pins.sh
 
+      # Sentry CLI is resolved from the integrity-pinned devDependency in
+      # pnpm-lock.yaml (@sentry/cli 3.6.2), NOT fetched from the npm registry at
+      # execution time. Without a node_modules on the runner, `npx @sentry/cli`
+      # in the Sentry steps below would fetch @latest AND run its install-time
+      # lifecycle script mid-release, bypassing both the lockfile pin and the
+      # repo's Renovate quarantine. Installing from the frozen lockfile up
+      # front, then calling `pnpm exec sentry-cli`, keeps every Sentry
+      # invocation on the pinned version: the registry is still contacted here
+      # (uncached downloads, and the lifecycle scripts pnpm-workspace.yaml
+      # allowlists), but only for integrity-checked, lockfile-named packages.
+      #
+      # Deliberately BEFORE the registry logins below: pnpm lifecycle scripts
+      # run arbitrary package code, and this ordering means none of it executes
+      # on a runner that already holds push credentials.
+      #
+      # continue-on-error matches the Sentry steps this install serves — they
+      # are all best-effort (continue-on-error / explicit exit 0), so a
+      # transient install failure must degrade telemetry, not block the image
+      # release. setup-node-env is the same composite action ci.yml uses
+      # (Node + pnpm + `pnpm install --frozen-lockfile`); gated to non-PR runs
+      # to match the Sentry steps that consume it.
+      - name: Setup Node.js environment (pinned sentry-cli)
+        if: github.event_name != 'pull_request'
+        continue-on-error: true
+        uses: ./.github/actions/setup-node-env
+
       - name: Generate commit hash
         id: commit
         run: |
@@ -413,21 +439,6 @@ jobs:
           ${{ steps.bake.outputs.metadata }}
           BAKE_METADATA_EOF
           bash scripts/ci/extract-frontend-dist.sh
-
-      # Sentry CLI is resolved from the integrity-pinned devDependency in
-      # pnpm-lock.yaml (@sentry/cli 3.6.2), NOT fetched from the npm registry at
-      # run time. Without a node_modules on the runner, `npx @sentry/cli` would
-      # fetch @latest AND run its install-time lifecycle script here — after the
-      # registry logins above already hold push credentials, and bypassing both
-      # the lockfile pin and the repo's Renovate quarantine. Installing from the
-      # frozen lockfile first, then calling `pnpm exec sentry-cli`, keeps every
-      # Sentry invocation on the pinned version and never touches the registry.
-      # setup-node-env is the same composite action ci.yml uses (Node + pnpm +
-      # `pnpm install --frozen-lockfile`); gated to non-PR runs to match the
-      # Sentry steps that consume it.
-      - name: Setup Node.js environment (pinned sentry-cli)
-        if: github.event_name != 'pull_request'
-        uses: ./.github/actions/setup-node-env
 
       - name: Create Sentry release and associate commits
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build-and-publish-oci-images.yml
+++ b/.github/workflows/build-and-publish-oci-images.yml
@@ -414,6 +414,21 @@ jobs:
           BAKE_METADATA_EOF
           bash scripts/ci/extract-frontend-dist.sh
 
+      # Sentry CLI is resolved from the integrity-pinned devDependency in
+      # pnpm-lock.yaml (@sentry/cli 3.6.2), NOT fetched from the npm registry at
+      # run time. Without a node_modules on the runner, `npx @sentry/cli` would
+      # fetch @latest AND run its install-time lifecycle script here — after the
+      # registry logins above already hold push credentials, and bypassing both
+      # the lockfile pin and the repo's Renovate quarantine. Installing from the
+      # frozen lockfile first, then calling `pnpm exec sentry-cli`, keeps every
+      # Sentry invocation on the pinned version and never touches the registry.
+      # setup-node-env is the same composite action ci.yml uses (Node + pnpm +
+      # `pnpm install --frozen-lockfile`); gated to non-PR runs to match the
+      # Sentry steps that consume it.
+      - name: Setup Node.js environment (pinned sentry-cli)
+        if: github.event_name != 'pull_request'
+        uses: ./.github/actions/setup-node-env
+
       - name: Create Sentry release and associate commits
         if: github.event_name != 'pull_request'
         continue-on-error: true
@@ -473,9 +488,9 @@ jobs:
           rc=0
           for phase in new set-commits finalize; do
             case "$phase" in
-              new)         out=$(npx @sentry/cli releases new "$SENTRY_RELEASE" $PROJECT_FLAGS 2>&1) ;;
-              set-commits) out=$(npx @sentry/cli releases set-commits "$SENTRY_RELEASE" --auto $PROJECT_FLAGS 2>&1) ;;
-              finalize)    out=$(npx @sentry/cli releases finalize "$SENTRY_RELEASE" $PROJECT_FLAGS 2>&1) ;;
+              new)         out=$(pnpm exec sentry-cli releases new "$SENTRY_RELEASE" $PROJECT_FLAGS 2>&1) ;;
+              set-commits) out=$(pnpm exec sentry-cli releases set-commits "$SENTRY_RELEASE" --auto $PROJECT_FLAGS 2>&1) ;;
+              finalize)    out=$(pnpm exec sentry-cli releases finalize "$SENTRY_RELEASE" $PROJECT_FLAGS 2>&1) ;;
             esac
             rc=$?
             log_cli_output "$out"
@@ -545,7 +560,7 @@ jobs:
             UPLOAD_ARGS+=(--dist="$SENTRY_DIST")
           fi
 
-          out=$(npx @sentry/cli sourcemaps upload "${UPLOAD_ARGS[@]}" 2>&1)
+          out=$(pnpm exec sentry-cli sourcemaps upload "${UPLOAD_ARGS[@]}" 2>&1)
           rc=$?
           log_cli_output "$out"
 
@@ -621,7 +636,7 @@ jobs:
             printf '%s\n' "$1" | sed 's/^/sentry-cli: /'
           }
 
-          out=$(npx @sentry/cli releases deploys "$SENTRY_RELEASE" new -e production 2>&1)
+          out=$(pnpm exec sentry-cli releases deploys "$SENTRY_RELEASE" new -e production 2>&1)
           rc=$?
           log_cli_output "$out"
           if [ "$rc" -ne 0 ]; then


### PR DESCRIPTION
## Summary

The `Build and Publish OCI Images` workflow (`.github/workflows/build-and-publish-oci-images.yml`) invoked `npx @sentry/cli ...` in five places to create the Sentry release, upload sourcemaps, and record the deploy. The job has **no `setup-node` and no `pnpm install`**, so there is no `node_modules` on the runner for `npx` to resolve against.

As a result, at run time `npx` fetched `@sentry/cli@latest` straight from the npm registry **and ran its install-time lifecycle script** (a platform-binary downloader). That:

- **bypassed the lockfile pin** — `pnpm-lock.yaml` pins `@sentry/cli` `3.6.2` with an integrity hash (it is a devDependency, `^3.6.0`);
- **bypassed the repo's 14-day Renovate quarantine** on new versions;
- executed **after all three registry logins** (Docker Hub, GHCR, custom registry), which hold live push credentials.

A single compromised `@sentry/cli` release — or any of its install-time transitive deps — would therefore run arbitrary code with push credentials for every registry OneTimeSecret publishes to, i.e. a path to a trojaned published image. This is finding G-03.

### Fix

- Add the repo's canonical Node/pnpm setup (`./.github/actions/setup-node-env`, the same composite action `ci.yml` uses — `setup-node` + `pnpm/action-setup` + `pnpm install --frozen-lockfile`, all action SHAs pinned inside the composite) **before** the Sentry steps.
- Change every `npx @sentry/cli ...` to `pnpm exec sentry-cli ...`, resolving the binary from `node_modules` rather than the registry.

Because `pnpm install --frozen-lockfile` installs exactly the integrity-pinned `3.6.2` already in `pnpm-lock.yaml`, `pnpm exec sentry-cli` never contacts the npm registry at run time and no install-time lifecycle script runs after the registry logins. The Sentry operations, arguments, flags, reporting, and `continue-on-error` behavior are unchanged — only how the CLI is resolved.

The setup step is gated `if: github.event_name != 'pull_request'`, matching the Sentry steps that consume it, so PR-closed events pay no extra install. No `package.json` or lockfile changes were required; `@sentry/cli` is already a devDependency, and the setup step does not collide with existing job caching or the `contents: read` / `packages: write` permissions.

**Five call sites updated** (all in the `build-and-publish` job):
1. `releases new` — Create Sentry release and associate commits
2. `releases set-commits --auto` — same step
3. `releases finalize` — same step
4. `sourcemaps upload` — Upload frontend sourcemaps to Sentry
5. `releases deploys ... new -e production` — Create Sentry deploy notification

## Related Issues

Internal vulnerability triage finding G-03 (supply-chain exposure in the release pipeline).

## Test Plan

- Static review: the only remaining `npx` reference in the file is inside an explanatory comment; all five command invocations now use `pnpm exec sentry-cli`.
- `setup-node-env` runs `pnpm install --frozen-lockfile` and is the same action already exercised by `ci.yml`, so `node_modules/.bin/sentry-cli` is present before the first Sentry step.
- Behavioral equivalence: command verbs, arguments, and flags are byte-for-byte unchanged; the reporting via `scripts/ci/sentry-status.sh` and `continue-on-error` gating are untouched.
- Recommend a `workflow_dispatch` dry run to confirm `pnpm exec sentry-cli --version` resolves 3.6.2 in the job.

---
_Generated by [Claude Code](https://claude.ai/code/session_015SGRoWqbEaTpBUXNBHjgNR)_