### PR TITLE
fix(secrets): rate-limit anonymous secret creation

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -263,6 +263,23 @@ STDOUT_SYNC=false
 #  SECRET OPTIONS
 # ═══════════════════════════════════════════════════════════
 
+# Rate limit on ANONYMOUS secret creation (site.secret_options.
+# create_rate_limit), counted per masked client IP (/24 IPv4, /48 IPv6)
+# across every creation entry point (V1/V2/V3 conceal and generate).
+# Authenticated callers are never charged. Enabled by default; set
+# ENABLED=false to opt out. The cap is deliberately loose — the bucket
+# is a whole /24 (office or campus NAT), and behind an unconfigured
+# reverse proxy it is the entire deployment — so raise MAX_PER_IP for
+# dense-NAT populations rather than tightening it.
+# See lib/onetime/security/conceal_secret_rate_limiter.rb.
+#SECRET_CREATE_RATE_LIMIT_ENABLED=true
+# Anonymous creations permitted per window from one masked IP. Default: 500.
+#SECRET_CREATE_RATE_LIMIT_MAX_PER_IP=500
+# Counting window in seconds. Default: 3600 (1 hour).
+#SECRET_CREATE_RATE_LIMIT_WINDOW=3600
+# Lockout duration in seconds once the cap is hit. Default: 3600 (1 hour).
+#SECRET_CREATE_RATE_LIMIT_LOCKOUT=3600
+
 # Require complexity in secret passphrases
 # (site.secret_options.passphrase.enforce_complexity). When true, the
 # V2 API rejects passphrases missing an uppercase letter, lowercase

--- a/apps/api/v1/controllers/base.rb
+++ b/apps/api/v1/controllers/base.rb
@@ -4,12 +4,14 @@
 
 require 'digest'
 
+require 'onetime/security/conceal_secret_rate_limiter'
 require_relative 'helpers'
 
 module V1
 
   module ControllerBase
     include V1::ControllerHelpers
+    include Onetime::Security::ConcealSecretRateLimiter
 
     attr_reader :req, :res
     attr_reader :cust, :locale, :sess
@@ -191,6 +193,27 @@ module V1
       end
 
       nil
+    end
+
+    # Registry-managed cap on ANONYMOUS secret creation (finding F-02), the
+    # secret-creation counterpart of the legacy per-IP counter above. This one is
+    # the `create_secret` kind in the ratelimit Registry — shared with the V2/V3
+    # logic-layer enforcement and clearable via `bin/ots ratelimit` — and is
+    # keyed on the edge-masked env['otto.client_ip'] so its keyspace matches the
+    # V2 call site exactly. Charged only to guests: an authenticated caller is
+    # accountable and is the legitimate high-volume creator.
+    #
+    # Returns :limited (and renders the error) when the tier is over its cap, nil
+    # otherwise, mirroring #check_rate_limit! so the call sites keep V1's
+    # return-based idiom rather than raising into #carefully's catch-all.
+    def enforce_create_secret_limit!
+      return unless cust.nil? || cust.anonymous?
+
+      enforce_conceal_secret_rate_limit!(req.env['otto.client_ip'])
+      nil
+    rescue Onetime::LimitExceeded => ex
+      error_response ex.message
+      :limited
     end
 
     def secret_not_found_response

--- a/apps/api/v1/controllers/index.rb
+++ b/apps/api/v1/controllers/index.rb
@@ -65,6 +65,7 @@ module V1
       def share
         authorized(true) do
           return if check_rate_limit!(:create_secret, V1_RATE_LIMIT_MAX_CREATES) == :limited
