### PR TITLE
fix(colonel): stop exposing live session-cookie values in session APIs

### DIFF
--- a/apps/api/colonel/logic/colonel/list_customer_sessions.rb
+++ b/apps/api/colonel/logic/colonel/list_customer_sessions.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require 'onetime/models/session_metadata'
 require 'onetime/operations/sessions/list_for_customer'
 
 module ColonelAPI
@@ -53,18 +54,31 @@ module ColonelAPI
             record: {},
             # safe_dump is the HTTP boundary (ADR-040): serialize it, never the
             # Result's #to_h (which exposes internal Entry objects + join keys).
+            # Rows now identify a session by its non-bearer session_handle (F-01),
+            # so the acting colonel's own row is matched by handle, not raw sid.
             details: result.safe_dump.merge(
-              current_session_id: current_session_id,
+              current_session_handle: current_session_handle,
             ),
           }
         end
 
         private
 
-        # The acting colonel's OWN request session id, as the plain sid string the
-        # sidecar rows are keyed by (safe_session_id yields a Rack SessionId object;
-        # #public_id is the cookie value == SessionMetadata#session_id). Returned so
-        # the UI can badge the colonel's own row and disable its (no-op) self-revoke.
+        # The acting colonel's OWN request session, as the non-bearer HANDLE the
+        # sidecar rows expose (SessionMetadata#session_handle), so the UI can badge
+        # the colonel's own row and disable its (no-op) self-revoke WITHOUT the
+        # response ever carrying a replayable cookie value — not even the acting
+        # colonel's own. nil when the session can't be identified.
+        def current_session_handle
+          sid = current_session_id
+          return nil if sid.nil?
+
+          Onetime::SessionMetadata.handle_for(sid)
+        end
+
+        # The colonel's own plain sid (safe_session_id yields a Rack SessionId
+        # object; #public_id is the cookie value == SessionMetadata#session_id).
+        # INTERNAL only — never serialized; it is digested into the handle above.
         # nil when the session can't be identified (e.g. Hash session in JSON auth).
         def current_session_id
           sid = safe_session_id

--- a/apps/api/colonel/logic/colonel/revoke_customer_session.rb
+++ b/apps/api/colonel/logic/colonel/revoke_customer_session.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require 'onetime/models/session_metadata'
 require 'onetime/operations/sessions/revoke_for_customer'
 
 module ColonelAPI
@@ -20,24 +21,42 @@ module ColonelAPI
       # Deleting a session logs that user out mid-flight, so the UI gates this
       # behind typed-confirmation (same as the global DeleteSession).
       #
-      # Idempotent: revoking an already-gone session still tidies + returns
-      # `revoked: true` (unlike the global {DeleteSession}, which reports
-      # `deleted: status == :deleted`).
+      # ## Non-bearer identifier (finding F-01)
+      #
+      # The route no longer accepts a raw session id — that value is the live
+      # `onetime.session` cookie and the `session:<sid>` blob key, so accepting
+      # (or returning) it would let a colonel replay another user's cookie. The
+      # per-customer list emits a non-reversible {Onetime::SessionMetadata#session_handle}
+      # instead, and this endpoint accepts THAT. Because the handle is one-way, we
+      # resolve the target sid by recomputing the handle over the OWNING customer's
+      # own `active_sessions` set and matching — so the untrusted handle can only
+      # ever name one of this customer's sessions, and the raw sid stays server-side.
+      #
+      # Idempotent within a live listing: revoking an already-gone session still
+      # returns `revoked: true`. A handle that matches none of the customer's
+      # current active sessions (stale/unknown) is a 404 — there is no session for
+      # it to name — mirroring the global {DeleteSession} not-found.
       #
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class RevokeCustomerSession < ColonelAPI::Logic::Base
-        attr_reader :user_id, :session_id, :result
+        attr_reader :user_id, :session_handle, :session_id, :result
 
         def process_params
-          @user_id    = sanitize_identifier(params['user_id'])
-          @session_id = sanitize_identifier(params['session_id'])
+          @user_id        = sanitize_identifier(params['user_id'])
+          @session_handle = sanitize_identifier(params['session_handle'])
           raise_form_error('User ID is required', field: :user_id) if user_id.to_s.empty?
-          raise_form_error('Session ID is required', field: :session_id) if session_id.to_s.empty?
+          raise_form_error('Session handle is required', field: :session_handle) if session_handle.to_s.empty?
         end
 
         def raise_concerns
           verify_one_of_roles!(colonel: true)
+
+          # Resolve the non-bearer handle back to the raw sid by matching it over
+          # the target customer's own active-session set (the sids never leave the
+          # server). 404 when it names none — a stale or unknown handle.
+          @session_id = resolve_session_id
+          raise_not_found('Session not found') if session_id.nil?
         end
 
         def process
@@ -54,13 +73,30 @@ module ColonelAPI
         def success_data
           {
             record: {
-              session_id: result.session_id,
+              # Echo the non-bearer handle the caller sent — NEVER the raw sid.
+              session_handle: session_handle,
               revoked: result.revoked,
             },
             details: {
               message: 'Session revoked successfully',
             },
           }
+        end
+
+        private
+
+        # Find the raw sid whose handle equals the submitted one, scanning only the
+        # named customer's active_sessions (a small, bounded set). Returns nil when
+        # the customer is unknown or no member matches. Customer resolution mirrors
+        # RevokeForCustomer / ListForCustomer: extid → email → objid.
+        def resolve_session_id
+          customer = Onetime::Customer.load_by_extid_or_email(user_id) ||
+                     Onetime::Customer.load(user_id)
+          return nil unless customer&.exists?
+
+          customer.active_sessions.revrange(0, -1).find do |sid|
+            Onetime::SessionMetadata.handle_for(sid) == session_handle
+          end
         end
       end
     end

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -110,7 +110,7 @@ DELETE /sessions/:session_id              ColonelAPI::Logic::Colonel::DeleteSess
 GET    /users/:user_id/sessions           ColonelAPI::Logic::Colonel::ListCustomerSessions response=json auth=sessionauth role=colonel scope=internal
 # Bulk revoke-all (offboarding/takeover). POST+verb (local convention for bulk-destructive) so it can't collide with the single-revoke DELETE below.
 POST   /users/:user_id/sessions/revoke-all ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions response=json auth=sessionauth role=colonel scope=internal
-DELETE /users/:user_id/sessions/:session_id ColonelAPI::Logic::Colonel::RevokeCustomerSession response=json auth=sessionauth role=colonel scope=internal
+DELETE /users/:user_id/sessions/:session_handle ColonelAPI::Logic::Colonel::RevokeCustomerSession response=json auth=sessionauth role=colonel scope=internal
 
 # Broadcast Banner (ticket #41)
 GET    /banner                            ColonelAPI::Logic::Colonel::GetBanner response=json auth=sessionauth role=colonel scope=internal

--- a/lib/onetime/models/session_metadata.rb
+++ b/lib/onetime/models/session_metadata.rb
@@ -2,6 +2,8 @@
 #
 # frozen_string_literal: true
 
+require 'openssl'
+
 module Onetime
   # SessionMetadata — a per-session, non-sensitive sidecar record that backs the
   # colonel's PER-CUSTOMER session view (spec docs/specs/colonel-ui/40-*).
@@ -37,6 +39,14 @@ module Onetime
   # filtering — is the feature's core security guarantee. Adding a field here is a
   # deliberate act of exposing it; do not add anything sensitive.
   #
+  # The raw session_id is a BEARER value — byte-identical to the `onetime.session`
+  # cookie and the `session:<sid>` blob key name (see "Keying" above) — so it is
+  # deliberately kept OUT of the allow-list (finding F-01): emitting it would hand
+  # a privileged operator a replayable session cookie for any user, i.e. silent
+  # impersonation past MFA. The colonel view instead identifies a session by
+  # #session_handle, a non-reversible keyed digest of the sid that round-trips to
+  # revoke but can never be replayed as a credential.
+  #
   # ## Population + lifetime
   #
   # Written best-effort from Onetime::Operations::Sessions::TrackMetadata, called
@@ -66,7 +76,9 @@ module Onetime
     # session's sidecar never expires out from under it.
     default_expiration 2_592_000
 
-    field :session_id       # plain sid; also the identifier and the blob key name
+    field :session_id       # plain sid; also the identifier and the blob key name.
+                            # BEARER value — kept OUT of safe_dump (F-01); the
+                            # colonel view exposes #session_handle instead.
     field :org_id           # active ORGANIZATION objid, resolved per write via OrganizationLoader (see TrackMetadata#active_org_id)
     field :user_id          # customer EXTERNAL id (extid, 'ur...'), matching colonel identity everywhere
     field :created_at       # epoch seconds, set once on first observation