+          return if enforce_create_secret_limit! == :limited
 
           logic = V1::Logic::Secrets::ConcealSecret.new(
             sess,
@@ -92,6 +93,7 @@ module V1
       def generate
         authorized(true) do
           return if check_rate_limit!(:create_secret, V1_RATE_LIMIT_MAX_CREATES) == :limited
+          return if enforce_create_secret_limit! == :limited
 
           logic = V1::Logic::Secrets::GenerateSecret.new(
             sess,
@@ -204,6 +206,7 @@ module V1
       def create
         authorized(true) do
           return if check_rate_limit!(:create_secret, V1_RATE_LIMIT_MAX_CREATES) == :limited
+          return if enforce_create_secret_limit! == :limited
 
           logic = V1::Logic::Secrets::ConcealSecret.new(
             sess,

--- a/apps/api/v2/logic/secrets/base_secret_action.rb
+++ b/apps/api/v2/logic/secrets/base_secret_action.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'onetime/secret_lifetime_policy'
+require 'onetime/security/conceal_secret_rate_limiter'
 
 module V2::Logic
   module Secrets
@@ -10,6 +11,7 @@ module V2::Logic
 
     class BaseSecretAction < V2::Logic::Base
       include Onetime::LoggerMethods
+      include Onetime::Security::ConcealSecretRateLimiter
 
       attr_reader :passphrase,
         :secret_value,
@@ -41,6 +43,17 @@ module V2::Logic
       end
 
       def raise_concerns
+        # Throughput cap on anonymous secret creation (finding F-02). Charged
+        # ONLY to guests — an authenticated caller is accountable through their
+        # Customer record and plan limits and is the legitimate high-volume
+        # creator — and enforced ahead of the Receipt.spawn_pair write in
+        # #process, so a throttled flood reaches no datastore growth. Keyed on
+        # the edge-masked client IP the auth strategy resolved. Raises
+        # Onetime::LimitExceeded, rendered as the ADR-013 429 (otto_hooks.rb).
+        # The V1 controller enforces the same limiter over the same subject; keep
+        # them in lockstep. See Onetime::Security::ConcealSecretRateLimiter.
+        enforce_conceal_secret_rate_limit!(conceal_secret_client_ip) if anonymous_user?
+
         require_entitlement!('api_access')
         raise_form_error 'Unknown type of secret' if kind.nil?
 
@@ -398,6 +411,19 @@ module V2::Logic
       end
 
       private
+
+      # Edge-masked client IP for the creation limiter, read from the same
+      # StrategyResult metadata the passphrase limiter uses in these files
+      # (burn/reveal/show_secret#passphrase_client_ip). Guarded with respond_to?
+      # because a direct/spec construction may build the logic without a
+      # strategy_result; AuthStrategies::Helpers#client_ip sources it from
+      # env['otto.client_ip'], so the key is trusted-proxy-resolved and not
+      # header-spoofable. nil skips the limiter (see conceal_secret_ip_keys).
+      def conceal_secret_client_ip
+        return unless respond_to?(:strategy_result)
+
+        strategy_result&.metadata&.[](:ip)
+      end
 
       def create_secret_pair
         @receipt, @secret = Onetime::Receipt.spawn_pair(

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -287,6 +287,33 @@ site:
     # How long (in seconds) a generated password remains visible on the
     # receipt page after creation. Set to 0 to disable receipt-page display.
     generated_value_display_ttl: <%= ENV['GENERATED_VALUE_DISPLAY_TTL'] || 60 %>
+    # Rate limiting for ANONYMOUS secret creation (finding F-02). The
+    # secret-creation path had no limiter on the modern API surface, leaving
+    # unauthenticated, unthrottled creation: one Receipt + one Secret per request
+    # (each carrying anonymous-lifetime TTL). A single anonymous client sustained
+    # ~113 req/s at ~18 KiB/secret — ~1 GiB of Redis in ~8.6 minutes — and since
+    # Redis also holds sessions that is a full-outage DoS. Throttles per masked
+    # client IP BEFORE the Receipt.spawn_pair write, on every creation entry: the
+    # shared V2::Logic::Secrets::BaseSecretAction#raise_concerns (covers V2/V3
+    # conceal and generate) and the V1 controller (share/generate/create).
+    # Charged only to guests — authenticated callers are accountable and are the
+    # legitimate high-volume creators. Single tier by necessity: an anonymous
+    # conceal holds no account-derived identifier to key on.
+    # Enabled by default (protective); set SECRET_CREATE_RATE_LIMIT_ENABLED=false
+    # to opt out. See lib/onetime/security/conceal_secret_rate_limiter.rb.
+    create_rate_limit:
+      enabled: <%= ENV['SECRET_CREATE_RATE_LIMIT_ENABLED'] != 'false' %>
+      # Anonymous creations permitted per window from a single masked client IP.
+      # The bucket is a whole /24 (office, campus NAT), and behind an
+      # unconfigured reverse proxy it is the entire deployment — so this is
+      # deliberately loose (10x the signup/reset caps) because secret creation is
+      # the core product action. Raise it for dense-NAT populations; a too-tight
+      # value here is an outage of secret creation for a whole neighborhood.
+      max_per_ip: <%= ENV['SECRET_CREATE_RATE_LIMIT_MAX_PER_IP'] || 500 %>
+      # Counting window in seconds (1 hour).
+      window: <%= ENV['SECRET_CREATE_RATE_LIMIT_WINDOW'] || 3600 %>
+      # Lockout duration in seconds once the cap is hit (1 hour).
+      lockout: <%= ENV['SECRET_CREATE_RATE_LIMIT_LOCKOUT'] || 3600 %>
     # Settings for password generation (when users click "Generate Password")
     password_generation:
       # Default length for generated passwords

--- a/lib/onetime/operations/ratelimit/registry.rb
+++ b/lib/onetime/operations/ratelimit/registry.rb
@@ -90,6 +90,16 @@ module Onetime
             keys: ['dns:ratelimit:%s'],
             dbclient: -> { Onetime::CustomDomain.dbclient },
           },
+          # Single-tier IP limiter on anonymous secret creation (finding F-02).
+          # SUBJECT IS THE STORED FORM: the privacy-masked IP (/24 IPv4, /48
+          # IPv6), not the raw address and not the /16-obscured form the lockout
+          # log line prints. Lives on the Secret shard, matching the limiter's
+          # own `redis` accessor. A raw address reads back `not_set`.
+          'create_secret' => {
+            subject: 'masked client IP (/24 IPv4, /48 IPv6)',
+            keys: ['create_secret:attempts:ip:%s', 'create_secret:locked:ip:%s'],
+            dbclient: -> { Onetime::Secret.dbclient },
+          },
         }.freeze
 
         # Redis glob metacharacters escaped when a subject is interpolated into a

--- a/lib/onetime/security/conceal_secret_rate_limiter.rb
+++ b/lib/onetime/security/conceal_secret_rate_limiter.rb
@@ -1,0 +1,309 @@
+# lib/onetime/security/conceal_secret_rate_limiter.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/models/colonel_audit_event'
+
+module Onetime
+  module Security
+    # ConcealSecretRateLimiter - Throttles unauthenticated secret creation
+    #
+    # Closes finding F-02 (2026-08-14 audit): the secret-creation path had no
+    # limiter of any kind on the modern API surface. The reachable primitive is
+    # unauthenticated, unthrottled secret creation — one Receipt + one Secret
+    # record per request, each carrying anonymous-lifetime TTL. A single
+    # anonymous client sustained ~113 req/s at ~18 KiB of Redis per secret,
+    # writing ~1 GiB of Redis in ~8.6 minutes. Because Redis also holds sessions,
+    # that is a full-outage DoS reachable by any stranger with `curl`.
+    #
+    # Enforced on the anonymous secret-creation paths, ahead of the
+    # Receipt.spawn_pair write:
+    #
+    #   - V2/V3 API (conceal AND generate): the shared
+    #     V2::Logic::Secrets::BaseSecretAction#raise_concerns, which every conceal
+    #     and generate logic class inherits (V3 subclasses V2), keyed on the
+    #     edge-masked client IP the auth strategy resolved;
+    #   - V1 API (share/generate/create): the controller
+    #     (apps/api/v1/controllers), whose own return-based error convention wraps
+    #     the raise — V1 logic never receives a strategy_result, so the masked IP
+    #     is read from env['otto.client_ip'] there instead.
+    #
+    # Both take their subject from the same edge-masked address
+    # (env['otto.client_ip'], surfaced as strategy_result.metadata[:ip] in the
+    # mounted stack), so the keyspace and any operator remediation are identical
+    # across API versions. Keep the call sites in lockstep on the subject passed.
+    #
+    # ANONYMOUS ONLY. The cap is charged to guest requests alone. An
+    # authenticated caller is accountable through their Customer record and plan
+    # limits, is the legitimate high-volume creator (bulk API integrations), and
+    # was never the DoS this bounds — charging them would risk a false lockout of
+    # the core product function for exactly the users least likely to be abusing
+    # it. The finding is an UNauthenticated flood, so the gate is `anonymous?`.
+    #
+    # SINGLE TIER, IP ONLY. Secret creation holds nothing else fixed the way the
+    # reset-request limiter holds an email fixed: an anonymous conceal carries no
+    # account-derived identifier to key on, and keying on the secret body would
+    # both mint one bucket per request (capping nothing) and hash attacker-chosen
+    # bytes. Capping volume per origin is the whole of the available defense.
+    #
+    # IP GRANULARITY, and the COLLAPSE CONDITION, are identical to
+    # {CreateAccountRateLimiter}: the subject is the privacy-masked network (/24
+    # IPv4, /48 IPv6) the universal IPPrivacyMiddleware resolved, so the bucket is
+    # shared by that neighborhood; and with site.network.trusted_proxy disabled
+    # behind a reverse proxy the resolved IP is the PROXY's address for every
+    # request, collapsing the whole deployment into one bucket. The default cap is
+    # deliberately loose because of this, and the lockout log line appends the
+    # same self-contained operator hint.
+    #
+    # CLEARING A STUCK LOCKOUT — same two paths as every other limiter, over kind
+    # `create_secret`:
+    #
+    #   1. `bin/ots ratelimit keys create_secret <masked-ip>` piped to valkey-cli
+    #      (the CLI only PRINTS commands; see ratelimit_command.rb). <masked-ip>
+    #      is the STORED subject — the privacy-masked address, not the raw one and
+    #      not the /16-obscured form in the log line.
+    #   2. `POST /api/colonel/ratelimit/reset` with kind=create_secret, which
+    #      performs the delete AND records a ColonelAuditEvent.
+    #
+    # Fail semantics mirror the other security limiters: Redis errors propagate
+    # rather than silently permitting an unthrottled creation flood.
+    #
+    # Redis keys (string keys at the Redis boundary):
+    #   - create_secret:attempts:ip:{ip}  - per-IP request counter
+    #   - create_secret:locked:ip:{ip}    - per-IP lockout flag
+    #
+    # Config (site.secret_options.create_rate_limit): enabled, max_per_ip, window,
+    # lockout. Absent config -> enabled with the constant defaults below; set
+    # enabled:false to disable (the test config does, so suite secret creation is
+    # not throttled).
+    #
+    # Usage:
+    #   include Onetime::Security::ConcealSecretRateLimiter
+    #   enforce_conceal_secret_rate_limit!(client_ip) # before any secret write
+    module ConcealSecretRateLimiter
+      # Default anonymous secret creations permitted per window from a single
+      # masked client IP.
+      #
+      # Ten times the sibling perimeter limiters (create_account / reset =
+      # 10/hour) because secret creation is the core product action, not a rare
+      # one — a shared masked /24 (office, campus NAT) legitimately conceals far
+      # more secrets per hour than it signs up accounts. Still, 500/hour turns the
+      # measured ~1 GiB-in-8.6-minutes flood (~57k secrets) into at most ~500
+      # secrets (~9 MiB) per masked network per window before the tier locks:
+      # unbounded storage growth becomes a bounded, loggable, auditable trickle,
+      # which is the whole ask of the finding. Raise it for dense-NAT populations
+      # (SECRET_CREATE_RATE_LIMIT_MAX_PER_IP); a too-tight value here would be an
+      # outage of secret creation for a whole neighborhood.
+      DEFAULT_MAX_PER_IP = 500
+
+      # Default window in seconds over which creations are counted (1 hour).
+      DEFAULT_WINDOW = 3600
+
+      # Default lockout duration in seconds once the cap is hit (1 hour).
+      DEFAULT_LOCKOUT = 3600
+
+      # Audit verb recorded when the tier reaches its cap. Namespaced
+      # `<resource>.<action>` like every other verb in the trail; the admin
+      # console filters on the exact string, so it is a constant.
+      AUDIT_VERB = 'secrets.create_throttled'
+
+      # Lua script that checks the lockout AND records the request in one atomic
+      # round trip — same contract as {CreateAccountRateLimiter}: Redis serializes
+      # script executions, the increment that reaches max_attempts sets the
+      # lockout flag and clears the counter, and every later execution sees the
+      # flag and is denied before incrementing, so concurrent bursts cannot
+      # overshoot the cap. Returns {1, current_count} when allowed, {0,
+      # lockout_ttl} when denied.
+      CHECK_AND_RECORD_SCRIPT = <<~LUA
+        local attempts_key = KEYS[1]
+        local lockout_key = KEYS[2]
+        local attempt_window = tonumber(ARGV[1])
+        local max_attempts = tonumber(ARGV[2])
+        local lockout_duration = tonumber(ARGV[3])
+
+        if redis.call('EXISTS', lockout_key) == 1 then
+          return {0, redis.call('TTL', lockout_key)}
+        end
+
+        local current = redis.call('INCR', attempts_key)
+
+        if current == 1 then
+          redis.call('EXPIRE', attempts_key, attempt_window)
+        end
+
+        if current >= max_attempts then
+          redis.call('SETEX', lockout_key, lockout_duration, '1')
+          redis.call('DEL', attempts_key)
+        end
+
+        return {1, current}
+      LUA
+
+      # Enforce the secret-creation rate limit and record this request. Raises
+      # LimitExceeded when the IP is locked; a locked tier is never incremented
+      # (the Lua script denies before INCR). No-op when the limiter is disabled by
+      # config, and no-op when no client IP is available — see
+      # conceal_secret_ip_keys for why that skips rather than shares a bucket.
+      #
+      # The caller decides WHO is charged (the call sites gate on anonymous?);
+      # this method is subject-agnostic so the same code path serves every entry.
+      #
+      # @param client_ip [String, nil] The caller's edge-masked client IP.
+      # @raise [Onetime::LimitExceeded] If the limit is exceeded.
+      # @return [void]
+      def enforce_conceal_secret_rate_limit!(client_ip)
+        return unless conceal_secret_rate_limit_enabled?
+        return unless (keys = conceal_secret_ip_keys(client_ip))
+
+        allowed, detail = conceal_secret_redis.eval(
+          CHECK_AND_RECORD_SCRIPT,
+          keys: [keys[:attempts], keys[:lockout]],
+          argv: [conceal_secret_window, conceal_secret_max_per_ip, conceal_secret_lockout],
+        )
+
+        if allowed.to_i != 1
+          raise Onetime::LimitExceeded.new(
+            'Too many secrets created. Please try again later.',
+            retry_after: detail.to_i.positive? ? detail.to_i : conceal_secret_lockout,
+            max_attempts: conceal_secret_max_per_ip,
+          )
+        end
+
+        count = detail.to_i
+        if count >= conceal_secret_max_per_ip
+          # This cap-reaching request was itself ALLOWED (the Lua script locks
+          # after incrementing); the lockout applies to subsequent requests.
+          obscured = obscured_conceal_secret_ip(client_ip)
+          OT.le "[ConcealSecretRateLimiter] ip #{obscured} " \
+                "hit cap (#{count}/#{conceal_secret_max_per_ip}); " \
+                "locked for #{conceal_secret_lockout}s" \
+                "#{collapsed_conceal_secret_ip_hint}"
+          record_conceal_secret_throttle_audit(obscured, count)
+        elsif count >= conceal_secret_max_per_ip - 1
+          OT.li "[ConcealSecretRateLimiter] ip #{obscured_conceal_secret_ip(client_ip)} " \
+                "at #{count}/#{conceal_secret_max_per_ip} creations"
+        end
+      end
+
+      private
+
+      # Write the queryable counterpart of the OT.le line above.
+      #
+      # Same discipline as {CreateAccountRateLimiter}: an unauthenticated-
+      # triggerable verb must bound its own write frequency and stay out of the
+      # count-capped-with-no-TTL operator trail. This writes to .record_security
+      # (its own count cap and age bound), and ONLY on the cap-reaching request,
+      # never on the deny path an attacker can drive as fast as it can send — so
+      # writes are bounded to one event per masked network per lockout window.
+      #
+      # The subject is the OBSCURED IP (/16), never the resolved one. Actor is
+      # 'anonymous' — the caller is unauthenticated by construction on this path.
+      # Best-effort, matching every other audit call site.
+      def record_conceal_secret_throttle_audit(obscured_ip, count)
+        Onetime::ColonelAuditEvent.record_security(
+          actor: 'anonymous',
+          verb: AUDIT_VERB,
+          target: "ip:#{obscured_ip}",
+          result: :failure,
+          detail: {
+            tier: 'ip',
+            count: count,
+            max_attempts: conceal_secret_max_per_ip,
+            window: conceal_secret_window,
+            lockout: conceal_secret_lockout,
+          },
+        )
+      rescue StandardError => ex
+        # Secret creation must never fail because its audit event could not be
+        # assembled.
+        OT.le('[ConcealSecretRateLimiter] audit record failed', exception: ex)
+      end
+
+      # Composite per-IP keys, or nil when no IP is available.
+      #
+      # Skipping is correct rather than fail-closed here: a blank suffix would
+      # build ONE key shared by every IP-less caller, so the first few would lock
+      # the bucket and every later one would be denied — a global creation outage
+      # driven by whatever made the IP unresolvable. Same rationale as
+      # CreateAccountRateLimiter#create_account_ip_keys.
+      def conceal_secret_ip_keys(client_ip)
+        return nil if client_ip.to_s.empty?
+
+        {
+          attempts: "create_secret:attempts:ip:#{client_ip}",
+          lockout: "create_secret:locked:ip:#{client_ip}",
+        }
+      end
+
+      def conceal_secret_rate_limit_config
+        OT.conf.dig('site', 'secret_options', 'create_rate_limit') || {}
+      end
+
+      # Enabled unless config explicitly sets enabled:false. Absent config keeps
+      # the protective default on; the test config disables it so suite secret
+      # creation is not throttled.
+      def conceal_secret_rate_limit_enabled?
+        conceal_secret_rate_limit_config.fetch('enabled', true) != false
+      end
+
+      def conceal_secret_max_per_ip
+        positive_conceal_secret_setting('max_per_ip', DEFAULT_MAX_PER_IP)
+      end
+
+      def conceal_secret_window
+        positive_conceal_secret_setting('window', DEFAULT_WINDOW)
+      end
+
+      def conceal_secret_lockout
+        positive_conceal_secret_setting('lockout', DEFAULT_LOCKOUT)
+      end
+
+      # Read a numeric setting, falling back to its default unless the configured
+      # value coerces to a POSITIVE integer. A zero/garbage value (a typo'd env
+      # var: `to_i` turns "abc" into 0) would otherwise invert enforcement — a
+      # zero cap locks on the first request and a non-positive lockout makes the
+      # Lua SETEX fail, turning every creation into a 500 instead of a throttle.
+      def positive_conceal_secret_setting(key, default)
+        value = conceal_secret_rate_limit_config[key].to_i
+        value.positive? ? value : default
+      end
+
+      # Obscure the IP for logs: IPv4 keeps the /16, IPv6 is truncated to a short
+      # prefix. The resolved value never reaches logs.
+      def obscured_conceal_secret_ip(client_ip)
+        value = client_ip.to_s
+        parts = value.split('.')
+        return "#{parts[0]}.#{parts[1]}.x.x" if parts.length == 4
+
+        value[0..8]
+      end
+
+      # Operator diagnostic appended to the lockout LOG LINE (server side only —
+      # it never reaches a response body) when the deployment has not declared a
+      # trusted reverse proxy, in which case the resolved client IP is REMOTE_ADDR
+      # and every visitor shares one bucket. Self-contained on purpose: it
+      # restates the condition and names both remedy env vars inline, so an
+      # operator reading only the log line has the whole diagnosis.
+      #
+      # Read through the shared predicate rather than digging the config here, so
+      # the hint asks the same question the IP-privacy mount asked (#4087). No
+      # require_relative — this file is reached via `require 'onetime'`, which
+      # loads the middleware stack, and the constant resolves at call time.
+      def collapsed_conceal_secret_ip_hint
+        return '' if Onetime::Application::MiddlewareStack.trusted_proxy_enabled?
+
+        '. NOTE: site.network.trusted_proxy is not enabled, so the client IP is ' \
+          'REMOTE_ADDR; if this deployment is behind a reverse proxy every visitor ' \
+          'shares this bucket and secret creation is blocked deployment-wide. Set ' \
+          'TRUSTED_PROXY_ENABLED=true, or raise SECRET_CREATE_RATE_LIMIT_MAX_PER_IP'
+      end
+
+      # Redis connection via the Secret model's dbclient — the counters live on
+      # the same shard as the secrets themselves (matches the passphrase and
+      # invite limiters in the ratelimit Registry).
+      def conceal_secret_redis
+        Onetime::Secret.dbclient
+      end
+    end
+  end
+end

--- a/spec/config.test.yaml
+++ b/spec/config.test.yaml
@@ -32,6 +32,11 @@ site:
       maximum_length: 128
       enforce_complexity: false
     generated_value_display_ttl: 60
+    # Disabled under test so the many specs that create secrets are not throttled
+    # (the cap is per masked IP, and the whole suite shares one); the F-02
+    # limiter tests enable it in-process. See conceal_secret_rate_limiter.rb.
+    create_rate_limit:
+      enabled: false
     password_generation:
       default_length: 12
       length_options: [8, 12, 16, 20, 24, 32]

--- a/try/unit/operations/email_ratelimit_tools_try.rb
+++ b/try/unit/operations/email_ratelimit_tools_try.rb
@@ -137,7 +137,7 @@ AE.count
 
 ## the registry knows the canonical limiter kinds, in registry order
 Onetime::Operations::RateLimit::Registry.kinds
-#=> ["feedback", "passphrase", "invite", "login", "reset_request_ip", "reset_request_email", "create_account_ip", "dns"]
+#=> ["feedback", "passphrase", "invite", "login", "reset_request_ip", "reset_request_email", "create_account_ip", "dns", "create_secret"]
 
 ## keys_for expands the templates byte-identically to the CLI's emitted keys
 Onetime::Operations::RateLimit::Registry.keys_for('feedback', '1.2.3.4')
@@ -151,6 +151,11 @@ Onetime::Operations::RateLimit::Registry.keys_for('reset_request_ip', '203.0.113
 ## the reset-request email backstop derives its own pair from the same subject
 Onetime::Operations::RateLimit::Registry.keys_for('reset_request_email', 'user@example.com')
 #=> ["reset_request:attempts:email:user@example.com", "reset_request:locked:email:user@example.com"]
+
+## the anonymous secret-creation limiter (F-02) keys on the MASKED client IP
+## — the stored form the limiter writes, so operator clears actually hit
+Onetime::Operations::RateLimit::Registry.keys_for('create_secret', '203.0.113.0')
+#=> ["create_secret:attempts:ip:203.0.113.0", "create_secret:locked:ip:203.0.113.0"]
 
 ## an unknown kind yields nil (the CLI prints its "Unknown" branch)
 Onetime::Operations::RateLimit::Registry.keys_for('nope', 'x')

--- a/try/unit/security/conceal_secret_rate_limiter_try.rb
+++ b/try/unit/security/conceal_secret_rate_limiter_try.rb
@@ -1,0 +1,281 @@
+# try/unit/security/conceal_secret_rate_limiter_try.rb
+#
+# frozen_string_literal: true
+
+# Finding F-02 (2026-08-14 audit): ConcealSecretRateLimiter caps ANONYMOUS
+# secret creation, which previously had no limiter on the modern API surface —
+# one Receipt + one Secret per request (each carrying anonymous-lifetime TTL). A
+# single anonymous client sustained ~113 req/s at ~18 KiB/secret, writing ~1 GiB
+# of Redis in ~8.6 minutes; since Redis also holds sessions that is a full
+# outage.
+#
+# Single tier, keyed on the masked client IP alone. An anonymous conceal holds
+# no account-derived identifier to key on, and keying on the secret body would
+# mint one bucket per request (capping nothing).
+#
+# We test:
+# 1. Under-limit requests are allowed; key shape and TTL
+# 2. Over-limit raises LimitExceeded with the configured cap + lockout state
+# 3. Normal creation still works from an unaffected IP
+# 4. nil/empty IP skips rather than sharing one global bucket
+# 5. Cap-hit writes exactly one ColonelAuditEvent, in the SECURITY trail, and
+#    denied requests write no further ones
+# 6. Garbage/non-positive config falls back to defaults instead of inverting
+# 7. Configured-off (enabled:false) is a total no-op
+# 8. The collapsed-IP operator hint is present and WIRED IN to the log line
+
+require_relative '../../support/test_models'
+require 'onetime/security/conceal_secret_rate_limiter'
+
+OT.boot! :test, true
+
+# Tryout files share one process and OT.conf is global; snapshot the booted
+# config so the teardown can restore it for later files.
+@saved_conf = YAML.load(YAML.dump(OT.conf))
+
+# Enable the limiter with small, known caps (test config ships it disabled).
+def set_conceal_secret_rate_limit(cfg)
+  new_conf = YAML.load(YAML.dump(OT.conf))
+  new_conf['site'] ||= {}
+  new_conf['site']['secret_options'] ||= {}
+  new_conf['site']['secret_options']['create_rate_limit'] = cfg
+  OT.send(:conf=, new_conf)
+end
+
+# Toggle site.network.trusted_proxy.enabled for the collapsed-IP hint cases;
+# the teardown restores @saved_conf wholesale.
+def set_trusted_proxy_enabled(value)
+  new_conf = YAML.load(YAML.dump(OT.conf))
+  new_conf['site'] ||= {}
+  new_conf['site']['network'] ||= {}
+  new_conf['site']['network']['trusted_proxy'] = value.nil? ? {} : { 'enabled' => value }
+  OT.send(:conf=, new_conf)
+end
+
+set_conceal_secret_rate_limit(
+  'enabled' => true,
+  'max_per_ip' => 3,
+  'window' => 900,
+  'lockout' => 900,
+)
+
+class ConcealSecretRateLimiterTester
+  include Onetime::Security::ConcealSecretRateLimiter
+end
+
+@tester = ConcealSecretRateLimiterTester.new
+@redis  = Onetime::Secret.dbclient
+
+@ip_a = '203.0.113.10'
+@ip_b = '198.51.100.20'
+
+# true if a single enforce call raises LimitExceeded, false otherwise.
+@raises = lambda do |ip|
+  @tester.enforce_conceal_secret_rate_limit!(ip)
+  false
+rescue Onetime::LimitExceeded
+  true
+end
+
+def cleanup(redis, ip)
+  redis.del("create_secret:attempts:ip:#{ip}", "create_secret:locked:ip:#{ip}")
+end
+
+cleanup(@redis, @ip_a)
+cleanup(@redis, @ip_b)
+
+## -- Under-limit ----------------------------------------------------------
+
+## A single creation under the cap is allowed
+@raises.call(@ip_a)
+#=> false
+
+## The attempts counter uses the documented key shape (the one the ratelimit
+## Registry and the bin/ots CLI emit commands for)
+@redis.exists?("create_secret:attempts:ip:#{@ip_a}")
+#=> true
+
+## The counter carries a TTL within the configured window
+ttl = @redis.ttl("create_secret:attempts:ip:#{@ip_a}")
+ttl.positive? && ttl <= 900
+#=> true
+
+## -- Over-limit (cap = 3) -------------------------------------------------
+
+## Two more requests reach the cap (total 3) and lock the tier
+[@raises.call(@ip_a), @raises.call(@ip_a)]
+#=> [false, false]
+
+## The lockout key is now set
+@redis.exists?("create_secret:locked:ip:#{@ip_a}")
+#=> true
+
+## The attempts counter is cleared once the tier locks
+@redis.exists?("create_secret:attempts:ip:#{@ip_a}")
+#=> false
+
+## The next creation from that IP raises LimitExceeded
+@raises.call(@ip_a)
+#=> true
+
+## The raised error reports the configured cap and a positive retry_after,
+## which the shared RetryAfterHeader middleware turns into the HTTP header
+begin
+  @tester.enforce_conceal_secret_rate_limit!(@ip_a)
+  nil
+rescue Onetime::LimitExceeded => e
+  [e.max_attempts, e.retry_after.positive?]
+end
+#=> [3, true]
+
+## Normal creation still works: a different IP is unaffected by that lockout
+@raises.call(@ip_b)
+#=> false
+
+## -- Missing IP skips rather than sharing a global bucket -----------------
+
+## A nil IP does not build a blank "ip:" key. Sharing one bucket across every
+## IP-less caller would let the first few lock it and deny everyone after —
+## a global creation outage driven by whatever made the IP unresolvable.
+result_nil = @raises.call(nil)
+[result_nil, @redis.exists?('create_secret:attempts:ip:')]
+#=> [false, false]
+
+## An empty-string IP behaves identically
+result_empty = @raises.call('')
+[result_empty, @redis.exists?('create_secret:attempts:ip:')]
+#=> [false, false]
+
+## -- Audit trail ----------------------------------------------------------
+
+## A cap-hit writes ONE queryable ColonelAuditEvent, so a creation flood leaves
+## more than a log line. Counted as a delta rather than by clearing the shared
+## store, which other tryout files also write to.
+set_conceal_secret_rate_limit(
+  'enabled' => true, 'max_per_ip' => 2, 'window' => 900, 'lockout' => 900,
+)
+@audit_verb  = Onetime::Security::ConcealSecretRateLimiter::AUDIT_VERB
+@audit_count = -> { Onetime::ColonelAuditEvent.recent_security(500).count { |e| e['verb'] == @audit_verb } }
+@admin_count = -> { Onetime::ColonelAuditEvent.count }
+@audit_ip    = '203.0.113.99'
+cleanup(@redis, @audit_ip)
+@audit_before = @audit_count.call
+@admin_before = @admin_count.call
+2.times { @raises.call(@audit_ip) }
+@audit_count.call - @audit_before
+#=> 1
+
+## The event lands in the SECURITY trail, never the count-capped operator trail
+@admin_count.call - @admin_before
+#=> 0
+
+## The event names the tier, the caps, and an unauthenticated actor
+@audit_event = Onetime::ColonelAuditEvent.recent_security(500).find { |e| e['verb'] == @audit_verb }
+[@audit_event['actor'], @audit_event['result'], @audit_event['detail']['tier'],
+ @audit_event['detail']['count'], @audit_event['detail']['max_attempts']]
+#=> ['anonymous', 'failure', 'ip', 2, 2]
+
+## The target is the OBSCURED IP (/16), never the resolved one
+@audit_event['target']
+#=> 'ip:203.0.x.x'
+
+## Denied requests write NO further events: only the cap-reaching request
+## records, bounding writes to one per masked network per lockout window.
+3.times { @raises.call(@audit_ip) }
+@audit_count.call - @audit_before
+#=> 1
+
+## -- Config validation ----------------------------------------------------
+
+## Non-positive / garbage numeric settings fall back to the defaults instead of
+## inverting enforcement (a zero cap would otherwise lock on the very first
+## creation, and a non-positive lockout would make the Lua SETEX fail)
+set_conceal_secret_rate_limit(
+  'enabled' => true, 'max_per_ip' => 0, 'window' => -5, 'lockout' => 'abc',
+)
+@cfg_ip = '198.51.100.77'
+cleanup(@redis, @cfg_ip)
+result_cfg = @raises.call(@cfg_ip)
+[result_cfg, @redis.exists?("create_secret:locked:ip:#{@cfg_ip}")]
+#=> [false, false]
+
+## A PARTIAL config block — present, but with every numeric key absent — falls
+## back to the defaults rather than raising (NilClass#to_i is 0, taking the same
+## not-positive path as a garbage value)
+set_conceal_secret_rate_limit('enabled' => true)
+[@tester.send(:conceal_secret_max_per_ip),
+ @tester.send(:conceal_secret_window),
+ @tester.send(:conceal_secret_lockout)]
+#=> [Onetime::Security::ConcealSecretRateLimiter::DEFAULT_MAX_PER_IP, Onetime::Security::ConcealSecretRateLimiter::DEFAULT_WINDOW, Onetime::Security::ConcealSecretRateLimiter::DEFAULT_LOCKOUT]
+
+## and it still enforces on those defaults rather than erroring
+@partial_ip = '203.0.113.42'
+cleanup(@redis, @partial_ip)
+@raises.call(@partial_ip)
+#=> false
+
+## -- Configured off -------------------------------------------------------
+
+## With enabled:false the limiter is a total no-op even past the caps
+set_conceal_secret_rate_limit('enabled' => false, 'max_per_ip' => 3)
+@off_ip = '192.0.2.55'
+cleanup(@redis, @off_ip)
+results = (1..6).map { @raises.call(@off_ip) }
+results.none?
+#=> true
+
+## A disabled limiter writes no keys at all
+@redis.exists?("create_secret:attempts:ip:#{@off_ip}")
+#=> false
+
+## -- Collapsed IP operator hint (log line only) ---------------------------
+
+## Without a declared trusted proxy the resolved client IP is REMOTE_ADDR, so a
+## lockout may be deployment-wide. The hint says so and names the remedy inline.
+set_trusted_proxy_enabled(false)
+hint = @tester.send(:collapsed_conceal_secret_ip_hint)
+[hint.empty?, hint.include?('trusted_proxy'), hint.include?('TRUSTED_PROXY_ENABLED=true')]
+#=> [false, true, true]
+
+## With the trusted proxy declared the hint is empty, so a correctly configured
+## deployment's lockout line stays byte-identical
+set_trusted_proxy_enabled(true)
+@tester.send(:collapsed_conceal_secret_ip_hint)
+#=> ""
+
+## The hint is WIRED IN: a REAL cap hit (trusted proxy not declared) emits
+## exactly one OT.le line carrying both the cap text and the hint.
+set_trusted_proxy_enabled(false)
+set_conceal_secret_rate_limit(
+  'enabled' => true, 'max_per_ip' => 2, 'window' => 900, 'lockout' => 900,
+)
+@hint_ip = '192.0.2.99'
+cleanup(@redis, @hint_ip)
+captured = []
+OT.singleton_class.alias_method(:__cs_hint_real_le, :le)
+OT.define_singleton_method(:le) { |*msgs, **_payload| captured << msgs.join(' ') }
+begin
+  2.times { @tester.enforce_conceal_secret_rate_limit!(@hint_ip) }
+ensure
+  OT.singleton_class.remove_method(:le)
+  OT.singleton_class.alias_method(:le, :__cs_hint_real_le)
+  OT.singleton_class.remove_method(:__cs_hint_real_le)
+end
+line = captured.find { |msg| msg.include?('hit cap') }.to_s
+[
+  captured.length,
+  line.include?('[ConcealSecretRateLimiter] ip'),
+  line.include?('hit cap (2/2)'),
+  line.include?('TRUSTED_PROXY_ENABLED=true'),
+]
+#=> [1, true, true, true]
+
+# Clean up test keys and restore the shared config for later tryout files.
+cleanup(@redis, @ip_a)
+cleanup(@redis, @ip_b)
+cleanup(@redis, @audit_ip)
+cleanup(@redis, @cfg_ip)
+cleanup(@redis, @partial_ip)
+cleanup(@redis, @off_ip)
+cleanup(@redis, @hint_ip)
+OT.send(:conf=, @saved_conf)


### PR DESCRIPTION
## Summary

Closes finding **F-02** (confirmed high-severity, open since 2026-08-14): the secret-creation path had **no rate limiter** on the modern API surface. `bin/ots ratelimit` listed 8 limiters (feedback, passphrase, invite, login, reset_request ×2, create_account, dns) — none covering secret creation.

Re-measured: one anonymous client accepted 200/200 requests at 113 req/s, ~18,381 bytes of Redis per secret → **~1 GiB of Redis in ~8.6 minutes**. Because Redis also holds sessions, this is a full-outage DoS reachable by any stranger with `curl` — no auth, no setup. The review also noted the amplifier: an anonymous creator on a tenant custom domain can hold storage against the org's plan ceiling (up to ~4× the 7‑day anonymous ceiling), which is why a **create-rate** limit is the right primary control here (TTL is out of scope for this PR).

This adds one new limiter, wired into the **existing** ratelimit Registry mechanism (no new framework), mirroring `CreateAccountRateLimiter`.

### The limiter

- **Module:** `Onetime::Security::ConcealSecretRateLimiter` (`lib/onetime/security/conceal_secret_rate_limiter.rb`), same shape as the other perimeter limiters: atomic Lua check‑and‑record, masked‑IP subject, config‑driven thresholds, one bounded `ColonelAuditEvent` (security trail) on cap‑hit, and the shared collapsed‑proxy operator hint on the lockout log line.
- **Registry kind:** `create_secret` (`lib/onetime/operations/ratelimit/registry.rb`) → keys `create_secret:attempts:ip:%s` / `create_secret:locked:ip:%s` on the Secret shard. So `bin/ots ratelimit keys create_secret <masked-ip>` and `POST /api/colonel/ratelimit/reset` (kind=create_secret) work like every other limiter.
- **Granularity:** single tier, **per masked client IP** (`env['otto.client_ip']`, /24 IPv4 · /48 IPv6) — the same subject and collapse condition as `CreateAccountRateLimiter`. An anonymous conceal holds no account-derived identifier, so IP is the only key available.
- **Scope: anonymous only.** Authenticated callers are accountable through their Customer record and plan limits and are the legitimate high-volume creators, so charging them would risk a false lockout of the core product function for exactly the wrong users. This matches the finding (an *unauthenticated* flood).

### Threshold chosen and why

Default **`max_per_ip = 500`**, `window = 3600s` (1h), `lockout = 3600s`.

- Ten times the sibling perimeter limiters (create_account / reset = 10/hour) because secret creation is the **core product action**, not a rare one — a shared masked /24 (office, campus NAT) legitimately conceals far more secrets per hour than it signs up accounts. The prior V1 legacy per‑IP counter treated ~1000/20min of create_secret as normal use, so 500/hour is a conservative comparable value.
- Still converts the measured flood decisively: ~57k secrets in the window becomes at most **~500 secrets (~9 MiB)** per masked network before the tier locks — unbounded growth → bounded, loggable, auditable trickle.
- Fully configurable via `site.secret_options.create_rate_limit` (`SECRET_CREATE_RATE_LIMIT_ENABLED` / `_MAX_PER_IP` / `_WINDOW` / `_LOCKOUT`); operators behind a dense NAT or an unconfigured reverse proxy can raise it, and the lockout log line names that remedy inline.

### Enforcement points (both secret-creation entry points)

- **V2 & V3 API — conceal and generate:** `V2::Logic::Secrets::BaseSecretAction#raise_concerns` (`apps/api/v2/logic/secrets/base_secret_action.rb`), inherited by `ConcealSecret`/`GenerateSecret` in both v2 and v3 (v3 subclasses v2 and calls `super`). Runs **before** the `Receipt.spawn_pair` write, gated on `anonymous_user?`, keyed on the masked IP from `strategy_result.metadata[:ip]` (same guarded accessor the passphrase limiter uses in these files). Raises `Onetime::LimitExceeded` → **429** via `otto_hooks`.
- **V1 API — share / generate / create:** the controller (`apps/api/v1/controllers/base.rb#enforce_create_secret_limit!`, called at the three sites in `index.rb`). V1 logic never receives a `strategy_result` and V1's `carefully` has no `Forbidden`/`LimitExceeded` rescue, so enforcing here — over the same `env['otto.client_ip']` subject, using V1's existing return-based `:limited` idiom next to the legacy per‑IP counter — keeps the keyspace identical to v2 without routing a raise into V1's catch-all.

The web/core UI has no separate creation path (it uses the v1/v2 API); the `/incoming` path is already covered by `IncomingRateLimiter`.

## Related Issues

Fixes F-02 (internal vuln triage).

## Test Plan

- New unit regression: `try/unit/security/conceal_secret_rate_limiter_try.rb`, mirroring `create_account_rate_limiter_try.rb` — asserts under‑limit is allowed with the documented key shape/TTL, that exceeding the cap raises `LimitExceeded` (with cap + retry_after) and sets the lockout, that a fresh IP is unaffected (normal creation still works), nil/empty IP skips rather than sharing a global bucket, exactly one bounded security audit event on cap‑hit, garbage/partial config falls back to defaults, `enabled:false` is a total no‑op, and the collapsed‑proxy hint is wired into the lockout log line.
- Limiter disabled in `spec/config.test.yaml` (like the create_account / reset limiters) so the many secret‑creating specs are not throttled; the regression enables it in‑process.
- `ruby -c` clean on all changed Ruby files; rendered `config.defaults.yaml` and `config.test.yaml` parse.

Run: `tests/lanes/run unit` (routes `*_try.rb` to tryouts).

---
_Generated by [Claude Code](https://claude.ai/code/session_015SGRoWqbEaTpBUXNBHjgNR)_