@@ -131,11 +143,55 @@ module Onetime
     end
     prepend GeoCountryNormalization
 
+    # Length (hex chars) of the truncated session handle — 128 bits, matching
+    # Onetime::Utils::EmailHash's precedent for a truncated keyed digest. Ample
+    # collision resistance for identifying one customer's handful of sessions.
+    HANDLE_LENGTH = 32
+
+    # Domain-separation label so this digest can never be confused with any other
+    # keyed digest of the same sid computed elsewhere in the app.
+    HANDLE_DOMAIN = 'session_metadata.handle.v1'
+
+    # Non-reversible, colonel-facing identifier for a session — the value the
+    # per-customer session view renders and the revoke endpoint accepts, in place
+    # of the raw (bearer) session_id (finding F-01).
+    #
+    # It is a truncated HMAC-SHA256 of the plain sid, keyed with the application
+    # global secret (the same root Onetime::Security::RequestContext and the
+    # IncomingConfig recipient hashing key off). Deterministic — the same sid
+    # always yields the same handle — so the revoke path can recover the target
+    # sid by matching this over the OWNING customer's active_sessions set, yet the
+    # sid itself cannot be recovered from the handle and the handle can never be
+    # replayed as a session cookie.
+    #
+    # @param session_id [String, nil]
+    # @return [String, nil] 32-char hex handle, or nil for a blank sid.
+    def self.handle_for(session_id)
+      sid = session_id.to_s
+      return nil if sid.empty?
+
+      digest = OpenSSL::Digest.new('sha256')
+      OpenSSL::HMAC.hexdigest(digest, OT.global_secret.to_s, "#{HANDLE_DOMAIN}:#{sid}")[0, HANDLE_LENGTH]
+    end
+
+    # Instance reader used by the safe_dump allow-list below. A plain derived
+    # method (not a stored field), so Familia's default field lambda resolves it
+    # via `send(:session_handle)` exactly like any getter — emitting the handle,
+    # never the raw sid.
+    #
+    # @return [String, nil]
+    def session_handle
+      self.class.handle_for(session_id)
+    end
+
     # POSITIVE allow-list — the security boundary. No token, no payload, no email.
+    # session_id (the raw bearer sid) is REPLACED by session_handle, a
+    # non-reversible digest (F-01): the colonel view can identify and revoke a
+    # session by the handle without ever receiving a replayable cookie value.
     # active_session_id_hmac is omitted on purpose: it is an internal join key,
     # not something the colonel view renders.
     safe_dump_fields(
-      :session_id,
+      :session_handle,
       :user_id,
       :org_id,
       :created_at,

--- a/src/apps/admin/components/AdminCustomerSessionsSection.vue
+++ b/src/apps/admin/components/AdminCustomerSessionsSection.vue
@@ -33,7 +33,7 @@
   const notifications = useNotificationsStore();
 
   const store = useAdminCustomerSessions();
-  const { sessions, currentSessionId, loading, error, validationError } = storeToRefs(store);
+  const { sessions, currentSessionHandle, loading, error, validationError } = storeToRefs(store);
 
   const loadFailed = computed(
     () => error.value !== null || validationError.value !== null
@@ -45,8 +45,8 @@
    * the row is badged and its per-row revoke is disabled instead of silently
    * doing nothing.
    */
-  function isCurrentSession(sessionId: string): boolean {
-    return currentSessionId.value !== null && sessionId === currentSessionId.value;
+  function isCurrentSession(sessionHandle: string): boolean {
+    return currentSessionHandle.value !== null && sessionHandle === currentSessionHandle.value;
   }
 
   const columns = computed<DataTableColumn<AdminCustomerSession>[]>(() => [
@@ -84,7 +84,7 @@
   // ---- Guarded revoke -------------------------------------------------------
 
   const revokeDialogOpen = ref(false);
-  /** The session id the confirm dialog is gating (request target). */
+  /** The session handle the confirm dialog is gating (request target). */
   const revokeTarget = ref('');
 
   const {
@@ -99,8 +99,8 @@
     await store.revoke(props.userId, revokeTarget.value);
   });
 
-  function requestRevoke(sessionId: string): void {
-    revokeTarget.value = sessionId;
+  function requestRevoke(sessionHandle: string): void {
+    revokeTarget.value = sessionHandle;
     resetRevoke();
     revokeDialogOpen.value = true;
   }
@@ -222,7 +222,7 @@
       v-else
       :columns="columns"
       :rows="sessions"
-      row-key="session_id"
+      row-key="session_handle"
       :loading="loading"
       :empty-text="t('web.admin.customers.detail.sessions.empty')"
       testid="sessions-section-table">
@@ -249,8 +249,8 @@
       <template #cell-actions="{ row }">
         <!-- The colonel's own session: badge it and disable the (no-op) self-revoke. -->
         <span
-          v-if="isCurrentSession(row.session_id)"
-          :data-testid="`session-current-${row.session_id}`"
+          v-if="isCurrentSession(row.session_handle)"
+          :data-testid="`session-current-${row.session_handle}`"
           class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
           :title="t('web.admin.customers.detail.sessions.current.tooltip')">
           <OIcon
@@ -262,9 +262,9 @@
         <button
           v-else
           type="button"
-          :data-testid="`session-revoke-${row.session_id}`"
+          :data-testid="`session-revoke-${row.session_handle}`"
           class="text-sm font-medium text-red-600 hover:text-red-800 focus:ring-2 focus:ring-red-500 focus:outline-none dark:text-red-400 dark:hover:text-red-300"
-          @click="requestRevoke(row.session_id)">
+          @click="requestRevoke(row.session_handle)">
           {{ t('web.admin.customers.detail.sessions.revoke.button') }}
         </button>
       </template>

--- a/src/apps/admin/stores/useAdminCustomerSessions.ts
+++ b/src/apps/admin/stores/useAdminCustomerSessions.ts
@@ -25,8 +25,12 @@ import { gracefulParse } from '@/utils/schemaValidation';
  * can appear because none exists on the model.
  *
  *   - fetchForCustomer(userId) → GET    /api/colonel/users/:user_id/sessions
- *   - revoke(userId, sessionId) → DELETE /api/colonel/users/:user_id/sessions/:session_id
+ *   - revoke(userId, sessionHandle) → DELETE /api/colonel/users/:user_id/sessions/:session_handle
  *   - revokeAll(userId) → POST /api/colonel/users/:user_id/sessions/revoke-all
+ *
+ * Sessions are identified by session_handle, a non-reversible digest of the raw
+ * session id (finding F-01) — the raw sid (a live cookie value) never reaches
+ * the client.
  *
  * `userId` is the customer EXTERNAL id (extid, 'ur…') — the same value the
  * detail view is keyed by. Not paginated: a single customer's active-session
@@ -61,11 +65,11 @@ export const useAdminCustomerSessions = defineStore('adminCustomerSessions', () 
   /** The customer's active session rows (whole list — never paginated). */
   const sessions = ref<AdminCustomerSession[]>([]);
   /**
-   * The acting colonel's own request session id whenever the API can identify
+   * The acting colonel's own request session HANDLE whenever the API can identify
    * it — independent of whether it appears in `sessions` (the component does
    * the row matching). Null when unidentifiable or before/after a failed fetch.
    */
-  const currentSessionId = ref<string | null>(null);
+  const currentSessionHandle = ref<string | null>(null);
   /** True while a request is in flight. */
   const loading = ref(false);
   /** The last thrown network/HTTP error, or null. */
@@ -88,7 +92,7 @@ export const useAdminCustomerSessions = defineStore('adminCustomerSessions', () 
     loading.value = true;
     error.value = null;
     validationError.value = null;
-    currentSessionId.value = null; // reset up-front; only a 2xx re-populates it
+    currentSessionHandle.value = null; // reset up-front; only a 2xx re-populates it
     try {
       const response = await $api.get(sessionsUrl(userId));
       const result = parseSessionsResponse(response.data);
@@ -99,7 +103,7 @@ export const useAdminCustomerSessions = defineStore('adminCustomerSessions', () 
         return null;
       }
       sessions.value = result.data.details?.sessions ?? [];
-      currentSessionId.value = result.data.details?.current_session_id ?? null;
+      currentSessionHandle.value = result.data.details?.current_session_handle ?? null;
       return sessions.value;
     } catch (err) {
       // Network/HTTP failure: clear stale rows and rethrow for the view to handle.
@@ -118,16 +122,16 @@ export const useAdminCustomerSessions = defineStore('adminCustomerSessions', () 
    * the row stays. The ack is schema-checked as a live tripwire (never fails the
    * action on drift). Throws the network/HTTP error for useAdminMutation to catch.
    */
-  async function revoke(userId: string, sessionId: string): Promise<void> {
+  async function revoke(userId: string, sessionHandle: string): Promise<void> {
     const response = await $api.delete(
-      `${sessionsUrl(userId)}/${encodeURIComponent(sessionId)}`
+      `${sessionsUrl(userId)}/${encodeURIComponent(sessionHandle)}`
     );
     gracefulParse(
       colonelCustomerSessionRevokeResponseSchema,
       response.data,
       'ColonelCustomerSessionRevokeResponse'
     );
-    sessions.value = sessions.value.filter((s) => s.session_id !== sessionId);
+    sessions.value = sessions.value.filter((s) => s.session_handle !== sessionHandle);
   }
 
   /** Revoke ALL sessions (offboarding/takeover); clears the list, returns kill counts. */
@@ -142,7 +146,7 @@ export const useAdminCustomerSessions = defineStore('adminCustomerSessions', () 
   /** Explicit manual reset — setup stores have no built-in $reset. */
   function $reset(): void {
     sessions.value = [];
-    currentSessionId.value = null;
+    currentSessionHandle.value = null;
     loading.value = false;
     error.value = null;
     validationError.value = null;
@@ -151,7 +155,7 @@ export const useAdminCustomerSessions = defineStore('adminCustomerSessions', () 
   return {
     // State
     sessions,
-    currentSessionId,
+    currentSessionHandle,
     loading,
     error,
     validationError,

--- a/src/schemas/api/internal/responses/colonel-customer-sessions.ts
+++ b/src/schemas/api/internal/responses/colonel-customer-sessions.ts
@@ -9,7 +9,11 @@
 // and the frontend physically cannot render one.
 //
 //   - ListCustomerSessions   → GET    /api/colonel/users/:user_id/sessions
-//   - RevokeCustomerSession  → DELETE /api/colonel/users/:user_id/sessions/:session_id
+//   - RevokeCustomerSession  → DELETE /api/colonel/users/:user_id/sessions/:session_handle
+//
+// Sessions are identified by session_handle, a non-reversible digest of the raw
+// session id (finding F-01). The raw sid is the live session cookie / Redis blob
+// key, so it is never sent to the client; the handle round-trips list → revoke.
 //
 // Shape verified VERBATIM against the SessionMetadata safe_dump_fields allow-list
 // (lib/onetime/models/session_metadata.rb) and the logic adapters
@@ -26,7 +30,9 @@ import { z } from 'zod';
 
 /**
  * A single per-customer session row — the SessionMetadata safe_dump shape
- * verbatim. Every field except session_id/user_id is nullable: org_id is the
+ * verbatim. session_handle is the non-reversible identifier (F-01) the revoke
+ * endpoint accepts; the raw session id never crosses the API. Every field except
+ * session_handle/user_id is nullable: org_id is the
  * active organization objid, resolved per write (null if the customer has no
  * org); ip_address/user_agent are copied as-is from the (already Otto-masked)
  * session data; auth_method is the primary login method stamped at auth time
@@ -40,7 +46,7 @@ import { z } from 'zod';
  * guarantee.
  */
 export const adminCustomerSessionSchema = z.object({
-  session_id: z.string(),
+  session_handle: z.string(),
   user_id: z.string(),
   org_id: z.string().nullable(),
   created_at: z.number().nullable(),
@@ -55,27 +61,27 @@ export const adminCustomerSessionSchema = z.object({
 /**
  * ListCustomerSessions `details`: the customer's session rows + a count.
  *
- * `current_session_id` is the acting colonel's OWN request session id whenever
- * it can be identified, regardless of whether it appears among these rows. The
- * UI matches it against the rows: on a match (colonel viewing their own customer
- * detail) it badges that row and disables its per-row revoke, since a
- * self-revoke is a no-op (Rack re-persists the current session's blob at the end
- * of the same request). Null/absent only when the current session can't be
- * identified (e.g. a Hash session under JSON auth).
+ * `current_session_handle` is the handle of the acting colonel's OWN request
+ * session whenever it can be identified, regardless of whether it appears among
+ * these rows. The UI matches it against the rows' session_handle: on a match
+ * (colonel viewing their own customer detail) it badges that row and disables
+ * its per-row revoke, since a self-revoke is a no-op (Rack re-persists the
+ * current session's blob at the end of the same request). Null/absent only when
+ * the current session can't be identified (e.g. a Hash session under JSON auth).
  */
 export const colonelCustomerSessionsDetailsSchema = z.object({
   sessions: z.array(adminCustomerSessionSchema),
   count: z.number(),
-  current_session_id: z.string().nullable().optional(),
+  current_session_handle: z.string().nullable().optional(),
 });
 
 // ============================================================================
 // RevokeCustomerSession — guarded revoke ack
 // ============================================================================
 
-/** RevokeCustomerSession `record`: the revoked session's id + a revoked flag. */
+/** RevokeCustomerSession `record`: the revoked session's handle + a revoked flag. */
 export const colonelCustomerSessionRevokeRecordSchema = z.object({
-  session_id: z.string(),
+  session_handle: z.string(),
   revoked: z.boolean(),
 });
 
@@ -131,7 +137,7 @@ export const colonelCustomerSessionsResponseSchema = createApiResponseSchema(
   colonelCustomerSessionsDetailsSchema
 );
 
-// DELETE /api/colonel/users/:user_id/sessions/:session_id → RevokeCustomerSession
+// DELETE /api/colonel/users/:user_id/sessions/:session_handle → RevokeCustomerSession
 export const colonelCustomerSessionRevokeResponseSchema = createApiResponseSchema(
   colonelCustomerSessionRevokeRecordSchema,
   colonelCustomerSessionRevokeDetailsSchema

--- a/src/schemas/api/internal/responses/colonel-customer-sessions.ts
+++ b/src/schemas/api/internal/responses/colonel-customer-sessions.ts
@@ -24,6 +24,18 @@
 import { createApiResponseSchema } from '@/schemas/api/base';
 import { z } from 'zod';
 
+/**
+ * The non-reversible session handle (F-01): the first 32 hex chars of an
+ * HMAC-SHA256 over the raw sid (SessionMetadata.handle_for). Validating the
+ * exact shape — not just z.string() — makes the schema a security tripwire:
+ * a backend regression that leaks the raw 64+-char sid (or anything else)
+ * under a *_handle key fails parsing here instead of flowing a replayable
+ * bearer value into the admin UI.
+ */
+export const sessionHandleSchema = z
+  .string()
+  .regex(/^[0-9a-f]{32}$/, 'session_handle must be a 32-char lowercase hex handle');
+
 // ============================================================================
 // ListCustomerSessions — one customer's session rows
 // ============================================================================
@@ -46,7 +58,7 @@ import { z } from 'zod';
  * guarantee.
  */
 export const adminCustomerSessionSchema = z.object({
-  session_handle: z.string(),
+  session_handle: sessionHandleSchema,
   user_id: z.string(),
   org_id: z.string().nullable(),
   created_at: z.number().nullable(),
@@ -72,7 +84,7 @@ export const adminCustomerSessionSchema = z.object({
 export const colonelCustomerSessionsDetailsSchema = z.object({
   sessions: z.array(adminCustomerSessionSchema),
   count: z.number(),
-  current_session_handle: z.string().nullable().optional(),
+  current_session_handle: sessionHandleSchema.nullable().optional(),
 });
 
 // ============================================================================
@@ -81,7 +93,7 @@ export const colonelCustomerSessionsDetailsSchema = z.object({
 
 /** RevokeCustomerSession `record`: the revoked session's handle + a revoked flag. */
 export const colonelCustomerSessionRevokeRecordSchema = z.object({
-  session_handle: z.string(),
+  session_handle: sessionHandleSchema,
   revoked: z.boolean(),
 });
 

--- a/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
@@ -42,7 +42,7 @@ const UNKNOWN = 'web.admin.customers.detail.sessions.unknown';
 
 function sessionRow(overrides: Record<string, unknown> = {}) {
   return {
-    session_id: 'sid_1',
+    session_handle: 'sid_1',
     user_id: USER_ID,
     org_id: null,
     created_at: 1700000000,
@@ -68,13 +68,13 @@ function sessionRowWithoutCountry(overrides: Record<string, unknown> = {}) {
 }
 
 function sessionsPayload(
-  rows = [sessionRow(), sessionRow({ session_id: 'sid_2' })],
-  currentSessionId: string | null = null
+  rows = [sessionRow(), sessionRow({ session_handle: 'sid_2' })],
+  currentSessionHandle: string | null = null
 ) {
   return {
     shrimp: '',
     record: {},
-    details: { sessions: rows, count: rows.length, current_session_id: currentSessionId },
+    details: { sessions: rows, count: rows.length, current_session_handle: currentSessionHandle },
   };
 }
 
@@ -139,7 +139,7 @@ describe('AdminCustomerSessionsSection — current-session badge', () => {
     expect(badge(wrapper, 'sid_2').exists()).toBe(false);
   });
 
-  it('shows no badge and all revoke buttons when currentSessionId is null', async () => {
+  it('shows no badge and all revoke buttons when currentSessionHandle is null', async () => {
     mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, null) });
     wrapper = mountSection();
     await flushPromises();
@@ -157,8 +157,8 @@ describe('adminCustomerSessionSchema — geo_country', () => {
     // crosses the API.
     const result = colonelCustomerSessionsResponseSchema.safeParse(
       sessionsPayload([
-        sessionRow({ session_id: 'sid_code', geo_country: 'DE' }),
-        sessionRow({ session_id: 'sid_null', geo_country: null }),
+        sessionRow({ session_handle: 'sid_code', geo_country: 'DE' }),
+        sessionRow({ session_handle: 'sid_null', geo_country: null }),
       ])
     );
     expect(result.success).toBe(true);
@@ -170,8 +170,8 @@ describe('adminCustomerSessionSchema — geo_country', () => {
 
   it('parses rows that OMIT geo_country entirely — deploy skew must not fail the whole list', () => {
     const payload = sessionsPayload([
-      sessionRowWithoutCountry({ session_id: 'sid_old' }),
-      sessionRow({ session_id: 'sid_new', geo_country: 'FR' }),
+      sessionRowWithoutCountry({ session_handle: 'sid_old' }),
+      sessionRow({ session_handle: 'sid_new', geo_country: 'FR' }),
     ]);
     const result = colonelCustomerSessionsResponseSchema.safeParse(payload);
     expect(result.success).toBe(true);
@@ -207,8 +207,8 @@ describe('AdminCustomerSessionsSection — country column', () => {
   it('renders a null and an absent geo_country as Unknown', async () => {
     mockApi.get.mockResolvedValue({
       data: sessionsPayload([
-        sessionRow({ session_id: 'sid_null', geo_country: null }),
-        sessionRowWithoutCountry({ session_id: 'sid_absent' }),
+        sessionRow({ session_handle: 'sid_null', geo_country: null }),
+        sessionRowWithoutCountry({ session_handle: 'sid_absent' }),
       ]),
     });
     wrapper = mountSection();
@@ -220,9 +220,9 @@ describe('AdminCustomerSessionsSection — country column', () => {
 
   it('never leaks an IP into the country cell — only a 2-letter code or Unknown', async () => {
     const rows = [
-      sessionRow({ session_id: 'sid_code', ip_address: '203.0.113.7', geo_country: 'DE' }),
-      sessionRow({ session_id: 'sid_null', ip_address: '192.0.2.44', geo_country: null }),
-      sessionRowWithoutCountry({ session_id: 'sid_absent', ip_address: '2001:db8::1' }),
+      sessionRow({ session_handle: 'sid_code', ip_address: '203.0.113.7', geo_country: 'DE' }),
+      sessionRow({ session_handle: 'sid_null', ip_address: '192.0.2.44', geo_country: null }),
+      sessionRowWithoutCountry({ session_handle: 'sid_absent', ip_address: '2001:db8::1' }),
     ];
     mockApi.get.mockResolvedValue({ data: sessionsPayload(rows) });
     wrapper = mountSection();

--- a/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
@@ -45,7 +45,7 @@ const UNKNOWN = 'web.admin.customers.detail.sessions.unknown';
 
 function sessionRow(overrides: Partial<AdminCustomerSession> = {}): AdminCustomerSession {
   return {
-    session_handle: 'sid_1',
+    session_handle: 'a15e5510000000000000000000000001',
     user_id: USER_ID,
     org_id: null,
     created_at: 1700000000,
@@ -75,7 +75,7 @@ function sessionRowWithoutCountry(
 }
 
 function sessionsPayload(
-  rows: AdminCustomerSession[] = [sessionRow(), sessionRow({ session_handle: 'sid_2' })],
+  rows: AdminCustomerSession[] = [sessionRow(), sessionRow({ session_handle: 'a15e5510000000000000000000000002' })],
   currentSessionHandle: string | null = null
 ) {
   return {
@@ -122,28 +122,28 @@ describe('AdminCustomerSessionsSection — current-session badge', () => {
   afterEach(() => wrapper?.unmount());
 
   it('badges the matching row and withholds its revoke button', async () => {
-    mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, 'sid_1') });
+    mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, 'a15e5510000000000000000000000001') });
     wrapper = mountSection();
     await flushPromises();
 
     // The colonel's own row: badge in, per-row revoke out (v-if/v-else).
-    expect(badge(wrapper, 'sid_1').exists()).toBe(true);
-    expect(revoke(wrapper, 'sid_1').exists()).toBe(false);
-    expect(badge(wrapper, 'sid_1').text()).toContain(
+    expect(badge(wrapper, 'a15e5510000000000000000000000001').exists()).toBe(true);
+    expect(revoke(wrapper, 'a15e5510000000000000000000000001').exists()).toBe(false);
+    expect(badge(wrapper, 'a15e5510000000000000000000000001').text()).toContain(
       'web.admin.customers.detail.sessions.current.badge'
     );
-    expect(badge(wrapper, 'sid_1').attributes('title')).toBe(
+    expect(badge(wrapper, 'a15e5510000000000000000000000001').attributes('title')).toBe(
       'web.admin.customers.detail.sessions.current.tooltip'
     );
   });
 
   it('renders the revoke button (and no badge) on non-matching rows', async () => {
-    mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, 'sid_1') });
+    mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, 'a15e5510000000000000000000000001') });
     wrapper = mountSection();
     await flushPromises();
 
-    expect(revoke(wrapper, 'sid_2').exists()).toBe(true);
-    expect(badge(wrapper, 'sid_2').exists()).toBe(false);
+    expect(revoke(wrapper, 'a15e5510000000000000000000000002').exists()).toBe(true);
+    expect(badge(wrapper, 'a15e5510000000000000000000000002').exists()).toBe(false);
   });
 
   it('shows no badge and all revoke buttons when currentSessionHandle is null', async () => {
@@ -153,8 +153,8 @@ describe('AdminCustomerSessionsSection — current-session badge', () => {
 
     // null must not accidentally match any row (the guard in isCurrentSession).
     expect(wrapper.find('[data-testid^="session-current-"]').exists()).toBe(false);
-    expect(revoke(wrapper, 'sid_1').exists()).toBe(true);
-    expect(revoke(wrapper, 'sid_2').exists()).toBe(true);
+    expect(revoke(wrapper, 'a15e5510000000000000000000000001').exists()).toBe(true);
+    expect(revoke(wrapper, 'a15e5510000000000000000000000002').exists()).toBe(true);
   });
 });
 
@@ -164,8 +164,8 @@ describe('adminCustomerSessionSchema — geo_country', () => {
     // crosses the API.
     const result = colonelCustomerSessionsResponseSchema.safeParse(
       sessionsPayload([
-        sessionRow({ session_handle: 'sid_code', geo_country: 'DE' }),
-        sessionRow({ session_handle: 'sid_null', geo_country: null }),
+        sessionRow({ session_handle: 'a15e551000000000000000000000c0de', geo_country: 'DE' }),
+        sessionRow({ session_handle: 'a15e55100000000000000000000000aa', geo_country: null }),
       ])
     );
     expect(result.success).toBe(true);
@@ -177,8 +177,8 @@ describe('adminCustomerSessionSchema — geo_country', () => {
 
   it('parses rows that OMIT geo_country entirely — deploy skew must not fail the whole list', () => {
     const payload = sessionsPayload([
-      sessionRowWithoutCountry({ session_handle: 'sid_old' }),
-      sessionRow({ session_handle: 'sid_new', geo_country: 'FR' }),
+      sessionRowWithoutCountry({ session_handle: 'a15e551000000000000000000000000d' }),
+      sessionRow({ session_handle: 'a15e551000000000000000000000000e', geo_country: 'FR' }),
     ]);
     const result = colonelCustomerSessionsResponseSchema.safeParse(payload);
     expect(result.success).toBe(true);
@@ -214,8 +214,8 @@ describe('AdminCustomerSessionsSection — country column', () => {
   it('renders a null and an absent geo_country as Unknown', async () => {
     mockApi.get.mockResolvedValue({
       data: sessionsPayload([
-        sessionRow({ session_handle: 'sid_null', geo_country: null }),
-        sessionRowWithoutCountry({ session_handle: 'sid_absent' }),
+        sessionRow({ session_handle: 'a15e55100000000000000000000000aa', geo_country: null }),
+        sessionRowWithoutCountry({ session_handle: 'a15e55100000000000000000000000ab' }),
       ]),
     });
     wrapper = mountSection();
@@ -227,9 +227,9 @@ describe('AdminCustomerSessionsSection — country column', () => {
 
   it('never leaks an IP into the country cell — only a 2-letter code or Unknown', async () => {
     const rows = [
-      sessionRow({ session_handle: 'sid_code', ip_address: '203.0.113.7', geo_country: 'DE' }),
-      sessionRow({ session_handle: 'sid_null', ip_address: '192.0.2.44', geo_country: null }),
-      sessionRowWithoutCountry({ session_handle: 'sid_absent', ip_address: '2001:db8::1' }),
+      sessionRow({ session_handle: 'a15e551000000000000000000000c0de', ip_address: '203.0.113.7', geo_country: 'DE' }),
+      sessionRow({ session_handle: 'a15e55100000000000000000000000aa', ip_address: '192.0.2.44', geo_country: null }),
+      sessionRowWithoutCountry({ session_handle: 'a15e55100000000000000000000000ab', ip_address: '2001:db8::1' }),
     ];
     mockApi.get.mockResolvedValue({ data: sessionsPayload(rows) });
     wrapper = mountSection();

--- a/src/tests/apps/admin/useAdminCustomerSessions.spec.ts
+++ b/src/tests/apps/admin/useAdminCustomerSessions.spec.ts
@@ -19,7 +19,7 @@ const USER_ID = 'ur_abc123';
 
 function sessionRow(overrides: Record<string, unknown> = {}) {
   return {
-    session_handle: 'sid_1',
+    session_handle: 'a15e5510000000000000000000000001',
     user_id: USER_ID,
     org_id: null,
     created_at: 1700000000,
@@ -33,7 +33,7 @@ function sessionRow(overrides: Record<string, unknown> = {}) {
 }
 
 function sessionsPayload(
-  rows = [sessionRow(), sessionRow({ session_handle: 'sid_2' })],
+  rows = [sessionRow(), sessionRow({ session_handle: 'a15e5510000000000000000000000002' })],
   currentSessionHandle: string | null = null
 ) {
   return {
@@ -43,7 +43,7 @@ function sessionsPayload(
   };
 }
 
-function revokePayload(sessionId = 'sid_1') {
+function revokePayload(sessionId = 'a15e5510000000000000000000000001') {
   return {
     shrimp: '',
     record: { session_handle: sessionId, revoked: true },
@@ -89,18 +89,18 @@ describe('useAdminCustomerSessions', () => {
     // 404s in prod but passes a naive mock. Assert it.
     expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/users/ur_abc123/sessions');
     expect(store.sessions).toHaveLength(2);
-    expect(store.sessions[0].session_handle).toBe('sid_1');
+    expect(store.sessions[0].session_handle).toBe('a15e5510000000000000000000000001');
     expect(store.sessions[0].ip_address).toBe('203.0.113.7');
     expect(store.validationError).toBeNull();
   });
 
   it('exposes details.current_session_handle (the colonel viewing their own detail)', async () => {
-    mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, 'sid_2') });
+    mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, 'a15e5510000000000000000000000002') });
     const store = useAdminCustomerSessions();
 
     await store.fetchForCustomer(USER_ID);
 
-    expect(store.currentSessionHandle).toBe('sid_2');
+    expect(store.currentSessionHandle).toBe('a15e5510000000000000000000000002');
   });
 
   it('defaults currentSessionHandle to null when the field is absent', async () => {
@@ -126,10 +126,10 @@ describe('useAdminCustomerSessions', () => {
   });
 
   it('clears currentSessionHandle on a network failure', async () => {
-    mockApi.get.mockResolvedValueOnce({ data: sessionsPayload(undefined, 'sid_2') });
+    mockApi.get.mockResolvedValueOnce({ data: sessionsPayload(undefined, 'a15e5510000000000000000000000002') });
     const store = useAdminCustomerSessions();
     await store.fetchForCustomer(USER_ID);
-    expect(store.currentSessionHandle).toBe('sid_2');
+    expect(store.currentSessionHandle).toBe('a15e5510000000000000000000000002');
 
     mockApi.get.mockRejectedValueOnce(new Error('Network Error'));
     await expect(store.fetchForCustomer(USER_ID)).rejects.toThrow('Network Error');
@@ -169,18 +169,18 @@ describe('useAdminCustomerSessions', () => {
 
   it('revoke DELETEs the per-session endpoint and optimistically drops the row', async () => {
     mockApi.get.mockResolvedValue({ data: sessionsPayload() });
-    mockApi.delete.mockResolvedValue({ data: revokePayload('sid_1') });
+    mockApi.delete.mockResolvedValue({ data: revokePayload('a15e5510000000000000000000000001') });
     const store = useAdminCustomerSessions();
     await store.fetchForCustomer(USER_ID);
     expect(store.sessions).toHaveLength(2);
 
-    await store.revoke(USER_ID, 'sid_1');
+    await store.revoke(USER_ID, 'a15e5510000000000000000000000001');
 
     expect(mockApi.delete).toHaveBeenCalledWith(
-      '/api/colonel/users/ur_abc123/sessions/sid_1'
+      '/api/colonel/users/ur_abc123/sessions/a15e5510000000000000000000000001'
     );
     expect(store.sessions).toHaveLength(1);
-    expect(store.sessions.map((s) => s.session_handle)).toEqual(['sid_2']);
+    expect(store.sessions.map((s) => s.session_handle)).toEqual(['a15e5510000000000000000000000002']);
   });
 
   it('keeps the row when revoke rejects', async () => {
@@ -189,7 +189,7 @@ describe('useAdminCustomerSessions', () => {
     const store = useAdminCustomerSessions();
     await store.fetchForCustomer(USER_ID);
 
-    await expect(store.revoke(USER_ID, 'sid_1')).rejects.toThrow('403');
+    await expect(store.revoke(USER_ID, 'a15e5510000000000000000000000001')).rejects.toThrow('403');
     expect(store.sessions).toHaveLength(2);
   });
 

--- a/src/tests/apps/admin/useAdminCustomerSessions.spec.ts
+++ b/src/tests/apps/admin/useAdminCustomerSessions.spec.ts
@@ -19,7 +19,7 @@ const USER_ID = 'ur_abc123';
 
 function sessionRow(overrides: Record<string, unknown> = {}) {
   return {
-    session_id: 'sid_1',
+    session_handle: 'sid_1',
     user_id: USER_ID,
     org_id: null,
     created_at: 1700000000,
@@ -33,20 +33,20 @@ function sessionRow(overrides: Record<string, unknown> = {}) {
 }
 
 function sessionsPayload(
-  rows = [sessionRow(), sessionRow({ session_id: 'sid_2' })],
-  currentSessionId: string | null = null
+  rows = [sessionRow(), sessionRow({ session_handle: 'sid_2' })],
+  currentSessionHandle: string | null = null
 ) {
   return {
     shrimp: '',
     record: {},
-    details: { sessions: rows, count: rows.length, current_session_id: currentSessionId },
+    details: { sessions: rows, count: rows.length, current_session_handle: currentSessionHandle },
   };
 }
 
 function revokePayload(sessionId = 'sid_1') {
   return {
     shrimp: '',
-    record: { session_id: sessionId, revoked: true },
+    record: { session_handle: sessionId, revoked: true },
     details: { message: 'Session revoked.' },
   };
 }
@@ -89,51 +89,51 @@ describe('useAdminCustomerSessions', () => {
     // 404s in prod but passes a naive mock. Assert it.
     expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/users/ur_abc123/sessions');
     expect(store.sessions).toHaveLength(2);
-    expect(store.sessions[0].session_id).toBe('sid_1');
+    expect(store.sessions[0].session_handle).toBe('sid_1');
     expect(store.sessions[0].ip_address).toBe('203.0.113.7');
     expect(store.validationError).toBeNull();
   });
 
-  it('exposes details.current_session_id (the colonel viewing their own detail)', async () => {
+  it('exposes details.current_session_handle (the colonel viewing their own detail)', async () => {
     mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, 'sid_2') });
     const store = useAdminCustomerSessions();
 
     await store.fetchForCustomer(USER_ID);
 
-    expect(store.currentSessionId).toBe('sid_2');
+    expect(store.currentSessionHandle).toBe('sid_2');
   });
 
-  it('defaults currentSessionId to null when the field is absent', async () => {
+  it('defaults currentSessionHandle to null when the field is absent', async () => {
     // Genuinely omit the key — the schema is `.nullable().optional()`, so
     // "key missing" and "key: null" are distinct inputs. This covers missing.
     const payload = sessionsPayload();
-    delete (payload.details as Record<string, unknown>).current_session_id;
+    delete (payload.details as Record<string, unknown>).current_session_handle;
     mockApi.get.mockResolvedValue({ data: payload });
     const store = useAdminCustomerSessions();
 
     await store.fetchForCustomer(USER_ID);
 
-    expect(store.currentSessionId).toBeNull();
+    expect(store.currentSessionHandle).toBeNull();
   });
 
-  it('keeps currentSessionId null when the field is explicitly null', async () => {
+  it('keeps currentSessionHandle null when the field is explicitly null', async () => {
     mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, null) });
     const store = useAdminCustomerSessions();
 
     await store.fetchForCustomer(USER_ID);
 
-    expect(store.currentSessionId).toBeNull();
+    expect(store.currentSessionHandle).toBeNull();
   });
 
-  it('clears currentSessionId on a network failure', async () => {
+  it('clears currentSessionHandle on a network failure', async () => {
     mockApi.get.mockResolvedValueOnce({ data: sessionsPayload(undefined, 'sid_2') });
     const store = useAdminCustomerSessions();
     await store.fetchForCustomer(USER_ID);
-    expect(store.currentSessionId).toBe('sid_2');
+    expect(store.currentSessionHandle).toBe('sid_2');
 
     mockApi.get.mockRejectedValueOnce(new Error('Network Error'));
     await expect(store.fetchForCustomer(USER_ID)).rejects.toThrow('Network Error');
-    expect(store.currentSessionId).toBeNull();
+    expect(store.currentSessionHandle).toBeNull();
   });
 
   it('url-encodes the customer id', async () => {
@@ -180,7 +180,7 @@ describe('useAdminCustomerSessions', () => {
       '/api/colonel/users/ur_abc123/sessions/sid_1'
     );
     expect(store.sessions).toHaveLength(1);
-    expect(store.sessions.map((s) => s.session_id)).toEqual(['sid_2']);
+    expect(store.sessions.map((s) => s.session_handle)).toEqual(['sid_2']);
   });
 
   it('keeps the row when revoke rejects', async () => {

--- a/try/integration/api/colonel/list_customer_sessions_try.rb
+++ b/try/integration/api/colonel/list_customer_sessions_try.rb
@@ -15,6 +15,8 @@
 # - 200 with both seeded sessions, NEWEST-FIRST (active_sessions score desc)
 # - each row is the safe_dump allow-list shape: user_id present, and NO
 #   email / token / decrypted-payload key (the allow-list is the security boundary)
+# - F-01: rows identify a session by session_handle (a non-bearer digest), and the
+#   raw sid (== live cookie / blob key) appears NOWHERE in the response
 # - an unknown user_id returns 200 with an empty list + count 0 (no raise)
 #
 # Sessions are seeded through the REAL write path (TrackMetadata) with a REAL
@@ -113,18 +115,24 @@ last_response.status
 
 # --- List newest-first via safe_dump -------------------------------------
 
-## 200 with both sessions, newest (highest score) first, count 2
+## 200 with both sessions, newest (highest score) first, count 2. Rows are keyed
+## by session_handle (non-bearer digest), NOT the raw sid (F-01).
 get URL, {}, colonel_headers
 @resp = JSON.parse(last_response.body)
 @d    = @resp['details']
-[last_response.status, @d['count'], @d['sessions'].map { |s| s['session_id'] }]
-#=> [200, 2, ["#{@sid_new}", "#{@sid_old}"]]
+[last_response.status, @d['count'], @d['sessions'].map { |s| s['session_handle'] }]
+#=> [200, 2, [Onetime::SessionMetadata.handle_for(@sid_new), Onetime::SessionMetadata.handle_for(@sid_old)]]
 
-## details carries current_session_id — the acting colonel's OWN request sid so
-## the UI can badge their own row. It's the colonel's session (not @target's), so
-## it won't match a listed row here; the contract just guarantees the key + a sid.
-@csid = @d['current_session_id']
-[@d.key?('current_session_id'), @csid.is_a?(String), @csid.match?(/\A[a-f0-9]{64,}\z/)]
+## F-01: the raw sid (== live cookie value / `session:<sid>` blob key) appears
+## NOWHERE in the response body — only the non-reversible handle crosses the wire
+[last_response.body.include?(@sid_new), last_response.body.include?(@sid_old)]
+#=> [false, false]
+
+## details carries current_session_handle — the digest of the acting colonel's OWN
+## request sid so the UI can badge their own row WITHOUT the response exposing the
+## colonel's own live cookie either. It's a 32-hex handle, never the 64-hex sid.
+@chandle = @d['current_session_handle']
+[@d.key?('current_session_handle'), @chandle.is_a?(String), @chandle.match?(/\A[a-f0-9]{32}\z/) ? true : false]
 #=> [true, true, true]
 
 ## each row is the safe_dump allow-list shape: user_id == target extid
@@ -133,12 +141,13 @@ get URL, {}, colonel_headers
 #=> ["#{@extid}", '203.0.113.1', 'UA']
 
 ## the row carries NO email, NO token, NO decrypted-payload key (security boundary)
-[@row.key?('email'), @row.key?('token'), @row.key?('authenticated'), @row.key?('external_id')]
-#=> [false, false, false, false]
+## and NO raw session_id — the bearer sid is replaced by session_handle (F-01)
+[@row.key?('email'), @row.key?('token'), @row.key?('authenticated'), @row.key?('external_id'), @row.key?('session_id')]
+#=> [false, false, false, false, false]
 
 ## the row exposes exactly the safe_dump keys and nothing more
 @row.keys.sort
-#=> ["auth_method", "created_at", "geo_country", "ip_address", "last_activity_at", "mfa_used", "org_id", "session_id", "user_agent", "user_id"]
+#=> ["auth_method", "created_at", "geo_country", "ip_address", "last_activity_at", "mfa_used", "org_id", "session_handle", "user_agent", "user_id"]
 
 # --- Unknown user_id -----------------------------------------------------
 

--- a/try/integration/api/colonel/revoke_customer_session_try.rb
+++ b/try/integration/api/colonel/revoke_customer_session_try.rb
@@ -5,18 +5,24 @@
 # Integration tests for the colonel per-customer session REVOKE endpoint
 # (spec docs/specs/colonel-ui/40-sessions-metadata-sidecar.md):
 #
-#   DELETE /api/colonel/users/:user_id/sessions/:session_id
+#   DELETE /api/colonel/users/:user_id/sessions/:session_handle
 #
 # The HTTP boundary over {Onetime::Operations::Sessions::RevokeForCustomer}. In
 # this codebase a session dies by deleting the encrypted `session:<sid>` blob
 # (adaptation #1), NOT by removing a Rodauth index row — so the blob is minted for
-# real and the invalidation is genuine, not mocked. Covers:
+# real and the invalidation is genuine, not mocked.
+#
+# F-01: the endpoint accepts the non-bearer session_handle (a digest of the sid),
+# NOT the raw sid — the raw sid is the live cookie / blob key and never leaves the
+# server. The adapter resolves the handle back to a sid by matching it over the
+# target customer's own active_sessions set. Covers:
 # - 403 for non-colonel, 401 for anonymous (dual-gate)
-# - a successful DELETE returns record.revoked=true; the live blob is GONE, the
-#   sidecar is destroyed, and the sid is ZREM'd from Customer#active_sessions
+# - a successful DELETE (by handle) returns record.revoked=true + echoes the
+#   handle; the live blob is GONE, the sidecar is destroyed, and the sid is ZREM'd
+# - the response NEVER carries the raw sid
 # - EXACTLY ONE ColonelAuditEvent per revoke (verb 'session.revoke', target = the
 #   target extid, actor = the acting colonel's extid)
-# - IDEMPOTENT: a second DELETE still returns revoked=true
+# - a stale handle (session already revoked / no longer in the active set) is a 404
 #
 # Run: try --agent try/integration/api/colonel/revoke_customer_session_try.rb
 
@@ -99,7 +105,9 @@ SM.load(@sid)&.destroy!
 DB.del(@key)
 seed_session(@target, @sid)
 
-URL = "/api/colonel/users/#{@extid}/sessions/#{@sid}"
+# The endpoint is keyed by the non-bearer handle (F-01), not the raw sid.
+@handle = SM.handle_for(@sid)
+URL = "/api/colonel/users/#{@extid}/sessions/#{@handle}"
 
 # --- Authorization -------------------------------------------------------
 
@@ -120,12 +128,16 @@ delete URL, {}, { 'HTTP_ACCEPT' => 'application/json' }
 [Store.find_key(DB, @sid), SM.load(@sid).nil?, @target.active_sessions.member?(@sid)]
 #=> [@key, false, true]
 
-## DELETE by the colonel returns 200 with record.revoked=true and the sid echoed
+## DELETE by the colonel returns 200 with record.revoked=true and the HANDLE echoed
 AE.events.clear
 delete URL, {}, colonel_headers
 @resp = JSON.parse(last_response.body)
-[last_response.status, @resp['record']['revoked'], @resp['record']['session_id'], @resp['details']['message']]
-#=> [200, true, "#{@sid}", 'Session revoked successfully']
+[last_response.status, @resp['record']['revoked'], @resp['record']['session_handle'], @resp['details']['message']]
+#=> [200, true, "#{@handle}", 'Session revoked successfully']
+
+## F-01: the response body NEVER carries the raw sid (== live cookie / blob key)
+last_response.body.include?(@sid)
+#=> false
 
 ## the live `session:<sid>` blob is GONE (this is what logs the user out)
 Store.find_key(DB, @sid)
@@ -143,14 +155,14 @@ Store.find_key(DB, @sid)
 AE.recent(1).first['detail']['session_id']
 #=> "#{@sid}"
 
-# --- Idempotent second revoke --------------------------------------------
+# --- Stale handle: the resolved session is gone --------------------------
 
-## a second DELETE still returns revoked=true (already-gone session tidied again)
+## a second DELETE with the now-stale handle 404s — the first revoke ZREM'd the
+## sid from the active set, so the handle resolves to no session to revoke
 AE.events.clear
 delete URL, {}, colonel_headers
-@resp2 = JSON.parse(last_response.body)
-[last_response.status, @resp2['record']['revoked']]
-#=> [200, true]
+last_response.status
+#=> 404
 
 # --- Teardown ------------------------------------------------------------
 SM.load(@sid)&.destroy!

--- a/try/unit/models/session_metadata_try.rb
+++ b/try/unit/models/session_metadata_try.rb
@@ -14,6 +14,8 @@
 #   surface through safe_dump. The model declares no such field, and Familia's
 #   allow-list is positive, so the guarantee is structural — asserted here as an
 #   exact key-set equality plus an explicit absence sweep of sensitive names.
+# - F-01 regression: the raw bearer sid (== live cookie / Redis blob key) is NEVER
+#   in safe_dump; the colonel view gets #session_handle, a non-reversible digest.
 #
 # Run: try --agent try/unit/models/session_metadata_try.rb
 
@@ -34,8 +36,10 @@ SM.load(@sid)&.destroy!
 
 # The exact positive allow-list declared on the model. Kept as the source of
 # truth for the equality assertion below; sensitive fields are absent BY DESIGN.
+# session_handle (a non-reversible digest) stands in for the raw bearer sid,
+# which is deliberately NOT exposed (F-01).
 ALLOWED = %i[
-  session_id user_id org_id created_at last_activity_at
+  session_handle user_id org_id created_at last_activity_at
   ip_address user_agent auth_method mfa_used geo_country
 ].freeze
 
@@ -67,6 +71,20 @@ ALLOWED = %i[
 ## the allow-list carries the metadata we set (ip/ua copied AS-IS, adaptation #3)
 [@dump[:user_id], @dump[:ip_address], @dump[:user_agent]]
 #=> ["ur_#{@nonce}", "203.0.113.0", "Chrome on macOS"]
+
+## F-01: the raw bearer sid is NOT emitted; the colonel view gets a handle instead
+[@dump.key?(:session_id), @dump.key?(:session_handle)]
+#=> [false, true]
+
+## the handle is the non-reversible digest of the sid (32 hex chars), not the sid
+@handle = SM.load(@sid).safe_dump[:session_handle]
+[@handle == SM.handle_for(@sid), @handle == @sid, @handle.length]
+#=> [true, false, 32]
+
+## F-01: the raw sid (== live cookie value / `session:<sid>` blob key) appears
+## NOWHERE in the serialized payload — no value carries it as a substring either
+@dump.values.map(&:to_s).any? { |v| v.include?(@sid) }
+#=> false
 
 ## SECURITY: no token / email / payload / secret / account_id key can leak
 @sensitive = %i[token email payload secret secret_value account_id password
@@ -111,6 +129,24 @@ DB.hset(SM.dbkey(@sid), 'geo_country', '"**"')
 @blank.geo_country = '  '
 @blank.geo_country
 #=> nil
+
+# ---- session_handle: non-reversible identifier (F-01) -----------------
+
+## handle_for is deterministic and non-empty for a real sid
+[SM.handle_for(@sid) == SM.handle_for(@sid), SM.handle_for(@sid).to_s.empty?]
+#=> [true, false]
+
+## handle_for returns nil for a blank/absent sid — no handle for "no session"
+[SM.handle_for(nil), SM.handle_for('')]
+#=> [nil, nil]
+
+## distinct sids get distinct handles (so a handle names exactly one session)
+SM.handle_for("#{@sid}_a") == SM.handle_for("#{@sid}_b")
+#=> false
+
+## the handle is not reversible to (and never equals) the sid it stands for
+SM.handle_for(@sid) == @sid
+#=> false
 
 # ---- expiration feature present ---------------------------------------
 

--- a/try/unit/operations/sessions/list_for_customer_try.rb
+++ b/try/unit/operations/sessions/list_for_customer_try.rb
@@ -70,28 +70,31 @@ track(@cust, @sid_new, @extid, @ts + 100)
 
 # ---- list newest-first via safe_dump ----------------------------------
 
-## resolves by extid and returns both sessions, newest (highest score) first
+## resolves by extid and returns both sessions, newest (highest score) first.
+## Rows are identified by session_handle (non-bearer digest), not the raw sid (F-01).
 @res = LFC.new(custid: @extid).call
-[@res.count, @res.sessions.map { |s| s[:session_id] }]
-#=> [2, ["#{@sid_new}", "#{@sid_old}"]]
+[@res.count, @res.sessions.map { |s| s[:session_handle] }]
+#=> [2, [SM.handle_for(@sid_new), SM.handle_for(@sid_old)]]
 
-## each row is the safe_dump allow-list shape (metadata only, no blob fields)
+## each row is the safe_dump allow-list shape (metadata only, no blob fields) and
+## carries NO raw session_id — only its non-reversible session_handle (F-01)
 @row = @res.sessions.first
-[@row[:user_id], @row.key?(:email), @row.key?(:token)]
-#=> ["#{@extid}", false, false]
+[@row[:user_id], @row.key?(:session_id), @row.key?(:session_handle), @row.key?(:email), @row.key?(:token)]
+#=> ["#{@extid}", false, true, false, false]
 
 ## geo_country is never Otto's '**' sentinel: a legacy sidecar that stored it
 ## verbatim emits nil through safe_dump (the SessionMetadata reader is the
 ## normalization chokepoint), while a real code passes through untouched
 DB.hset(SM.dbkey(@sid_new), 'geo_country', '"**"')
 DB.hset(SM.dbkey(@sid_old), 'geo_country', '"NZ"')
-@geo_rows = LFC.new(custid: @extid).call.sessions.to_h { |s| [s[:session_id], s[:geo_country]] }
-[@geo_rows[@sid_new], @geo_rows[@sid_old]]
+@geo_rows = LFC.new(custid: @extid).call.sessions.to_h { |s| [s[:session_handle], s[:geo_country]] }
+[@geo_rows[SM.handle_for(@sid_new)], @geo_rows[SM.handle_for(@sid_old)]]
 #=> [nil, "NZ"]
 
-## internal join keys accompany safe rows without a second sidecar read
-@res.entries.to_h { |e| [e.session[:session_id], e.active_session_id_hmac] }
-#=> {"#{@sid_new}" => "hmac_#{@sid_new}", "#{@sid_old}" => "hmac_#{@sid_old}"}
+## internal join keys accompany safe rows without a second sidecar read (the
+## public row is keyed by its handle; the hmac stays an internal join value)
+@res.entries.to_h { |e| [e.session[:session_handle], e.active_session_id_hmac] }
+#=> {SM.handle_for(@sid_new) => "hmac_#{@sid_new}", SM.handle_for(@sid_old) => "hmac_#{@sid_old}"}
 
 ## safe_dump is the public boundary: the row carries NO internal join key
 @entry = @res.entries.first
@@ -128,8 +131,8 @@ ensure
   SM.singleton_class.alias_method(:load_multi, :__lfc_real_load_multi)
   SM.singleton_class.remove_method(:__lfc_real_load_multi)
 end
-@batch_fallback.sessions.map { |s| s[:session_id] }
-#=> ["#{@sid_new}", "#{@sid_old}"]
+@batch_fallback.sessions.map { |s| s[:session_handle] }
+#=> [SM.handle_for(@sid_new), SM.handle_for(@sid_old)]
 
 ## an unreadable sidecar (batch fails, then that row's fallback load fails too)
 ## skips only that row and leaves its index member intact
@@ -154,8 +157,8 @@ ensure
   SM.singleton_class.alias_method(:load, :__list_for_customer_real_load)
   SM.singleton_class.remove_method(:__list_for_customer_real_load)
 end
-[@degraded.count, @degraded.sessions.map { |s| s[:session_id] }, @cust.active_sessions.member?(@sid_old)]
-#=> [1, ["#{@sid_new}"], true]
+[@degraded.count, @degraded.sessions.map { |s| s[:session_handle] }, @cust.active_sessions.member?(@sid_old)]
+#=> [1, [SM.handle_for(@sid_new)], true]
 
 # ---- self-heal: stale index member is pruned (sidecar gone) -----------
 
@@ -164,8 +167,8 @@ SM.load(@sid_old)&.destroy!            # drop the sidecar, leave the index membe
 @before = @cust.active_sessions.member?(@sid_old)
 @res2   = LFC.new(custid: @extid).call
 @after  = @cust.active_sessions.member?(@sid_old)
-[@before, @res2.count, @res2.sessions.map { |s| s[:session_id] }, @after]
-#=> [true, 1, ["#{@sid_new}"], false]
+[@before, @res2.count, @res2.sessions.map { |s| s[:session_handle] }, @after]
+#=> [true, 1, [SM.handle_for(@sid_new)], false]
 
 ## a transient self-heal write failure skips its stale row without hiding readable sessions
 @write_failure_sid = "trylist_write_failure_#{@nonce}"
@@ -185,8 +188,8 @@ ensure
   @active_sessions_class.alias_method(:remove, :__list_for_customer_real_remove)
   @active_sessions_class.remove_method(:__list_for_customer_real_remove)
 end
-[@write_failure_result.count, @write_failure_result.sessions.map { |s| s[:session_id] }, @cust.active_sessions.member?(@write_failure_sid)]
-#=> [1, ["#{@sid_new}"], true]
+[@write_failure_result.count, @write_failure_result.sessions.map { |s| s[:session_handle] }, @cust.active_sessions.member?(@write_failure_sid)]
+#=> [1, [SM.handle_for(@sid_new)], true]
 
 # ---- blob-liveness reconcile: dead session pruned (blob gone) ----------
 


### PR DESCRIPTION
## Summary

Internal security finding **F-01** (high severity): colonel (admin) session APIs returned live session-cookie values, enabling silent, unattributable impersonation of any user past MFA.

`Onetime::SessionMetadata#safe_dump` listed `:session_id` in its positive allow-list. That field is the plain session id — byte-identical to the `onetime.session` cookie value and to the `session:<sid>` Redis blob key (the model's own comment notes the plain sid "is also the identifier and the blob key name"). Every colonel-facing endpoint that serialized a `SessionMetadata` via `safe_dump` — the per-customer session view — therefore handed a privileged operator a **replayable session cookie** for an arbitrary user, including other colonels.

### The fix: a non-bearer handle

`:session_id` is removed from the `safe_dump` allow-list and replaced with `:session_handle` — a non-reversible, truncated **HMAC-SHA256** of the sid, keyed with the application global secret (the same root `Security::RequestContext` and `IncomingConfig` recipient hashing key off) and domain-separated with a fixed label. It is 32 hex chars (128 bits).

Properties:
- **Not a credential.** The raw sid cannot be recovered from the handle, and the handle can never be replayed as a session cookie.
- **Deterministic + round-trips.** The colonel list returns the handle; the revoke endpoint accepts it. The raw sid never crosses the API.
- The `session_id` field itself is unchanged (still the model identifier / blob key); it is simply no longer exposed. `active_session_id_hmac` remains an internal-only join key.

### Revoke call-site updates

The security boundary is the untrusted-input edge, so resolution happens in the colonel logic adapters; the audited `RevokeForCustomer` / `RevokeAllForCustomer` operations stay keyed by the raw sid internally, preserving their invalidation and takeover-mitigation semantics.

- `list_customer_sessions.rb` — rows now identify by `session_handle` (via the model change); `current_session_id` becomes `current_session_handle` (digest of the acting colonel's own sid) so the UI can still badge/disable the colonel's own row without the response carrying even the colonel's own live cookie.
- `revoke_customer_session.rb` — accepts the handle and resolves it back to a sid by recomputing the handle over the **owning customer's own `active_sessions` set** and matching, so a handle can only ever name one of that customer's sessions. A stale/unknown handle is a 404 (mirroring the global `DeleteSession`). The response echoes the handle, never the raw sid.
- `routes.txt` — the per-customer DELETE param is renamed `:session_id` → `:session_handle`.
- `revoke_all_customer_sessions.rb` — unchanged: it takes no per-session identifier (revokes all, reading sids server-side).

### Sites reviewed and left unchanged (deliberately)

- **End-user `/auth/active-sessions`** consumes `ListForCustomer` but joins on the Rodauth `active_session_id` HMAC and reads only display fields (ip/ua/geo/timestamps) from the sidecar — it never read the raw sid, so removing it changes nothing there.
- **Global session console** (`ListSessions` / `GetSessionDetail` / `DeleteSession`) is a separate scan/decrypt path that does not go through `SessionMetadata#safe_dump`; it is a distinct concern and out of scope for F-01.

### Frontend

Minimal, consistency-only rename in the per-customer admin view so the revoke identifier round-trips: response schema (`session_handle`, `current_session_handle`), the Pinia store, and the sessions section component (row key, current-row match, revoke target, test ids). The global `AdminSessions` view is untouched.

## Related Issues

Internal appsec triage finding F-01 (open since 2026-08-20). No public issue number.

## Test Plan

Adjusted the regression specs that encoded the old raw-sid contract and added F-01 assertions:

- `try/unit/models/session_metadata_try.rb` — `safe_dump` emits `:session_handle` and **not** `:session_id`; the raw sid appears in no dumped value; the handle is deterministic, 32 hex, and never equals the sid; blank sid → nil handle.
- `try/unit/operations/sessions/list_for_customer_try.rb` — rows key by `session_handle`; no `:session_id` key.
- `try/integration/api/colonel/list_customer_sessions_try.rb` — response rows carry `session_handle`; the raw sid appears nowhere in the body; `current_session_handle` is a 32-hex digest, not the 64-hex sid.
- `try/integration/api/colonel/revoke_customer_session_try.rb` — DELETE by handle revokes the right session (blob gone, sidecar destroyed, index pruned, exactly one audit event whose detail records the resolved sid server-side); the response body never carries the raw sid; a stale handle 404s.
- Frontend per-customer specs updated to the renamed field.

Run: `tests/lanes/run unit` for the tryouts and `pnpm` vitest for the frontend specs. (Not executed in this environment: no `.test-mode` sentinel / lane services here per AGENTS.md, and frontend deps were not installed. Ruby syntax-checked all changed `.rb` files.)

---
_Generated by [Claude Code](https://claude.ai/code/session_015SGRoWqbEaTpBUXNBHjgNR)_