### PR TITLE
Colonel Hardening: server-side confirmation, step-up sudo, interlocks, rate limits, opaque session IDs, admin lifetime & network gating (#4323)

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1393,6 +1393,11 @@ ASSUME_HTTPS=false
 # and both surfaces 404. Filter mode with no explicit CIDRs trusts every
 # private-network peer as a proxy, which restores exactly the forwarded-host
 # spoofing the provenance rule exists to block.
+# THIS AND ADMIN_ALLOWED_CIDRS ARE ALSO WHAT PROMOTE the 15 destructive colonel
+# routes (purge, role change, revoke, delete, DLQ purge) from an ADVISORY
+# network requirement to an ENFORCED one (#4332). Set BOTH or neither: setting
+# only one gives you neither promotion and logs a boot WARN saying so. A
+# wildcard here does not count as set for this purpose.
 # Example: admin.example.com
 #ADMIN_ALLOWED_HOSTS=
 
@@ -1415,6 +1420,9 @@ ASSUME_HTTPS=false
 # matcher the privacy layer installs, so /32 and /128 entries work — see
 # docs/operations/admin-network-isolation.md, "CIDR precision and privacy
 # masking".
+# Paired with ADMIN_ALLOWED_HOSTS above, this is what promotes the 15
+# destructive colonel routes from an advisory network requirement to an
+# enforced one (#4332). Set BOTH or neither.
 # Example: 100.64.0.0/10,10.0.0.0/8
 #ADMIN_ALLOWED_CIDRS=
 

--- a/.env.reference
+++ b/.env.reference
@@ -1454,6 +1454,36 @@ ASSUME_HTTPS=false
 #COLONEL_ELEVATION_MAX_ATTEMPTS=5
 #COLONEL_ELEVATION_RATE_WINDOW=900
 #COLONEL_ELEVATION_LOCKOUT=900
+# Every MUTATING colonel verb (issue #4329), charged once per request from the
+# colonel logic base constructor. 120 per 5 minutes is far above any human
+# operator and above a bulk console session, so it only trips on scripted abuse.
+# A lockout here also blocks POST /ratelimit/reset (itself a mutation), so clear
+# this one with the commands `bin/ots ratelimit keys colonel_mutation <extid>`
+# prints.
+#COLONEL_MUTATION_RATE_LIMIT_ENABLED=true
+#COLONEL_MUTATION_MAX_ATTEMPTS=120
+#COLONEL_MUTATION_RATE_WINDOW=300
+#COLONEL_MUTATION_LOCKOUT=300
+# TIER 1 (destructive) verbs only: purge account, change role, revoke sessions,
+# delete org/domain/secret, DLQ purge. Charged LAST — after step-up,
+# confirmation and the per-verb interlocks all pass — so a rejected attempt
+# costs nothing and an attacker holding the cookie cannot burn the real
+# operator's budget with cheap 403s. 10 real actions per 5 minutes with a
+# 15-minute lockout: enough for an incident-response burst, and low enough that
+# a scripted purge stalls long before it can flush the count-capped audit trail.
+# Bulk work belongs on the CLI. Clear a lockout with POST /ratelimit/reset
+# (kind=colonel_destructive), which needs no elevation.
+#COLONEL_DESTRUCTIVE_RATE_LIMIT_ENABLED=true
+#COLONEL_DESTRUCTIVE_MAX_ATTEMPTS=10
+#COLONEL_DESTRUCTIVE_RATE_WINDOW=300
+#COLONEL_DESTRUCTIVE_LOCKOUT=900
+# The two session reads that resolve an opaque session handle (#4330) and may
+# fall back to a bounded 10 000-key scan plus as many HMACs. Every OTHER colonel
+# read is deliberately unlimited — the console fetches them on every screen.
+#COLONEL_HANDLE_RESOLVE_RATE_LIMIT_ENABLED=true
+#COLONEL_HANDLE_RESOLVE_MAX_ATTEMPTS=60
+#COLONEL_HANDLE_RESOLVE_RATE_WINDOW=300
+#COLONEL_HANDLE_RESOLVE_LOCKOUT=300
 
 
 # ═══════════════════════════════════════════════════════════

--- a/.env.reference
+++ b/.env.reference
@@ -1484,6 +1484,24 @@ ASSUME_HTTPS=false
 #COLONEL_HANDLE_RESOLVE_MAX_ATTEMPTS=60
 #COLONEL_HANDLE_RESOLVE_RATE_WINDOW=300
 #COLONEL_HANDLE_RESOLVE_LOCKOUT=300
+# Session bounds for the ADMIN API SURFACE (/api/colonel) only (issue #4331).
+# These do NOT shorten the onetime.session cookie and do NOT gate the /colonel
+# SPA shell: one session serves the admin console, the tenant app and the auth
+# app, so expiring the object would log a colonel out of the customer app too —
+# and on a self-hosted install the colonel is often the only customer. A stale
+# admin tab loads the shell, its first API call 401s, and the console renders an
+# expired banner with a sign-in link.
+# ADMIN_SESSION_IDLE_TIMEOUT reads the best-effort SessionMetadata sidecar and
+# is SKIPPED (never failed) when no record exists. It only bites because the
+# admin console makes no periodic requests, and the sidecar is a site-wide
+# activity clock, so tenant traffic keeps the admin window open too.
+# ADMIN_SESSION_ABSOLUTE_TIMEOUT reads session['authenticated_at'] — nothing a
+# stolen cookie can do advances it, so it is the bound that always binds.
+# Set either to 0 to disable that bound; ADMIN_SESSION_LIFETIME_ENABLED=false
+# disables both and restores the pre-#4331 24h rolling posture.
+#ADMIN_SESSION_LIFETIME_ENABLED=true
+#ADMIN_SESSION_IDLE_TIMEOUT=3600
+#ADMIN_SESSION_ABSOLUTE_TIMEOUT=43200
 
 
 # ═══════════════════════════════════════════════════════════

--- a/.env.reference
+++ b/.env.reference
@@ -1418,6 +1418,43 @@ ASSUME_HTTPS=false
 # Example: 100.64.0.0/10,10.0.0.0/8
 #ADMIN_ALLOWED_CIDRS=
 
+# Step-up (sudo) re-authentication for destructive colonel actions
+# (config site.admin.elevation, issue #4327). ON BY DEFAULT.
+# A colonel session alone is no longer sufficient for a tier-1 verb (purge
+# account, change role, revoke sessions, delete org/domain/secret, DLQ purge):
+# the operator must have re-proven a credential through
+# POST /api/colonel/elevation within the window. Confirmation (#4326) still
+# applies on top. Set to false to restore pre-#4327 behaviour.
+#COLONEL_ELEVATION_ENABLED=true
+# Window length in seconds (default 600 = 10 minutes).
+#COLONEL_ELEVATION_WINDOW=600
+# Seconds after sign-in during which a PASSWORD-LESS (SSO-only) colonel may
+# elevate with factor=recent_auth and no credential. DEFAULT 0 = OFF.
+# Available ONLY to accounts that cannot satisfy the password factor: giving it
+# to password holders would make step-up a no-op for the first N seconds after
+# every sign-in. In FULL auth mode every account counts as password-holding
+# (the Rodauth hash table is not reachable from the logic layer), so recent_auth
+# is unavailable there and an SSO-only full-mode fleet sets
+# COLONEL_ELEVATION_ENABLED=false instead. MFA as a step-up factor is not
+# implemented. AN SSO-ONLY FLEET MUST SET ONE OF THESE TWO OR ITS COLONELS
+# CANNOT PERFORM TIER-1 ACTIONS AT ALL.
+#COLONEL_ELEVATION_REAUTH_GRACE=0
+
+# Rate limits for the colonel API surface (config site.admin.rate_limit).
+# Keyed on the acting colonel's public external id (extid) — the same value the
+# audit trail records as `actor` — never on a session id. The parent flag
+# short-circuits every bucket.
+#COLONEL_RATE_LIMIT_ENABLED=true
+# Step-up attempts. The Rodauth password check behind POST /api/colonel/elevation
+# is an internal request and does NOT increment Rodauth's own lockout counter,
+# so this is the only backstop against guessing there. A locked-out operator
+# clears it with POST /api/colonel/ratelimit/reset (kind=colonel_elevation) or
+# the commands `bin/ots ratelimit keys colonel_elevation <extid>` prints.
+#COLONEL_ELEVATION_RATE_LIMIT_ENABLED=true
+#COLONEL_ELEVATION_MAX_ATTEMPTS=5
+#COLONEL_ELEVATION_RATE_WINDOW=900
+#COLONEL_ELEVATION_LOCKOUT=900
+
 
 # ═══════════════════════════════════════════════════════════
 #  MIDDLEWARE

--- a/.env.reference
+++ b/.env.reference
@@ -1444,8 +1444,10 @@ ASSUME_HTTPS=false
 # (the Rodauth hash table is not reachable from the logic layer), so recent_auth
 # is unavailable there and an SSO-only full-mode fleet sets
 # COLONEL_ELEVATION_ENABLED=false instead. MFA as a step-up factor is not
-# implemented. AN SSO-ONLY FLEET MUST SET ONE OF THESE TWO OR ITS COLONELS
-# CANNOT PERFORM TIER-1 ACTIONS AT ALL.
+# implemented. AN SSO-ONLY FLEET MUST CONFIGURE THIS OR COLONEL_ELEVATION_ENABLED
+# OR ITS COLONELS CANNOT PERFORM TIER-1 ACTIONS AT ALL — and which one depends on
+# the auth mode: in SIMPLE mode set this grace > 0 (or ENABLED=false); in FULL
+# mode recent_auth is never offered, so only ENABLED=false works.
 #COLONEL_ELEVATION_REAUTH_GRACE=0
 
 # Rate limits for the colonel API surface (config site.admin.rate_limit).

--- a/apps/api/colonel/auth_strategies.rb
+++ b/apps/api/colonel/auth_strategies.rb
@@ -3,7 +3,6 @@
 # frozen_string_literal: true
 
 require 'otto/utils'
-require 'uri'
 
 module ColonelAPI
   module AuthStrategies
@@ -52,8 +51,8 @@ module ColonelAPI
 
       # DoS ceiling on the ENCODED header, not a token-length limit: the real cap
       # is MAX_CONFIRM_LENGTH (characters, post-decode) in the logic layer. It is
-      # measured on the encoded bytes, which encodeURIComponent expands up to 12
-      # per 4-byte codepoint, so a max-length (255-char) token can approach 3 KB
+      # measured on the encoded bytes, which percent-encoding expands up to 12 per
+      # 4-byte codepoint, so a max-length (255-char) token can approach 3 KB
       # encoded. An over-long header is REJECTED, never truncated: slicing the
       # encoded bytes would sever a %XX escape or a multibyte character and turn a
       # valid token — e.g. a 100-char CJK org display_name, ~900 bytes encoded —
@@ -106,18 +105,23 @@ module ColonelAPI
       # ISO-8859-1 header charset both sides agree on. An absent, empty, oversized
       # or undecodable header is "no token" — never a crash, never a partial match.
       #
-      # URI.decode_uri_component, NOT Rack::Utils.unescape: it matches the console's
-      # encodeURIComponent exactly and does NOT map '+' to space, so a plus-addressed
-      # email sent raw by a non-browser client (X-OTS-Confirm: ops+admin@example.com)
-      # is not silently mangled into "ops admin@example.com" and 403'd. Oversized
-      # headers are rejected whole (see MAX_CONFIRM_BYTES) rather than sliced, so a
-      # legitimate multibyte token is never severed mid-escape.
+      # FORM decoding (Rack::Utils.unescape), which accepts the widest range of
+      # correct encodings for a token that routinely contains SPACES (org
+      # display_names): the console's encodeURIComponent ('%20'), a raw space, AND
+      # form-encoding ('+') from curl / Rack::Utils.escape / a Ruby client. A
+      # component decoder that kept '+' literal would 403 every form-encoded
+      # space — i.e. most DeleteOrganization / AddMembership / entitlement calls
+      # from a non-browser client. The one cost is that a raw, UNENCODED literal
+      # '+' decodes to a space; clients that mean a literal '+' encode it '%2B'
+      # (encodeURIComponent and every form encoder both do), which round-trips.
+      # Oversized headers are rejected whole (see MAX_CONFIRM_BYTES) rather than
+      # sliced, so a legitimate multibyte token is never severed mid-escape.
       def confirm_token_from(env)
         raw = env[CONFIRM_HEADER].to_s
         return nil if raw.empty?
         return nil if raw.bytesize > MAX_CONFIRM_BYTES
 
-        URI.decode_uri_component(raw, Encoding::UTF_8)
+        Rack::Utils.unescape(raw, Encoding::UTF_8)
       rescue StandardError
         nil
       end

--- a/apps/api/colonel/auth_strategies.rb
+++ b/apps/api/colonel/auth_strategies.rb
@@ -43,13 +43,27 @@ module ColonelAPI
         HTTP_APX_INCOMING_HOST
       ].freeze
 
+      # Destructive-action confirmation token (#4326). Carried as a REQUEST HEADER,
+      # never a query parameter: the tokens are frequently PII (a target's email,
+      # an org display name) and a query string is logged verbatim by every default
+      # access-log format, lands in browser history, and can leak via Referer.
+      CONFIRM_HEADER = 'HTTP_X_OTS_CONFIRM'
+
+      # Cap applied BEFORE percent-decoding so a huge header cannot force a huge
+      # allocation. The logic layer caps again after decoding (MAX_CONFIRM_LENGTH).
+      MAX_CONFIRM_BYTES = 512
+
       protected
 
       # Capture a fixed, non-sensitive subset only for the diagnostic route.
       # Its `network=admin` requirement makes both admin allowlists mandatory;
       # no request headers are added to ordinary Colonel strategy metadata.
+      #
+      # The confirmation token is the ONE exception: it is merged on EVERY colonel
+      # request, before the diagnostic branch's early exit, because it is how the
+      # logic layer receives it (logic classes never see the Rack env).
       def build_metadata(env, additional = {})
-        metadata = super
+        metadata = super(env, additional.merge(confirm_token: confirm_token_from(env)))
         return metadata unless Otto::Utils.normalize_path(env['PATH_INFO']) == PROXY_DEBUG_HEADERS_PATH
 
         metadata.merge(
@@ -70,6 +84,18 @@ module ColonelAPI
         keys.to_h do |key|
           [key.delete_prefix('HTTP_').tr('_', '-').downcase, env[key]]
         end
+      end
+
+      # Percent-decoded so a non-ASCII token (org display names) survives the
+      # ISO-8859-1 header charset both sides agree on. An absent, empty or
+      # undecodable header is "no token" — never a crash, never a partial match.
+      def confirm_token_from(env)
+        raw = env[CONFIRM_HEADER].to_s
+        return nil if raw.empty?
+
+        Rack::Utils.unescape(raw[0, MAX_CONFIRM_BYTES], Encoding::UTF_8)
+      rescue StandardError
+        nil
       end
     end
 

--- a/apps/api/colonel/auth_strategies.rb
+++ b/apps/api/colonel/auth_strategies.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'otto/utils'
+require 'uri'
 
 module ColonelAPI
   module AuthStrategies
@@ -49,9 +50,16 @@ module ColonelAPI
       # access-log format, lands in browser history, and can leak via Referer.
       CONFIRM_HEADER = 'HTTP_X_OTS_CONFIRM'
 
-      # Cap applied BEFORE percent-decoding so a huge header cannot force a huge
-      # allocation. The logic layer caps again after decoding (MAX_CONFIRM_LENGTH).
-      MAX_CONFIRM_BYTES = 512
+      # DoS ceiling on the ENCODED header, not a token-length limit: the real cap
+      # is MAX_CONFIRM_LENGTH (characters, post-decode) in the logic layer. It is
+      # measured on the encoded bytes, which encodeURIComponent expands up to 12
+      # per 4-byte codepoint, so a max-length (255-char) token can approach 3 KB
+      # encoded. An over-long header is REJECTED, never truncated: slicing the
+      # encoded bytes would sever a %XX escape or a multibyte character and turn a
+      # valid token — e.g. a 100-char CJK org display_name, ~900 bytes encoded —
+      # into a permanent 403. 4 KB clears the largest legitimate token with room
+      # to spare while still bounding the decode.
+      MAX_CONFIRM_BYTES = 4096
 
       protected
 
@@ -95,13 +103,21 @@ module ColonelAPI
       end
 
       # Percent-decoded so a non-ASCII token (org display names) survives the
-      # ISO-8859-1 header charset both sides agree on. An absent, empty or
-      # undecodable header is "no token" — never a crash, never a partial match.
+      # ISO-8859-1 header charset both sides agree on. An absent, empty, oversized
+      # or undecodable header is "no token" — never a crash, never a partial match.
+      #
+      # URI.decode_uri_component, NOT Rack::Utils.unescape: it matches the console's
+      # encodeURIComponent exactly and does NOT map '+' to space, so a plus-addressed
+      # email sent raw by a non-browser client (X-OTS-Confirm: ops+admin@example.com)
+      # is not silently mangled into "ops admin@example.com" and 403'd. Oversized
+      # headers are rejected whole (see MAX_CONFIRM_BYTES) rather than sliced, so a
+      # legitimate multibyte token is never severed mid-escape.
       def confirm_token_from(env)
         raw = env[CONFIRM_HEADER].to_s
         return nil if raw.empty?
+        return nil if raw.bytesize > MAX_CONFIRM_BYTES
 
-        Rack::Utils.unescape(raw[0, MAX_CONFIRM_BYTES], Encoding::UTF_8)
+        URI.decode_uri_component(raw, Encoding::UTF_8)
       rescue StandardError
         nil
       end

--- a/apps/api/colonel/auth_strategies.rb
+++ b/apps/api/colonel/auth_strategies.rb
@@ -59,11 +59,19 @@ module ColonelAPI
       # Its `network=admin` requirement makes both admin allowlists mandatory;
       # no request headers are added to ordinary Colonel strategy metadata.
       #
-      # The confirmation token is the ONE exception: it is merged on EVERY colonel
-      # request, before the diagnostic branch's early exit, because it is how the
-      # logic layer receives it (logic classes never see the Rack env).
+      # The confirmation token and the request method are the TWO exceptions:
+      # both are merged on EVERY colonel request, before the diagnostic branch's
+      # early exit, because they are how the logic layer receives them (logic
+      # classes never see the Rack env). The method is what lets
+      # ColonelAPI::Logic::Base tell a mutation from a read and charge the broad
+      # colonel:mutation bucket accordingly (#4329) — neither value is a request
+      # header echo, and neither is sensitive.
       def build_metadata(env, additional = {})
-        metadata = super(env, additional.merge(confirm_token: confirm_token_from(env)))
+        colonel_context = {
+          confirm_token: confirm_token_from(env),
+          request_method: env['REQUEST_METHOD'],
+        }
+        metadata        = super(env, additional.merge(colonel_context))
         return metadata unless Otto::Utils.normalize_path(env['PATH_INFO']) == PROXY_DEBUG_HEADERS_PATH
 
         metadata.merge(

--- a/apps/api/colonel/destructive_actions.rb
+++ b/apps/api/colonel/destructive_actions.rb
@@ -1,0 +1,74 @@
+# apps/api/colonel/destructive_actions.rb
+#
+# frozen_string_literal: true
+
+module ColonelAPI
+  # Which colonel verbs are destructive, and how hard they are gated (#4326).
+  #
+  # TIER1 — irreversible / credential-revoking / privilege-granting. Requires
+  #   server-side confirmation (#4326), a live elevation window (#4327), the tight
+  #   rate-limit bucket (#4329) and the network=admin_if_configured annotation
+  #   (#4332).
+  # TIER2 — reversible but removes a defence, denies service, or grants
+  #   privilege. Confirmation only.
+  # TIER3_REVIEWED — mutating verbs deliberately left un-gated. This list is
+  #   REQUIRED, not optional: spec/unit/colonel/destructive_actions_spec.rb parses
+  #   routes.txt and fails when a mutating handler appears in none of the three
+  #   lists, so a new destructive route cannot ship un-triaged.
+  #
+  # Values are the UNQUALIFIED logic class names under ColonelAPI::Logic::Colonel.
+  module DestructiveActions
+    TIER1 = %w[
+      DeleteSecret ChangeUserEmail SetUserRole PurgeUser
+      TransferDomain DeleteDomainConfig RemoveCustomDomain
+      TransferOrganizationOwnership SetMembershipRole RemoveMembership
+      DeleteOrganization
+      DeleteSession RevokeAllCustomerSessions RevokeCustomerSession
+      PurgeDlq
+    ].freeze
+
+    TIER2 = %w[
+      UnverifyUser SuspendUser
+      RepairDomain OverrideDomainVerification UpsertDomainConfig
+      ManageEntitlementOverride AddMembership ManageMembershipEntitlementOverride
+      ReplayDlq ResetRateLimit
+    ].freeze
+
+    # Reviewed 2026-09-01 for epic #4323 and deliberately un-gated. One reason
+    # each; re-review when a listed class gains new capability.
+    TIER3_REVIEWED = {
+      'SetEntitlementPreview' => 'session-scoped preview, no durable write',
+      'UpdateUserPlan' => 'billing state, reversible, own reconciliation',
+      'CreateCheckoutLink' => 'additive; produces a link, changes nothing',
+      'VerifyUser' => 'restorative arm of the verification pair',
+      'UnsuspendUser' => 'restorative arm of the suspension pair',
+      'CreateCustomDomain' => 'additive; ownership still requires DNS proof',
+      'VerifyCustomDomain' => 'runs the DNS check; does not bypass it',
+      'EnsureDomainConfigs' => 'idempotent backfill of missing config rows',
+      'CreateOrganizationCheckoutLink' => 'additive; produces a link',
+      'InvestigateOrganization' => 'read-shaped diagnostic written as POST',
+      'ReconcileOrganization' => 'convergence to authoritative state',
+      'UpdateOrganizationPlan' => 'billing state, reversible',
+      'SetBanner' => 'cosmetic site notice',
+      'ClearBanner' => 'cosmetic site notice',
+      'SendTestEmail' => 'sends one message to an operator address',
+      'AddEmailSuppression' => 'additive; denies OUR sending, not user access',
+      'RemoveEmailSuppression' => 'restorative arm of the suppression pair',
+      'IngestEmailDeliverabilityEvents' => 'append-only telemetry',
+      'SyncEmailDeliverability' => 'convergence to provider state',
+    }.freeze
+
+    ALL = (TIER1 + TIER2).freeze
+
+    extend self
+
+    def tier1?(klass) = TIER1.include?(short_name(klass))
+    def tier2?(klass) = TIER2.include?(short_name(klass))
+    def gated?(klass) = ALL.include?(short_name(klass))
+    def classified?(klass) = gated?(klass) || TIER3_REVIEWED.key?(short_name(klass))
+
+    def short_name(klass)
+      (klass.is_a?(Class) ? klass.name : klass.to_s).split('::').last
+    end
+  end
+end

--- a/apps/api/colonel/destructive_actions.rb
+++ b/apps/api/colonel/destructive_actions.rb
@@ -55,9 +55,15 @@ module ColonelAPI
       'SetBanner' => 'cosmetic site notice',
       'ClearBanner' => 'cosmetic site notice',
       'SendTestEmail' => 'sends one message to an operator address',
-      'AddEmailSuppression' => 'additive; denies OUR sending, not user access',
+      'AddEmailSuppression' =>
+        'suppresses OUR sending to an address; residual risk: the shipped model has no ' \
+        'per-category scope, so a suppressed address also loses OTS-originated ' \
+        'account-recovery mail (password reset, verification) until RemoveEmailSuppression clears it',
       'RemoveEmailSuppression' => 'restorative arm of the suppression pair',
-      'IngestEmailDeliverabilityEvents' => 'append-only telemetry',
+      'IngestEmailDeliverabilityEvents' =>
+        'suppresses bounced/complained/imported addresses (changes send behavior), but is an ' \
+        'operator cron/CLI batch firehose so per-request gating is impractical; ' \
+        'reversible via RemoveEmailSuppression',
       'SyncEmailDeliverability' => 'convergence to provider state',
     }.freeze
 

--- a/apps/api/colonel/destructive_actions.rb
+++ b/apps/api/colonel/destructive_actions.rb
@@ -37,6 +37,9 @@ module ColonelAPI
     # Reviewed 2026-09-01 for epic #4323 and deliberately un-gated. One reason
     # each; re-review when a listed class gains new capability.
     TIER3_REVIEWED = {
+      'GetElevationStatus' => 'read-only status of the caller\'s own step-up window',
+      'ElevateSession' => 'step-up itself: carries its own throttle and audit events (#4327)',
+      'DropElevation' => 'strictly de-escalating: ends the caller\'s own window',
       'SetEntitlementPreview' => 'session-scoped preview, no durable write',
       'UpdateUserPlan' => 'billing state, reversible, own reconciliation',
       'CreateCheckoutLink' => 'additive; produces a link, changes nothing',

--- a/apps/api/colonel/logic/base.rb
+++ b/apps/api/colonel/logic/base.rb
@@ -16,10 +16,36 @@
 require 'onetime/logic/base'
 require 'onetime/application/authorization_policies'
 
+require_relative '../destructive_actions'
+require_relative 'destructive_action'
+
 module ColonelAPI
   module Logic
+    # ## The shared seam for the colonel hardening guards (epic #4323)
+    #
+    # {ColonelAPI::Logic::DestructiveAction} is included here, so every colonel
+    # logic class HAS the guards; only the classes named in
+    # {ColonelAPI::DestructiveActions} CALL them. Which classes those are — and
+    # which mutating verbs are deliberately un-gated — is committed data in
+    # `apps/api/colonel/destructive_actions.rb`, not prose.
+    #
+    # GUARD ORDER CONTRACT — inside raise_concerns, always, in this order:
+    #
+    #   1. verify_one_of_roles!(colonel: true)
+    #   2. resolve the target; existing 404 / 422 / enum / allowlist guards
+    #   3. guard_destructive_action!(...)      <- elevation (#4327), then
+    #                                             confirmation (#4326)
+    #   4. per-verb interlocks (self-target, last-colonel, sole-owner) (#4328)
+    #   5. charge_destructive_budget!          <- tier 1 only, ALWAYS LAST (#4329)
+    #
+    # Reordering it re-opens an information oracle (interlock 422s answering
+    # "is this the last colonel?" to a caller who proved nothing) or a
+    # budget-exhaustion DoS (cheap rejected requests burning the real operator's
+    # destructive allowance). Verbs with a `dry_run` preview run steps 3-5 on the
+    # apply path only.
     class Base < Onetime::Logic::Base
       include Onetime::Application::AuthorizationPolicies
+      include ColonelAPI::Logic::DestructiveAction
 
       using Familia::Refinements::TimeLiterals
 

--- a/apps/api/colonel/logic/base.rb
+++ b/apps/api/colonel/logic/base.rb
@@ -17,6 +17,7 @@ require 'onetime/logic/base'
 require 'onetime/application/authorization_policies'
 
 require_relative '../destructive_actions'
+require_relative 'colonel/elevation'
 require_relative 'destructive_action'
 
 module ColonelAPI
@@ -45,6 +46,9 @@ module ColonelAPI
     # apply path only.
     class Base < Onetime::Logic::Base
       include Onetime::Application::AuthorizationPolicies
+      # Elevation first: DestructiveAction#require_elevation! is written against
+      # this module's window arithmetic (#4327).
+      include ColonelAPI::Logic::Colonel::Elevation
       include ColonelAPI::Logic::DestructiveAction
 
       using Familia::Refinements::TimeLiterals

--- a/apps/api/colonel/logic/base.rb
+++ b/apps/api/colonel/logic/base.rb
@@ -15,6 +15,7 @@
 
 require 'onetime/logic/base'
 require 'onetime/application/authorization_policies'
+require 'onetime/security/colonel_rate_limiter'
 
 require_relative '../destructive_actions'
 require_relative 'colonel/elevation'
@@ -50,8 +51,51 @@ module ColonelAPI
       # this module's window arithmetic (#4327).
       include ColonelAPI::Logic::Colonel::Elevation
       include ColonelAPI::Logic::DestructiveAction
+      # The four colonel rate-limit buckets (#4329): the tight destructive one
+      # step 5 charges through DestructiveAction#charge_destructive_budget!, the
+      # broad mutation one #initialize below charges, the handle-resolve one the
+      # two session reads charge, and the step-up one ElevateSession charges.
+      include Onetime::Security::ColonelRateLimiter
 
       using Familia::Refinements::TimeLiterals
+
+      # HTTP methods that can change state. PUT is here for the one PUT route
+      # (`PUT /domains/:extid/configs/:kind`); PATCH is unused today and listed
+      # so a future route is covered the day it appears.
+      MUTATING_METHODS = %w[POST PUT PATCH DELETE].freeze
+
+      # Charge the broad colonel-mutation bucket once per mutating request
+      # (#4329, 120 / 300 s).
+      #
+      # HERE rather than in raise_concerns because none of the ~86 concrete
+      # colonel classes call `super` in raise_concerns, so a base-class hook
+      # there would be silently skipped; and the router has ALREADY enforced
+      # role=colonel by the time a logic class is constructed, so `cust` is the
+      # authenticated colonel. Self-gated on has_system_role? anyway, so this can
+      # never charge an unauthenticated caller. This is the ONE deliberate
+      # exception to "every authorization guard lives in raise_concerns" — it is
+      # a budget charge, not an authorization decision.
+      #
+      # It is also the ONLY bucket charged before the guards run, and it is
+      # deliberately coarse: it bounds request VOLUME. The tight destructive
+      # bucket is charged LAST, after elevation and confirmation pass (see the
+      # guard-order contract above), so an attacker holding the cookie cannot
+      # burn the real operator's destructive budget with cheap 403s.
+      #
+      # Reads are deliberately NOT limited here: the console fetches several of
+      # them on every screen and a limiter there would break the dashboard. The
+      # two handle-resolving session reads are the one exception and charge
+      # their own bucket explicitly (#4330).
+      #
+      # KNOWN GAP: process_params runs inside `super` and may raise first, so a
+      # malformed-param flood is not charged. Accepted — such a request mutates
+      # nothing.
+      def initialize(strategy_result, params, locale = nil)
+        super
+        return unless mutating_colonel_request?
+
+        enforce_colonel_mutation_limit!(cust.extid)
+      end
 
       # Transform v2 response data to Colonel API format
       #
@@ -79,6 +123,28 @@ module ColonelAPI
         end
 
         colonel_data
+      end
+
+      private
+
+      # Whether this request is a mutating one made by an authenticated colonel.
+      #
+      # The method arrives through StrategyResult#metadata (the colonel session
+      # auth strategy puts it there) because logic classes never receive the Rack
+      # request or env. A metadata hash without it — any caller that did not come
+      # through the colonel router, including every bare `double(...)` in the
+      # spec suites — reads as "not a mutation" and charges nothing, which is the
+      # right answer for a caller the strategy never saw.
+      #
+      # Method first, role second: the method is a Hash lookup while the role
+      # check touches the Customer model, so a read (or a non-HTTP caller) never
+      # pays for it.
+      def mutating_colonel_request?
+        return false unless MUTATING_METHODS.include?(
+          strategy_result&.metadata&.dig(:request_method).to_s.upcase,
+        )
+
+        has_system_role?('colonel')
       end
     end
   end

--- a/apps/api/colonel/logic/colonel.rb
+++ b/apps/api/colonel/logic/colonel.rb
@@ -36,6 +36,9 @@ require_relative 'colonel/delete_secret'
 # Shared identifier handling (email-tolerant account lookup)
 require_relative 'colonel/account_identifier'
 
+# Shared identity of the acting colonel's OWN session (self-target interlocks)
+require_relative 'colonel/current_session'
+
 # User management
 require_relative 'colonel/list_users'
 require_relative 'colonel/get_user_details'

--- a/apps/api/colonel/logic/colonel.rb
+++ b/apps/api/colonel/logic/colonel.rb
@@ -11,6 +11,14 @@ module ColonelAPI
   end
 end
 
+# Step-up (sudo) window for tier-1 verbs (#4327). The shared mixin is already
+# loaded by base.rb (DestructiveAction#require_elevation! is written against
+# it); listed here so the manifest names every colonel-namespaced file.
+require_relative 'colonel/elevation'
+require_relative 'colonel/get_elevation_status'
+require_relative 'colonel/elevate_session'
+require_relative 'colonel/drop_elevation'
+
 # System info and stats
 require_relative 'colonel/get_colonel_info'
 require_relative 'colonel/get_colonel_stats'

--- a/apps/api/colonel/logic/colonel/add_membership.rb
+++ b/apps/api/colonel/logic/colonel/add_membership.rb
@@ -49,6 +49,16 @@ module ColonelAPI
 
           @customer = resolve_customer(@customer_id)
           raise_not_found('Customer not found') unless @customer
+
+          # TIER 2 (#4326): privilege-granting — it hands an account access to
+          # that org's data. The URL carries the org id; the confirmation is its
+          # NAME.
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: org_confirm_token(org),
+            confirm_subject: "the organization's name",
+            field: :org_id,
+          )
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/change_user_email.rb
+++ b/apps/api/colonel/logic/colonel/change_user_email.rb
@@ -75,6 +75,20 @@ module ColonelAPI
           raise_not_found('User not found') unless user&.exists?
 
           raise_form_error('Cannot modify anonymous user', field: :user_id) if user.anonymous?
+
+          # PREVIEW EXEMPTION (#4326): a dry run writes nothing, so only the
+          # apply path is gated. dry_run defaults to TRUE here.
+          return if dry_run
+
+          # TIER 1. The token is the account's CURRENT address — the one the
+          # operator is changing away from, which the URL (an extid) never carries.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: user.email,
+            confirm_subject: "the account's current email address",
+            field: :user_id,
+          )
+          charge_destructive_budget!
         end
 
         def process
@@ -206,10 +220,6 @@ module ColonelAPI
           when :no_change then 'User already uses that email address'
           else result.status.to_s
           end
-        end
-
-        def truthy?(value)
-          %w[true 1 yes on].include?(value.to_s.strip.downcase)
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/change_user_email.rb
+++ b/apps/api/colonel/logic/colonel/change_user_email.rb
@@ -5,6 +5,7 @@
 require_relative '../base'
 require_relative 'account_identifier'
 require 'auth/operations/customers/change_email'
+require 'onetime/operations/customers/role_support'
 
 module ColonelAPI
   module Logic
@@ -88,7 +89,38 @@ module ColonelAPI
             confirm_subject: "the account's current email address",
             field: :user_id,
           )
+
+          refuse_last_colonel_lockout!
           charge_destructive_budget!
+        end
+
+        # INTERLOCK (#4328 review). ChangeEmail resets verification with
+        # enforce_interlocks:false (the address itself is changing, so refusing the
+        # verification RESET would be strictly worse — it would leave a colonel
+        # verified against an address nobody has proven). But clearing verification
+        # on the LAST active colonel locks the whole install out of /colonel —
+        # has_system_role? refuses every unverified account — recoverable only from
+        # the shell, the exact outcome #4328 exists to prevent, reached through the
+        # one path the roster interlock is switched off for. So gate the EMAIL
+        # CHANGE itself here: refuse when it would strip the last active colonel's
+        # verification. keep_verified is the deliberate escape hatch — it preserves
+        # verification on the new address (accepting an unproven-verified colonel,
+        # the lesser evil) for the operator who cannot promote a second colonel
+        # first. `!keep_verified` mirrors the require_verification: !keep_verified
+        # passed to the op, so this fires exactly when verification will be cleared.
+        def refuse_last_colonel_lockout!
+          return if keep_verified
+          return unless Onetime::Operations::Customers::RoleSupport
+            .last_colonel_by_verification?(user)
+
+          raise_form_error(
+            "Refusing to change the last active colonel's email: it would clear " \
+            'their verification and lock this install out of the admin console ' \
+            '(recoverable only from the CLI). Promote and verify another colonel ' \
+            'first, or re-send with keep_verified=true to keep verification on the ' \
+            'new address.',
+            field: :user_id,
+          )
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/change_user_email.rb
+++ b/apps/api/colonel/logic/colonel/change_user_email.rb
@@ -83,10 +83,14 @@ module ColonelAPI
 
           # TIER 1. The token is the account's CURRENT address — the one the
           # operator is changing away from, which the URL (an extid) never carries.
+          # account_confirm_token falls back to the extid for an account with no
+          # email (mirroring PurgeUser); a bare `user.email` would blank the token
+          # and turn require_confirmation! into a GuardMisconfigured 500 instead of
+          # a clean refusal.
           guard_destructive_action!(
             tier: :destructive,
-            confirm_with: user.email,
-            confirm_subject: "the account's current email address",
+            confirm_with: account_confirm_token(user),
+            confirm_subject: "the account's current email address (or its external id when it has none)",
             field: :user_id,
           )
 

--- a/apps/api/colonel/logic/colonel/current_session.rb
+++ b/apps/api/colonel/logic/colonel/current_session.rb
@@ -1,0 +1,44 @@
+# apps/api/colonel/logic/colonel/current_session.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/models/session_metadata'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # The acting colonel's own session identity (#4328).
+      #
+      # Extracted from {ListCustomerSessions}, which computed it inline, so the
+      # console's "this is you" badge and the server-side self-revoke interlocks
+      # cannot drift into two different answers.
+      #
+      # INTERNAL: {#current_session_id} is the raw bearer sid — byte-identical to
+      # the `onetime.session` cookie — and must NEVER be serialized. Only the
+      # HANDLE crosses the wire, and only the handle is used in the interlock
+      # comparisons, so the bearer value never enters a comparison path against
+      # attacker-supplied input.
+      module CurrentSession
+        # The colonel's own plain sid. `safe_session_id` yields a Rack SessionId
+        # object whose `#public_id` is the cookie value (== SessionMetadata's
+        # session_id); a Hash-backed session (JSON auth, some specs) yields nil.
+        #
+        # @return [String, nil]
+        def current_session_id
+          sid = safe_session_id
+          return nil if sid.nil?
+
+          sid.respond_to?(:public_id) ? sid.public_id : sid.to_s
+        end
+
+        # The same session as the non-bearer handle the sidecar rows expose.
+        #
+        # @return [String, nil]
+        def current_session_handle
+          sid = current_session_id
+          sid && Onetime::SessionMetadata.handle_for(sid)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/delete_domain_config.rb
+++ b/apps/api/colonel/logic/colonel/delete_domain_config.rb
@@ -44,6 +44,17 @@ module ColonelAPI
           raise_not_found('Domain not found') unless custom_domain
 
           raise_not_found('Unknown config kind') unless Onetime::CustomDomain::ConfigRegistry.kind?(kind)
+
+          # TIER 1 (#4326). The composed token names BOTH halves of what is being
+          # destroyed; the URL carries the extid, not the hostname. Both halves
+          # are non-blank by the two guards above.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: "#{custom_domain.display_domain}:#{kind}",
+            confirm_subject: 'the domain name and config kind joined by a colon',
+            field: :kind,
+          )
+          charge_destructive_budget!
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/delete_organization.rb
+++ b/apps/api/colonel/logic/colonel/delete_organization.rb
@@ -92,6 +92,19 @@ module ColonelAPI
 
           @org = resolve_org(@org_id)
           raise_not_found('Organization not found') unless @org&.exists?
+
+          # PREVIEW EXEMPTION (#4326): the preview IS the plan the operator
+          # confirms against, and it writes nothing. dry_run defaults to TRUE.
+          return if dry_run
+
+          # TIER 1. The URL carries the org id; the confirmation is its NAME.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: org_confirm_token(org),
+            confirm_subject: "the organization's name",
+            field: :org_id,
+          )
+          charge_destructive_budget!
         end
 
         def process
@@ -202,10 +215,6 @@ module ColonelAPI
           return '' if result.domains.empty?
 
           ": #{result.domains.join(', ')}"
-        end
-
-        def truthy?(value)
-          %w[true 1 yes on].include?(value.to_s.strip.downcase)
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/delete_secret.rb
+++ b/apps/api/colonel/logic/colonel/delete_secret.rb
@@ -77,9 +77,13 @@ module ColonelAPI
           # shortid is independent of :secret_id and forces the replay to know a
           # second identifier (design §1.1). `@audit_target` stays secret.shortid
           # for the audit record only — the two are deliberately not conflated.
+          # LAZY token (a lambda, not confirmation_token itself): its receiptless
+          # fail-closed raise must run AFTER require_elevation!, or an unelevated
+          # caller gets a 500 GuardMisconfigured where the guard-order contract
+          # promises 403 ElevationRequired first (no confirmation oracle).
           guard_destructive_action!(
             tier: :destructive,
-            confirm_with: confirmation_token,
+            confirm_with: -> { confirmation_token },
             confirm_subject: 'the receipt shortid',
             field: :secret_id,
           )

--- a/apps/api/colonel/logic/colonel/delete_secret.rb
+++ b/apps/api/colonel/logic/colonel/delete_secret.rb
@@ -63,21 +63,51 @@ module ColonelAPI
           @audit_target = secret.shortid
           @audit_state  = secret.state.to_s
 
-          # Load associated receipt
+          # Load associated receipt (also the source of the confirmation token
+          # below).
           if secret.receipt_identifier
             @receipt = Onetime::Receipt.load(secret.receipt_identifier)
           end
 
-          # TIER 1 (#4326). The shortid is an identifier the URL does not carry:
-          # the route is keyed by :secret_id (the objid), so a scraped-URL replay
-          # must additionally know the receipt shortid.
+          # TIER 1 (#4326). The confirmation token is the RECEIPT shortid — an
+          # identifier the URL does NOT carry. The route is keyed by :secret_id
+          # (the secret objid), and secret.shortid is just secret_id[0,8], so
+          # confirming with it would be no second factor at all: a scraped-URL
+          # replay derives it for free. The receipt has its own objid, so its
+          # shortid is independent of :secret_id and forces the replay to know a
+          # second identifier (design §1.1). `@audit_target` stays secret.shortid
+          # for the audit record only — the two are deliberately not conflated.
           guard_destructive_action!(
             tier: :destructive,
-            confirm_with: @audit_target,
-            confirm_subject: 'the secret shortid',
+            confirm_with: confirmation_token,
+            confirm_subject: 'the receipt shortid',
             field: :secret_id,
           )
           charge_destructive_budget!
+        end
+
+        # The confirmation token for this destroy: the RECEIPT shortid (#4326).
+        # Independent of :secret_id by construction — the receipt has its own
+        # objid, so its shortid is not derivable from the URL. Prefer the stored
+        # `receipt_shortid` field; fall back to the loaded receipt's shortid
+        # (the field is not populated on legacy pairs, but the receipt is).
+        #
+        # FAIL-CLOSED when neither yields a shortid: a secret with no resolvable
+        # receipt has no non-URL identifier to confirm against. Rather than fall
+        # back to the URL-derivable secret shortid — which would silently defeat
+        # #4326 — we refuse (GuardMisconfigured, 500) and the operator removes it
+        # with the CLI. Preferring refusal over a weak token is the safe
+        # direction for a TIER 1 destroy; over-refusing a receiptless secret is
+        # acceptable, admitting a replayable one is not.
+        def confirmation_token
+          token = secret.receipt_shortid.to_s.strip
+          token = receipt.shortid.to_s if token.empty? && receipt&.exists?
+          return token unless token.empty?
+
+          OT.le "[DeleteSecret] no receipt shortid for secret #{@audit_target}; refusing confirmation (#4326)"
+          raise Onetime::GuardMisconfigured,
+            'Cannot confirm secret deletion: this secret has no receipt to derive an ' \
+            'independent confirmation token from. Remove it with the CLI instead.'
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/delete_secret.rb
+++ b/apps/api/colonel/logic/colonel/delete_secret.rb
@@ -67,6 +67,17 @@ module ColonelAPI
           if secret.receipt_identifier
             @receipt = Onetime::Receipt.load(secret.receipt_identifier)
           end
+
+          # TIER 1 (#4326). The shortid is an identifier the URL does not carry:
+          # the route is keyed by :secret_id (the objid), so a scraped-URL replay
+          # must additionally know the receipt shortid.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: @audit_target,
+            confirm_subject: 'the secret shortid',
+            field: :secret_id,
+          )
+          charge_destructive_budget!
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/delete_session.rb
+++ b/apps/api/colonel/logic/colonel/delete_session.rb
@@ -49,8 +49,12 @@ module ColonelAPI
 
         def raise_concerns
           verify_one_of_roles!(colonel: true)
-          # P5 (#4329) inserts enforce_colonel_handle_resolve_limit! here: handle
-          # resolution is the one colonel path whose cost is not O(1).
+          # Handle resolution is the one colonel path whose cost is not O(1) — a
+          # bounded scan plus up to MAX_SCAN HMACs when the owner hint misses —
+          # so it carries its own bucket (#4329), charged before the resolution
+          # it bounds. This is NOT the destructive budget: that one is charged as
+          # the last line of this method, only for requests about to execute.
+          enforce_colonel_handle_resolve_limit!(cust&.extid)
 
           # 404 when the handle names no live session (unknown, stale, or
           # malformed — indistinguishable on purpose), so the UI can tell

--- a/apps/api/colonel/logic/colonel/delete_session.rb
+++ b/apps/api/colonel/logic/colonel/delete_session.rb
@@ -6,6 +6,7 @@ require_relative '../base'
 require_relative 'account_identifier'
 require 'onetime/operations/sessions/store'
 require 'onetime/operations/sessions/delete_session'
+require 'onetime/operations/sessions/inspect_session'
 
 module ColonelAPI
   module Logic
@@ -59,8 +60,19 @@ module ColonelAPI
             Familia.dbclient, session_handle, owner_hint: @owner_hint
           )
           raise_not_found('Session not found') unless session_id
-          # P2 inserts guard_destructive_action! here; P4 inserts the self-target
-          # interlock AFTER it; P5 inserts charge_destructive_budget! last (§0.2).
+
+          # TIER 1 (#4326). The URL carries only the opaque handle, so the
+          # confirmation is the session OWNER — an identifier the operator reads
+          # off the row and the handle cannot be transformed into.
+          # P4 (#4328) inserts the self-target interlock AFTER this call and
+          # BEFORE charge_destructive_budget! (guard order §0.2).
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: owner_token,
+            confirm_subject: owner_subject,
+            field: :session_handle,
+          )
+          charge_destructive_budget!
         end
 
         def process
@@ -85,6 +97,39 @@ module ColonelAPI
               message: 'Session revoked successfully',
             },
           }
+        end
+
+        private
+
+        # The confirmation token: the session owner's email, its external id when
+        # the payload carries no address, and the handle itself for an anonymous
+        # (identity-less) session — which has no owner to name. Never blank, so
+        # the guard's blank-expected tripwire stays a programming-error signal.
+        # Mirrors the console row, which computes the same three-way fallback.
+        def owner_token
+          @owner_token ||= begin
+            data = inspected_payload
+            [data['email'], data['external_id'], data['account_external_id']]
+              .map { |value| value.to_s.strip }
+              .find { |value| !value.empty? } || session_handle
+          end
+        end
+
+        # Names what to retype, honestly: an anonymous session's token is the
+        # handle, and telling the operator to send an email address they cannot
+        # find would be an unanswerable 403.
+        def owner_subject
+          if owner_token == session_handle
+            'the session handle (this session carries no owner identity)'
+          else
+            "the session owner's email address"
+          end
+        end
+
+        # Read-only, and the ONLY reason this mutation loads the payload: the
+        # confirmation token has to name the owner. Reads never audit.
+        def inspected_payload
+          Onetime::Operations::Sessions::Inspect.new(session_id: session_id).call.data || {}
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/delete_session.rb
+++ b/apps/api/colonel/logic/colonel/delete_session.rb
@@ -4,6 +4,7 @@
 
 require_relative '../base'
 require_relative 'account_identifier'
+require_relative 'current_session'
 require 'onetime/operations/sessions/store'
 require 'onetime/operations/sessions/delete_session'
 require 'onetime/operations/sessions/inspect_session'
@@ -32,6 +33,7 @@ module ColonelAPI
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class DeleteSession < ColonelAPI::Logic::Base
         include AccountIdentifier
+        include CurrentSession
 
         attr_reader :session_handle, :session_id, :result
 
@@ -64,14 +66,26 @@ module ColonelAPI
           # TIER 1 (#4326). The URL carries only the opaque handle, so the
           # confirmation is the session OWNER — an identifier the operator reads
           # off the row and the handle cannot be transformed into.
-          # P4 (#4328) inserts the self-target interlock AFTER this call and
-          # BEFORE charge_destructive_budget! (guard order §0.2).
           guard_destructive_action!(
             tier: :destructive,
             confirm_with: owner_token,
             confirm_subject: owner_subject,
             field: :session_handle,
           )
+
+          # INTERLOCK — step 4, after proof (#4328). Revoking the session you
+          # are working in signs YOU out mid-incident; sign-out is the verb for
+          # that. Placed after the guard so the 422 cannot be used as a free
+          # "is this handle mine?" oracle over the whole session list by a
+          # caller holding nothing but the cookie. Compares HANDLES, so the raw
+          # bearer sid never enters the comparison path.
+          if current_session_handle && current_session_handle == session_handle
+            raise_form_error(
+              'Cannot revoke your own active session. Use sign-out instead.',
+              field: :session_handle,
+            )
+          end
+
           charge_destructive_budget!
         end
 

--- a/apps/api/colonel/logic/colonel/delete_session.rb
+++ b/apps/api/colonel/logic/colonel/delete_session.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'account_identifier'
 require 'onetime/operations/sessions/store'
 require 'onetime/operations/sessions/delete_session'
 
@@ -16,27 +17,50 @@ module ColonelAPI
       # This class keeps only the HTTP concerns (param validation + the not-found
       # 404); the op owns the model mutation and the ColonelAuditEvent.
       #
-      # Deleting a session logs that user out mid-flight, so the UI gates this
-      # behind AdminConfirmDialog typed-confirmation (retype the session id).
+      # Deleting a session logs that user out mid-flight, so the UI gates it behind
+      # AdminConfirmDialog typed-confirmation (retype the session owner's email).
+      #
+      # ## Non-bearer identifier (#4330)
+      #
+      # The route takes a {Onetime::SessionMetadata.handle_for} handle — the same
+      # shape the per-customer {RevokeCustomerSession} already accepted — never the
+      # raw sid, which IS the `onetime.session` cookie. The handle is resolved back
+      # server-side; the op receives the sid, the response echoes the handle.
       #
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class DeleteSession < ColonelAPI::Logic::Base
-        attr_reader :session_id, :result
+        include AccountIdentifier
+
+        attr_reader :session_handle, :session_id, :result
 
         def process_params
-          @session_id = sanitize_identifier(params['session_id'])
-          raise_form_error('Session ID is required', field: :session_id) if session_id.to_s.empty?
+          @session_handle = sanitize_identifier(params['session_handle']).to_s.downcase
+          # Optional owner hint (see Store.resolve_handle). NOT authorization — it
+          # only picks a cheaper search space; a wrong hint falls through to the
+          # bounded scan. sanitize_account_identifier, not sanitize_identifier:
+          # the latter strips `@` and `.` out of an email hint.
+          @owner_hint     = sanitize_account_identifier(params['user_id'])
+          raise_form_error('Session handle is required', field: :session_handle) if session_handle.empty?
         end
 
         def raise_concerns
           verify_one_of_roles!(colonel: true)
+          # P5 (#4329) inserts enforce_colonel_handle_resolve_limit! here: handle
+          # resolution is the one colonel path whose cost is not O(1).
 
-          # 404 when there is no live session for this id, so the UI can tell
+          # 404 when the handle names no live session (unknown, stale, or
+          # malformed — indistinguishable on purpose), so the UI can tell
           # "already gone" from a real failure. The op is idempotent regardless.
-          unless Onetime::Operations::Sessions::Store.find_key(Familia.dbclient, session_id)
-            raise_not_found('Session not found')
-          end
+          # resolve_handle answers [sid, scan_capped]; the truncation flag is
+          # surfaced by the detail READ, not by a mutation ack, so only the sid
+          # is kept here.
+          @session_id, = Onetime::Operations::Sessions::Store.resolve_handle(
+            Familia.dbclient, session_handle, owner_hint: @owner_hint
+          )
+          raise_not_found('Session not found') unless session_id
+          # P2 inserts guard_destructive_action! here; P4 inserts the self-target
+          # interlock AFTER it; P5 inserts charge_destructive_budget! last (§0.2).
         end
 
         def process
@@ -53,7 +77,8 @@ module ColonelAPI
         def success_data
           {
             record: {
-              session_id: result.session_id,
+              # Echo the non-bearer handle the caller sent — NEVER the raw sid.
+              session_handle: session_handle,
               deleted: result.status == :deleted,
             },
             details: {

--- a/apps/api/colonel/logic/colonel/drop_elevation.rb
+++ b/apps/api/colonel/logic/colonel/drop_elevation.rb
@@ -1,0 +1,70 @@
+# apps/api/colonel/logic/colonel/drop_elevation.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # DELETE /api/colonel/elevation — end the step-up (sudo) window early
+      # (#4327).
+      #
+      # Strictly de-escalating, and idempotent: dropping a window that is not
+      # live is a no-op that still answers 200, because the operator's intent
+      # ("I am done with elevated access") is satisfied either way and a 404 here
+      # would only tell them whether they were elevated.
+      #
+      # Audited with .record — a deliberate, operator-initiated action on the
+      # same trail as the matching ElevateSession success, so the pair reads as
+      # one bracket. It shares that class's documented exception to CONTRACT 4:
+      # there is no Operations class because the mutation is a session field.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class DropElevation < ColonelAPI::Logic::Base
+        AUDIT_VERB = 'colonel.elevate_drop'
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          @was_elevated = elevated?
+          drop_elevation!
+          record_audit
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              elevated: false,
+              expires_at: nil,
+              seconds_remaining: 0,
+            },
+            details: {
+              message: 'Elevation dropped',
+              was_elevated: @was_elevated,
+            },
+          }
+        end
+
+        private
+
+        def record_audit
+          Onetime::ColonelAuditEvent.record(
+            actor: cust.extid,
+            verb: AUDIT_VERB,
+            target: cust.extid,
+            result: :success,
+            detail: { was_elevated: @was_elevated },
+          )
+        rescue StandardError => ex
+          OT.le('[DropElevation] audit record failed', exception: ex)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/elevate_session.rb
+++ b/apps/api/colonel/logic/colonel/elevate_session.rb
@@ -113,7 +113,22 @@ module ColonelAPI
           return 'Password verification failed.' if factor == 'password'
 
           if elevation_password_available?
-            'This account has a password; re-enter it to elevate.'
+            # In FULL auth mode the password factor cannot be probed from the
+            # logic layer, so EVERY account is treated as password-holding
+            # (fail-closed) — including SSO-only ones that have no password.
+            # Telling such an operator to "re-enter your password" is
+            # misinformation, so name what actually applies in full mode:
+            # recent_auth is categorically unavailable there, password holders
+            # elevate with their password, and an SSO-only fleet needs elevation
+            # disabled.
+            if Onetime.auth_config.full_enabled?
+              'Password-less (recent_auth) step-up is not available in full ' \
+                'authentication mode. Elevate with your account password, or for ' \
+                'an SSO-only fleet ask an administrator to set ' \
+                'COLONEL_ELEVATION_ENABLED=false.'
+            else
+              'This account has a password; re-enter it to elevate.'
+            end
           elsif elevation_reauth_grace.zero?
             'Password-less step-up is not enabled on this install. ' \
               'Ask an administrator to set COLONEL_ELEVATION_REAUTH_GRACE.'

--- a/apps/api/colonel/logic/colonel/elevate_session.rb
+++ b/apps/api/colonel/logic/colonel/elevate_session.rb
@@ -1,0 +1,151 @@
+# apps/api/colonel/logic/colonel/elevate_session.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+require 'onetime/security/colonel_rate_limiter'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # POST /api/colonel/elevation — mint a step-up (sudo) window (#4327).
+      #
+      # Two factors, both defined in {Elevation}:
+      #
+      #   password    — dual-mode re-verification, the only factor available by
+      #                 default and the only one a password-holding account may
+      #                 ever use.
+      #   recent_auth — elevate with no further credential inside a post-sign-in
+      #                 grace. Available ONLY to accounts that cannot satisfy the
+      #                 password factor, and ONLY when an operator configured a
+      #                 non-zero grace (the shipped default is 0). Handing it to
+      #                 password holders would make step-up a no-op for the first
+      #                 N seconds after every colonel sign-in, which is verbatim
+      #                 the condition #4327 exists to remove.
+      #
+      # AUDIT — a documented FOURTH exception to CONTRACT 4 ("the Operations
+      # class owns the ColonelAuditEvent; adapters do not audit"). There is no
+      # Operations class here because the mutation is a session field, not a
+      # model. Do not add a fifth.
+      #
+      #   success -> .record          (authenticated operator activity, bounded
+      #                                to `max_attempts` per lockout window by
+      #                                the limiter below). The `factor` detail is
+      #                                REQUIRED: it is what makes a recent_auth
+      #                                elevation visible in the trail as the
+      #                                weaker path.
+      #   failure -> .record_security (drivable on demand by whoever holds the
+      #                                cookie; the operator trail is count-capped
+      #                                with no TTL).
+      #   refusal of a tier-1 verb for want of elevation -> nothing at all, see
+      #                                DestructiveAction#require_elevation!.
+      #
+      # The submitted password is NEVER sanitized, NEVER logged, NEVER echoed and
+      # has no attr_reader. ColonelAuditEvent's SENSITIVE_KEY_PATTERN would blank
+      # it; do not rely on that.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class ElevateSession < ColonelAPI::Logic::Base
+        include Onetime::Security::ColonelRateLimiter
+
+        AUDIT_VERB = 'colonel.elevate'
+
+        attr_reader :factor
+
+        def process_params
+          @factor   = sanitize_plain_text(params['factor']).to_s.strip
+          @factor   = 'password' if factor.empty?
+          # Deliberately raw and deliberately not exposed.
+          @password = params['password'].to_s
+        end
+
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+
+          raise_form_error("Unknown step-up factor '#{factor}'", field: :factor) unless Elevation::FACTORS.include?(factor)
+          raise_form_error('Step-up authentication is disabled', field: :factor) unless elevation_enabled?
+
+          # Throttle BEFORE verifying. Auth::Config.valid_login_and_password? is
+          # an internal request: it is not a login and it does not increment
+          # Rodauth's lockout counter, so this is the only backstop against
+          # password guessing here.
+          enforce_colonel_elevation_limit!(cust.extid)
+        end
+
+        def process
+          verified = case factor
+                     when 'password'    then verify_elevation_password(@password)
+                     when 'recent_auth' then within_reauth_grace?
+                     end
+
+          unless verified
+            record_failure_audit
+            raise Onetime::ElevationFailed.new(failure_message, factor: factor)
+          end
+
+          grant_elevation!
+          record_success_audit
+
+          success_data
+        end
+
+        def success_data
+          {
+            record: {
+              elevated: true,
+              expires_at: elevated_until,
+              seconds_remaining: elevation_seconds_remaining,
+            },
+            details: {
+              factor: factor,
+              window: elevation_window,
+            },
+          }
+        end
+
+        private
+
+        # Distinguish the three ways recent_auth can fail so the console can help
+        # rather than loop. None of these is an oracle: every fact is already in
+        # GET /api/colonel/elevation for the caller's OWN account.
+        def failure_message
+          return 'Password verification failed.' if factor == 'password'
+
+          if elevation_password_available?
+            'This account has a password; re-enter it to elevate.'
+          elsif elevation_reauth_grace.zero?
+            'Password-less step-up is not enabled on this install. ' \
+              'Ask an administrator to set COLONEL_ELEVATION_REAUTH_GRACE.'
+          else
+            'Sign-in is not recent enough to elevate. Sign out and sign in again.'
+          end
+        end
+
+        def record_success_audit
+          Onetime::ColonelAuditEvent.record(
+            actor: cust.extid,
+            verb: AUDIT_VERB,
+            target: cust.extid,
+            result: :success,
+            detail: { factor: factor, window: elevation_window },
+          )
+        rescue StandardError => ex
+          OT.le('[ElevateSession] audit record failed', exception: ex)
+        end
+
+        def record_failure_audit
+          Onetime::ColonelAuditEvent.record_security(
+            actor: cust.extid,
+            verb: AUDIT_VERB,
+            target: cust.extid,
+            result: :failure,
+            detail: { factor: factor },
+          )
+        rescue StandardError => ex
+          OT.le('[ElevateSession] security audit record failed', exception: ex)
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/elevation.rb
+++ b/apps/api/colonel/logic/colonel/elevation.rb
@@ -1,0 +1,220 @@
+# apps/api/colonel/logic/colonel/elevation.rb
+#
+# frozen_string_literal: true
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # The colonel step-up (sudo) window (#4327).
+      #
+      # One definition of the window arithmetic, the identity binding and the
+      # dual-mode credential check, shared by the three /elevation endpoints and
+      # by {ColonelAPI::Logic::DestructiveAction#require_elevation!} — which is
+      # what every TIER 1 verb calls. Included into ColonelAPI::Logic::Base, so
+      # every colonel logic class HAS these methods; only the elevation
+      # endpoints and the tier-1 guard CALL them.
+      #
+      # ## Where the window lives
+      #
+      # `sess['elevated_until']`, a REGISTERED session sidecar field
+      # (lib/onetime/session/sidecar.rb) holding an OBJECT, not a bare epoch:
+      #
+      #     { 'extid' => <acting colonel's public id>, 'exp' => <unix seconds> }
+      #
+      # One onetime.session cookie can outlive an identity change — simple-mode
+      # login (apps/web/core/controllers/authentication.rb) neither clears nor
+      # renews the session, and full-mode :renew carries the session hash to a
+      # new sid — so a bare epoch would let the account signing in second
+      # inherit the first account's live elevation. {#elevation_record} ignores
+      # a record naming any other extid; both login paths also delete the field
+      # outright, so the binding is a backstop rather than the only defence.
+      #
+      # STRING key on purpose: the auth side uses string keys throughout and
+      # base_session_auth_strategy.rb records the bug a symbol key caused.
+      #
+      # ## Residual risk, stated rather than hidden
+      #
+      # Elevation is carried by the SESSION. While a window is live, a stolen
+      # cookie is exactly as capable as it was before this feature existed. What
+      # the window buys is that the capability is time-bounded, operator-
+      # initiated and audited instead of standing. Binding it to a value the
+      # cookie does not carry (an elevation nonce echoed as a request header) is
+      # the follow-up, not this epic.
+      module Elevation
+        # STRING key — see base_session_auth_strategy.rb:36-38 for the bug a
+        # symbol key caused on this side of the session.
+        SESSION_KEY = 'elevated_until'
+
+        # 10 minutes: long enough for a multi-step triage session, short enough
+        # that an idle console is not a standing destructive capability.
+        DEFAULT_WINDOW = 600
+
+        # OFF by default. See #within_reauth_grace? for why a non-zero grace is
+        # only ever offered to accounts that cannot satisfy the password factor.
+        DEFAULT_REAUTH_GRACE = 0
+
+        # The factors POST /api/colonel/elevation accepts. Which of them a GIVEN
+        # account may actually use is #available_factors, not this list.
+        FACTORS = %w[password recent_auth].freeze
+
+        def elevation_enabled?
+          elevation_config.fetch('enabled', true) != false
+        end
+
+        def elevation_window
+          value = elevation_config['window'].to_i
+          value.positive? ? value : DEFAULT_WINDOW
+        end
+
+        # 0 legitimately DISABLES the grace and is the shipped default, so this
+        # cannot use the positive_* guard's fall-back-to-default behaviour: a
+        # configured 0 must stay 0, not become DEFAULT_REAUTH_GRACE.
+        def elevation_reauth_grace
+          raw = elevation_config['reauth_grace']
+          return DEFAULT_REAUTH_GRACE if raw.nil?
+
+          value = raw.to_i
+          value.negative? ? DEFAULT_REAUTH_GRACE : value
+        end
+
+        # The stored capability, or nil. Identity-bound: a record naming a
+        # different extid is IGNORED, never honoured.
+        #
+        # Tolerates both shapes the sidecar can hand back — a Hash (the codec
+        # round-trips JSON objects natively) and a JSON string (a plaintext or
+        # pre-decode read) — and treats anything else, including the bare epoch
+        # an earlier draft would have written, as no elevation at all.
+        def elevation_record
+          raw = sess && sess[SESSION_KEY]
+          raw = Familia::JsonSerializer.parse(raw) if raw.is_a?(String) && raw.start_with?('{')
+          return nil unless raw.is_a?(Hash)
+
+          holder = raw['extid'].to_s
+          return nil if holder.empty? || holder != cust&.extid.to_s
+
+          raw
+        rescue StandardError
+          nil
+        end
+
+        def elevated_until
+          elevation_record&.fetch('exp', 0).to_i
+        end
+
+        def elevated?
+          elevated_until > Familia.now.to_i
+        end
+
+        def elevation_seconds_remaining
+          [elevated_until - Familia.now.to_i, 0].max
+        end
+
+        # Within the grace window the caller has just proven their primary
+        # credential at sign-in, so re-proving it adds nothing.
+        #
+        # Available ONLY to accounts that cannot satisfy the password factor,
+        # and only when an operator configured a non-zero grace. Handing it to
+        # password holders would make step-up a no-op for the first N seconds
+        # after every colonel sign-in — verbatim the condition #4327 exists to
+        # remove, and reachable by a cookie thief because cookie theft happens
+        # while the operator is working.
+        def within_reauth_grace?
+          grace = elevation_reauth_grace
+          return false unless grace.positive?
+          return false if elevation_password_available?
+
+          stamped = sess && sess['authenticated_at'].to_i
+          return false unless stamped.to_i.positive?
+
+          (Familia.now.to_i - stamped.to_i) <= grace
+        end
+
+        # The factors THIS account may use, not the constant list: it is what
+        # lets the console render an actionable remediation instead of looping
+        # on a prompt the operator cannot satisfy.
+        def available_factors
+          factors = ['password']
+          factors << 'recent_auth' if elevation_reauth_grace.positive? && !elevation_password_available?
+          factors
+        end
+
+        def grant_elevation!
+          sess[SESSION_KEY] = {
+            'extid' => cust.extid.to_s,
+            'exp' => Familia.now.to_i + elevation_window,
+          }
+        end
+
+        def drop_elevation!
+          sess.delete(SESSION_KEY)
+        end
+
+        # Dual-mode password verification. MUST branch on full_enabled? BEFORE
+        # naming Auth::Config: registry.rb drops the whole apps/web/auth tree in
+        # simple mode, so the constant does not exist there. Copied from
+        # apps/api/account/logic/account/update_password.rb.
+        def verify_elevation_password(password)
+          return false if password.to_s.empty?
+
+          if Onetime.auth_config.full_enabled?
+            verify_elevation_password_full_mode(password)
+          else
+            cust.passphrase?(password)
+          end
+        end
+
+        def verify_elevation_password_full_mode(password)
+          Auth::Config.valid_login_and_password?(login: cust.email, password: password)
+        rescue Rodauth::InternalRequestError => ex
+          OT.le('[colonel-elevate] Rodauth verification failed', exception: ex)
+          false
+        rescue StandardError => ex
+          OT.le('[colonel-elevate] password verification error', exception: ex)
+          false
+        end
+
+        # Can this account satisfy the password factor?
+        #
+        # Gates the recent_auth factor: the grace exists so password-LESS
+        # operators can elevate at all, not so password holders can skip
+        # re-entry. FAIL CLOSED — an unknown answer counts as "has a password",
+        # which REFUSES recent_auth rather than granting it, mirroring
+        # features/mfa.rb's account_has_challengeable_password?(error_result: true).
+        #
+        # Full mode answers a flat `true` by design, not by omission. The
+        # Rodauth-side probe needs `db[password_hash_table]` scoped to the
+        # account row, which only exists inside a Rodauth instance; reaching it
+        # from a logic class would mean inventing a second probe, and a wrong
+        # one grants the WEAKER factor. So full-mode accounts are treated as
+        # password-holding and recent_auth is simply unavailable there. A
+        # full-mode SSO-only fleet sets COLONEL_ELEVATION_ENABLED=false instead;
+        # this is recorded in the operator guide, not a defect.
+        def elevation_password_available?
+          return @elevation_password_available if defined?(@elevation_password_available)
+
+          @elevation_password_available = resolve_elevation_password_available
+        end
+
+        def elevation_config
+          OT.conf.dig('site', 'admin', 'elevation') || {}
+        end
+
+        private
+
+        # Memoized by #elevation_password_available? — within_reauth_grace?,
+        # available_factors and ElevateSession#process all ask, and in full mode
+        # the answer would otherwise be a DB round-trip each time.
+        def resolve_elevation_password_available
+          return true if cust.respond_to?(:has_passphrase?) && cust.has_passphrase?
+
+          # Fail closed (see the doc block): full mode cannot be probed from
+          # here, so its accounts count as password-holding.
+          Onetime.auth_config.full_enabled?
+        rescue StandardError => ex
+          OT.le('[colonel-elevate] password availability probe failed', exception: ex)
+          true
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/ensure_domain_configs.rb
+++ b/apps/api/colonel/logic/colonel/ensure_domain_configs.rb
@@ -78,12 +78,6 @@ module ColonelAPI
             },
           }
         end
-
-        private
-
-        def truthy?(value)
-          %w[true 1 yes on].include?(value.to_s.strip.downcase)
-        end
       end
     end
   end

--- a/apps/api/colonel/logic/colonel/get_elevation_status.rb
+++ b/apps/api/colonel/logic/colonel/get_elevation_status.rb
@@ -1,0 +1,63 @@
+# apps/api/colonel/logic/colonel/get_elevation_status.rb
+#
+# frozen_string_literal: true
+
+require_relative '../base'
+
+module ColonelAPI
+  module Logic
+    module Colonel
+      # GET /api/colonel/elevation — the step-up (sudo) window's status (#4327).
+      #
+      # A cheap read the console fetches on admin mount, after every
+      # elevate/drop, and whenever a tier-1 verb answers 403 elevation_required.
+      # It is deliberately NOT polled: TrackMetadata advances last_activity_at on
+      # every authenticated request, so a polling banner would make #4331's idle
+      # timeout unreachable while an admin tab is open. The countdown between
+      # fetches is computed client-side from expires_at.
+      #
+      # A dedicated endpoint rather than a field on GET /info: GetColonelInfo is
+      # pinned to the frozen `colonelInfo` response contract, which this epic
+      # does not disturb.
+      #
+      # Read-only, so NOTHING is audited (CONTRACT 4).
+      #
+      # `details.factors` is per-ACCOUNT, not the constant list: it is what lets
+      # the console say "your account has no password and no grace is configured,
+      # ask an administrator to set COLONEL_ELEVATION_REAUTH_GRACE" instead of
+      # looping on a prompt the operator cannot satisfy.
+      #
+      # Security invariant (epic #20): BOTH the router (role=colonel) AND this
+      # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
+      class GetElevationStatus < ColonelAPI::Logic::Base
+        def raise_concerns
+          verify_one_of_roles!(colonel: true)
+        end
+
+        def process
+          success_data
+        end
+
+        def success_data
+          live = elevated?
+
+          {
+            record: {
+              elevated: live,
+              expires_at: live ? elevated_until : nil,
+              seconds_remaining: elevation_seconds_remaining,
+            },
+            details: {
+              enabled: elevation_enabled?,
+              window: elevation_window,
+              reauth_grace: elevation_reauth_grace,
+              grace_available: within_reauth_grace?,
+              password_available: elevation_password_available?,
+              factors: available_factors,
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/colonel/get_session_detail.rb
+++ b/apps/api/colonel/logic/colonel/get_session_detail.rb
@@ -3,6 +3,8 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'account_identifier'
+require 'onetime/operations/sessions/store'
 require 'onetime/operations/sessions/inspect_session'
 
 module ColonelAPI
@@ -15,22 +17,53 @@ module ColonelAPI
       # in raise_concerns (404 when absent) and surfaces a typed field read-out plus
       # the full parsed payload for the detail drawer's raw inspector.
       #
+      # ## Non-bearer identifier (#4330)
+      #
+      # The route takes a {Onetime::SessionMetadata.handle_for} handle, not the raw
+      # session id: that id is byte-identical to the `onetime.session` cookie, so
+      # rendering it in the console handed every screen share and log capture a
+      # replayable credential. The handle is resolved back to a sid server-side by
+      # {Onetime::Operations::Sessions::Store.resolve_handle} and the sid never
+      # crosses the HTTP boundary — not in `record`, not in `details.data`.
+      #
       # Read-only: no ColonelAuditEvent (CONTRACT 4).
       #
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class GetSessionDetail < ColonelAPI::Logic::Base
-        attr_reader :session_id, :result
+        include AccountIdentifier
+
+        # Session payload keys the raw inspector must never render: the drawer
+        # prints `details.data` verbatim through JsonViewer and `csrf` is a live
+        # token. Redaction is server-side so no client can regress it.
+        REDACTED_PAYLOAD_KEYS = %w[csrf].freeze
+
+        attr_reader :session_handle, :result, :scan_capped
 
         def process_params
-          @session_id = sanitize_identifier(params['session_id'])
-          raise_form_error('Session ID is required', field: :session_id) if session_id.to_s.empty?
+          @session_handle = sanitize_identifier(params['session_handle']).to_s.downcase
+          # Optional owner hint (see Store.resolve_handle). NOT authorization — it
+          # only picks a cheaper search space; a wrong hint falls through to the
+          # bounded scan. sanitize_account_identifier, not sanitize_identifier:
+          # the latter strips `@` and `.` out of an email hint.
+          @owner_hint     = sanitize_account_identifier(params['user_id'])
+          raise_form_error('Session handle is required', field: :session_handle) if session_handle.empty?
         end
 
         def raise_concerns
           verify_one_of_roles!(colonel: true)
+          # P5 (#4329) inserts enforce_colonel_handle_resolve_limit! here: this is
+          # the one colonel read whose cost is not O(1) — a bounded scan plus up
+          # to MAX_SCAN HMACs when the owner hint misses.
 
-          @result = Onetime::Operations::Sessions::Inspect.new(session_id: session_id).call
+          # A malformed handle resolves to nothing and 404s like an unknown one,
+          # so a scanner cannot tell "bad shape" from "no such session".
+          @session_id, @scan_capped = Onetime::Operations::Sessions::Store.resolve_handle(
+            Familia.dbclient, session_handle, owner_hint: @owner_hint
+          )
+          raise_not_found('Session not found') unless @session_id
+
+          @result = Onetime::Operations::Sessions::Inspect.new(session_id: @session_id).call
           raise_not_found('Session not found') unless result.found
         end
 
@@ -39,11 +72,12 @@ module ColonelAPI
         end
 
         def success_data
-          data = result.data || {}
+          data = redacted_payload(result.data || {})
           {
             record: {
-              session_id: result.session_id,
-              key: result.key,
+              # The non-bearer handle the caller sent — NEVER the raw sid, and
+              # never `result.key` (which is literally "session:<sid>").
+              session_handle: session_handle,
               ttl: result.ttl,
               authenticated: data['authenticated'] ? true : false,
               email: data['email'],
@@ -64,10 +98,24 @@ module ColonelAPI
             },
             details: {
               # Full parsed session payload for the raw inspector (colonel-only;
-              # parity with `bin/ots session inspect`, which prints every key).
+              # parity with `bin/ots session inspect`, which prints every key),
+              # minus the credential keys.
               data: data,
+              # True when the bounded scan hit its cap during resolution: a 404
+              # from this endpoint then means "not among the keys sampled", not
+              # "does not exist". The console says so rather than lying.
+              scan_capped: scan_capped,
             },
           }
+        end
+
+        private
+
+        # Strip live credential material from the payload the drawer renders
+        # verbatim. Note `elevated_until` (#4327) is deliberately NOT redacted —
+        # it is elevation state, not a credential.
+        def redacted_payload(data)
+          data.reject { |key, _| REDACTED_PAYLOAD_KEYS.include?(key.to_s) }
         end
 
         # The active org id from the namespaced `org_context:<uuid>` key the

--- a/apps/api/colonel/logic/colonel/get_session_detail.rb
+++ b/apps/api/colonel/logic/colonel/get_session_detail.rb
@@ -52,9 +52,12 @@ module ColonelAPI
 
         def raise_concerns
           verify_one_of_roles!(colonel: true)
-          # P5 (#4329) inserts enforce_colonel_handle_resolve_limit! here: this is
-          # the one colonel read whose cost is not O(1) — a bounded scan plus up
-          # to MAX_SCAN HMACs when the owner hint misses.
+          # The one exception to "colonel reads are never rate-limited" (#4329):
+          # this is the one colonel read whose cost is not O(1) — a bounded scan
+          # plus up to MAX_SCAN HMACs when the owner hint misses. Charged before
+          # the resolution it bounds, and before the 404, so a scanner cannot
+          # walk the handle space for free.
+          enforce_colonel_handle_resolve_limit!(cust&.extid)
 
           # A malformed handle resolves to nothing and 404s like an unknown one,
           # so a scanner cannot tell "bad shape" from "no such session".

--- a/apps/api/colonel/logic/colonel/list_customer_sessions.rb
+++ b/apps/api/colonel/logic/colonel/list_customer_sessions.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'current_session'
 require 'onetime/models/session_metadata'
 require 'onetime/operations/sessions/list_for_customer'
 
@@ -28,6 +29,13 @@ module ColonelAPI
       # boundary: rows carry NO token, NO decrypted payload, NO email/secret
       # material — the frontend physically cannot render one.
       class ListCustomerSessions < ColonelAPI::Logic::Base
+        # The acting colonel's own session identity, as the non-bearer HANDLE the
+        # sidecar rows expose — so the UI can badge the colonel's own row and
+        # disable its self-revoke WITHOUT the response ever carrying a replayable
+        # cookie value, not even the acting colonel's own. Shared with the
+        # self-revoke interlocks so badge and gate cannot disagree (#4328).
+        include CurrentSession
+
         SCHEMAS = { response: 'colonelCustomerSessions' }.freeze
 
         attr_reader :user_id, :result
@@ -60,31 +68,6 @@ module ColonelAPI
               current_session_handle: current_session_handle,
             ),
           }
-        end
-
-        private
-
-        # The acting colonel's OWN request session, as the non-bearer HANDLE the
-        # sidecar rows expose (SessionMetadata#session_handle), so the UI can badge
-        # the colonel's own row and disable its (no-op) self-revoke WITHOUT the
-        # response ever carrying a replayable cookie value — not even the acting
-        # colonel's own. nil when the session can't be identified.
-        def current_session_handle
-          sid = current_session_id
-          return nil if sid.nil?
-
-          Onetime::SessionMetadata.handle_for(sid)
-        end
-
-        # The colonel's own plain sid (safe_session_id yields a Rack SessionId
-        # object; #public_id is the cookie value == SessionMetadata#session_id).
-        # INTERNAL only — never serialized; it is digested into the handle above.
-        # nil when the session can't be identified (e.g. Hash session in JSON auth).
-        def current_session_id
-          sid = safe_session_id
-          return nil if sid.nil?
-
-          sid.respond_to?(:public_id) ? sid.public_id : sid.to_s
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/list_organizations.rb
+++ b/apps/api/colonel/logic/colonel/list_organizations.rb
@@ -253,9 +253,6 @@ module ColonelAPI
 
         # Matches the sibling colonel logic classes (repair_domain,
         # transfer_domain, purge_dlq) rather than introducing a shared helper.
-        def truthy?(value)
-          %w[true 1 yes on].include?(value.to_s.strip.downcase)
-        end
 
         def build_org_data(org)
           owner = org.owner

--- a/apps/api/colonel/logic/colonel/list_sessions.rb
+++ b/apps/api/colonel/logic/colonel/list_sessions.rb
@@ -15,6 +15,12 @@ module ColonelAPI
       # the HTTP concerns (param coercion + role gate); the op owns the bounded
       # scan, the optional search filter, and pagination.
       #
+      # Rows identify a session by `session_handle` only: this adapter does NOT
+      # pass `reveal_session_id`, so the op strips the raw sid and its Redis key
+      # before they can reach the wire (#4330). The search term matches identity
+      # fields or a handle prefix, so the console's search box still works over
+      # what it now displays.
+      #
       # Read-only: no ColonelAuditEvent (CONTRACT 4 — audit is for mutations).
       #
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this

--- a/apps/api/colonel/logic/colonel/list_sessions.rb
+++ b/apps/api/colonel/logic/colonel/list_sessions.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'current_session'
 require 'onetime/operations/sessions/list_sessions'
 
 module ColonelAPI
@@ -26,6 +27,11 @@ module ColonelAPI
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class ListSessions < ColonelAPI::Logic::Base
+        # Same mixin the per-customer panel uses, so the global console can badge
+        # and disable the acting colonel's own row against the SAME definition
+        # the DeleteSession interlock refuses on (#4328).
+        include CurrentSession
+
         SCHEMAS = { response: 'colonelSessions' }.freeze
 
         attr_reader :sessions, :pagination_meta
@@ -75,6 +81,11 @@ module ColonelAPI
               sessions: sessions,
               pagination: pagination_meta,
               scan: @scan_meta,
+              # The acting colonel's own row, as a HANDLE (never the sid). The
+              # console disables its revoke button; the server refuses it too
+              # (DeleteSession, #4328) — this only spares the operator the 422.
+              # nil when the session can't be identified.
+              current_session_handle: current_session_handle,
             },
           }
         end

--- a/apps/api/colonel/logic/colonel/manage_entitlement_override.rb
+++ b/apps/api/colonel/logic/colonel/manage_entitlement_override.rb
@@ -97,12 +97,18 @@ module ColonelAPI
           @org = load_organization
           raise_not_found('Organization not found') unless @org&.exists?
 
-          # Validate entitlement name is known (optional, but helps catch typos)
-          return if @action == 'clear'
-          return if Onetime::Operations::Org::EntitlementOverride.known_entitlement?(@entitlement)
+          # TIER 2 (#4326), ALL arms: grant is privilege-granting and clear is
+          # irreversible, so a per-arm split would buy nothing but a place to
+          # make a mistake. The URL carries the org id; the confirmation is its
+          # NAME.
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: org_confirm_token(@org),
+            confirm_subject: "the organization's name",
+            field: :org_id,
+          )
 
-          # Warn but don't block - allows granting future entitlements
-          OT.info "[colonel] Granting unknown entitlement '#{@entitlement}' to org #{@org_id}"
+          warn_unknown_entitlement
         end
 
         def process
@@ -135,6 +141,16 @@ module ColonelAPI
         end
 
         private
+
+        # Warn but don't block — allows granting future entitlements. Validation
+        # of the entitlement NAME is advisory (it helps catch typos); it is not a
+        # guard, so it deliberately runs after the confirmation gate.
+        def warn_unknown_entitlement
+          return if @action == 'clear'
+          return if Onetime::Operations::Org::EntitlementOverride.known_entitlement?(@entitlement)
+
+          OT.info "[colonel] Granting unknown entitlement '#{@entitlement}' to org #{@org_id}"
+        end
 
         # Statuses the op returns for input it refused. process_params already
         # rejects both ahead of the call, so these are a defensive backstop that

--- a/apps/api/colonel/logic/colonel/manage_membership_entitlement_override.rb
+++ b/apps/api/colonel/logic/colonel/manage_membership_entitlement_override.rb
@@ -115,16 +115,16 @@ module ColonelAPI
           @customer = resolve_customer(@member_id)
           raise_not_found('Member not found') unless @customer
 
-          # Validate entitlement name is known (optional, but helps catch typos)
-          return if @action == 'clear'
-          return if Onetime::Operations::Memberships::EntitlementOverride.known_entitlement?(@entitlement)
+          # TIER 2 (#4326), ALL arms. The URL carries the member's extid; the
+          # confirmation is their EMAIL.
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: account_confirm_token(@customer),
+            confirm_subject: "the member's email address",
+            field: :member_id,
+          )
 
-          # Warn but don't block - allows granting future entitlements. Only
-          # grant/revoke reach here (clear returned above), so the verb is a
-          # two-way pick; @org is resolved by now, so log its extid rather than
-          # the raw request param.
-          verb = @action == 'grant' ? 'Granting' : 'Revoking'
-          OT.info "[colonel] #{verb} unknown entitlement '#{@entitlement}' for member #{@customer.extid} in org #{@org.extid}"
+          warn_unknown_entitlement
         end
 
         def process
@@ -158,6 +158,19 @@ module ColonelAPI
         end
 
         private
+
+        # Warn but don't block — allows granting future entitlements. Only
+        # grant/revoke reach the log line (clear returns first), so the verb is a
+        # two-way pick; @org is resolved by now, so log its extid rather than the
+        # raw request param. Advisory, not a guard: it runs after the
+        # confirmation gate.
+        def warn_unknown_entitlement
+          return if @action == 'clear'
+          return if Onetime::Operations::Memberships::EntitlementOverride.known_entitlement?(@entitlement)
+
+          verb = @action == 'grant' ? 'Granting' : 'Revoking'
+          OT.info "[colonel] #{verb} unknown entitlement '#{@entitlement}' for member #{@customer.extid} in org #{@org.extid}"
+        end
 
         # :invalid_action / :missing_entitlement are a defensive backstop —
         # process_params already rejects both ahead of the call. :not_found is

--- a/apps/api/colonel/logic/colonel/override_domain_verification.rb
+++ b/apps/api/colonel/logic/colonel/override_domain_verification.rb
@@ -54,6 +54,16 @@ module ColonelAPI
 
           @custom_domain = resolve_custom_domain(extid)
           raise_not_found('Domain not found') unless custom_domain
+
+          # TIER 2 (#4326): this bypasses DNS proof of ownership. No preview arm
+          # exists on this surface. The URL carries the extid; the confirmation
+          # is the hostname.
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: custom_domain.display_domain,
+            confirm_subject: 'the domain name',
+            field: :extid,
+          )
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/purge_dlq.rb
+++ b/apps/api/colonel/logic/colonel/purge_dlq.rb
@@ -25,7 +25,7 @@ module ColonelAPI
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class PurgeDlq < ColonelAPI::Logic::Base
-        attr_reader :dlq_name, :result
+        attr_reader :queue, :dlq_name, :result
 
         def process_params
           @queue    = sanitize_queue_name(params['queue'])
@@ -43,6 +43,20 @@ module ColonelAPI
           unless $rmq_conn&.open?
             raise_form_error('Message queue is not connected')
           end
+
+          # PREVIEW EXEMPTION (#4326): a dry run counts, it does not purge.
+          # dry_run defaults to FALSE here, unlike the domain/org verbs.
+          return if @dry_run
+
+          # TIER 1. The ONLY gated verb whose token is the URL parameter: a queue
+          # has no second identifier. Said plainly rather than dressed up.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: queue,
+            confirm_subject: 'the queue name',
+            field: :queue,
+          )
+          charge_destructive_budget!
         end
 
         def process
@@ -62,10 +76,6 @@ module ColonelAPI
 
         def sanitize_queue_name(value)
           value.to_s.downcase.gsub(/[^a-z0-9._-]/, '')
-        end
-
-        def truthy?(value)
-          %w[1 true yes].include?(value.to_s.downcase)
         end
 
         def success_data

--- a/apps/api/colonel/logic/colonel/purge_user.rb
+++ b/apps/api/colonel/logic/colonel/purge_user.rb
@@ -41,7 +41,23 @@ module ColonelAPI
           raise_not_found('User not found') unless user&.exists?
 
           raise_form_error('Cannot purge anonymous user', field: :user_id) if user.anonymous?
+
+          # TIER 1 (#4326). The URL carries the extid; the confirmation is the
+          # account's EMAIL (its extid only when it has none), so a scraped-id
+          # replay must also know an identifier the URL never carried.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: account_confirm_token(user),
+            confirm_subject: 'the account email address (or its external id when it has none)',
+            field: :user_id,
+          )
+
+          # INTERLOCK — after proof (guard order §0.2): a 422 here would
+          # otherwise tell a caller who has proven nothing whether the named
+          # account is their own.
           raise_form_error('Cannot purge your own account', field: :user_id) if user.objid == cust.objid
+
+          charge_destructive_budget!
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/purge_user.rb
+++ b/apps/api/colonel/logic/colonel/purge_user.rb
@@ -5,6 +5,7 @@
 require_relative '../base'
 require_relative 'account_identifier'
 require 'auth/operations/customers/purge'
+require 'onetime/operations/customers/role_support'
 
 module ColonelAPI
   module Logic
@@ -56,6 +57,26 @@ module ColonelAPI
           # otherwise tell a caller who has proven nothing whether the named
           # account is their own.
           raise_form_error('Cannot purge your own account', field: :user_id) if user.objid == cust.objid
+
+          # INTERLOCK (#4328): purging the last active colonel deletes the last
+          # administrator — a HARDER lockout than demote/unverify (the account is
+          # gone, not merely stripped) and, being irreversible, one this op cannot
+          # post-write roll back the way SetRole/SetVerification do. Refuse it at
+          # the pre-check. An UNVERIFIED colonel-role target is not an active
+          # colonel (last_colonel_by_verification? requires verified?), so purging
+          # it cannot empty the roster and is allowed. The residual concurrent
+          # double-purge (two colonels purging each other past this non-atomic
+          # check) cannot be undone here — a purged account cannot be recreated —
+          # and is the one gap purge's irreversibility leaves that the reversible
+          # verbs close with a post-write rollback.
+          if Onetime::Operations::Customers::RoleSupport.last_colonel_by_verification?(user)
+            raise_form_error(
+              'Refusing to purge the last active colonel: it would leave the install ' \
+              'with no administrator (recoverable only from the CLI). Promote and ' \
+              'verify another colonel first.',
+              field: :user_id,
+            )
+          end
 
           charge_destructive_budget!
         end

--- a/apps/api/colonel/logic/colonel/remove_custom_domain.rb
+++ b/apps/api/colonel/logic/colonel/remove_custom_domain.rb
@@ -40,6 +40,19 @@ module ColonelAPI
 
           @custom_domain = resolve_custom_domain(extid)
           raise_not_found('Domain not found') unless custom_domain
+
+          # PREVIEW EXEMPTION (#4326): a dry run writes nothing. dry_run
+          # defaults to TRUE here, so only an explicit apply is gated.
+          return if dry_run
+
+          # TIER 1. The URL carries the extid; the confirmation is the hostname.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: custom_domain.display_domain,
+            confirm_subject: 'the domain name',
+            field: :extid,
+          )
+          charge_destructive_budget!
         end
 
         def process
@@ -75,12 +88,6 @@ module ColonelAPI
               reasserts_survivor: result.reasserts_survivor,
             },
           }
-        end
-
-        private
-
-        def truthy?(value)
-          %w[true 1 yes on].include?(value.to_s.strip.downcase)
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/remove_membership.rb
+++ b/apps/api/colonel/logic/colonel/remove_membership.rb
@@ -46,6 +46,17 @@ module ColonelAPI
 
           @customer = resolve_customer(@member_id)
           raise_not_found('Member not found') unless @customer
+
+          # TIER 1 (#4326). The URL carries the member's extid; the confirmation
+          # is their EMAIL. The sole-owner interlock stays in the op, which runs
+          # in #process — structurally after this guard.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: account_confirm_token(customer),
+            confirm_subject: "the member's email address",
+            field: :member_id,
+          )
+          charge_destructive_budget!
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/repair_domain.rb
+++ b/apps/api/colonel/logic/colonel/repair_domain.rb
@@ -46,11 +46,24 @@ module ColonelAPI
 
           # Resolve the optional target org for the ORPHANED case (by objid or extid).
           # The op ignores it when the domain already has an org_id.
-          return if org_id.to_s.empty?
+          unless org_id.to_s.empty?
+            @target_org = Onetime::Organization.load(org_id) ||
+                          Onetime::Organization.find_by_extid(org_id)
+            raise_form_error('Organization not found', field: :org_id) unless target_org
+          end
 
-          @target_org = Onetime::Organization.load(org_id) ||
-                        Onetime::Organization.find_by_extid(org_id)
-          raise_form_error('Organization not found', field: :org_id) unless target_org
+          # PREVIEW EXEMPTION (#4326): a dry run mutates and audits nothing.
+          # dry_run defaults to TRUE here.
+          return if dry_run
+
+          # TIER 2: repair rewrites ownership state. The URL carries the extid;
+          # the confirmation is the hostname.
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: custom_domain.display_domain,
+            confirm_subject: 'the domain name',
+            field: :extid,
+          )
         end
 
         def process
@@ -81,12 +94,6 @@ module ColonelAPI
               repairs_applied: result.repairs_applied,
             },
           }
-        end
-
-        private
-
-        def truthy?(value)
-          %w[true 1 yes on].include?(value.to_s.strip.downcase)
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/replay_dlq.rb
+++ b/apps/api/colonel/logic/colonel/replay_dlq.rb
@@ -24,7 +24,7 @@ module ColonelAPI
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class ReplayDlq < ColonelAPI::Logic::Base
-        attr_reader :dlq_name, :result
+        attr_reader :queue, :dlq_name, :result
 
         def process_params
           @queue    = sanitize_queue_name(params['queue'])
@@ -43,6 +43,18 @@ module ColonelAPI
           unless $rmq_conn&.open?
             raise_form_error('Message queue is not connected')
           end
+
+          # PREVIEW EXEMPTION (#4326): a dry run counts, it does not republish.
+          return if @dry_run
+
+          # TIER 2: replay re-injects side-effecting messages (emails, webhooks).
+          # A queue has no second identifier, so the token IS the URL parameter.
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: queue,
+            confirm_subject: 'the queue name',
+            field: :queue,
+          )
         end
 
         def process
@@ -63,10 +75,6 @@ module ColonelAPI
 
         def sanitize_queue_name(value)
           value.to_s.downcase.gsub(/[^a-z0-9._-]/, '')
-        end
-
-        def truthy?(value)
-          %w[1 true yes].include?(value.to_s.downcase)
         end
 
         def success_data

--- a/apps/api/colonel/logic/colonel/reset_rate_limit.rb
+++ b/apps/api/colonel/logic/colonel/reset_rate_limit.rb
@@ -51,6 +51,33 @@ module ColonelAPI
             confirm_subject: 'the limiter kind and subject joined by a colon',
             field: :kind,
           )
+
+          refuse_self_colonel_reset!
+        end
+
+        # INTERLOCK (#4329 review): a colonel may not clear their OWN colonel_*
+        # limiter over HTTP. Those buckets exist to bound the ACTING colonel:
+        # colonel_elevation is the sole backstop against step-up brute force
+        # (Auth::Config.valid_login_and_password? is an internal request and never
+        # trips Rodauth's own lockout — see colonel_rate_limiter.rb), colonel_destructive
+        # keeps the tier-1 count under the audit cap, and colonel_mutation bounds
+        # the surface. Self-clearing any of them from a cookie turns the bucket into
+        # a no-op — brute-force elevation, reset, repeat — so recovery of one's own
+        # colonel lockout is CLI-only (shell access is the higher bar the registry
+        # already documents). Resetting a PEER colonel's bucket, or any non-colonel
+        # limiter, is unaffected: that is the operator-recovery use case. The
+        # confirmation token here is caller-supplied (kind:subject) and proves
+        # nothing, so this guard — not the token — is what stops the loop.
+        def refuse_self_colonel_reset!
+          return unless kind.start_with?('colonel_')
+          return unless subject == cust&.extid.to_s
+
+          raise_form_error(
+            'Refusing to clear your own colonel rate limiter over the API; a leaked ' \
+            'colonel cookie could otherwise reset its own lockout in a loop. Clear it ' \
+            "from the CLI instead (bin/ots ratelimit keys #{kind} #{subject}).",
+            field: :subject,
+          )
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/reset_rate_limit.rb
+++ b/apps/api/colonel/logic/colonel/reset_rate_limit.rb
@@ -40,6 +40,17 @@ module ColonelAPI
           unless Onetime::Operations::RateLimit::Registry.known?(kind)
             raise_not_found("Unknown rate limiter: #{kind}")
           end
+
+          # TIER 2 (#4326): a reset removes an active defence. The composed token
+          # DEPENDS on the two required-field guards above — without them an
+          # empty kind and subject would compose the non-blank string ":" and
+          # slip past the blank-expected tripwire in require_confirmation!.
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: "#{kind}:#{subject}",
+            confirm_subject: 'the limiter kind and subject joined by a colon',
+            field: :kind,
+          )
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/revoke_all_customer_sessions.rb
+++ b/apps/api/colonel/logic/colonel/revoke_all_customer_sessions.rb
@@ -30,7 +30,7 @@ module ColonelAPI
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class RevokeAllCustomerSessions < ColonelAPI::Logic::Base
-        attr_reader :user_id, :result
+        attr_reader :user_id, :user, :result
 
         def process_params
           @user_id = sanitize_identifier(params['user_id'])
@@ -39,6 +39,24 @@ module ColonelAPI
 
         def raise_concerns
           verify_one_of_roles!(colonel: true)
+
+          # Resolved for the CONFIRMATION TOKEN only — this is deliberately not a
+          # 404 guard today (the op is idempotent on an unknown custid). P4
+          # (#4328) adds the existence check and the self-target interlock here,
+          # between this resolve and the guard below.
+          @user = Onetime::Customer.load_by_extid_or_email(user_id) ||
+                  Onetime::Customer.load(user_id)
+
+          # TIER 1 (#4326). The URL carries the extid; the confirmation is the
+          # account's EMAIL. An account the console cannot resolve falls back to
+          # the identifier the caller sent, so the expected token is never blank.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: user&.exists? ? account_confirm_token(user) : user_id,
+            confirm_subject: "the target account's email address (or its external id when it has none)",
+            field: :user_id,
+          )
+          charge_destructive_budget!
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/revoke_all_customer_sessions.rb
+++ b/apps/api/colonel/logic/colonel/revoke_all_customer_sessions.rb
@@ -3,7 +3,10 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'account_identifier'
+require_relative 'current_session'
 require 'onetime/operations/sessions/revoke_all_for_customer'
+require 'onetime/operations/sessions/revoke_all_for_customer_except_current'
 
 module ColonelAPI
   module Logic
@@ -27,44 +30,79 @@ module ColonelAPI
       # confirm dialog. The record's counts are surfaced to the operator so they
       # see how total the revoke actually was.
       #
+      # ## Self-target is SUPPORTED, not refused (#4328)
+      #
+      # Every other self-target verb in this package answers 422. This one does
+      # not, deliberately: the scenario the whole epic is written for is a leaked
+      # colonel cookie, and "kill all my sessions" is the operator's first
+      # containment step. Refusing it would remove their only in-console remedy
+      # for the very compromise they are containing. So a self-target request is
+      # routed to {Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent},
+      # which spares the session they are working in — and the response says so.
+      # If the current sid cannot be resolved at all (a Hash-backed session), we
+      # refuse rather than revoke the operator's own session out from under them.
+      #
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class RevokeAllCustomerSessions < ColonelAPI::Logic::Base
+        include AccountIdentifier
+        include CurrentSession
+
+        SELF_TARGET_MESSAGE = 'Revoked all of your other sessions; this one was kept.'
+
         attr_reader :user_id, :user, :result
 
         def process_params
-          @user_id = sanitize_identifier(params['user_id'])
+          # sanitize_account_identifier (NOT sanitize_identifier) — the latter
+          # strips '@' and '.', which silently destroys an email identifier.
+          # See AccountIdentifier.
+          @user_id = sanitize_account_identifier(params['user_id'])
           raise_form_error('User ID is required', field: :user_id) if user_id.to_s.empty?
+        end
+
+        # @return [Boolean] the target resolved to the acting colonel
+        def self_target?
+          @self_target
         end
 
         def raise_concerns
           verify_one_of_roles!(colonel: true)
 
-          # Resolved for the CONFIRMATION TOKEN only — this is deliberately not a
-          # 404 guard today (the op is idempotent on an unknown custid). P4
-          # (#4328) adds the existence check and the self-target interlock here,
-          # between this resolve and the guard below.
-          @user = Onetime::Customer.load_by_extid_or_email(user_id) ||
-                  Onetime::Customer.load(user_id)
+          # Resolve by PUBLIC id (extid) first, then email, then objid. The 404
+          # is new with #4328: revoke-all against an unknown identifier used to
+          # return zero counts, which reads as "done" for a typo'd id. The
+          # self-target routing and the confirmation token both need the record
+          # anyway.
+          @user = resolve_account(user_id)
+          raise_not_found('User not found') unless user&.exists?
+
+          @self_target = user.objid == cust.objid
 
           # TIER 1 (#4326). The URL carries the extid; the confirmation is the
-          # account's EMAIL. An account the console cannot resolve falls back to
-          # the identifier the caller sent, so the expected token is never blank.
+          # account's EMAIL (its extid only when it has none).
           guard_destructive_action!(
             tier: :destructive,
-            confirm_with: user&.exists? ? account_confirm_token(user) : user_id,
+            confirm_with: account_confirm_token(user),
             confirm_subject: "the target account's email address (or its external id when it has none)",
             field: :user_id,
           )
+
+          # INTERLOCK — step 4, after proof (#4328). The ONLY refusal on this
+          # verb: a self-target whose current sid we cannot identify would fall
+          # through to the all-inclusive op and sign the operator out. Fail safe.
+          if self_target? && current_session_id.to_s.empty?
+            raise_form_error(
+              'Cannot revoke your own sessions: this request has no identifiable session to keep. ' \
+              'Use sign-out, or revoke from a browser session.',
+              field: :user_id,
+            )
+          end
+
           charge_destructive_budget!
         end
 
         def process
-          # actor is the acting colonel's PUBLIC id (extid), never an objid.
-          @result = Onetime::Operations::Sessions::RevokeAllForCustomer.new(
-            custid: user_id,
-            actor: cust.extid,
-          ).call
+          @result = self_target? ? revoke_all_except_current : revoke_all
 
           success_data
         end
@@ -75,13 +113,41 @@ module ColonelAPI
               revoked: result.revoked,
               blobs_deleted: result.blobs_deleted,
               untracked_deleted: result.untracked_deleted,
-              rodauth_rows_deleted: result.rodauth_rows_deleted,
+              # The except-current op is Redis-only by contract (it is also the
+              # self-service password-change primitive), so it has no Rodauth
+              # row count to report. Zero, not nil: the ack shape is fixed.
+              rodauth_rows_deleted: self_target? ? 0 : result.rodauth_rows_deleted,
               scan_capped: result.scan_capped,
             },
             details: {
-              message: 'All sessions revoked successfully',
+              message: self_target? ? SELF_TARGET_MESSAGE : 'All sessions revoked successfully',
             },
           }
+        end
+
+        private
+
+        # The offboarding primitive: kills EVERY session and writes the
+        # ColonelAuditEvent (CONTRACT 4 — the op owns the trail).
+        def revoke_all
+          Onetime::Operations::Sessions::RevokeAllForCustomer.new(
+            custid: user_id,
+            actor: cust.extid, # acting colonel's PUBLIC id, never an objid
+          ).call
+        end
+
+        # Containment for the acting colonel's own account: same guaranteed
+        # tracked kill plus best-effort untracked sweep, but the session this
+        # request arrived on is preserved. Redis-only (no Rodauth rows — see the
+        # op's doc block). Naming an `actor` is what makes it write the one
+        # ColonelAuditEvent this admin action owes the trail; the self-service
+        # callers pass none and stay out of it.
+        def revoke_all_except_current
+          Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent.new(
+            custid: user_id,
+            except_session_id: current_session_id,
+            actor: cust.extid, # acting colonel's PUBLIC id, never an objid
+          ).call
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/revoke_customer_session.rb
+++ b/apps/api/colonel/logic/colonel/revoke_customer_session.rb
@@ -40,7 +40,7 @@ module ColonelAPI
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class RevokeCustomerSession < ColonelAPI::Logic::Base
-        attr_reader :user_id, :session_handle, :session_id, :result
+        attr_reader :user_id, :session_handle, :session_id, :customer, :result
 
         def process_params
           @user_id        = sanitize_identifier(params['user_id'])
@@ -57,6 +57,17 @@ module ColonelAPI
           # server). 404 when it names none — a stale or unknown handle.
           @session_id = resolve_session_id
           raise_not_found('Session not found') if session_id.nil?
+
+          # TIER 1 (#4326). The URL carries the owner's extid and an opaque
+          # handle; the confirmation is the owner's EMAIL. `customer` is non-nil
+          # here — resolve_session_id returns nil (⇒ 404 above) when it is not.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: account_confirm_token(customer),
+            confirm_subject: "the session owner's email address",
+            field: :session_handle,
+          )
+          charge_destructive_budget!
         end
 
         def process
@@ -90,8 +101,8 @@ module ColonelAPI
         # the customer is unknown or no member matches. Customer resolution mirrors
         # RevokeForCustomer / ListForCustomer: extid → email → objid.
         def resolve_session_id
-          customer = Onetime::Customer.load_by_extid_or_email(user_id) ||
-                     Onetime::Customer.load(user_id)
+          @customer = Onetime::Customer.load_by_extid_or_email(user_id) ||
+                      Onetime::Customer.load(user_id)
           return nil unless customer&.exists?
 
           customer.active_sessions.revrange(0, -1).find do |sid|

--- a/apps/api/colonel/logic/colonel/revoke_customer_session.rb
+++ b/apps/api/colonel/logic/colonel/revoke_customer_session.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'current_session'
 require 'onetime/models/session_metadata'
 require 'onetime/operations/sessions/revoke_for_customer'
 
@@ -40,6 +41,8 @@ module ColonelAPI
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class RevokeCustomerSession < ColonelAPI::Logic::Base
+        include CurrentSession
+
         attr_reader :user_id, :session_handle, :session_id, :customer, :result
 
         def process_params
@@ -67,6 +70,18 @@ module ColonelAPI
             confirm_subject: "the session owner's email address",
             field: :session_handle,
           )
+
+          # INTERLOCK — step 4, after proof (#4328). Identical to the global
+          # DeleteSession guard: a colonel revoking their own session through
+          # the per-customer panel is the same mistake, and the per-customer
+          # list already badges the row. Handles, never sids.
+          if current_session_handle && current_session_handle == session_handle
+            raise_form_error(
+              'Cannot revoke your own active session. Use sign-out instead.',
+              field: :session_handle,
+            )
+          end
+
           charge_destructive_budget!
         end
 

--- a/apps/api/colonel/logic/colonel/send_test_email.rb
+++ b/apps/api/colonel/logic/colonel/send_test_email.rb
@@ -73,12 +73,6 @@ module ColonelAPI
             },
           }
         end
-
-        private
-
-        def truthy?(value)
-          %w[true 1 yes on].include?(value.to_s.strip.downcase)
-        end
       end
     end
   end

--- a/apps/api/colonel/logic/colonel/set_membership_role.rb
+++ b/apps/api/colonel/logic/colonel/set_membership_role.rb
@@ -45,6 +45,16 @@ module ColonelAPI
 
           @customer = resolve_customer(@member_id)
           raise_not_found('Member not found') unless @customer
+
+          # TIER 1 (#4326): a membership role grants access to that org's data.
+          # The URL carries the member's extid; the confirmation is their EMAIL.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: account_confirm_token(customer),
+            confirm_subject: "the member's email address",
+            field: :member_id,
+          )
+          charge_destructive_budget!
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/set_user_role.rb
+++ b/apps/api/colonel/logic/colonel/set_user_role.rb
@@ -41,13 +41,25 @@ module ColonelAPI
 
           raise_form_error('Cannot modify anonymous user', field: :user_id) if user.anonymous?
 
-          return if Auth::Operations::Customers::SetRole::VALID_ROLES.include?(new_role)
+          unless Auth::Operations::Customers::SetRole::VALID_ROLES.include?(new_role)
+            raise_form_error(
+              "Invalid role '#{new_role}'. Valid roles: " \
+              "#{Auth::Operations::Customers::SetRole::VALID_ROLES.join(', ')}",
+              field: :role,
+            )
+          end
 
-          raise_form_error(
-            "Invalid role '#{new_role}'. Valid roles: " \
-            "#{Auth::Operations::Customers::SetRole::VALID_ROLES.join(', ')}",
-            field: :role,
+          # TIER 1 (#4326). The URL carries the extid; the confirmation is the
+          # target's EMAIL, so a scraped-id replay needs a second identifier.
+          # P4 (#4328) inserts the self-demotion / last-colonel interlocks AFTER
+          # this call and BEFORE charge_destructive_budget! (guard order §0.2).
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: account_confirm_token(user),
+            confirm_subject: "the target account's email address",
+            field: :user_id,
           )
+          charge_destructive_budget!
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/set_user_role.rb
+++ b/apps/api/colonel/logic/colonel/set_user_role.rb
@@ -3,7 +3,9 @@
 # frozen_string_literal: true
 
 require_relative '../base'
+require_relative 'account_identifier'
 require 'auth/operations/customers/set_role'
+require 'onetime/operations/customers/role_support'
 
 module ColonelAPI
   module Logic
@@ -15,13 +17,27 @@ module ColonelAPI
       # ColonelAuditEvent — this class only handles HTTP concerns (param
       # sanitization, authorization, response shape).
       #
+      # ## No dry_run (#4328)
+      #
+      # `dry_run` is pinned false here, matching transfer_organization_ownership.rb:
+      # the console has no preview flow for role changes, and adding one would be
+      # a UI feature this epic does not scope. The defect the issue names — a
+      # one-click privilege change — is answered by typed confirmation, step-up
+      # elevation and the interlocks below, not by a preview.
+      #
       # Security invariant (epic #20): BOTH the router (role=colonel) AND this
       # logic (verify_one_of_roles!(colonel: true)) enforce the colonel role.
       class SetUserRole < ColonelAPI::Logic::Base
+        include AccountIdentifier
+
         attr_reader :user_id, :user, :new_role, :old_role, :change_status
 
         def process_params
-          @user_id  = sanitize_identifier(params['user_id'])
+          # sanitize_account_identifier (NOT sanitize_identifier) — the latter
+          # strips '@' and '.', so an email identifier arrived as
+          # `userexamplecom` and this endpoint 404'd on every address an
+          # operator pasted. See AccountIdentifier.
+          @user_id  = sanitize_account_identifier(params['user_id'])
           @new_role = sanitize_plain_text(params['role'])
 
           raise_form_error('User ID is required', field: :user_id) if user_id.to_s.empty?
@@ -35,8 +51,7 @@ module ColonelAPI
           # extid, so every admin surface routes by it — then email, then objid.
           # Mirrors Auth::Operations::Customers::Show#resolve (show.rb): a plain
           # Customer.load only resolves the internal objid, so an extid would 404.
-          @user = Onetime::Customer.load_by_extid_or_email(user_id) ||
-                  Onetime::Customer.load(user_id)
+          @user = resolve_account(user_id)
           raise_not_found('User not found') unless user&.exists?
 
           raise_form_error('Cannot modify anonymous user', field: :user_id) if user.anonymous?
@@ -51,14 +66,15 @@ module ColonelAPI
 
           # TIER 1 (#4326). The URL carries the extid; the confirmation is the
           # target's EMAIL, so a scraped-id replay needs a second identifier.
-          # P4 (#4328) inserts the self-demotion / last-colonel interlocks AFTER
-          # this call and BEFORE charge_destructive_budget! (guard order §0.2).
           guard_destructive_action!(
             tier: :destructive,
             confirm_with: account_confirm_token(user),
             confirm_subject: "the target account's email address",
             field: :user_id,
           )
+
+          enforce_role_interlocks!
+
           charge_destructive_budget!
         end
 
@@ -68,9 +84,12 @@ module ColonelAPI
           result         = Auth::Operations::Customers::SetRole.new(
             customer: user,
             role: new_role,
-            actor: cust.extid, # acting colonel's PUBLIC id (never an objid)
+            actor: cust.extid,       # acting colonel's PUBLIC id (never an objid)
+            actor_objid: cust.objid, # INTERNAL id, for the self-demotion check only
           ).call
           @change_status = result.status
+
+          handle_change_status
 
           success_data
         end
@@ -90,6 +109,53 @@ module ColonelAPI
               message: 'User role updated successfully',
             },
           }
+        end
+
+        private
+
+        # STEP 4 of the guard-order contract (logic/destructive_action.rb).
+        # These run AFTER elevation + confirmation so a caller holding only the
+        # cookie cannot use the 422s to learn who the last colonel is, or
+        # whether a given account is their own.
+        #
+        # Both refusals are ALSO enforced by the op (shared with
+        # `bin/ots customers role demote`, which has no HTTP layer to put them
+        # in); these adapter checks exist so the console gets a friendly,
+        # remediation-naming 422 rather than a bare status — exactly as
+        # set_user_suspension.rb does for its privilege guard. The op remains
+        # the backstop, and #handle_change_status maps it if it ever wins.
+        def enforce_role_interlocks!
+          if user.objid == cust.objid && new_role != 'colonel'
+            raise_form_error(
+              'Cannot demote your own colonel account. Have another colonel demote you, ' \
+              'or use `bin/ots customers role demote`.',
+              field: :user_id,
+            )
+          end
+
+          return unless Onetime::Operations::Customers::RoleSupport.last_colonel?(user, new_role)
+
+          raise_form_error(
+            'Cannot demote the last remaining colonel. Promote another account first.',
+            field: :user_id,
+          )
+        end
+
+        # Map the op's Result#status. The interlock statuses are reachable only
+        # if the roster changed between raise_concerns and the mutation (or a
+        # future caller skips the adapter checks), so they answer the same 422s
+        # rather than a silent success. The `else` arm exists so a status added
+        # to the op fails loudly here instead of being reported as "changed".
+        def handle_change_status
+          case change_status
+          when :success, :no_change then nil
+          when :self_demotion
+            raise_form_error('Cannot demote your own colonel account.', field: :user_id)
+          when :last_colonel
+            raise_form_error('Cannot demote the last remaining colonel.', field: :user_id)
+          else
+            raise_form_error("Role change did not complete (#{change_status})", field: :role)
+          end
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/set_user_suspension.rb
+++ b/apps/api/colonel/logic/colonel/set_user_suspension.rb
@@ -46,9 +46,21 @@ module ColonelAPI
 
           raise_form_error('Cannot modify anonymous user', field: :user_id) if user.anonymous?
 
-          # Privilege guard (UX-level; the op enforces it again as a backstop):
-          # colonel accounts cannot be suspended — demote the role first.
-          return unless suspended_target && user.role?('colonel')
+          # Only the SUSPEND arm is gated (#4326, TIER 2): it denies a user
+          # service. UnsuspendUser is the restorative arm and stays un-gated.
+          return unless suspended_target
+
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: account_confirm_token(user),
+            confirm_subject: "the target account's email address",
+            field: :user_id,
+          )
+
+          # INTERLOCK — after proof (guard order §0.2). Privilege guard
+          # (UX-level; the op enforces it again as a backstop): colonel accounts
+          # cannot be suspended — demote the role first.
+          return unless user.role?('colonel')
 
           raise_form_error('Colonel accounts cannot be suspended. Demote the role first.', field: :user_id)
         end

--- a/apps/api/colonel/logic/colonel/set_user_verification.rb
+++ b/apps/api/colonel/logic/colonel/set_user_verification.rb
@@ -5,6 +5,7 @@
 require_relative '../base'
 require_relative 'account_identifier'
 require 'auth/operations/customers/set_verification'
+require 'onetime/operations/customers/role_support'
 
 module ColonelAPI
   module Logic
@@ -56,7 +57,8 @@ module ColonelAPI
           # Only the UNVERIFY arm is gated (#4326, TIER 2): has_system_role?
           # refuses every elevated role to an unverified account, so unverifying
           # strips colonel eligibility. VerifyUser is the restorative arm and
-          # stays un-gated. P4 (#4328) adds the last-colonel interlock AFTER this.
+          # stays un-gated — this one `return` guards the gate AND the interlocks
+          # below, so a refactor that hoists either above it would gate recovery.
           return if verified_target
 
           guard_destructive_action!(
@@ -65,15 +67,20 @@ module ColonelAPI
             confirm_subject: "the target account's email address",
             field: :user_id,
           )
+
+          enforce_unverify_interlocks!
         end
 
         def process
           @change_result = Auth::Operations::Customers::SetVerification.new(
             customer: user,
             verified: verified_target,
-            actor: cust.extid, # acting colonel's PUBLIC id (never an objid)
+            actor: cust.extid,       # acting colonel's PUBLIC id (never an objid)
+            actor_objid: cust.objid, # INTERNAL id, for the self-unverify check only
             verified_by: verified_by_tag,
           ).call
+
+          handle_change_result
 
           success_data
         rescue Auth::Operations::SetCustomerVerification::NoAuthDatabase => ex
@@ -98,6 +105,51 @@ module ColonelAPI
               message: verified_target ? 'User verified' : 'User unverified',
             },
           }
+        end
+
+        private
+
+        # STEP 4 of the guard-order contract (logic/destructive_action.rb), and
+        # unverify-only by construction (the caller returns on the verify arm).
+        #
+        # Unverifying a colonel is a demotion by another name: has_system_role?
+        # refuses every elevated role to an unverified account. Without these,
+        # an attacker refused a demotion by RoleSupport.last_colonel? would
+        # simply call unverify instead. After proof, so the 422s cannot be used
+        # as a "who is the last colonel" oracle. The op enforces both again for
+        # `bin/ots customers unverify`.
+        def enforce_unverify_interlocks!
+          if user.objid == cust.objid
+            raise_form_error(
+              'Cannot unverify your own account: verification is required to hold the ' \
+              'colonel role. Have another colonel do it, or use the CLI.',
+              field: :user_id,
+            )
+          end
+
+          return unless Onetime::Operations::Customers::RoleSupport.last_colonel_by_verification?(user)
+
+          raise_form_error(
+            'Cannot unverify the last remaining colonel — the install would have no ' \
+            'administrator. Promote and verify another account first.',
+            field: :user_id,
+          )
+        end
+
+        # The op's symbol contract. The two interlock statuses are reachable only
+        # if the roster changed between raise_concerns and the write; they answer
+        # the same 422s rather than reporting a change that did not happen. The
+        # `else` arm makes a status added to the op fail loudly here.
+        def handle_change_result
+          case change_result
+          when :success, :no_change then nil
+          when :self_unverify
+            raise_form_error('Cannot unverify your own account.', field: :user_id)
+          when :last_colonel
+            raise_form_error('Cannot unverify the last remaining colonel.', field: :user_id)
+          else
+            raise_form_error("Verification change did not complete (#{change_result})", field: :user_id)
+          end
         end
       end
 

--- a/apps/api/colonel/logic/colonel/set_user_verification.rb
+++ b/apps/api/colonel/logic/colonel/set_user_verification.rb
@@ -52,6 +52,19 @@ module ColonelAPI
           raise_not_found('User not found') unless user&.exists?
 
           raise_form_error('Cannot modify anonymous user', field: :user_id) if user.anonymous?
+
+          # Only the UNVERIFY arm is gated (#4326, TIER 2): has_system_role?
+          # refuses every elevated role to an unverified account, so unverifying
+          # strips colonel eligibility. VerifyUser is the restorative arm and
+          # stays un-gated. P4 (#4328) adds the last-colonel interlock AFTER this.
+          return if verified_target
+
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: account_confirm_token(user),
+            confirm_subject: "the target account's email address",
+            field: :user_id,
+          )
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/transfer_domain.rb
+++ b/apps/api/colonel/logic/colonel/transfer_domain.rb
@@ -57,10 +57,24 @@ module ColonelAPI
           raise_form_error('Destination organization not found', field: :to_org) unless to_org
 
           # Optional explicit source org (ownership assertion).
-          return if from_org_id.to_s.empty?
+          unless from_org_id.to_s.empty?
+            @from_org = resolve_org(from_org_id)
+            raise_form_error('Source organization not found', field: :from_org) unless from_org
+          end
 
-          @from_org = resolve_org(from_org_id)
-          raise_form_error('Source organization not found', field: :from_org) unless from_org
+          # PREVIEW EXEMPTION (#4326): a dry run writes nothing. dry_run
+          # defaults to TRUE here, so only an explicit apply is gated.
+          return if dry_run
+
+          # TIER 1. The URL carries the extid; the confirmation is the domain's
+          # hostname.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: custom_domain.display_domain,
+            confirm_subject: 'the domain name',
+            field: :extid,
+          )
+          charge_destructive_budget!
         end
 
         def process
@@ -111,10 +125,6 @@ module ColonelAPI
         def resolve_org(identifier)
           Onetime::Organization.load(identifier) ||
             Onetime::Organization.find_by_extid(identifier)
-        end
-
-        def truthy?(value)
-          %w[true 1 yes on].include?(value.to_s.strip.downcase)
         end
       end
     end

--- a/apps/api/colonel/logic/colonel/transfer_organization_ownership.rb
+++ b/apps/api/colonel/logic/colonel/transfer_organization_ownership.rb
@@ -66,6 +66,17 @@ module ColonelAPI
 
           @new_owner = resolve_customer(@new_owner_id)
           raise_not_found('Customer not found') unless @new_owner
+
+          # TIER 1 (#4326). `dry_run` is pinned false on this surface, so there
+          # is no preview arm to exempt. The URL carries the org id; the
+          # confirmation is the organization's NAME.
+          guard_destructive_action!(
+            tier: :destructive,
+            confirm_with: org_confirm_token(org),
+            confirm_subject: "the organization's name",
+            field: :org_id,
+          )
+          charge_destructive_budget!
         end
 
         def process

--- a/apps/api/colonel/logic/colonel/upsert_domain_config.rb
+++ b/apps/api/colonel/logic/colonel/upsert_domain_config.rb
@@ -58,6 +58,16 @@ module ColonelAPI
             )
           end
 
+          # TIER 2 (#4326): the mutating twin of DeleteDomainConfig — it can
+          # overwrite the same record with attacker-chosen values. Same composed
+          # token, so an operator learns one rule for both verbs.
+          guard_destructive_action!(
+            tier: :sensitive,
+            confirm_with: "#{custom_domain.display_domain}:#{kind}",
+            confirm_subject: 'the domain name and config kind joined by a colon',
+            field: :kind,
+          )
+
           @attrs = validated_attrs
         end
 

--- a/apps/api/colonel/logic/destructive_action.rb
+++ b/apps/api/colonel/logic/destructive_action.rb
@@ -101,7 +101,35 @@ module ColonelAPI
         )
       end
 
-      # Step 3 of the guard-order contract. P3 (#4327) fills in require_elevation!.
+      # Refuse unless the session holds a live, identity-matched step-up window
+      # (#4327). No-op when elevation is disabled by config.
+      #
+      # Writes NO audit event: a Forbidden-family rejection is drivable on demand
+      # by whoever holds the cookie, and the operator trail is count-capped with
+      # no TTL. The window arithmetic and the identity binding live in
+      # ColonelAPI::Logic::Colonel::Elevation.
+      #
+      # @raise [Onetime::ElevationRequired] 403
+      def require_elevation!
+        return unless elevation_enabled?
+        return if elevated?
+
+        raise Onetime::ElevationRequired.new(
+          'Step-up authentication required. Re-authenticate to continue ' \
+          "(POST /api/colonel/elevation), then retry within #{elevation_window / 60} minutes.",
+          window: elevation_window,
+        )
+      end
+
+      # Step 3 of the guard-order contract: elevation (tier 1 only), THEN
+      # confirmation.
+      #
+      # Elevation first is deliberate: an unelevated caller must never learn
+      # whether their confirmation-token guess was right (no confirmation
+      # oracle), and the console prompts for sudo before the operator wastes
+      # their typing. TIER 2 is deliberately not elevation-gated — those verbs
+      # are reversible, and gating them would double the sudo prompts an
+      # operator sees during routine triage.
       #
       # @param tier [Symbol] :destructive (TIER1) or :sensitive (TIER2)
       # @param confirm_with [String] the expected confirmation token
@@ -113,7 +141,7 @@ module ColonelAPI
           raise Onetime::GuardMisconfigured, "unknown destructive-action tier #{tier.inspect} (#{self.class.name})"
         end
 
-        # P3 (#4327) inserts: require_elevation! if tier == :destructive
+        require_elevation! if tier == :destructive
         require_confirmation!(confirm_with, subject: confirm_subject, field: field)
       end
 

--- a/apps/api/colonel/logic/destructive_action.rb
+++ b/apps/api/colonel/logic/destructive_action.rb
@@ -1,0 +1,142 @@
+# apps/api/colonel/logic/destructive_action.rb
+#
+# frozen_string_literal: true
+
+require 'rack/utils'
+
+module ColonelAPI
+  module Logic
+    # Shared guard for destructive and sensitive colonel verbs (epic #4323).
+    #
+    # Included into ColonelAPI::Logic::Base, so every colonel logic class HAS these
+    # methods; only the classes named in ColonelAPI::DestructiveActions CALL them.
+    # Declare-and-call rather than inherit-and-override: none of the ~86 concrete
+    # classes call `super` in raise_concerns, so a base-class hook would be silently
+    # skipped.
+    #
+    # GUARD ORDER CONTRACT — inside raise_concerns, always:
+    #   1. verify_one_of_roles!(colonel: true)
+    #   2. resolve the target; existing 404 / 422 / enum / allowlist guards
+    #   3. guard_destructive_action!(...)      <- elevation, then confirmation
+    #   4. per-verb interlocks (self-target, last-colonel, sole-owner)
+    #   5. charge_destructive_budget!          <- tier 1 only, ALWAYS LAST
+    #
+    # Interlocks run AFTER proof so their 422s do not disclose "is this the last
+    # colonel" / "is this handle mine" to a caller who has proven nothing but
+    # possession of the cookie. The destructive budget is charged LAST so only
+    # requests that are about to execute consume it — otherwise the designed
+    # attempt/elevate/retry flow double-charges every operator action, and an
+    # attacker can pre-emptively lock the real operator out with cheap 403s.
+    # Volume is still bounded by the broad colonel:mutation bucket charged in
+    # ColonelAPI::Logic::Base#initialize.
+    #
+    # PREVIEW EXEMPTION: verbs with a dry_run flag call ALL of 3-5 only on the
+    # apply path (`return if dry_run` before the guard). A preview writes nothing,
+    # so gating it would break the console's preview-then-apply flow for no benefit
+    # — the same asymmetry delete_organization.rb already documents for its
+    # guardrail statuses. This is asserted, not assumed: see
+    # try/unit/colonel/dry_run_side_effects_try.rb.
+    module DestructiveAction
+      MAX_CONFIRM_LENGTH = 255
+      TRUTHY_VALUES      = %w[true 1 yes on].freeze
+
+      # The only two tiers guard_destructive_action! accepts. A typo'd tier would
+      # silently drop elevation and the destructive budget once P3/P5 land, so it
+      # is a 500 here rather than a quiet downgrade.
+      GUARD_TIERS = [:destructive, :sensitive].freeze
+
+      # Hoisted from the ten colonel classes that each defined their own (two of
+      # which disagreed: purge_dlq/replay_dlq accepted only %w[1 true yes] and did
+      # not strip). This is the widest of the existing forms.
+      def truthy?(value)
+        TRUTHY_VALUES.include?(value.to_s.strip.downcase)
+      end
+
+      # The supplied confirmation token, or ''.
+      #
+      # Read from strategy metadata (the X-OTS-Confirm header, see
+      # ColonelAPI::AuthStrategies::SessionAuthStrategy), NOT from params: a query
+      # parameter would put target emails into access logs and browser history,
+      # and a DELETE body is not reliably parsed in this stack.
+      #
+      # Deliberately NOT run through sanitize_identifier: the token is frequently an
+      # email address, and sanitize_identifier strips '@' and '.' (the exact bug
+      # AccountIdentifier#sanitize_account_identifier exists to fix). It is only ever
+      # compared against a known-good expected string — never interpolated into a
+      # Redis key, a query, or a log line — so a length cap is the whole hygiene
+      # requirement.
+      #
+      # @return [String]
+      def supplied_confirmation
+        strategy_result&.metadata&.dig(:confirm_token).to_s.strip[0, MAX_CONFIRM_LENGTH].to_s
+      end
+
+      # Reject unless the caller echoed the expected token.
+      #
+      # @param expected [String] exact token; a blank expected value is a programming
+      #   error and raises Onetime::GuardMisconfigured (500) rather than admitting
+      #   the request.
+      # @param subject [String] human phrase naming WHAT to send, e.g.
+      #   'the account email address'. Never interpolate the expected value itself
+      #   into the message for a caller who may not know it.
+      # @param field [Symbol] the param the console should highlight.
+      # @raise [Onetime::GuardMisconfigured] 500 when `expected` is blank
+      # @raise [Onetime::ConfirmationRequired] 403 when the caller did not match
+      # @return [true]
+      def require_confirmation!(expected, subject:, field: :confirm)
+        expected = expected.to_s.strip
+        if expected.empty?
+          OT.le "[DestructiveAction] blank expected confirmation token in #{self.class.name}"
+          raise Onetime::GuardMisconfigured, "blank expected confirmation token (#{self.class.name})"
+        end
+
+        supplied = supplied_confirmation
+        return true if !supplied.empty? && Rack::Utils.secure_compare(supplied, expected)
+
+        # Identical rejection whether the header was absent or merely wrong: no
+        # oracle on which half the caller got right.
+        raise Onetime::ConfirmationRequired.new(
+          "Confirmation required: re-send this request with the X-OTS-Confirm header set to #{subject}.",
+          field: field,
+        )
+      end
+
+      # Step 3 of the guard-order contract. P3 (#4327) fills in require_elevation!.
+      #
+      # @param tier [Symbol] :destructive (TIER1) or :sensitive (TIER2)
+      # @param confirm_with [String] the expected confirmation token
+      # @param confirm_subject [String] human phrase for the error message
+      # @param field [Symbol]
+      def guard_destructive_action!(tier:, confirm_with:, confirm_subject:, field: :confirm)
+        unless GUARD_TIERS.include?(tier)
+          OT.le "[DestructiveAction] unknown tier #{tier.inspect} in #{self.class.name}"
+          raise Onetime::GuardMisconfigured, "unknown destructive-action tier #{tier.inspect} (#{self.class.name})"
+        end
+
+        # P3 (#4327) inserts: require_elevation! if tier == :destructive
+        require_confirmation!(confirm_with, subject: confirm_subject, field: field)
+      end
+
+      # Step 5. Separate call, ALWAYS the last line of raise_concerns, tier 1 only.
+      # Two calls rather than one is deliberate: it is greppable, and
+      # spec/unit/colonel/destructive_actions_spec.rb asserts both are present in
+      # every TIER 1 class.
+      def charge_destructive_budget!
+        # P5 (#4329) inserts: enforce_colonel_destructive_limit!(cust&.extid)
+      end
+
+      # Human-meaningful, non-URL identifier for an account. The extid fallback
+      # keeps the expected token non-blank by construction (a blank one is a 500).
+      def account_confirm_token(customer)
+        email = customer.respond_to?(:email) ? customer.email.to_s.strip : ''
+        email.empty? ? customer.extid.to_s : email
+      end
+
+      # Human-meaningful, non-URL identifier for an organization.
+      def org_confirm_token(org)
+        name = org.respond_to?(:display_name) ? org.display_name.to_s.strip : ''
+        name.empty? ? org.extid.to_s : name
+      end
+    end
+  end
+end

--- a/apps/api/colonel/logic/destructive_action.rb
+++ b/apps/api/colonel/logic/destructive_action.rb
@@ -149,8 +149,20 @@ module ColonelAPI
       # Two calls rather than one is deliberate: it is greppable, and
       # spec/unit/colonel/destructive_actions_spec.rb asserts both are present in
       # every TIER 1 class.
+      #
+      # Charged LAST — after elevation, confirmation and the per-verb interlocks
+      # — so only requests that are about to EXECUTE consume the budget (#4329).
+      # Charging it earlier would double-charge the console's designed
+      # attempt → 403 → elevate → retry flow, and would hand an attacker holding
+      # the cookie a way to impose a 15-minute destructive lockout on the
+      # operator trying to contain the incident, using nothing but cheap 403s.
+      #
+      # `cust&.extid`, not `cust.extid`: this runs inside raise_concerns, and a
+      # blank subject is skipped rather than sharing one global bucket.
+      #
+      # @raise [Onetime::LimitExceeded] 429
       def charge_destructive_budget!
-        # P5 (#4329) inserts: enforce_colonel_destructive_limit!(cust&.extid)
+        enforce_colonel_destructive_limit!(cust&.extid)
       end
 
       # Human-meaningful, non-URL identifier for an account. The extid fallback

--- a/apps/api/colonel/logic/destructive_action.rb
+++ b/apps/api/colonel/logic/destructive_action.rb
@@ -132,7 +132,14 @@ module ColonelAPI
       # operator sees during routine triage.
       #
       # @param tier [Symbol] :destructive (TIER1) or :sensitive (TIER2)
-      # @param confirm_with [String] the expected confirmation token
+      # @param confirm_with [String, #call] the expected confirmation token, or a
+      #   callable that RETURNS it. Pass a callable when computing the token can
+      #   itself raise (e.g. DeleteSecret#confirmation_token, which fails closed on
+      #   a receiptless secret): a bare argument is evaluated by the CALLER before
+      #   this method runs, so a raise there would pre-empt require_elevation! and
+      #   hand an unelevated caller a 500 where the contract promises a 403 — the
+      #   very confirmation oracle "elevation first" exists to deny. A callable is
+      #   invoked HERE, after elevation, so the ordering holds.
       # @param confirm_subject [String] human phrase for the error message
       # @param field [Symbol]
       def guard_destructive_action!(tier:, confirm_with:, confirm_subject:, field: :confirm)
@@ -142,7 +149,8 @@ module ColonelAPI
         end
 
         require_elevation! if tier == :destructive
-        require_confirmation!(confirm_with, subject: confirm_subject, field: field)
+        expected = confirm_with.respond_to?(:call) ? confirm_with.call : confirm_with
+        require_confirmation!(expected, subject: confirm_subject, field: field)
       end
 
       # Step 5. Separate call, ALWAYS the last line of raise_concerns, tier 1 only.

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -100,8 +100,8 @@ GET    /usage/export                      ColonelAPI::Logic::Colonel::ExportUsag
 
 # Sessions (ticket #40)
 GET    /sessions                          ColonelAPI::Logic::Colonel::ListSessions response=json auth=sessionauth role=colonel scope=internal
-GET    /sessions/:session_id              ColonelAPI::Logic::Colonel::GetSessionDetail response=json auth=sessionauth role=colonel scope=internal
-DELETE /sessions/:session_id              ColonelAPI::Logic::Colonel::DeleteSession response=json auth=sessionauth role=colonel scope=internal
+GET    /sessions/:session_handle          ColonelAPI::Logic::Colonel::GetSessionDetail response=json auth=sessionauth role=colonel scope=internal
+DELETE /sessions/:session_handle          ColonelAPI::Logic::Colonel::DeleteSession response=json auth=sessionauth role=colonel scope=internal
 GET    /users/:user_id/sessions           ColonelAPI::Logic::Colonel::ListCustomerSessions response=json auth=sessionauth role=colonel scope=internal
 # Bulk revoke-all (offboarding/takeover). POST+verb (local convention for bulk-destructive) so it can't collide with the single-revoke DELETE below.
 POST   /users/:user_id/sessions/revoke-all ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions response=json auth=sessionauth role=colonel scope=internal

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -11,6 +11,14 @@ GET    /info                              ColonelAPI::Logic::Colonel::GetColonel
 GET    /stats                             ColonelAPI::Logic::Colonel::GetColonelStats response=json auth=sessionauth role=colonel scope=internal
 GET    /config                            ColonelAPI::Logic::Colonel::GetSystemSettings response=json auth=sessionauth role=colonel scope=internal
 
+# Step-up (sudo) window for destructive verbs (#4327). GET is a cheap status
+# read the console fetches on mount and after a 403; POST mints a window; DELETE
+# drops one. GET is deliberately NOT polled — see the idle-timeout interaction
+# in docs/operations/colonel-admin-guide.md.
+GET    /elevation                         ColonelAPI::Logic::Colonel::GetElevationStatus response=json auth=sessionauth role=colonel scope=internal
+POST   /elevation                         ColonelAPI::Logic::Colonel::ElevateSession response=json auth=sessionauth role=colonel scope=internal
+DELETE /elevation                         ColonelAPI::Logic::Colonel::DropElevation response=json auth=sessionauth role=colonel scope=internal
+
 # Entitlement Preview Mode
 GET    /available-plans                   ColonelAPI::Logic::Colonel::GetAvailablePlans response=json auth=sessionauth role=colonel scope=internal
 POST   /entitlement-preview                  ColonelAPI::Logic::Colonel::SetEntitlementPreview response=json auth=sessionauth role=colonel scope=internal

--- a/apps/api/colonel/routes.txt
+++ b/apps/api/colonel/routes.txt
@@ -5,6 +5,16 @@
 #
 # Defense-in-depth: role=colonel enforces role check at Otto routing layer,
 # rejecting non-colonel requests before they reach the logic layer.
+#
+# network=admin_if_configured (#4332) marks the 15 tier-1 DESTRUCTIVE routes —
+# exactly ColonelAPI::DestructiveActions::TIER1, and asserted against it by
+# spec/unit/onetime/application/colonel_route_annotations_spec.rb. It enforces
+# the admin route requirement only where the operator set BOTH
+# ADMIN_ALLOWED_HOSTS and ADMIN_ALLOWED_CIDRS, and still denies when
+# AdminNetworkIsolation is absent from the stack. The strict network=admin
+# below (on /system/proxy-headers) has no such fall-through and would 404 a
+# stock self-hosted install; do not use it on a route the console calls.
+# The 12 reversible tier-2 routes are deliberately NOT annotated.
 
 # Colonel API  endpoints
 GET    /info                              ColonelAPI::Logic::Colonel::GetColonelInfo response=json auth=sessionauth role=colonel scope=internal
@@ -26,7 +36,7 @@ POST   /entitlement-preview                  ColonelAPI::Logic::Colonel::SetEnti
 # Secret Management
 GET    /secrets                           ColonelAPI::Logic::Colonel::ListSecrets response=json auth=sessionauth role=colonel scope=internal
 GET    /secrets/:secret_id                ColonelAPI::Logic::Colonel::GetSecretReceipt response=json auth=sessionauth role=colonel scope=internal
-DELETE /secrets/:secret_id                ColonelAPI::Logic::Colonel::DeleteSecret response=json auth=sessionauth role=colonel scope=internal
+DELETE /secrets/:secret_id                ColonelAPI::Logic::Colonel::DeleteSecret response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 
 # User Management
 GET    /users                             ColonelAPI::Logic::Colonel::ListUsers response=json auth=sessionauth role=colonel scope=internal
@@ -36,13 +46,13 @@ POST   /users/:user_id/plan               ColonelAPI::Logic::Colonel::UpdateUser
 POST   /users/:user_id/checkout-link      ColonelAPI::Logic::Colonel::CreateCheckoutLink response=json auth=sessionauth role=colonel scope=internal
 # Change account email (#3731 PR-C3, D43). Destructive + cross-store: dry_run
 # defaults to TRUE, so the console previews then re-issues with dry_run=false.
-POST   /users/:user_id/email              ColonelAPI::Logic::Colonel::ChangeUserEmail response=json auth=sessionauth role=colonel scope=internal
-POST   /users/:user_id/role               ColonelAPI::Logic::Colonel::SetUserRole response=json auth=sessionauth role=colonel scope=internal
+POST   /users/:user_id/email              ColonelAPI::Logic::Colonel::ChangeUserEmail response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
+POST   /users/:user_id/role               ColonelAPI::Logic::Colonel::SetUserRole response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 POST   /users/:user_id/verify             ColonelAPI::Logic::Colonel::VerifyUser response=json auth=sessionauth role=colonel scope=internal
 POST   /users/:user_id/unverify           ColonelAPI::Logic::Colonel::UnverifyUser response=json auth=sessionauth role=colonel scope=internal
 POST   /users/:user_id/suspend            ColonelAPI::Logic::Colonel::SuspendUser response=json auth=sessionauth role=colonel scope=internal
 POST   /users/:user_id/unsuspend          ColonelAPI::Logic::Colonel::UnsuspendUser response=json auth=sessionauth role=colonel scope=internal
-DELETE /users/:user_id                    ColonelAPI::Logic::Colonel::PurgeUser response=json auth=sessionauth role=colonel scope=internal
+DELETE /users/:user_id                    ColonelAPI::Logic::Colonel::PurgeUser response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 
 # System Monitoring
 GET    /system/proxy-headers              ColonelAPI::Logic::Colonel::GetProxyHeadersDebug response=json auth=sessionauth role=colonel network=admin scope=internal
@@ -61,15 +71,15 @@ POST   /domains/:extid/verify             ColonelAPI::Logic::Colonel::VerifyCust
 GET    /domains/:extid/probe             ColonelAPI::Logic::Colonel::ProbeDomain response=json auth=sessionauth role=colonel scope=internal
 POST   /domains/:extid/repair            ColonelAPI::Logic::Colonel::RepairDomain response=json auth=sessionauth role=colonel scope=internal
 POST   /domains/:extid/override          ColonelAPI::Logic::Colonel::OverrideDomainVerification response=json auth=sessionauth role=colonel scope=internal
-POST   /domains/:extid/transfer          ColonelAPI::Logic::Colonel::TransferDomain response=json auth=sessionauth role=colonel scope=internal
+POST   /domains/:extid/transfer          ColonelAPI::Logic::Colonel::TransferDomain response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 # Per-domain config records (signin/signup/homepage/api/incoming/sso/mailer): view/upsert/delete + ensure-missing (v0.26.2 outage class)
 GET    /domains/:extid/configs           ColonelAPI::Logic::Colonel::GetDomainConfigs response=json auth=sessionauth role=colonel scope=internal
 POST   /domains/:extid/configs/ensure    ColonelAPI::Logic::Colonel::EnsureDomainConfigs response=json auth=sessionauth role=colonel scope=internal
 PUT    /domains/:extid/configs/:kind     ColonelAPI::Logic::Colonel::UpsertDomainConfig response=json auth=sessionauth role=colonel scope=internal
-DELETE /domains/:extid/configs/:kind     ColonelAPI::Logic::Colonel::DeleteDomainConfig response=json auth=sessionauth role=colonel scope=internal
+DELETE /domains/:extid/configs/:kind     ColonelAPI::Logic::Colonel::DeleteDomainConfig response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 # Per-domain detail (DNS panel + post-verify refresh). Literal /domains/orphaned above still wins.
 GET    /domains/:extid                   ColonelAPI::Logic::Colonel::GetCustomDomain response=json auth=sessionauth role=colonel scope=internal
-DELETE /domains/:extid                   ColonelAPI::Logic::Colonel::RemoveCustomDomain response=json auth=sessionauth role=colonel scope=internal
+DELETE /domains/:extid                   ColonelAPI::Logic::Colonel::RemoveCustomDomain response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 
 # Organizations
 GET    /organizations                     ColonelAPI::Logic::Colonel::ListOrganizations response=json auth=sessionauth role=colonel scope=internal
@@ -80,7 +90,7 @@ POST   /organizations/:org_id/reconcile   ColonelAPI::Logic::Colonel::ReconcileO
 # Plan change (org-level successor to /users/:user_id/plan — billing lives on Organization)
 POST   /organizations/:org_id/plan        ColonelAPI::Logic::Colonel::UpdateOrganizationPlan response=json auth=sessionauth role=colonel scope=internal
 # Ownership transfer (#3907: op-backed, shared with `bin/ots org transfer-ownership`). Applies immediately — dry_run pinned false (D12: no preview flow in the console).
-POST   /organizations/:org_id/transfer-ownership ColonelAPI::Logic::Colonel::TransferOrganizationOwnership response=json auth=sessionauth role=colonel scope=internal
+POST   /organizations/:org_id/transfer-ownership ColonelAPI::Logic::Colonel::TransferOrganizationOwnership response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 
 # Entitlement Overrides (Phase 2: grant/revoke per-org entitlements)
 POST   /organizations/:org_id/entitlements/:action  ColonelAPI::Logic::Colonel::ManageEntitlementOverride response=json auth=sessionauth role=colonel scope=internal
@@ -88,8 +98,8 @@ DELETE /organizations/:org_id/entitlements/overrides ColonelAPI::Logic::Colonel:
 
 # Memberships (#3731: add/remove/set-role — op-backed, shared with `bin/ots memberships`)
 POST   /organizations/:org_id/members                   ColonelAPI::Logic::Colonel::AddMembership response=json auth=sessionauth role=colonel scope=internal
-POST   /organizations/:org_id/members/:member_id/role   ColonelAPI::Logic::Colonel::SetMembershipRole response=json auth=sessionauth role=colonel scope=internal
-DELETE /organizations/:org_id/members/:member_id         ColonelAPI::Logic::Colonel::RemoveMembership response=json auth=sessionauth role=colonel scope=internal
+POST   /organizations/:org_id/members/:member_id/role   ColonelAPI::Logic::Colonel::SetMembershipRole response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
+DELETE /organizations/:org_id/members/:member_id         ColonelAPI::Logic::Colonel::RemoveMembership response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 
 # Membership Entitlement Overrides (#3907: per-membership grant/revoke, shared with `bin/ots memberships entitlement`)
 POST   /organizations/:org_id/members/:member_id/entitlements/:action   ColonelAPI::Logic::Colonel::ManageMembershipEntitlementOverride response=json auth=sessionauth role=colonel scope=internal
@@ -101,7 +111,7 @@ DELETE /organizations/:org_id/members/:member_id/entitlements/overrides ColonelA
 # Declared LAST of the /organizations/:org_id DELETEs, after the deeper member
 # and entitlement paths, for the same reason /domains/:extid is: the single
 # segment pattern must not get first refusal on a longer path.
-DELETE /organizations/:org_id                            ColonelAPI::Logic::Colonel::DeleteOrganization response=json auth=sessionauth role=colonel scope=internal
+DELETE /organizations/:org_id                            ColonelAPI::Logic::Colonel::DeleteOrganization response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 
 # Usage Export
 GET    /usage/export                      ColonelAPI::Logic::Colonel::ExportUsage response=json auth=sessionauth role=colonel scope=internal
@@ -109,11 +119,11 @@ GET    /usage/export                      ColonelAPI::Logic::Colonel::ExportUsag
 # Sessions (ticket #40)
 GET    /sessions                          ColonelAPI::Logic::Colonel::ListSessions response=json auth=sessionauth role=colonel scope=internal
 GET    /sessions/:session_handle          ColonelAPI::Logic::Colonel::GetSessionDetail response=json auth=sessionauth role=colonel scope=internal
-DELETE /sessions/:session_handle          ColonelAPI::Logic::Colonel::DeleteSession response=json auth=sessionauth role=colonel scope=internal
+DELETE /sessions/:session_handle          ColonelAPI::Logic::Colonel::DeleteSession response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 GET    /users/:user_id/sessions           ColonelAPI::Logic::Colonel::ListCustomerSessions response=json auth=sessionauth role=colonel scope=internal
 # Bulk revoke-all (offboarding/takeover). POST+verb (local convention for bulk-destructive) so it can't collide with the single-revoke DELETE below.
-POST   /users/:user_id/sessions/revoke-all ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions response=json auth=sessionauth role=colonel scope=internal
-DELETE /users/:user_id/sessions/:session_handle ColonelAPI::Logic::Colonel::RevokeCustomerSession response=json auth=sessionauth role=colonel scope=internal
+POST   /users/:user_id/sessions/revoke-all ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
+DELETE /users/:user_id/sessions/:session_handle ColonelAPI::Logic::Colonel::RevokeCustomerSession response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 
 # Broadcast Banner (ticket #41)
 GET    /banner                            ColonelAPI::Logic::Colonel::GetBanner response=json auth=sessionauth role=colonel scope=internal
@@ -124,7 +134,7 @@ DELETE /banner                            ColonelAPI::Logic::Colonel::ClearBanne
 GET    /queues/dlq                        ColonelAPI::Logic::Colonel::ListDlqs response=json auth=sessionauth role=colonel scope=internal
 GET    /queues/dlq/:queue                 ColonelAPI::Logic::Colonel::GetDlqMessages response=json auth=sessionauth role=colonel scope=internal
 POST   /queues/dlq/:queue/replay          ColonelAPI::Logic::Colonel::ReplayDlq response=json auth=sessionauth role=colonel scope=internal
-POST   /queues/dlq/:queue/purge           ColonelAPI::Logic::Colonel::PurgeDlq response=json auth=sessionauth role=colonel scope=internal
+POST   /queues/dlq/:queue/purge           ColonelAPI::Logic::Colonel::PurgeDlq response=json auth=sessionauth role=colonel network=admin_if_configured scope=internal
 
 # Email + Rate-limit Tools (ticket #44)
 GET    /email/templates                       ColonelAPI::Logic::Colonel::ListEmailTemplates response=json auth=sessionauth role=colonel scope=internal

--- a/apps/api/colonel/spec/auth_strategies_spec.rb
+++ b/apps/api/colonel/spec/auth_strategies_spec.rb
@@ -78,4 +78,57 @@ RSpec.describe ColonelAPI::AuthStrategies::SessionAuthStrategy do
       expect(strategy.send(:build_metadata, env)).not_to have_key(:proxy_header_debug)
     end
   end
+
+  # Destructive-action confirmation transport (#4326). This is the ONLY request
+  # header ordinary colonel metadata carries: logic classes never see the Rack
+  # env, so the X-OTS-Confirm value has to arrive through here.
+  describe 'the confirmation header' do
+    def confirm_token_for(raw)
+      request_env = { 'PATH_INFO' => '/users/ur_target' }
+      request_env['HTTP_X_OTS_CONFIRM'] = raw unless raw.nil?
+      strategy.send(:build_metadata, request_env)[:confirm_token]
+    end
+
+    it 'surfaces the header on an ordinary colonel request' do
+      expect(confirm_token_for('victim%40example.com')).to eq('victim@example.com')
+    end
+
+    it 'surfaces it on the diagnostic route too (merged before that branch)' do
+      env['HTTP_X_OTS_CONFIRM'] = 'anything'
+      metadata = strategy.send(:build_metadata, env)
+
+      expect(metadata[:confirm_token]).to eq('anything')
+      expect(metadata).to have_key(:proxy_header_debug)
+    end
+
+    it 'is nil when the header is absent or empty' do
+      expect(confirm_token_for(nil)).to be_nil
+      expect(confirm_token_for('')).to be_nil
+    end
+
+    # HTTP header values are ISO-8859-1 by RFC 7230, so a non-ASCII token (an
+    # org display name) has to be percent-encoded by the client and decoded here.
+    it 'percent-decodes a non-ASCII token back to UTF-8' do
+      token = confirm_token_for('Acme%20Gmbh%20%C3%9Cberwachung')
+
+      expect(token).to eq('Acme Gmbh Überwachung')
+      expect(token.encoding).to eq(Encoding::UTF_8)
+    end
+
+    it 'leaves a plain ASCII token untouched, so curl works as typed' do
+      expect(confirm_token_for('victim@example.com')).to eq('victim@example.com')
+    end
+
+    it 'caps the raw header before decoding so a huge value cannot force a huge allocation' do
+      cap = described_class::MAX_CONFIRM_BYTES
+
+      expect(confirm_token_for('a' * (cap * 4)).bytesize).to eq(cap)
+    end
+
+    it 'treats an undecodable header as no token rather than raising' do
+      allow(Rack::Utils).to receive(:unescape).and_raise(ArgumentError, 'bad encoding')
+
+      expect(confirm_token_for('anything')).to be_nil
+    end
+  end
 end

--- a/apps/api/colonel/spec/auth_strategies_spec.rb
+++ b/apps/api/colonel/spec/auth_strategies_spec.rb
@@ -140,15 +140,18 @@ RSpec.describe ColonelAPI::AuthStrategies::SessionAuthStrategy do
       expect(confirm_token_for(encoded)).to eq(name)
     end
 
-    # #4326: decode the way the console encodes (encodeURIComponent), so '+' is a
-    # literal plus, not a space. Rack::Utils.unescape (form decoding) mangled a
-    # plus-addressed email token sent raw by a non-browser API client.
-    it 'preserves a literal + (plus-addressed email) instead of decoding it to a space' do
-      expect(confirm_token_for('ops+admin@example.com')).to eq('ops+admin@example.com')
+    # #4326: FORM decoding accepts the widest range of correct encodings for a
+    # token that routinely contains SPACES (org display_names): a form-encoded
+    # space ('+') decodes to a space, so it confirms whether the client sent '%20'
+    # or '+'. A literal '+' is sent '%2B' (encodeURIComponent and form encoders
+    # both do), which round-trips to a literal '+'.
+    it 'decodes a form-encoded space (+) to a space, and %2B to a literal +' do
+      expect(confirm_token_for('Acme+Corp')).to eq('Acme Corp')
+      expect(confirm_token_for('ops%2Badmin@example.com')).to eq('ops+admin@example.com')
     end
 
     it 'treats an undecodable header as no token rather than raising' do
-      allow(URI).to receive(:decode_uri_component).and_raise(ArgumentError, 'bad encoding')
+      allow(Rack::Utils).to receive(:unescape).and_raise(ArgumentError, 'bad encoding')
 
       expect(confirm_token_for('anything')).to be_nil
     end

--- a/apps/api/colonel/spec/auth_strategies_spec.rb
+++ b/apps/api/colonel/spec/auth_strategies_spec.rb
@@ -119,14 +119,36 @@ RSpec.describe ColonelAPI::AuthStrategies::SessionAuthStrategy do
       expect(confirm_token_for('victim@example.com')).to eq('victim@example.com')
     end
 
-    it 'caps the raw header before decoding so a huge value cannot force a huge allocation' do
+    it 'rejects an over-long header whole rather than truncating it (a sliced token would 403 anyway)' do
       cap = described_class::MAX_CONFIRM_BYTES
 
-      expect(confirm_token_for('a' * (cap * 4)).bytesize).to eq(cap)
+      # Over the ceiling → no token. Truncating instead would sever a %XX escape
+      # or a multibyte char and turn a valid token into a permanent 403.
+      expect(confirm_token_for('a' * (cap + 1))).to be_nil
+      # Exactly at the ceiling still decodes.
+      expect(confirm_token_for('a' * cap)).to eq('a' * cap)
+    end
+
+    # #4326: the cap is on the ENCODED bytes, so a max-length multibyte token —
+    # an org display_name is up to 100 chars, ~900 bytes once encodeURIComponent'd
+    # — must survive. The old 512-byte slice severed it into a 403.
+    it 'decodes a long percent-encoded multibyte token that exceeds the former cap' do
+      name    = '中' * 100
+      encoded = name.chars.map { |ch| ch.bytes.map { |b| format('%%%02X', b) }.join }.join
+
+      expect(encoded.bytesize).to be > 512 # would have been truncated before
+      expect(confirm_token_for(encoded)).to eq(name)
+    end
+
+    # #4326: decode the way the console encodes (encodeURIComponent), so '+' is a
+    # literal plus, not a space. Rack::Utils.unescape (form decoding) mangled a
+    # plus-addressed email token sent raw by a non-browser API client.
+    it 'preserves a literal + (plus-addressed email) instead of decoding it to a space' do
+      expect(confirm_token_for('ops+admin@example.com')).to eq('ops+admin@example.com')
     end
 
     it 'treats an undecodable header as no token rather than raising' do
-      allow(Rack::Utils).to receive(:unescape).and_raise(ArgumentError, 'bad encoding')
+      allow(URI).to receive(:decode_uri_component).and_raise(ArgumentError, 'bad encoding')
 
       expect(confirm_token_for('anything')).to be_nil
     end

--- a/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
@@ -27,10 +27,15 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
       email: 'old@example.com', exists?: true, anonymous?: false)
   end
 
-  let(:strategy_result) do
+  # The apply path requires the account's CURRENT address in X-OTS-Confirm
+  # (#4326); the preview path requires nothing. `confirm_token` is where the
+  # colonel session auth strategy puts the percent-decoded header — never params.
+  def strategy_result_for(confirm_token = 'old@example.com')
     double('StrategyResult', session: {}, user: colonel,
-      auth_method: 'sessionauth', metadata: {})
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
+
+  let(:strategy_result) { strategy_result_for }
 
   # Defaults mirror the op's reporting under this adapter's flags
   # (require_verification: true, revoke_sessions: true): the swap-landed
@@ -78,6 +83,40 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
     allow(OT).to receive(:li)
     allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(target)
     allow(Auth::Operations::Customers::ChangeEmail).to receive(:new).and_return(op)
+  end
+
+  # ---- Server-side confirmation (#4326) --------------------------------------
+  #
+  # The token is the account's CURRENT address, not the new one: it names what
+  # the operator is changing away from, and the URL (an extid) never carries it.
+  # The preview is EXEMPT — it writes nothing.
+  describe 'confirmation' do
+    let(:expected_confirm_token) { 'old@example.com' }
+
+    def confirmed_logic_for(confirm_token)
+      allow(op).to receive(:call).and_return(build_result(status: :success))
+      described_class.new(
+        strategy_result_for(confirm_token),
+        { 'user_id' => 'ur_target', 'new_email' => 'new@example.com', 'dry_run' => 'false' },
+      )
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'requires no confirmation for a dry-run preview' do
+      allow(op).to receive(:call).and_return(build_result(status: :planned))
+      logic = described_class.new(
+        strategy_result_for(nil),
+        { 'user_id' => 'ur_target', 'new_email' => 'new@example.com' },
+      )
+
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+
+    it 'does not accept the NEW address as confirmation' do
+      expect { confirmed_logic_for('new@example.com').raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
   end
 
   describe 'dry_run defaults to preview' do

--- a/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
@@ -117,6 +117,24 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
       expect { confirmed_logic_for('new@example.com').raise_concerns }
         .to raise_error(Onetime::ConfirmationRequired)
     end
+
+    # An account with no email address has no "current address" to confirm with,
+    # so the token falls back to the extid (account_confirm_token) — the same
+    # fallback PurgeUser uses. A bare `user.email` would blank the token and turn
+    # the confirmation guard into a GuardMisconfigured 500 rather than a refusal.
+    it 'falls back to the extid for an account with no email address' do
+      emailless = instance_double(Onetime::Customer,
+        objid: 'cust_target', extid: 'ur_target', role: 'customer',
+        email: '', exists?: true, anonymous?: false)
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(emailless)
+      allow(op).to receive(:call).and_return(build_result(status: :success))
+      logic = described_class.new(
+        strategy_result_for('ur_target'),
+        { 'user_id' => 'ur_target', 'new_email' => 'new@example.com', 'dry_run' => 'false' },
+      )
+
+      expect { logic.raise_concerns }.not_to raise_error
+    end
   end
 
   # ---- Step-up (sudo) window (#4327) -----------------------------------------

--- a/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
   # The apply path requires the account's CURRENT address in X-OTS-Confirm
   # (#4326); the preview path requires nothing. `confirm_token` is where the
   # colonel session auth strategy puts the percent-decoded header — never params.
-  def strategy_result_for(confirm_token = 'old@example.com')
-    double('StrategyResult', session: {}, user: colonel,
+  def strategy_result_for(confirm_token = 'old@example.com', session = {})
+    double('StrategyResult', session: session, user: colonel,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
@@ -117,6 +117,21 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
       expect { confirmed_logic_for('new@example.com').raise_concerns }
         .to raise_error(Onetime::ConfirmationRequired)
     end
+  end
+
+  # ---- Step-up (sudo) window (#4327) -----------------------------------------
+  describe 'elevation' do
+    let(:expected_confirm_token) { 'old@example.com' }
+
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      allow(op).to receive(:call).and_return(build_result(status: :success))
+      described_class.new(
+        strategy_result_for(confirm_token, session),
+        { 'user_id' => 'ur_target', 'new_email' => 'new@example.com', 'dry_run' => 'false' },
+      )
+    end
+
+    it_behaves_like 'an elevated colonel action'
   end
 
   describe 'dry_run defaults to preview' do

--- a/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/change_user_email_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
 
   let(:target) do
     instance_double(Onetime::Customer,
-      objid: 'cust_target', extid: 'ur_target',
+      objid: 'cust_target', extid: 'ur_target', role: 'customer',
       email: 'old@example.com', exists?: true, anonymous?: false)
   end
 
@@ -187,6 +187,60 @@ RSpec.describe ColonelAPI::Logic::Colonel::ChangeUserEmail do
 
       expect(Auth::Operations::Customers::ChangeEmail).to have_received(:new)
         .with(hash_including(require_verification: false))
+    end
+  end
+
+  # ---- Last active colonel lockout interlock (#4328 review) ------------------
+  #
+  # ChangeEmail clears verification with enforce_interlocks:false, so changing the
+  # last active colonel's email would unverify them, and has_system_role? refuses
+  # every unverified account — locking the install out of /colonel entirely. The
+  # apply path refuses that; keep_verified is the escape hatch.
+  describe 'last active colonel lockout' do
+    let(:colonel_target) do
+      instance_double(Onetime::Customer,
+        objid: 'cust_last', extid: 'ur_last', email: 'boss@example.com',
+        role: 'colonel', verified?: true, exists?: true, anonymous?: false)
+    end
+
+    def change_email_logic(params = {})
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel_target)
+      allow(op).to receive(:call).and_return(build_result(status: :success))
+      described_class.new(
+        double('StrategyResult', session: {}, user: colonel,
+          auth_method: 'sessionauth', metadata: { confirm_token: 'boss@example.com' }),
+        { 'user_id' => 'ur_last', 'new_email' => 'new@example.com', 'dry_run' => 'false' }.merge(params),
+      )
+    end
+
+    it 'refuses when the change would clear the last active colonel verification' do
+      allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel').and_return([colonel_target])
+
+      expect { change_email_logic.raise_concerns }
+        .to raise_error(Onetime::FormError, /last active colonel/i)
+      expect(op).not_to have_received(:call)
+    end
+
+    it 'allows it when keep_verified=true preserves verification (the escape hatch)' do
+      allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel').and_return([colonel_target])
+
+      expect { change_email_logic('keep_verified' => 'true').raise_concerns }.not_to raise_error
+    end
+
+    it 'allows it when a second verified colonel exists (roster stays populated)' do
+      second = instance_double(Onetime::Customer,
+        objid: 'cust_second', role: 'colonel', verified?: true, exists?: true)
+      allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel')
+        .and_return([colonel_target, second])
+
+      expect { change_email_logic.raise_concerns }.not_to raise_error
+    end
+
+    it 'does not fire on a plain (non-colonel) target' do
+      # target is role: customer; the default apply-path examples already exercise
+      # this, but pin it: no roster read, no refusal.
+      expect { logic_for({ 'dry_run' => 'false' }, status: :success).raise_concerns }
+        .not_to raise_error
     end
   end
 

--- a/apps/api/colonel/spec/logic/colonel/delete_organization_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_organization_spec.rb
@@ -24,13 +24,18 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteOrganization do
 
   let(:org) do
     instance_double(Onetime::Organization,
-      objid: 'org_internal', extid: 'or_target', exists?: true)
+      objid: 'org_internal', extid: 'or_target', display_name: 'Target Org', exists?: true)
   end
 
-  let(:strategy_result) do
+  # The apply path requires the org's NAME in X-OTS-Confirm (#4326); the preview
+  # path requires nothing. `confirm_token` is where the colonel session auth
+  # strategy puts the percent-decoded header — never params.
+  def strategy_result_for(confirm_token = 'Target Org')
     double('StrategyResult', session: {}, user: colonel,
-      auth_method: 'sessionauth', metadata: {})
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
+
+  let(:strategy_result) { strategy_result_for }
 
   def build_result(status:, **overrides)
     result_class.new(
@@ -70,6 +75,37 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteOrganization do
     allow(Onetime::Organization).to receive(:find_by_extid).and_return(org)
     allow(Onetime::Operations::Org::Delete).to receive(:new).and_return(op)
     allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  # ---- Server-side confirmation (#4326) --------------------------------------
+  #
+  # The preview is EXEMPT: it writes nothing, and it is the payload the operator
+  # confirms against. Only the apply is gated.
+  describe 'confirmation' do
+    let(:expected_confirm_token) { 'Target Org' }
+
+    def confirmed_logic_for(confirm_token)
+      allow(op).to receive(:call).and_return(build_result(status: :success))
+      described_class.new(
+        strategy_result_for(confirm_token),
+        { 'org_id' => 'or_target', 'dry_run' => 'false' },
+      )
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'requires no confirmation for a dry-run preview' do
+      allow(op).to receive(:call).and_return(build_result(status: :planned))
+      logic = described_class.new(strategy_result_for(nil), { 'org_id' => 'or_target' })
+
+      expect { logic.raise_concerns }.not_to raise_error
+      expect(logic.process[:details][:dry_run]).to be true
+    end
+
+    it 'falls back to the org extid when the organization has no display name' do
+      allow(org).to receive(:display_name).and_return('')
+      expect { confirmed_logic_for('or_target').raise_concerns }.not_to raise_error
+    end
   end
 
   describe 'dry-run default (destructive verb, preview posture)' do

--- a/apps/api/colonel/spec/logic/colonel/delete_organization_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_organization_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteOrganization do
   # The apply path requires the org's NAME in X-OTS-Confirm (#4326); the preview
   # path requires nothing. `confirm_token` is where the colonel session auth
   # strategy puts the percent-decoded header — never params.
-  def strategy_result_for(confirm_token = 'Target Org')
-    double('StrategyResult', session: {}, user: colonel,
+  def strategy_result_for(confirm_token = 'Target Org', session = {})
+    double('StrategyResult', session: session, user: colonel,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
@@ -105,6 +105,30 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteOrganization do
     it 'falls back to the org extid when the organization has no display name' do
       allow(org).to receive(:display_name).and_return('')
       expect { confirmed_logic_for('or_target').raise_concerns }.not_to raise_error
+    end
+  end
+
+  # ---- Step-up (sudo) window (#4327) -----------------------------------------
+  describe 'elevation' do
+    let(:expected_confirm_token) { 'Target Org' }
+
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      allow(op).to receive(:call).and_return(build_result(status: :success))
+      described_class.new(
+        strategy_result_for(confirm_token, session),
+        { 'org_id' => 'or_target', 'dry_run' => 'false' },
+      )
+    end
+
+    it_behaves_like 'an elevated colonel action'
+
+    # Same preview exemption as the confirmation gate: a dry run writes nothing.
+    it 'requires no elevation for a dry-run preview' do
+      stub_colonel_elevation(enabled: true)
+      allow(op).to receive(:call).and_return(build_result(status: :planned))
+      logic = described_class.new(strategy_result_for(nil, {}), { 'org_id' => 'or_target' })
+
+      expect { logic.raise_concerns }.not_to raise_error
     end
   end
 

--- a/apps/api/colonel/spec/logic/colonel/delete_secret_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_secret_spec.rb
@@ -42,14 +42,29 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSecret do
       destroy!: true)
   end
 
-  def strategy_result_for(user)
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header (#4326) — never params.
+  def strategy_result_for(user, confirm_token = 'sec12345')
     double('StrategyResult', session: {}, user: user,
-      auth_method: 'sessionauth', metadata: {})
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
   def logic_for(user = colonel)
     described_class.new(strategy_result_for(user), { 'secret_id' => 'sec12345abcdef' })
   end
+
+  # ---- Server-side confirmation (#4326) --------------------------------------
+
+  let(:expected_confirm_token) { 'sec12345' }
+
+  def confirmed_logic_for(confirm_token)
+    described_class.new(
+      strategy_result_for(colonel, confirm_token),
+      { 'secret_id' => 'sec12345abcdef' },
+    )
+  end
+
+  it_behaves_like 'a confirmed colonel action'
 
   before do
     allow(OT).to receive(:info)

--- a/apps/api/colonel/spec/logic/colonel/delete_secret_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_secret_spec.rb
@@ -121,6 +121,30 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSecret do
     end
 
     it_behaves_like 'an elevated colonel action'
+
+    # Guard order (§0.2 step 3): elevation precedes token COMPUTATION, not just
+    # token comparison (#4326/#4327 review). A receiptless secret's
+    # confirmation_token fails closed (GuardMisconfigured, 500), but that raise
+    # must not pre-empt require_elevation! — an unelevated caller gets 403
+    # ElevationRequired first, so the 500 is never a confirmation oracle.
+    context 'with a receiptless secret (confirmation_token fails closed)' do
+      before do
+        stub_colonel_elevation(enabled: true, window: 600)
+        allow(secret).to receive(:receipt_identifier).and_return(nil)
+        allow(secret).to receive(:receipt_shortid).and_return(nil)
+      end
+
+      it 'answers ElevationRequired (403), NOT GuardMisconfigured (500), when unelevated' do
+        expect { elevated_logic_for({}).raise_concerns }
+          .to raise_error(Onetime::ElevationRequired)
+      end
+
+      it 'still fails closed with GuardMisconfigured once the caller IS elevated' do
+        session = elevated_session(colonel.extid)
+        expect { elevated_logic_for(session).raise_concerns }
+          .to raise_error(Onetime::GuardMisconfigured)
+      end
+    end
   end
 
   describe 'success path' do

--- a/apps/api/colonel/spec/logic/colonel/delete_secret_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_secret_spec.rb
@@ -31,6 +31,9 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSecret do
       state: 'new',
       owner_id: 'cust_owner_internal',
       receipt_identifier: 'rec_internal_objid',
+      # nil, as on real records: the stored field is not populated by spawn_pair,
+      # so the confirmation token falls back to the loaded receipt's shortid.
+      receipt_shortid: nil,
       destroy!: true)
   end
 
@@ -43,8 +46,9 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSecret do
   end
 
   # `confirm_token` is where the colonel session auth strategy puts the
-  # percent-decoded X-OTS-Confirm header (#4326) — never params.
-  def strategy_result_for(user, confirm_token = 'sec12345', session = {})
+  # percent-decoded X-OTS-Confirm header (#4326) — never params. The default is
+  # the RECEIPT shortid: the accepted token is independent of :secret_id (#4326).
+  def strategy_result_for(user, confirm_token = 'rec98765', session = {})
     double('StrategyResult', session: session, user: user,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
@@ -55,7 +59,10 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSecret do
 
   # ---- Server-side confirmation (#4326) --------------------------------------
 
-  let(:expected_confirm_token) { 'sec12345' }
+  # The receipt shortid, NOT the secret shortid: the route is keyed by
+  # :secret_id and secret.shortid == secret_id[0,8], so a token equal to it
+  # would be derivable from the URL and no second factor at all (design §1.1).
+  let(:expected_confirm_token) { 'rec98765' }
 
   def confirmed_logic_for(confirm_token)
     described_class.new(
@@ -65,6 +72,34 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSecret do
   end
 
   it_behaves_like 'a confirmed colonel action'
+
+  # ---- Confirmation-token independence from the URL (#4326) -------------------
+  #
+  # The whole point of #4326 is that a scraped-URL replay needs a SECOND,
+  # non-URL identifier. The route is keyed by :secret_id, so the accepted token
+  # must have entropy the URL does not carry — it must NOT equal, nor be a
+  # prefix of, the :secret_id path parameter. secret.shortid IS secret_id[0,8]
+  # (a prefix), so it must be rejected; the receipt shortid (its own objid) is
+  # what is accepted.
+  describe 'confirmation-token independence from :secret_id (#4326)' do
+    let(:secret_id_param) { 'sec12345abcdef' }
+
+    it 'requires a token that is neither equal to nor a prefix of :secret_id' do
+      expect(expected_confirm_token).not_to eq(secret_id_param)
+      expect(secret_id_param).not_to start_with(expected_confirm_token)
+      expect(secret_id_param).not_to include(expected_confirm_token)
+    end
+
+    it 'rejects the secret shortid (= :secret_id[0,8]), which the URL carries' do
+      logic = confirmed_logic_for(secret.shortid)
+      expect { logic.raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+    end
+
+    it 'accepts the receipt shortid, which the URL does not carry' do
+      logic = confirmed_logic_for(receipt.shortid)
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+  end
 
   before do
     allow(OT).to receive(:info)

--- a/apps/api/colonel/spec/logic/colonel/delete_secret_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_secret_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSecret do
 
   # `confirm_token` is where the colonel session auth strategy puts the
   # percent-decoded X-OTS-Confirm header (#4326) — never params.
-  def strategy_result_for(user, confirm_token = 'sec12345')
-    double('StrategyResult', session: {}, user: user,
+  def strategy_result_for(user, confirm_token = 'sec12345', session = {})
+    double('StrategyResult', session: session, user: user,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
@@ -74,6 +74,18 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSecret do
     allow(Onetime::Secret).to receive(:load).and_return(secret)
     allow(Onetime::Receipt).to receive(:load).and_return(receipt)
     allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  # ---- Step-up (sudo) window (#4327) -----------------------------------------
+  describe 'elevation' do
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      described_class.new(
+        strategy_result_for(colonel, confirm_token, session),
+        { 'secret_id' => 'sec12345abcdef' },
+      )
+    end
+
+    it_behaves_like 'an elevated colonel action'
   end
 
   describe 'success path' do

--- a/apps/api/colonel/spec/logic/colonel/delete_session_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_session_spec.rb
@@ -1,0 +1,165 @@
+# apps/api/colonel/spec/logic/colonel/delete_session_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# DELETE /api/colonel/sessions/:session_handle. The route used to take the raw
+# session id — the user's live `onetime.session` cookie value — straight off the
+# console listing (#4330). These examples pin what this adapter owns now:
+#
+#   - the handle resolves to a sid SERVER-SIDE, and the OP is handed that sid;
+#   - the response echoes the handle and nothing else identifying;
+#   - an unresolvable handle 404s before anything is deleted;
+#   - the adapter records NO audit event of its own — Sessions::Delete owns the
+#     trail (CONTRACT 4), and a rejection records nothing at all.
+#
+# The audit target itself (a handle, never the sid) is proven against a real
+# write in try/unit/operations/sessions/delete_session_audit_try.rb.
+RSpec.describe ColonelAPI::Logic::Colonel::DeleteSession do
+  let(:handle) { '0123456789abcdef0123456789abcdef' }
+  let(:session_id) { 'b' * 64 }
+
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain',
+      role: 'customer', verified?: true, anonymous?: false)
+  end
+
+  let(:delete_result) do
+    Onetime::Operations::Sessions::Delete::Result.new(
+      status: :deleted, session_id: session_id, key: "session:#{session_id}",
+    )
+  end
+
+  let(:delete_op) do
+    instance_double(Onetime::Operations::Sessions::Delete, call: delete_result)
+  end
+
+  def strategy_result_for(user)
+    double('StrategyResult', session: {}, user: user,
+      auth_method: 'sessionauth', metadata: {})
+  end
+
+  def logic_for(user = colonel, params = { 'session_handle' => handle })
+    described_class.new(strategy_result_for(user), params)
+  end
+
+  def stub_resolution(sid: session_id, scan_capped: false)
+    allow(Onetime::Operations::Sessions::Store).to receive(:resolve_handle)
+      .and_return([sid, scan_capped])
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Familia).to receive(:dbclient).and_return(double('Redis'))
+    allow(Onetime::Operations::Sessions::Delete).to receive(:new).and_return(delete_op)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  describe 'handle resolution' do
+    it 'hands the OP the resolved sid, never the submitted handle' do
+      stub_resolution
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::Operations::Sessions::Delete).to have_received(:new)
+        .with(session_id: session_id, actor: 'ur_colonel')
+    end
+
+    it 'passes the optional owner hint through to the resolver' do
+      stub_resolution
+      logic_for(colonel, { 'session_handle' => handle, 'user_id' => 'ur_alice' })
+        .raise_concerns
+
+      expect(Onetime::Operations::Sessions::Store).to have_received(:resolve_handle)
+        .with(anything, handle, owner_hint: 'ur_alice')
+    end
+
+    it '404s and deletes nothing when the handle resolves to no live session' do
+      stub_resolution(sid: nil)
+
+      expect { logic_for.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+      expect(Onetime::Operations::Sessions::Delete).not_to have_received(:new)
+    end
+
+    it '404s on a malformed handle rather than 422 (same answer as unknown)' do
+      allow(Onetime::Operations::Sessions::Store).to receive(:resolve_handle).and_call_original
+
+      expect { logic_for(colonel, { 'session_handle' => 'nope' }).raise_concerns }
+        .to raise_error(Onetime::RecordNotFound)
+    end
+
+    it '422s only when no handle was supplied at all' do
+      expect { logic_for(colonel, { 'session_handle' => '' }) }
+        .to raise_error(Onetime::FormError)
+    end
+  end
+
+  describe 'response shape' do
+    subject(:response) do
+      stub_resolution
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+    end
+
+    it 'echoes the handle the caller sent' do
+      expect(response[:record][:session_handle]).to eq(handle)
+    end
+
+    it 'reports the delete' do
+      expect(response[:record][:deleted]).to be true
+      expect(response[:details][:message]).to eq('Session revoked successfully')
+    end
+
+    it 'never leaks the raw sid anywhere in the returned hash' do
+      expect(response.to_s).not_to include(session_id)
+      expect(response[:record]).not_to have_key(:session_id)
+    end
+
+    it 'reports deleted:false when the op found nothing left to remove' do
+      stub_resolution
+      allow(delete_op).to receive(:call).and_return(
+        Onetime::Operations::Sessions::Delete::Result.new(
+          status: :not_found, session_id: session_id, key: nil,
+        ),
+      )
+      logic = logic_for
+      logic.raise_concerns
+
+      expect(logic.process[:record][:deleted]).to be false
+    end
+  end
+
+  describe 'authorization' do
+    it 'refuses a non-colonel, deletes nothing and writes NO audit event' do
+      stub_resolution
+      logic = logic_for(customer)
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::Forbidden)
+      expect(Onetime::Operations::Sessions::Delete).not_to have_received(:new)
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+
+    it 'records no event of its own on success — the op owns the trail' do
+      stub_resolution
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/delete_session_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_session_spec.rb
@@ -43,9 +43,22 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSession do
     instance_double(Onetime::Operations::Sessions::Delete, call: delete_result)
   end
 
-  def strategy_result_for(user)
+  # The confirmation token (#4326) is the session OWNER, read off the inspected
+  # payload — the handle in the URL cannot be transformed into it.
+  let(:owner_email) { 'owner@example.com' }
+
+  let(:inspect_result) do
+    Onetime::Operations::Sessions::Inspect::Result.new(
+      found: true, session_id: session_id, key: "session:#{session_id}", ttl: 3600,
+      data: { 'email' => owner_email, 'external_id' => 'ur_owner' },
+    )
+  end
+
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header — never params.
+  def strategy_result_for(user, confirm_token = owner_email)
     double('StrategyResult', session: {}, user: user,
-      auth_method: 'sessionauth', metadata: {})
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
   def logic_for(user = colonel, params = { 'session_handle' => handle })
@@ -64,7 +77,62 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSession do
     allow(OT).to receive(:le)
     allow(Familia).to receive(:dbclient).and_return(double('Redis'))
     allow(Onetime::Operations::Sessions::Delete).to receive(:new).and_return(delete_op)
+    allow(Onetime::Operations::Sessions::Inspect).to receive(:new).and_return(
+      instance_double(Onetime::Operations::Sessions::Inspect, call: inspect_result),
+    )
     allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  # ---- Server-side confirmation (#4326) --------------------------------------
+
+  describe 'confirmation' do
+    let(:expected_confirm_token) { owner_email }
+
+    def confirmed_logic_for(confirm_token)
+      described_class.new(
+        strategy_result_for(colonel, confirm_token),
+        { 'session_handle' => handle },
+      )
+    end
+
+    before { stub_resolution }
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'falls back to the owner external id when the payload carries no email' do
+      allow(Onetime::Operations::Sessions::Inspect).to receive(:new).and_return(
+        instance_double(
+          Onetime::Operations::Sessions::Inspect,
+          call: Onetime::Operations::Sessions::Inspect::Result.new(
+            found: true, session_id: session_id, key: "session:#{session_id}", ttl: 1,
+            data: { 'external_id' => 'ur_owner' },
+          ),
+        ),
+      )
+
+      expect { confirmed_logic_for('ur_owner').raise_concerns }.not_to raise_error
+    end
+
+    it 'falls back to the handle for an anonymous session, and says so' do
+      allow(Onetime::Operations::Sessions::Inspect).to receive(:new).and_return(
+        instance_double(
+          Onetime::Operations::Sessions::Inspect,
+          call: Onetime::Operations::Sessions::Inspect::Result.new(
+            found: true, session_id: session_id, key: "session:#{session_id}", ttl: 1,
+            data: { 'csrf' => 'tok' },
+          ),
+        ),
+      )
+
+      expect { confirmed_logic_for(handle).raise_concerns }.not_to raise_error
+
+      error = begin
+        confirmed_logic_for(nil).raise_concerns
+      rescue Onetime::ConfirmationRequired => ex
+        ex
+      end
+      expect(error.message).to include('session handle')
+    end
   end
 
   describe 'handle resolution' do

--- a/apps/api/colonel/spec/logic/colonel/delete_session_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_session_spec.rb
@@ -56,8 +56,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSession do
 
   # `confirm_token` is where the colonel session auth strategy puts the
   # percent-decoded X-OTS-Confirm header — never params.
-  def strategy_result_for(user, confirm_token = owner_email)
-    double('StrategyResult', session: {}, user: user,
+  def strategy_result_for(user, confirm_token = owner_email, session = {})
+    double('StrategyResult', session: session, user: user,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
@@ -133,6 +133,22 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSession do
       end
       expect(error.message).to include('session handle')
     end
+  end
+
+  # ---- Step-up (sudo) window (#4327) -----------------------------------------
+  describe 'elevation' do
+    let(:expected_confirm_token) { owner_email }
+
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      described_class.new(
+        strategy_result_for(colonel, confirm_token, session),
+        { 'session_handle' => handle },
+      )
+    end
+
+    before { stub_resolution }
+
+    it_behaves_like 'an elevated colonel action'
   end
 
   describe 'handle resolution' do

--- a/apps/api/colonel/spec/logic/colonel/delete_session_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/delete_session_spec.rb
@@ -227,6 +227,56 @@ RSpec.describe ColonelAPI::Logic::Colonel::DeleteSession do
     end
   end
 
+  # ---- Self-target interlock (#4328) -----------------------------------------
+  #
+  # Revoking the session you are working in signs YOU out mid-incident. The
+  # comparison is over HANDLES, so the raw bearer sid never meets
+  # attacker-supplied input; and it runs at step 4, after the confirmation gate,
+  # so the 422 is not a free "is this handle mine?" oracle over the listing.
+  describe 'self-target' do
+    # A Rack SessionId: #public_id is the cookie value the handle is digested
+    # from. safe_session_id reads it off `sess`.
+    let(:own_sid) { 'c' * 64 }
+    let(:own_handle) { Onetime::SessionMetadata.handle_for(own_sid) }
+
+    def own_session_logic(handle_param, confirm_token = owner_email)
+      described_class.new(
+        double('StrategyResult',
+          session: double('Session', id: double('SessionId', public_id: own_sid)),
+          user: colonel, auth_method: 'sessionauth',
+          metadata: { confirm_token: confirm_token }),
+        { 'session_handle' => handle_param },
+      )
+    end
+
+    before { stub_resolution }
+
+    it 'refuses revoking your own active session, naming session_handle' do
+      error = begin
+        own_session_logic(own_handle).raise_concerns
+      rescue Onetime::FormError => ex
+        ex
+      end
+
+      expect(error.message).to match(/Cannot revoke your own active session/)
+      expect(Onetime::Operations::Sessions::Delete).not_to have_received(:new)
+    end
+
+    it 'proceeds for any other handle' do
+      expect { own_session_logic(handle).raise_concerns }.not_to raise_error
+    end
+
+    it 'does not raise when the request session has no resolvable id' do
+      expect { logic_for.raise_concerns }.not_to raise_error
+    end
+
+    # M-2 oracle guard: without the confirmation the answer must be the 403.
+    it 'answers 403 (not the interlock 422) when the confirmation is missing' do
+      expect { own_session_logic(own_handle, nil).raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
+  end
+
   describe 'authorization' do
     it 'refuses a non-colonel, deletes nothing and writes NO audit event' do
       stub_resolution

--- a/apps/api/colonel/spec/logic/colonel/destructive_budget_order_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/destructive_budget_order_spec.rb
@@ -1,0 +1,198 @@
+# apps/api/colonel/spec/logic/colonel/destructive_budget_order_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# WHERE the tight colonel:destructive bucket is charged (#4329) — step 5 of the
+# guard-order contract, the LAST line of raise_concerns.
+#
+# This is a regression guard, not a feature test. Charging the destructive budget
+# FIRST is the obvious implementation and it is wrong twice over:
+#
+#   1. The console's designed flow is attempt -> 403 elevation_required ->
+#      elevate -> retry. A charge before the elevation check bills that ONE
+#      operator action TWICE, so a 10/300s bucket really admits five actions
+#      before a 900s lockout.
+#   2. Worse adversarially: the bucket is keyed on cust.extid, so an attacker
+#      holding the cookie could burn the legitimate colonel's entire destructive
+#      budget with ten cheap, unelevated, unconfirmed requests — imposing a
+#      15-minute lockout on the operator trying to contain the incident.
+#
+# So: a request refused for missing elevation, missing/wrong confirmation, or a
+# per-verb interlock must consume NOTHING. Volume is still bounded, because the
+# broad colonel:mutation bucket is charged in the base constructor before any of
+# this runs (rate_limit_hook_spec.rb).
+#
+# PurgeUser is the subject because it is the only class carrying all three
+# refusals — elevation, confirmation and a self-target interlock — over one set
+# of params. The equivalent ordering for every other TIER 1 class is pinned
+# structurally by spec/unit/colonel/destructive_actions_spec.rb, which asserts
+# guard_destructive_action! and charge_destructive_budget! are both present and
+# that the charge is last.
+#
+# The limiter call is spied, not executed: the colonel unit suite runs without
+# Redis. The limiter body is proven against real Redis in
+# try/unit/security/colonel_rate_limiter_try.rb.
+#
+# RUN:
+#   RACK_ENV=test bundle exec rspec \
+#     apps/api/colonel/spec/logic/colonel/destructive_budget_order_spec.rb
+RSpec.describe ColonelAPI::Logic::Colonel::PurgeUser do
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel', email: 'colonel@example.com',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:target) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_target', extid: 'ur_target', email: 'victim@example.com',
+      exists?: true, anonymous?: false)
+  end
+
+  let(:purge_result) do
+    instance_double(Auth::Operations::Customers::Purge::Result, status: :success)
+  end
+
+  let(:op) { instance_double(Auth::Operations::Customers::Purge, call: purge_result) }
+
+  def strategy_result_for(confirm_token, session = {})
+    double('StrategyResult', session: session, user: colonel,
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token, request_method: 'DELETE' })
+  end
+
+  # Returns the logic instance with the destructive charge spied, so each example
+  # asserts on whether it was called rather than on a Redis counter.
+  def spied_logic(confirm_token: 'victim@example.com', session: {})
+    logic = described_class.new(strategy_result_for(confirm_token, session), { 'user_id' => 'ur_target' })
+    allow(logic).to receive(:enforce_colonel_destructive_limit!)
+    logic
+  end
+
+  let(:live_session) { elevated_session('ur_colonel') }
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(target)
+    allow(Onetime::Customer).to receive(:load).and_return(target)
+    allow(Auth::Operations::Customers::Purge).to receive(:new).and_return(op)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+    stub_colonel_elevation(enabled: true, window: 600)
+  end
+
+  describe 'a rejected attempt costs nothing' do
+    it 'does not charge when elevation is missing' do
+      logic = spied_logic(session: {})
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::ElevationRequired)
+      expect(logic).not_to have_received(:enforce_colonel_destructive_limit!)
+    end
+
+    it 'does not charge when the elevation window has expired' do
+      logic = spied_logic(session: elevated_session('ur_colonel', expires_in: -1))
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::ElevationRequired)
+      expect(logic).not_to have_received(:enforce_colonel_destructive_limit!)
+    end
+
+    it 'does not charge when the confirmation header is absent' do
+      logic = spied_logic(confirm_token: nil, session: live_session)
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+      expect(logic).not_to have_received(:enforce_colonel_destructive_limit!)
+    end
+
+    it 'does not charge when the confirmation token is wrong' do
+      logic = spied_logic(confirm_token: 'not-the-token', session: live_session)
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+      expect(logic).not_to have_received(:enforce_colonel_destructive_limit!)
+    end
+
+    # The interlock is step 4 — after proof, before the charge. A fully proven
+    # request that the business rules refuse still executes nothing, so it still
+    # costs nothing.
+    it 'does not charge when a per-verb interlock refuses the action' do
+      allow(target).to receive(:objid).and_return('cust_colonel')
+      logic = spied_logic(session: live_session)
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::FormError, /Cannot purge your own account/)
+      expect(logic).not_to have_received(:enforce_colonel_destructive_limit!)
+    end
+
+    it 'does not charge when the caller is not a colonel at all' do
+      not_a_colonel = instance_double(Onetime::Customer,
+        objid: 'cust_plain', extid: 'ur_plain', role: 'customer', verified?: true, anonymous?: false)
+      logic = described_class.new(
+        double('StrategyResult', session: live_session, user: not_a_colonel,
+          auth_method: 'sessionauth',
+          metadata: { confirm_token: 'victim@example.com', request_method: 'DELETE' }),
+        { 'user_id' => 'ur_target' },
+      )
+      allow(logic).to receive(:enforce_colonel_destructive_limit!)
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::Forbidden)
+      expect(logic).not_to have_received(:enforce_colonel_destructive_limit!)
+    end
+  end
+
+  describe 'an executable attempt is charged exactly once' do
+    it 'charges the acting colonel PUBLIC extid when every guard passes' do
+      logic = spied_logic(session: live_session)
+
+      logic.raise_concerns
+
+      expect(logic).to have_received(:enforce_colonel_destructive_limit!).once.with('ur_colonel')
+    end
+
+    it 'charges in raise_concerns, not in process — a 429 must purge nothing' do
+      logic = spied_logic(session: live_session)
+      logic.raise_concerns
+
+      expect(Auth::Operations::Customers::Purge).not_to have_received(:new)
+    end
+
+    # The bucket subject is the audit `actor`, never an internal objid: an objid
+    # in a limiter key would surface it in `bin/ots ratelimit keys`, in
+    # GET /ratelimit/inspect and in a `redis-cli --scan`.
+    it 'never keys the bucket on an objid' do
+      logic = spied_logic(session: live_session)
+      logic.raise_concerns
+
+      expect(logic).not_to have_received(:enforce_colonel_destructive_limit!).with('cust_colonel')
+    end
+  end
+
+  describe 'a 429 from the budget stops the action' do
+    it 'raises LimitExceeded out of raise_concerns and purges nothing' do
+      logic = described_class.new(
+        strategy_result_for('victim@example.com', live_session), { 'user_id' => 'ur_target' },
+      )
+      allow(logic).to receive(:enforce_colonel_destructive_limit!)
+        .and_raise(Onetime::LimitExceeded.new('Too many destructive admin actions.',
+          retry_after: 900, max_attempts: 10))
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::LimitExceeded)
+      expect(Auth::Operations::Customers::Purge).not_to have_received(:new)
+    end
+
+    # LimitExceeded < Forbidden, so AuditedFailure drops it: a throttled caller
+    # cannot mint operator-trail events by hammering the gate. Only the
+    # cap-REACHING request writes one, and it writes it via .record_security.
+    it 'writes no operator-trail audit event' do
+      logic = described_class.new(
+        strategy_result_for('victim@example.com', live_session), { 'user_id' => 'ur_target' },
+      )
+      allow(logic).to receive(:enforce_colonel_destructive_limit!)
+        .and_raise(Onetime::LimitExceeded.new('nope', retry_after: 900, max_attempts: 10))
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::LimitExceeded)
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/destructive_budget_order_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/destructive_budget_order_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ColonelAPI::Logic::Colonel::PurgeUser do
   let(:target) do
     instance_double(Onetime::Customer,
       objid: 'cust_target', extid: 'ur_target', email: 'victim@example.com',
-      exists?: true, anonymous?: false)
+      role: 'customer', exists?: true, anonymous?: false)
   end
 
   let(:purge_result) do

--- a/apps/api/colonel/spec/logic/colonel/drop_elevation_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/drop_elevation_spec.rb
@@ -1,0 +1,97 @@
+# apps/api/colonel/spec/logic/colonel/drop_elevation_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# DELETE /api/colonel/elevation — ending the step-up window early (#4327).
+#
+# Strictly de-escalating, so it is idempotent by design: dropping a window that
+# is not live still answers 200. A 404 there would only tell the operator
+# whether they happened to be elevated, and the intent ("I am done with elevated
+# access") is satisfied either way.
+#
+# It DOES audit, with .record: a deliberate operator action, on the same trail as
+# the matching colonel.elevate success so the pair reads as one bracket. That is
+# safe where the elevation FAILURE path is not, because this one cannot be
+# driven usefully — it de-escalates.
+RSpec.describe ColonelAPI::Logic::Colonel::DropElevation do
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel', email: 'colonel@example.com',
+      role: 'colonel', verified?: true, anonymous?: false, has_passphrase?: true)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain', email: 'plain@example.com',
+      role: 'customer', verified?: true, anonymous?: false, has_passphrase?: true)
+  end
+
+  def logic_for(user = colonel, session = {})
+    described_class.new(
+      double('StrategyResult', session: session, user: user,
+        auth_method: 'sessionauth', metadata: {}),
+      {},
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+    stub_colonel_elevation(enabled: true, window: 600)
+  end
+
+  it 'refuses a non-colonel' do
+    expect { logic_for(customer).raise_concerns }.to raise_error(Onetime::Forbidden)
+  end
+
+  it 'removes a live window from the session' do
+    session = elevated_session('ur_colonel')
+    logic = logic_for(colonel, session)
+    logic.raise_concerns
+    data = logic.process
+
+    expect(session).not_to have_key('elevated_until')
+    expect(data[:record][:elevated]).to be false
+    expect(data[:details][:was_elevated]).to be true
+  end
+
+  it 'is a 200 no-op when nothing was elevated' do
+    logic = logic_for
+    logic.raise_concerns
+    data = logic.process
+
+    expect(data[:record][:elevated]).to be false
+    expect(data[:details][:was_elevated]).to be false
+  end
+
+  it 'records colonel.elevate_drop with the acting colonel as actor and target' do
+    logic = logic_for(colonel, elevated_session('ur_colonel'))
+    logic.raise_concerns
+    logic.process
+
+    expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+      hash_including(
+        actor: 'ur_colonel', verb: 'colonel.elevate_drop', target: 'ur_colonel',
+        result: :success,
+      ),
+    )
+  end
+
+  # A stale record belonging to somebody else reads as "not elevated", but the
+  # delete must still clear it — otherwise a foreign record could sit in the
+  # session with no way for its holder to remove it.
+  it 'clears a record belonging to a different identity too' do
+    session = elevated_session('ur_someone_else')
+    logic = logic_for(colonel, session)
+    logic.raise_concerns
+    logic.process
+
+    expect(session).not_to have_key('elevated_until')
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/elevate_session_recent_auth_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/elevate_session_recent_auth_spec.rb
@@ -160,5 +160,20 @@ RSpec.describe ColonelAPI::Logic::Colonel::ElevateSession, 'the recent_auth fact
     it 'refuses recent_auth there' do
       expect { elevate(sso_only) }.to raise_error(Onetime::ElevationFailed)
     end
+
+    # #4327 message accuracy: full mode treats every account as password-holding
+    # (fail-closed), but an SSO-only account has NO password — so telling the
+    # operator to re-enter one is misinformation. The full-mode branch names the
+    # real remedy instead.
+    it 'does not tell an SSO-only operator they have a password' do
+      error = begin
+        elevate(sso_only)
+      rescue Onetime::ElevationFailed => ex
+        ex
+      end
+
+      expect(error.message).not_to include('This account has a password')
+      expect(error.message).to include('full authentication mode')
+    end
   end
 end

--- a/apps/api/colonel/spec/logic/colonel/elevate_session_recent_auth_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/elevate_session_recent_auth_spec.rb
@@ -1,0 +1,164 @@
+# apps/api/colonel/spec/logic/colonel/elevate_session_recent_auth_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# The `recent_auth` factor (#4327) — and the regression set for the security
+# review's B-3 finding, which is the reason this factor is shaped the way it is.
+#
+# The rejected first draft let ANY colonel elevate with no credential inside a
+# 300s post-sign-in grace, and the console called it silently before prompting.
+# For five minutes after every colonel sign-in, "a colonel session alone" WAS
+# sufficient for every tier-1 verb — verbatim the condition #4327 exists to
+# remove — and a scripted cookie holder reached the same state in two requests.
+# The objection that a stolen cookie cannot make `authenticated_at` recent is
+# true and irrelevant: the attacker needs the VICTIM to have signed in recently,
+# which is the ordinary case for theft that happens while the operator works.
+#
+# So the factor ships with two independent locks, and both are asserted here:
+#
+#   1. `reauth_grace` defaults to 0, i.e. the factor is OFF unless an operator
+#      turns it on;
+#   2. even switched on, it is offered ONLY to accounts that cannot satisfy the
+#      password factor. A password holder always re-enters their password.
+#
+# The remaining purpose of the factor is SSO-only operator fleets, which would
+# otherwise be locked out of every tier-1 verb.
+RSpec.describe ColonelAPI::Logic::Colonel::ElevateSession, 'the recent_auth factor' do
+  let(:signed_in_at) { Familia.now.to_i - 60 }
+  let(:session) { { 'authenticated_at' => signed_in_at } }
+
+  def colonel_with(passphrase:)
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel', email: 'colonel@example.com',
+      role: 'colonel', verified?: true, anonymous?: false,
+      has_passphrase?: passphrase)
+  end
+
+  let(:password_holder) { colonel_with(passphrase: true) }
+  let(:sso_only) { colonel_with(passphrase: false) }
+
+  def logic_for(user, sess = session)
+    described_class.new(
+      double('StrategyResult', session: sess, user: user, auth_method: 'sessionauth', metadata: {}),
+      { 'factor' => 'recent_auth' },
+    )
+  end
+
+  def elevate(user, sess = session)
+    logic = logic_for(user, sess)
+    logic.raise_concerns
+    logic.process
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+    allow(Onetime::ColonelAuditEvent).to receive(:record_security)
+    allow(Onetime.auth_config).to receive(:full_enabled?).and_return(false)
+    allow_any_instance_of(described_class).to receive(:enforce_colonel_elevation_limit!) # rubocop:disable RSpec/AnyInstance
+  end
+
+  describe 'with the SHIPPED default (reauth_grace: 0)' do
+    before { stub_colonel_elevation(enabled: true, reauth_grace: 0) }
+
+    it 'refuses a password-less account one second after sign-in' do
+      expect { elevate(sso_only, { 'authenticated_at' => Familia.now.to_i - 1 }) }
+        .to raise_error(Onetime::ElevationFailed)
+    end
+
+    it 'refuses a password holder too' do
+      expect { elevate(password_holder) }.to raise_error(Onetime::ElevationFailed)
+    end
+
+    it 'tells the operator which knob is missing, not that they guessed wrong' do
+      error = begin
+        elevate(sso_only)
+      rescue Onetime::ElevationFailed => ex
+        ex
+      end
+
+      expect(error.message).to include('COLONEL_ELEVATION_REAUTH_GRACE')
+    end
+
+    it 'offers password as the only factor' do
+      expect(logic_for(sso_only).available_factors).to eq(['password'])
+    end
+  end
+
+  describe 'with a grace configured' do
+    before { stub_colonel_elevation(enabled: true, reauth_grace: 300) }
+
+    it 'still refuses an account that HAS a password' do
+      expect { elevate(password_holder) }.to raise_error(Onetime::ElevationFailed)
+    end
+
+    it 'tells a password holder to use their password' do
+      error = begin
+        elevate(password_holder)
+      rescue Onetime::ElevationFailed => ex
+        ex
+      end
+
+      expect(error.message).to include('re-enter it to elevate')
+    end
+
+    it 'does not offer recent_auth to a password holder' do
+      expect(logic_for(password_holder).available_factors).to eq(['password'])
+    end
+
+    it 'elevates a password-less account inside the grace' do
+      elevate(sso_only)
+
+      expect(session['elevated_until']['extid']).to eq('ur_colonel')
+    end
+
+    it 'offers recent_auth to a password-less account' do
+      expect(logic_for(sso_only).available_factors).to contain_exactly('password', 'recent_auth')
+    end
+
+    it 'records the WEAKER path in the audit detail so the trail can show it' do
+      elevate(sso_only)
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+        hash_including(verb: 'colonel.elevate', detail: hash_including(factor: 'recent_auth')),
+      )
+    end
+
+    it 'refuses a password-less account whose sign-in is older than the grace' do
+      stale = { 'authenticated_at' => Familia.now.to_i - 301 }
+
+      expect { elevate(sso_only, stale) }.to raise_error(Onetime::ElevationFailed, /not recent enough/)
+    end
+
+    it 'refuses a session carrying no sign-in watermark at all' do
+      expect { elevate(sso_only, {}) }.to raise_error(Onetime::ElevationFailed)
+    end
+  end
+
+  describe 'in FULL auth mode' do
+    before do
+      stub_colonel_elevation(enabled: true, reauth_grace: 300)
+      allow(Onetime.auth_config).to receive(:full_enabled?).and_return(true)
+    end
+
+    # Documented scoping decision, not an oversight: the Rodauth password-hash
+    # probe is only reachable inside a Rodauth instance, and inventing a second
+    # probe risks granting the WEAKER factor on a wrong answer. Full mode
+    # therefore fails closed — every account counts as password-holding — and an
+    # SSO-only full-mode fleet sets COLONEL_ELEVATION_ENABLED=false instead.
+    it 'treats even a passphrase-less account as password-holding' do
+      expect(logic_for(sso_only).elevation_password_available?).to be true
+      expect(logic_for(sso_only).available_factors).to eq(['password'])
+    end
+
+    it 'refuses recent_auth there' do
+      expect { elevate(sso_only) }.to raise_error(Onetime::ElevationFailed)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/elevate_session_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/elevate_session_spec.rb
@@ -1,0 +1,243 @@
+# apps/api/colonel/spec/logic/colonel/elevate_session_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# POST /api/colonel/elevation — minting the step-up (sudo) window (#4327).
+#
+# What this layer owns, and what these examples pin:
+#
+#   - the DUAL-MODE branch. `Auth::Config` does not exist in simple mode
+#     (registry.rb drops the whole apps/web/auth tree), so the password check
+#     MUST test Onetime.auth_config.full_enabled? before naming it. The
+#     simple-mode examples assert the constant is never touched, which is the
+#     regression this design exists to prevent;
+#   - the audit split: .record on success carrying the FACTOR, .record_security
+#     on failure, and nothing at all on an unelevated tier-1 refusal (that last
+#     one is asserted by the 'an elevated colonel action' shared example);
+#   - the shape of what lands in the session: an identity-bound {extid, exp}
+#     object, never a bare epoch;
+#   - the throttle running BEFORE verification, because the Rodauth internal
+#     request behind the password check does not increment Rodauth's lockout.
+#
+# It deliberately does NOT test the window arithmetic (elevation_spec covers the
+# mixin) or the tier-1 gate (the shared example covers every TIER 1 class).
+RSpec.describe ColonelAPI::Logic::Colonel::ElevateSession do
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel', email: 'colonel@example.com',
+      role: 'colonel', verified?: true, anonymous?: false,
+      has_passphrase?: true)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain', email: 'plain@example.com',
+      role: 'customer', verified?: true, anonymous?: false,
+      has_passphrase?: true)
+  end
+
+  # The Rack session hash the auth strategy hands the logic class. A real one is
+  # mutable, which is the whole point here: grant_elevation! writes into it.
+  let(:session) { {} }
+
+  def strategy_result_for(user = colonel, sess = session)
+    double('StrategyResult', session: sess, user: user,
+      auth_method: 'sessionauth', metadata: {})
+  end
+
+  def logic_for(params = {}, user: colonel, sess: session)
+    described_class.new(strategy_result_for(user, sess), { 'factor' => 'password' }.merge(params))
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+    allow(Onetime::ColonelAuditEvent).to receive(:record_security)
+    stub_colonel_elevation(enabled: true, window: 600)
+    # The limiter has its own tryout; here it must not touch Redis.
+    allow_any_instance_of(described_class).to receive(:enforce_colonel_elevation_limit!) # rubocop:disable RSpec/AnyInstance
+  end
+
+  describe 'authorization and shape' do
+    it 'refuses a non-colonel before anything else' do
+      expect { logic_for(user: customer).raise_concerns }.to raise_error(Onetime::Forbidden)
+    end
+
+    it 'defaults an absent factor to password' do
+      expect(logic_for({ 'factor' => '' }).factor).to eq('password')
+    end
+
+    it 'rejects an unknown factor with a 422' do
+      expect { logic_for({ 'factor' => 'telepathy' }).raise_concerns }
+        .to raise_error(Onetime::FormError, /Unknown step-up factor/)
+    end
+
+    it 'rejects every factor with a 422 when elevation is disabled by config' do
+      stub_colonel_elevation(enabled: false)
+      expect { logic_for.raise_concerns }
+        .to raise_error(Onetime::FormError, /Step-up authentication is disabled/)
+    end
+
+    it 'throttles BEFORE verifying — the internal-request check bypasses Rodauth lockout' do
+      logic = logic_for
+      expect(logic).to receive(:enforce_colonel_elevation_limit!).with('ur_colonel') # rubocop:disable RSpec/MessageSpies
+      logic.raise_concerns
+    end
+  end
+
+  describe 'the password factor in SIMPLE mode' do
+    before do
+      allow(Onetime.auth_config).to receive(:full_enabled?).and_return(false)
+    end
+
+    it 'verifies against the Redis passphrase and NEVER names Auth::Config' do
+      allow(colonel).to receive(:passphrase?).with('hunter2').and_return(true)
+      # If the class reached for Auth::Config here it would NameError in simple
+      # mode, where apps/web/auth is not loaded at all.
+      expect(defined?(Auth::Config) ? Auth::Config : nil).not_to receive(:valid_login_and_password?) if defined?(Auth::Config) # rubocop:disable RSpec/MessageSpies
+
+      logic = logic_for({ 'password' => 'hunter2' })
+      logic.raise_concerns
+      logic.process
+
+      expect(colonel).to have_received(:passphrase?).with('hunter2')
+    end
+
+    it 'stores an identity-bound {extid, exp} object, never a bare epoch' do
+      allow(colonel).to receive(:passphrase?).and_return(true)
+
+      logic = logic_for({ 'password' => 'hunter2' })
+      logic.raise_concerns
+      logic.process
+
+      stored = session['elevated_until']
+      expect(stored).to be_a(Hash)
+      expect(stored['extid']).to eq('ur_colonel')
+      expect(stored['exp']).to be_within(5).of(Familia.now.to_i + 600)
+    end
+
+    it 'returns the window in the ack' do
+      allow(colonel).to receive(:passphrase?).and_return(true)
+
+      logic = logic_for({ 'password' => 'hunter2' })
+      logic.raise_concerns
+      data = logic.process
+
+      expect(data[:record][:elevated]).to be true
+      expect(data[:details][:factor]).to eq('password')
+      expect(data[:details][:window]).to eq(600)
+    end
+
+    it 'records exactly one colonel.elevate event carrying the factor' do
+      allow(colonel).to receive(:passphrase?).and_return(true)
+
+      logic = logic_for({ 'password' => 'hunter2' })
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+        hash_including(
+          actor: 'ur_colonel', verb: 'colonel.elevate', target: 'ur_colonel',
+          result: :success, detail: { factor: 'password', window: 600 },
+        ),
+      )
+    end
+
+    it 'treats a blank password as a failure without calling the verifier' do
+      allow(colonel).to receive(:passphrase?)
+
+      expect { logic_for({ 'password' => '' }).tap(&:raise_concerns).process }
+        .to raise_error(Onetime::ElevationFailed)
+      expect(colonel).not_to have_received(:passphrase?)
+    end
+
+    describe 'a wrong password' do
+      before { allow(colonel).to receive(:passphrase?).and_return(false) }
+
+      it 'raises ElevationFailed with error_code elevation_failed' do
+        error = begin
+          logic_for({ 'password' => 'nope' }).tap(&:raise_concerns).process
+        rescue Onetime::ElevationFailed => ex
+          ex
+        end
+
+        expect(error).to be_a(Onetime::Forbidden)
+        expect(error.to_h).to include(
+          error_type: 'ElevationFailed', error_code: 'elevation_failed', factor: 'password',
+        )
+      end
+
+      it 'grants nothing' do
+        expect { logic_for({ 'password' => 'nope' }).tap(&:raise_concerns).process }
+          .to raise_error(Onetime::ElevationFailed)
+        expect(session).not_to have_key('elevated_until')
+      end
+
+      # record_security (1k cap + 7d retention), never .record: a failed
+      # elevation is drivable on demand by whoever holds the cookie, and the
+      # operator trail is count-capped with NO TTL.
+      it 'records the failure as a SECURITY event and not on the operator trail' do
+        expect { logic_for({ 'password' => 'nope' }).tap(&:raise_concerns).process }
+          .to raise_error(Onetime::ElevationFailed)
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record_security).once.with(
+          hash_including(
+            actor: 'ur_colonel', verb: 'colonel.elevate', target: 'ur_colonel',
+            result: :failure, detail: { factor: 'password' },
+          ),
+        )
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+      end
+
+      it 'never puts the submitted password in the audit detail' do
+        expect { logic_for({ 'password' => 's3cr3t-value' }).tap(&:raise_concerns).process }
+          .to raise_error(Onetime::ElevationFailed)
+
+        detail = nil
+        expect(Onetime::ColonelAuditEvent).to have_received(:record_security) { |args| detail = args[:detail] }
+        expect(detail.to_s).not_to include('s3cr3t-value')
+      end
+    end
+  end
+
+  describe 'the password factor in FULL mode' do
+    before do
+      allow(Onetime.auth_config).to receive(:full_enabled?).and_return(true)
+      stub_const('Auth::Config', class_double('Auth::Config'))
+      # Both constants only exist in a full-mode process; this spec runs in a
+      # simple-mode one. Naming Rodauth::InternalRequestError in the rescue
+      # clause is the in-repo idiom (update_password.rb, destroy_account.rb) and
+      # is reachable only behind the same full_enabled? branch, so the stub
+      # reproduces the real load order rather than papering over one.
+      stub_const('Rodauth::InternalRequestError', Class.new(StandardError))
+    end
+
+    it 'verifies through the Rodauth internal request, not the Redis passphrase' do
+      allow(Auth::Config).to receive(:valid_login_and_password?).and_return(true)
+      allow(colonel).to receive(:passphrase?)
+
+      logic = logic_for({ 'password' => 'hunter2' })
+      logic.raise_concerns
+      logic.process
+
+      expect(Auth::Config).to have_received(:valid_login_and_password?)
+        .with(login: 'colonel@example.com', password: 'hunter2')
+      expect(colonel).not_to have_received(:passphrase?)
+      expect(session['elevated_until']['extid']).to eq('ur_colonel')
+    end
+
+    it 'treats a verifier error as a failure rather than an admit' do
+      allow(Auth::Config).to receive(:valid_login_and_password?).and_raise(StandardError, 'authdb down')
+
+      expect { logic_for({ 'password' => 'hunter2' }).tap(&:raise_concerns).process }
+        .to raise_error(Onetime::ElevationFailed)
+      expect(session).not_to have_key('elevated_until')
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/elevate_session_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/elevate_session_spec.rb
@@ -43,6 +43,31 @@ RSpec.describe ColonelAPI::Logic::Colonel::ElevateSession do
   # mutable, which is the whole point here: grant_elevation! writes into it.
   let(:session) { {} }
 
+  # Stand-in for the full-mode password verifier, declaring the exact signature
+  # Elevation#verify_elevation_password_full_mode calls.
+  #
+  # `class_double('Auth::Config')` (by NAME) cannot be used, and neither can a
+  # `defined?(Auth::Config)` guard. This spec runs in a SIMPLE-mode process where
+  # the constant is normally absent — but `spec:apps_fast` merges every app spec
+  # into one process, and any spec there that loads apps/web/auth/config.rb
+  # leaves `Auth::Config` defined as a bare Rodauth::Auth subclass. The
+  # `valid_login_and_password?` class method is installed by Rodauth's
+  # :internal_request feature, which only runs inside `Auth::Config.configure`
+  # during a full-mode boot, so rspec would verify the stub against a half-built
+  # class and reject it — making these examples pass or fail on the load order of
+  # the whole merged process (seed 35522 reproduces the failure).
+  #
+  # Doubling this stand-in is deterministic in both processes AND stricter than
+  # the unverified double a name-based `class_double` degrades to when the
+  # constant is absent: a call with the wrong keywords fails here.
+  let(:auth_config_class) do
+    Class.new do
+      def self.valid_login_and_password?(login:, password:)
+        raise NotImplementedError, "stand-in only (#{login}/#{password})"
+      end
+    end
+  end
+
   def strategy_result_for(user = colonel, sess = session)
     double('StrategyResult', session: sess, user: user,
       auth_method: 'sessionauth', metadata: {})
@@ -99,8 +124,14 @@ RSpec.describe ColonelAPI::Logic::Colonel::ElevateSession do
     it 'verifies against the Redis passphrase and NEVER names Auth::Config' do
       allow(colonel).to receive(:passphrase?).with('hunter2').and_return(true)
       # If the class reached for Auth::Config here it would NameError in simple
-      # mode, where apps/web/auth is not loaded at all.
-      expect(defined?(Auth::Config) ? Auth::Config : nil).not_to receive(:valid_login_and_password?) if defined?(Auth::Config) # rubocop:disable RSpec/MessageSpies
+      # mode, where apps/web/auth is not loaded at all. Stubbed unconditionally:
+      # the old `if defined?(Auth::Config)` guard SKIPPED this assertion outright
+      # in a standalone colonel run (where the constant is absent — i.e. exactly
+      # the run this file is normally executed in) and blew up in the merged
+      # spec:apps_fast process. The stand-in is present either way.
+      auth_config = class_double(auth_config_class)
+      stub_const('Auth::Config', auth_config)
+      expect(auth_config).not_to receive(:valid_login_and_password?) # rubocop:disable RSpec/MessageSpies
 
       logic = logic_for({ 'password' => 'hunter2' })
       logic.raise_concerns
@@ -209,7 +240,7 @@ RSpec.describe ColonelAPI::Logic::Colonel::ElevateSession do
   describe 'the password factor in FULL mode' do
     before do
       allow(Onetime.auth_config).to receive(:full_enabled?).and_return(true)
-      stub_const('Auth::Config', class_double('Auth::Config'))
+      stub_const('Auth::Config', class_double(auth_config_class))
       # Both constants only exist in a full-mode process; this spec runs in a
       # simple-mode one. Naming Rodauth::InternalRequestError in the rescue
       # clause is the in-repo idiom (update_password.rb, destroy_account.rb) and

--- a/apps/api/colonel/spec/logic/colonel/elevation_identity_binding_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/elevation_identity_binding_spec.rb
@@ -1,0 +1,147 @@
+# apps/api/colonel/spec/logic/colonel/elevation_identity_binding_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# The identity binding on the step-up window (#4327) — the regression set for
+# the security review's B-2 finding.
+#
+# The rejected first draft stored a bare epoch in `sess['elevated_until']` with
+# nothing recording WHO elevated. That defends the wrong boundary. The codec's
+# sid/field binding already stops a Redis-writing attacker replaying one
+# session's value under another sid; what leaks is an IDENTITY CHANGE WITHIN THE
+# SAME SID, and this codebase has two:
+#
+#   - simple mode: Core::Controllers::Authentication#perform_authentication
+#     assigns the new identity into the session and neither clears nor renews it
+#     (compare session_helpers.rb, the other authenticate path, which does both);
+#   - full mode: Rodauth's :renew after a password change carries the session
+#     hash to a new sid where it is re-externalized.
+#
+# So the stored value is {extid, exp} and every read compares the extid against
+# the CURRENT customer. Both login paths ALSO delete the field outright (see
+# spec/unit/onetime/session/elevation_dropped_on_login_spec.rb); this file pins
+# the read-side half, which is what holds if a third identity-change path is
+# ever added.
+#
+# GetElevationStatus stands in for "any colonel logic class": the window
+# arithmetic lives in the shared Elevation mixin included into
+# ColonelAPI::Logic::Base, so every one of them answers identically.
+RSpec.describe ColonelAPI::Logic::Colonel::Elevation do
+  def colonel_named(extid)
+    instance_double(Onetime::Customer,
+      objid: "cust_#{extid}", extid: extid, email: "#{extid}@example.com",
+      role: 'colonel', verified?: true, anonymous?: false, has_passphrase?: true)
+  end
+
+  let(:alice) { colonel_named('ur_alice') }
+  let(:bob) { colonel_named('ur_bob') }
+
+  # Any colonel logic class carries the mixin; this is the cheapest host.
+  def logic_for(user, session)
+    ColonelAPI::Logic::Colonel::GetElevationStatus.new(
+      double('StrategyResult', session: session, user: user,
+        auth_method: 'sessionauth', metadata: {}),
+      {},
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    stub_colonel_elevation(enabled: true, window: 600)
+  end
+
+  describe 'a live window' do
+    let(:session) { elevated_session('ur_alice') }
+
+    it 'is honoured for the identity that minted it' do
+      expect(logic_for(alice, session).elevated?).to be true
+    end
+
+    # The finding, in one example: sign in as B on a browser that held A's
+    # elevated session and the window must not transfer.
+    it 'is IGNORED for a different identity in the same session' do
+      expect(logic_for(bob, session).elevated?).to be false
+    end
+
+    it 'reports no time remaining to the other identity' do
+      expect(logic_for(bob, session).elevation_seconds_remaining).to eq(0)
+    end
+  end
+
+  describe 'values that are not a valid record' do
+    it 'ignores a bare epoch (the shape the first draft would have written)' do
+      session = { 'elevated_until' => Familia.now.to_i + 600 }
+      expect(logic_for(alice, session).elevated?).to be false
+    end
+
+    it 'ignores an unparseable string' do
+      session = { 'elevated_until' => '{not json at all' }
+      expect(logic_for(alice, session).elevated?).to be false
+    end
+
+    it 'ignores a record with a blank extid' do
+      session = { 'elevated_until' => { 'extid' => '', 'exp' => Familia.now.to_i + 600 } }
+      expect(logic_for(alice, session).elevated?).to be false
+    end
+
+    it 'ignores an absent field' do
+      expect(logic_for(alice, {}).elevated?).to be false
+    end
+
+    it 'ignores an expired record even for its own identity' do
+      expect(logic_for(alice, elevated_session('ur_alice', expires_in: -1)).elevated?).to be false
+    end
+
+    # The sidecar codec round-trips JSON objects natively, but a plaintext or
+    # pre-decode read can hand back the serialized form; both must work.
+    it 'accepts the JSON-string form of its own record' do
+      session = { 'elevated_until' => Familia::JsonSerializer.dump(
+        { 'extid' => 'ur_alice', 'exp' => Familia.now.to_i + 600 },
+      ) }
+      expect(logic_for(alice, session).elevated?).to be true
+    end
+  end
+
+  describe 'granting and dropping' do
+    it 'writes the ACTING identity, not whatever was there before' do
+      session = elevated_session('ur_bob')
+      logic_for(alice, session).grant_elevation!
+
+      expect(session['elevated_until']['extid']).to eq('ur_alice')
+    end
+
+    it 'writes an exp one window ahead' do
+      session = {}
+      logic_for(alice, session).grant_elevation!
+
+      expect(session['elevated_until']['exp']).to be_within(5).of(Familia.now.to_i + 600)
+    end
+
+    it 'drops the field entirely rather than parking a falsy value' do
+      session = elevated_session('ur_alice')
+      logic_for(alice, session).drop_elevation!
+
+      expect(session).not_to have_key('elevated_until')
+    end
+  end
+
+  describe 'the field is a registered session sidecar field' do
+    # Absence must be the safe state, which is the sidecar admission rule. It is
+    # externalized so the capability carries its own short TTL rather than
+    # riding the 24h session blob.
+    it 'is registered with the policy the design requires' do
+      policy = Onetime::SessionSidecar::FIELDS[described_class::SESSION_KEY]
+
+      expect(policy).to include(
+        encrypted: true, merge_on_read: true, externalize: true, absent_when_falsy: true,
+      )
+      expect(policy[:ttl]).to be > described_class::DEFAULT_WINDOW
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/get_elevation_status_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/get_elevation_status_spec.rb
@@ -1,0 +1,136 @@
+# apps/api/colonel/spec/logic/colonel/get_elevation_status_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# GET /api/colonel/elevation — the status read the console fetches on mount,
+# after every elevate/drop, and on a 403 elevation_required (#4327).
+#
+# Two properties matter beyond the obvious shape:
+#
+#   - it is a READ, so it audits NOTHING (CONTRACT 4). The console calls it
+#     often enough that auditing here would be a self-inflicted flood of the
+#     count-capped operator trail;
+#   - `details.factors` and `details.password_available` are per-ACCOUNT, which
+#     is what lets the console render an actionable remediation for an SSO-only
+#     operator instead of looping on a prompt they cannot satisfy.
+RSpec.describe ColonelAPI::Logic::Colonel::GetElevationStatus do
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel', email: 'colonel@example.com',
+      role: 'colonel', verified?: true, anonymous?: false, has_passphrase?: true)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain', email: 'plain@example.com',
+      role: 'customer', verified?: true, anonymous?: false, has_passphrase?: true)
+  end
+
+  def logic_for(user = colonel, session = {})
+    described_class.new(
+      double('StrategyResult', session: session, user: user,
+        auth_method: 'sessionauth', metadata: {}),
+      {},
+    )
+  end
+
+  def status_for(user = colonel, session = {})
+    logic = logic_for(user, session)
+    logic.raise_concerns
+    logic.process
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+    allow(Onetime::ColonelAuditEvent).to receive(:record_security)
+    allow(Onetime.auth_config).to receive(:full_enabled?).and_return(false)
+    stub_colonel_elevation(enabled: true, window: 600)
+  end
+
+  it 'refuses a non-colonel' do
+    expect { logic_for(customer).raise_concerns }.to raise_error(Onetime::Forbidden)
+  end
+
+  it 'audits nothing — it is a read' do
+    status_for
+
+    expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    expect(Onetime::ColonelAuditEvent).not_to have_received(:record_security)
+  end
+
+  describe 'not elevated' do
+    it 'reports elevated false with a null expiry and no time remaining' do
+      data = status_for
+
+      expect(data[:record]).to eq(elevated: false, expires_at: nil, seconds_remaining: 0)
+    end
+
+    it 'still reports the configured window so the console can name it' do
+      expect(status_for[:details][:window]).to eq(600)
+    end
+  end
+
+  describe 'elevated' do
+    it 'reports the expiry and a positive countdown seed' do
+      data = status_for(colonel, elevated_session('ur_colonel', expires_in: 420))
+
+      expect(data[:record][:elevated]).to be true
+      expect(data[:record][:expires_at]).to be_within(5).of(Familia.now.to_i + 420)
+      expect(data[:record][:seconds_remaining]).to be_within(5).of(420)
+    end
+
+    it 'reports NOT elevated when the window belongs to another identity' do
+      data = status_for(colonel, elevated_session('ur_someone_else'))
+
+      expect(data[:record][:elevated]).to be false
+      expect(data[:record][:expires_at]).to be_nil
+    end
+  end
+
+  describe 'disabled by config' do
+    before { stub_colonel_elevation(enabled: false) }
+
+    it 'says so, so the console can hide the banner and the prompt' do
+      expect(status_for[:details][:enabled]).to be false
+    end
+  end
+
+  describe 'per-account factors' do
+    it 'offers password only for an account that has one' do
+      data = status_for
+
+      expect(data[:details][:password_available]).to be true
+      expect(data[:details][:factors]).to eq(['password'])
+      expect(data[:details][:grace_available]).to be false
+    end
+
+    it 'offers recent_auth to a password-less account once a grace is configured' do
+      stub_colonel_elevation(enabled: true, reauth_grace: 300)
+      allow(colonel).to receive(:has_passphrase?).and_return(false)
+
+      data = status_for(colonel, { 'authenticated_at' => Familia.now.to_i - 30 })
+
+      expect(data[:details][:password_available]).to be false
+      expect(data[:details][:factors]).to contain_exactly('password', 'recent_auth')
+      expect(data[:details][:grace_available]).to be true
+      expect(data[:details][:reauth_grace]).to eq(300)
+    end
+
+    it 'withholds recent_auth from a password-less account when no grace is configured' do
+      allow(colonel).to receive(:has_passphrase?).and_return(false)
+
+      data = status_for(colonel, { 'authenticated_at' => Familia.now.to_i - 30 })
+
+      expect(data[:details][:factors]).to eq(['password'])
+      expect(data[:details][:grace_available]).to be false
+      expect(data[:details][:reauth_grace]).to eq(0)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/get_session_detail_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/get_session_detail_spec.rb
@@ -1,0 +1,223 @@
+# apps/api/colonel/spec/logic/colonel/get_session_detail_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# GET /api/colonel/sessions/:session_handle used to take — and echo — the raw
+# session id, a value byte-identical to the user's `onetime.session` cookie
+# (#4330). These examples pin the boundary this adapter now owns:
+#
+#   - the route param is an opaque handle, resolved to a sid SERVER-SIDE;
+#   - neither the sid nor its Redis key (`session:<sid>`) appears anywhere in
+#     the response, and neither does the live `csrf` token in the raw payload;
+#   - an unknown OR malformed handle answers the same 404, so a scanner learns
+#     nothing from the shape of its guess;
+#   - the bounded-scan truncation is disclosed rather than hidden behind a 404;
+#   - being read-only, no path here writes a ColonelAuditEvent (CONTRACT 4).
+#
+# What this layer does NOT own: the resolution itself (Sessions::Store —
+# try/unit/operations/sessions_try.rb) and the role gate at the router.
+RSpec.describe ColonelAPI::Logic::Colonel::GetSessionDetail do
+  let(:handle) { '0123456789abcdef0123456789abcdef' }
+  let(:session_id) { 'a' * 64 }
+
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain',
+      role: 'customer', verified?: true, anonymous?: false)
+  end
+
+  let(:payload) do
+    {
+      'authenticated' => true,
+      'email' => 'alice@example.com',
+      'external_id' => 'ur_alice',
+      'account_id' => 42,
+      'role' => 'customer',
+      'locale' => 'en',
+      'ip_address' => '203.0.113.7',
+      'user_agent' => 'Mozilla/5.0',
+      'org_context:019f4ac1-b8d6-7ca9-858d-ba3d7e1e0210' => true,
+      'authenticated_at' => 1_700_000_000,
+      'authenticated_by' => ['password'],
+      'active_session_id' => 'as_1',
+      'csrf' => 'live-csrf-token',
+    }
+  end
+
+  let(:inspect_result) do
+    Onetime::Operations::Sessions::Inspect::Result.new(
+      found: true, session_id: session_id, key: "session:#{session_id}",
+      ttl: 3600, data: payload,
+    )
+  end
+
+  def strategy_result_for(user)
+    double('StrategyResult', session: {}, user: user,
+      auth_method: 'sessionauth', metadata: {})
+  end
+
+  def logic_for(user = colonel, params = { 'session_handle' => handle })
+    described_class.new(strategy_result_for(user), params)
+  end
+
+  # Resolution is stubbed at the Store boundary: this adapter owns "what the
+  # handle buys you", not the two-stage lookup itself.
+  def stub_resolution(sid: session_id, scan_capped: false)
+    allow(Onetime::Operations::Sessions::Store).to receive(:resolve_handle)
+      .and_return([sid, scan_capped])
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Familia).to receive(:dbclient).and_return(double('Redis'))
+    allow(Onetime::Operations::Sessions::Inspect).to receive(:new).and_return(
+      instance_double(Onetime::Operations::Sessions::Inspect, call: inspect_result),
+    )
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  describe 'handle resolution' do
+    it 'resolves the handle server-side and inspects the resolved sid' do
+      stub_resolution
+      logic = logic_for
+      logic.raise_concerns
+
+      expect(Onetime::Operations::Sessions::Inspect).to have_received(:new)
+        .with(session_id: session_id)
+    end
+
+    it 'passes the optional owner hint through to the resolver' do
+      stub_resolution
+      logic_for(colonel, { 'session_handle' => handle, 'user_id' => 'alice@example.com' })
+        .raise_concerns
+
+      expect(Onetime::Operations::Sessions::Store).to have_received(:resolve_handle)
+        .with(anything, handle, owner_hint: 'alice@example.com')
+    end
+
+    it 'downcases the submitted handle so a pasted uppercase value still resolves' do
+      stub_resolution
+      logic_for(colonel, { 'session_handle' => handle.upcase }).raise_concerns
+
+      expect(Onetime::Operations::Sessions::Store).to have_received(:resolve_handle)
+        .with(anything, handle, owner_hint: '')
+    end
+
+    it '404s when the handle resolves to nothing' do
+      stub_resolution(sid: nil)
+
+      expect { logic_for.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+    end
+
+    it '404s — never 422 — on a malformed handle, so a scanner cannot tell them apart' do
+      # An unparseable handle never reaches the datastore: resolve_handle
+      # rejects the shape and answers [nil, false].
+      allow(Onetime::Operations::Sessions::Store).to receive(:resolve_handle).and_call_original
+
+      expect { logic_for(colonel, { 'session_handle' => 'not-a-handle' }).raise_concerns }
+        .to raise_error(Onetime::RecordNotFound)
+    end
+
+    it '422s only when no handle was supplied at all' do
+      expect { logic_for(colonel, { 'session_handle' => '' }) }
+        .to raise_error(Onetime::FormError)
+    end
+
+    it '404s when the resolved sid has no live session' do
+      stub_resolution
+      allow(Onetime::Operations::Sessions::Inspect).to receive(:new).and_return(
+        instance_double(Onetime::Operations::Sessions::Inspect,
+          call: Onetime::Operations::Sessions::Inspect::Result.new(
+            found: false, session_id: session_id, key: nil, ttl: nil, data: nil,
+          )),
+      )
+
+      expect { logic_for.raise_concerns }.to raise_error(Onetime::RecordNotFound)
+    end
+  end
+
+  describe 'response shape' do
+    subject(:response) do
+      stub_resolution
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+    end
+
+    it 'identifies the session by handle' do
+      expect(response[:record][:session_handle]).to eq(handle)
+    end
+
+    it 'never carries the raw sid or its Redis key' do
+      expect(response[:record]).not_to have_key(:session_id)
+      expect(response[:record]).not_to have_key(:key)
+      expect(response.to_s).not_to include(session_id)
+    end
+
+    it 'strips the live csrf token out of the raw payload the drawer renders' do
+      expect(payload).to have_key('csrf') # the session really carries one
+      expect(response[:details][:data]).not_to have_key('csrf')
+      expect(response[:details][:data]['email']).to eq('alice@example.com')
+    end
+
+    it 'still surfaces the typed read-out fields' do
+      expect(response[:record]).to include(
+        ttl: 3600,
+        authenticated: true,
+        email: 'alice@example.com',
+        external_id: 'ur_alice',
+        account_id: 42,
+        org_context: '019f4ac1-b8d6-7ca9-858d-ba3d7e1e0210',
+      )
+    end
+  end
+
+  describe 'bounded-scan truncation' do
+    it 'discloses scan_capped so a 404 is not read as "does not exist"' do
+      stub_resolution(scan_capped: true)
+      logic = logic_for
+      logic.raise_concerns
+
+      expect(logic.process[:details][:scan_capped]).to be true
+    end
+
+    it 'reports false when the resolution did not hit the cap' do
+      stub_resolution
+      logic = logic_for
+      logic.raise_concerns
+
+      expect(logic.process[:details][:scan_capped]).to be false
+    end
+  end
+
+  describe 'authorization' do
+    it 'refuses a non-colonel and writes NO audit event' do
+      stub_resolution
+      logic = logic_for(customer)
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::Forbidden)
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+
+    it 'writes no audit event on the success path either — reads never audit' do
+      stub_resolution
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/override_domain_verification_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/override_domain_verification_spec.rb
@@ -12,10 +12,15 @@ RSpec.describe ColonelAPI::Logic::Colonel::OverrideDomainVerification do
       verified?: true, anonymous?: false)
   end
 
-  let(:strategy_result) do
+  # This verb bypasses DNS proof of ownership, so it requires the domain name in
+  # X-OTS-Confirm (#4326, TIER 2). `confirm_token` is where the colonel session
+  # auth strategy puts the percent-decoded header — never params.
+  def strategy_result_for(confirm_token = 'secrets.example.com')
     double('StrategyResult', session: {}, user: colonel,
-      auth_method: 'sessionauth', metadata: {})
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
+
+  let(:strategy_result) { strategy_result_for }
 
   # Mutable stand-in for Onetime::CustomDomain so mutation (or the absence
   # of mutation) is directly observable without a datastore.
@@ -60,6 +65,26 @@ RSpec.describe ColonelAPI::Logic::Colonel::OverrideDomainVerification do
     allow(OT).to receive(:li)
     allow(Onetime::CustomDomain).to receive(:find_by_extid).and_return(custom_domain)
     allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  # ---- Server-side confirmation (#4326) --------------------------------------
+
+  describe 'confirmation' do
+    let(:expected_confirm_token) { 'secrets.example.com' }
+
+    def confirmed_logic_for(confirm_token)
+      described_class.new(
+        strategy_result_for(confirm_token),
+        { 'extid' => 'cd_target', 'verified' => 'true' },
+      )
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'does not accept the extid the URL already carried' do
+      expect { confirmed_logic_for('cd_target').raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
   end
 
   describe 'success_data change indicators' do

--- a/apps/api/colonel/spec/logic/colonel/purge_dlq_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/purge_dlq_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::PurgeDlq do
 
   # `confirm_token` is where the colonel session auth strategy puts the
   # percent-decoded X-OTS-Confirm header — never params.
-  def strategy_result_for(user, confirm_token)
-    double('StrategyResult', session: {}, user: user,
+  def strategy_result_for(user, confirm_token, session = {})
+    double('StrategyResult', session: session, user: user,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
@@ -79,6 +79,20 @@ RSpec.describe ColonelAPI::Logic::Colonel::PurgeDlq do
       expect { logic_for(colonel, nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
       expect(Onetime::Operations::Dlq::Purge).not_to have_received(:new)
     end
+  end
+
+  # ---- Step-up (sudo) window (#4327) -----------------------------------------
+  describe 'elevation' do
+    let(:expected_confirm_token) { short_name }
+
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      described_class.new(
+        strategy_result_for(colonel, confirm_token, session),
+        { 'queue' => short_name },
+      )
+    end
+
+    it_behaves_like 'an elevated colonel action'
   end
 
   describe 'preview exemption' do

--- a/apps/api/colonel/spec/logic/colonel/purge_dlq_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/purge_dlq_spec.rb
@@ -1,0 +1,130 @@
+# apps/api/colonel/spec/logic/colonel/purge_dlq_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# POST /api/colonel/queues/dlq/:queue/purge — irreversible message loss, TIER 1.
+#
+# The ONE gated verb whose confirmation token IS the URL parameter: a queue has
+# no second identifier (no email, no display name, no hostname). That is stated
+# plainly rather than dressed up as replay resistance it does not provide.
+#
+# `dry_run` defaults to FALSE here — the opposite of the domain/org verbs — so
+# the preview exemption is worth pinning in both directions.
+RSpec.describe ColonelAPI::Logic::Colonel::PurgeDlq do
+  let(:queue) { Onetime::Operations::Dlq::Store.all_dlq_names.first }
+  let(:short_name) { queue.sub('dlq.', '') }
+
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain',
+      role: 'customer', verified?: true, anonymous?: false)
+  end
+
+  let(:op) do
+    instance_double(
+      Onetime::Operations::Dlq::Purge,
+      call: Onetime::Operations::Dlq::Purge::Result.new(
+        status: :purged, queue: queue, count: 3, purged: 3,
+      ),
+    )
+  end
+
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header — never params.
+  def strategy_result_for(user, confirm_token)
+    double('StrategyResult', session: {}, user: user,
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
+  end
+
+  def logic_for(user = colonel, confirm_token = short_name, params = {})
+    described_class.new(
+      strategy_result_for(user, confirm_token),
+      { 'queue' => short_name }.merge(params),
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::Operations::Dlq::Purge).to receive(:new).and_return(op)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+    # The adapter's broker-availability guard reads the shared boot-time
+    # connection; a real broker is a tryout's job, not a unit spec's.
+    $rmq_conn = double('BunnyConnection', open?: true)
+  end
+
+  after { $rmq_conn = nil }
+
+  describe 'confirmation (#4326)' do
+    let(:expected_confirm_token) { short_name }
+
+    def confirmed_logic_for(confirm_token)
+      logic_for(colonel, confirm_token)
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'purges nothing when the confirmation is refused' do
+      expect { logic_for(colonel, nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+      expect(Onetime::Operations::Dlq::Purge).not_to have_received(:new)
+    end
+  end
+
+  describe 'preview exemption' do
+    let(:preview_op) do
+      instance_double(
+        Onetime::Operations::Dlq::Purge,
+        call: Onetime::Operations::Dlq::Purge::Result.new(
+          status: :dry_run, queue: queue, count: 3, purged: 0,
+        ),
+      )
+    end
+
+    it 'needs no confirmation for a dry run (it counts, it does not purge)' do
+      allow(Onetime::Operations::Dlq::Purge).to receive(:new).and_return(preview_op)
+      logic = logic_for(colonel, nil, 'dry_run' => 'true')
+
+      expect { logic.raise_concerns }.not_to raise_error
+      expect(logic.process[:record][:dry_run]).to be true
+    end
+
+    it 'still requires it when dry_run is absent (this verb defaults to APPLY)' do
+      expect { logic_for(colonel, nil).raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
+  end
+
+  describe 'guard order (§0.2)' do
+    it 'rejects an unknown queue BEFORE the confirmation gate (allowlist, not secret)' do
+      expect { logic_for(colonel, nil, 'queue' => 'not-a-queue').raise_concerns }
+        .to raise_error(Onetime::RecordNotFound, /Unknown dead-letter queue/)
+    end
+
+    it 'rejects a non-colonel before either' do
+      expect { logic_for(customer, nil).raise_concerns }.to raise_error(Onetime::Forbidden)
+    end
+  end
+
+  describe 'the happy path still works' do
+    it 'hands the op the resolved queue name and the colonel extid' do
+      logic = logic_for
+      logic.raise_concerns
+      data = logic.process
+
+      expect(Onetime::Operations::Dlq::Purge).to have_received(:new)
+        .with(hash_including(queue: queue, actor: 'ur_colonel', dry_run: false))
+      expect(data[:record][:purged]).to eq(3)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/purge_user_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/purge_user_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ColonelAPI::Logic::Colonel::PurgeUser do
   let(:target) do
     instance_double(Onetime::Customer,
       objid: 'cust_target', extid: 'ur_target', email: 'victim@example.com',
-      exists?: true, anonymous?: false)
+      role: 'customer', exists?: true, anonymous?: false)
   end
 
   let(:purge_result) do
@@ -137,6 +137,52 @@ RSpec.describe ColonelAPI::Logic::Colonel::PurgeUser do
 
       expect { logic_for.raise_concerns }
         .to raise_error(Onetime::FormError, /Cannot purge your own account/)
+    end
+  end
+
+  # ---- Last active colonel interlock (#4328 follow-up) -----------------------
+  #
+  # Purging the last active colonel deletes the last administrator. Purge is
+  # irreversible, so this is a PRE-CHECK (no post-write rollback like the demote/
+  # unverify verbs). An unverified colonel-role target is not an active colonel,
+  # so purging it is allowed.
+  describe 'last active colonel' do
+    let(:colonel_victim) do
+      instance_double(Onetime::Customer,
+        objid: 'cust_last', extid: 'ur_last', email: 'boss@example.com',
+        role: 'colonel', verified?: true, exists?: true, anonymous?: false)
+    end
+
+    def purge_colonel_logic(victim = colonel_victim, confirm = 'boss@example.com')
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(victim)
+      allow(Onetime::Customer).to receive(:load).and_return(victim)
+      described_class.new(strategy_result_for(colonel, confirm), { 'user_id' => victim.extid })
+    end
+
+    it 'refuses purging the last active colonel and purges nothing' do
+      allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel').and_return([colonel_victim])
+
+      expect { purge_colonel_logic.raise_concerns }
+        .to raise_error(Onetime::FormError, /last active colonel/i)
+      expect(Auth::Operations::Customers::Purge).not_to have_received(:new)
+    end
+
+    it 'allows purging a colonel when a second verified colonel exists' do
+      second = instance_double(Onetime::Customer,
+        objid: 'cust_second', role: 'colonel', verified?: true, exists?: true)
+      allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel')
+        .and_return([colonel_victim, second])
+
+      expect { purge_colonel_logic.raise_concerns }.not_to raise_error
+    end
+
+    it 'allows purging an UNVERIFIED colonel-role account (not an active colonel)' do
+      unverified = instance_double(Onetime::Customer,
+        objid: 'cust_unver', extid: 'ur_unver', email: 'stale@example.com',
+        role: 'colonel', verified?: false, exists?: true, anonymous?: false)
+
+      # verified? == false short-circuits before any roster read.
+      expect { purge_colonel_logic(unverified, 'stale@example.com').raise_concerns }.not_to raise_error
     end
   end
 

--- a/apps/api/colonel/spec/logic/colonel/purge_user_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/purge_user_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::PurgeUser do
 
   # `confirm_token` is where the colonel session auth strategy puts the
   # percent-decoded X-OTS-Confirm header (#4326) — never params.
-  def strategy_result_for(user, confirm_token = 'victim@example.com')
-    double('StrategyResult', session: {}, user: user,
+  def strategy_result_for(user, confirm_token = 'victim@example.com', session = {})
+    double('StrategyResult', session: session, user: user,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
@@ -88,6 +88,37 @@ RSpec.describe ColonelAPI::Logic::Colonel::PurgeUser do
     it 'purges nothing when the confirmation is refused' do
       expect { logic_for(colonel, nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
       expect(Auth::Operations::Customers::Purge).not_to have_received(:new)
+    end
+  end
+
+  # ---- Step-up (sudo) window (#4327) -----------------------------------------
+  describe 'elevation' do
+    let(:expected_confirm_token) { 'victim@example.com' }
+
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      described_class.new(
+        strategy_result_for(colonel, confirm_token, session),
+        { 'user_id' => 'ur_target' },
+      )
+    end
+
+    it_behaves_like 'an elevated colonel action'
+
+    it 'purges nothing when the elevation is refused' do
+      stub_colonel_elevation(enabled: true)
+
+      expect { elevated_logic_for({}).raise_concerns }.to raise_error(Onetime::ElevationRequired)
+      expect(Auth::Operations::Customers::Purge).not_to have_received(:new)
+    end
+
+    # An unelevated caller must not reach the self-target interlock either: it
+    # is the last of the three refusals in the guard order, and its 422 is the
+    # "is this account me?" oracle §0.2 moved behind proof.
+    it 'answers the elevation refusal, not the self-target refusal, when both apply' do
+      stub_colonel_elevation(enabled: true)
+      allow(target).to receive(:objid).and_return('cust_colonel')
+
+      expect { elevated_logic_for({}).raise_concerns }.to raise_error(Onetime::ElevationRequired)
     end
   end
 

--- a/apps/api/colonel/spec/logic/colonel/purge_user_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/purge_user_spec.rb
@@ -1,0 +1,139 @@
+# apps/api/colonel/spec/logic/colonel/purge_user_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# DELETE /api/colonel/users/:user_id — the single most destructive colonel verb.
+#
+# This adapter owns HTTP concerns only: it resolves the target, refuses the
+# obviously-wrong targets, gates the request on the #4326 confirmation, and hands
+# the customer to Auth::Operations::Customers::Purge, which owns the teardown AND
+# the ColonelAuditEvent (CONTRACT 4 — this class never audits).
+#
+# What these examples pin, beyond the shared confirmation contract:
+#
+#   - the confirmation token is the account's EMAIL, an identifier the URL (an
+#     extid) does not carry, so a scraped-URL replay needs a second fact;
+#   - the self-target interlock runs AFTER the confirmation gate (guard order
+#     §0.2): its 422 must not tell an un-confirmed caller whether the account
+#     they named is their own.
+RSpec.describe ColonelAPI::Logic::Colonel::PurgeUser do
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel', email: 'colonel@example.com',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain',
+      role: 'customer', verified?: true, anonymous?: false)
+  end
+
+  let(:target) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_target', extid: 'ur_target', email: 'victim@example.com',
+      exists?: true, anonymous?: false)
+  end
+
+  let(:purge_result) do
+    instance_double(Auth::Operations::Customers::Purge::Result, status: :success)
+  end
+
+  let(:op) { instance_double(Auth::Operations::Customers::Purge, call: purge_result) }
+
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header (#4326) — never params.
+  def strategy_result_for(user, confirm_token = 'victim@example.com')
+    double('StrategyResult', session: {}, user: user,
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
+  end
+
+  def logic_for(user = colonel, confirm_token = 'victim@example.com')
+    described_class.new(strategy_result_for(user, confirm_token), { 'user_id' => 'ur_target' })
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(target)
+    allow(Onetime::Customer).to receive(:load).and_return(target)
+    allow(Auth::Operations::Customers::Purge).to receive(:new).and_return(op)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  describe 'confirmation (#4326)' do
+    let(:expected_confirm_token) { 'victim@example.com' }
+
+    def confirmed_logic_for(confirm_token)
+      logic_for(colonel, confirm_token)
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'does not accept the extid the URL already carried' do
+      expect { logic_for(colonel, 'ur_target').raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
+
+    it 'falls back to the extid for an account with no email address' do
+      allow(target).to receive(:email).and_return('')
+      expect { logic_for(colonel, 'ur_target').raise_concerns }.not_to raise_error
+    end
+
+    it 'purges nothing when the confirmation is refused' do
+      expect { logic_for(colonel, nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+      expect(Auth::Operations::Customers::Purge).not_to have_received(:new)
+    end
+  end
+
+  describe 'guard order (§0.2): interlocks run after proof' do
+    # The self-target 422 is interlock state. Reaching it without a valid
+    # confirmation would turn purge into a free "is this account me?" oracle.
+    it 'answers the confirmation refusal, not the self-target refusal, when both apply' do
+      allow(target).to receive(:objid).and_return('cust_colonel')
+
+      expect { logic_for(colonel, nil).raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
+
+    it 'still refuses a confirmed self-purge with a 422' do
+      allow(target).to receive(:objid).and_return('cust_colonel')
+
+      expect { logic_for.raise_concerns }
+        .to raise_error(Onetime::FormError, /Cannot purge your own account/)
+    end
+  end
+
+  describe 'authorization' do
+    it 'refuses a non-colonel before anything else, and writes NO audit event' do
+      expect { logic_for(customer).raise_concerns }.to raise_error(Onetime::Forbidden)
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+
+  describe 'the happy path still works' do
+    it 'hands the op the resolved customer and the acting colonel extid' do
+      logic = logic_for
+      logic.raise_concerns
+      data = logic.process
+
+      expect(Auth::Operations::Customers::Purge).to have_received(:new)
+        .with(hash_including(customer: target, actor: 'ur_colonel'))
+      expect(data[:record][:deleted]).to be true
+      expect(data[:record][:extid]).to eq('ur_target')
+    end
+
+    it 'records no audit event of its own (the op owns the trail)' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/rate_limit_hook_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/rate_limit_hook_spec.rb
@@ -1,0 +1,168 @@
+# apps/api/colonel/spec/logic/colonel/rate_limit_hook_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# The broad colonel:mutation charge (#4329), which lives in
+# ColonelAPI::Logic::Base#initialize rather than in raise_concerns.
+#
+# WHY THE CONSTRUCTOR: none of the ~86 concrete colonel logic classes call
+# `super` in raise_concerns, so a base-class hook there would be silently
+# skipped, and covering 46 mutating verbs one file at a time is exactly the
+# maintenance shape that leaves the 47th uncovered. By construction time Otto has
+# already enforced role=colonel, so `cust` is the authenticated colonel — this is
+# a budget charge on an authenticated request, not a pre-auth guard, and it is
+# self-gated on has_system_role? so it can never charge an anonymous caller.
+#
+# What these examples own: WHICH requests are charged and with WHAT subject. The
+# limiter body itself (key shapes, TTLs, the lockout, the audit write) is proven
+# against real Redis in try/unit/security/colonel_rate_limiter_try.rb.
+#
+# The test subclass overrides `enforce_colonel_mutation_limit!` with a recorder,
+# so these examples touch no datastore — the colonel unit suite runs without
+# Redis and must keep doing so.
+#
+# RUN:
+#   RACK_ENV=test bundle exec rspec \
+#     apps/api/colonel/spec/logic/colonel/rate_limit_hook_spec.rb
+RSpec.describe ColonelAPI::Logic::Base do
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel', email: 'colonel@example.com',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain',
+      role: 'customer', verified?: true, anonymous?: false)
+  end
+
+  # Every subject the hook passed to the limiter, in call order.
+  let(:charged) { [] }
+
+  # A minimal concrete colonel logic class. Anonymous so it cannot drift with any
+  # one endpoint's params, and so the examples describe the BASE contract rather
+  # than one verb's.
+  let(:logic_class) do
+    log = charged
+    Class.new(described_class) do
+      define_method(:enforce_colonel_mutation_limit!) { |subject| log << subject }
+      def process_params; end
+    end
+  end
+
+  # `request_method` is what the colonel session auth strategy puts in the
+  # strategy metadata (logic classes never see the Rack env). `:absent` means the
+  # key was never merged — every pre-#4329 spec double, and any non-HTTP caller.
+  def build(user: colonel, request_method: 'POST')
+    metadata = { confirm_token: nil }
+    metadata[:request_method] = request_method unless request_method == :absent
+
+    logic_class.new(
+      double('StrategyResult', session: {}, user: user, auth_method: 'sessionauth', metadata: metadata),
+      {},
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+  end
+
+  describe 'which requests are charged' do
+    %w[POST PUT PATCH DELETE].each do |method|
+      it "charges one unit for a #{method}" do
+        build(request_method: method)
+        expect(charged).to eq(['ur_colonel'])
+      end
+    end
+
+    # The console fetches several reads on every screen; a limiter there would
+    # break the dashboard. The two handle-resolving session reads are the one
+    # exception and charge their OWN bucket, explicitly, in their own classes.
+    %w[GET HEAD OPTIONS].each do |method|
+      it "charges nothing for a #{method}" do
+        build(request_method: method)
+        expect(charged).to be_empty
+      end
+    end
+
+    it 'is case-insensitive about the method' do
+      build(request_method: 'delete')
+      expect(charged).to eq(['ur_colonel'])
+    end
+  end
+
+  describe 'who is charged' do
+    it 'keys on the acting colonel PUBLIC extid, never an objid' do
+      build
+      expect(charged).to eq(['ur_colonel'])
+      expect(charged).not_to include('cust_colonel')
+    end
+
+    # Otto rejects a non-colonel before a logic class is built, so this is a
+    # belt-and-braces gate: the charge must never be reachable by an identity
+    # the router would not have admitted, and must never mint a bucket for one.
+    it 'charges nothing when the caller does not hold the colonel role' do
+      build(user: customer)
+      expect(charged).to be_empty
+    end
+
+    it 'charges nothing for an anonymous (nil) caller' do
+      build(user: nil)
+      expect(charged).to be_empty
+    end
+
+    # has_system_role? refuses every elevated role to an unverified account
+    # (defence in depth, authorization_policies.rb).
+    it 'charges nothing for an unverified colonel' do
+      unverified = instance_double(Onetime::Customer,
+        objid: 'cust_x', extid: 'ur_x', role: 'colonel', verified?: false, anonymous?: false)
+
+      build(user: unverified)
+      expect(charged).to be_empty
+    end
+  end
+
+  describe 'metadata robustness' do
+    # Every colonel spec written before #4329 builds a bare double whose metadata
+    # carries no request_method. Reading that as "not a mutation" is the right
+    # answer for a caller that did not come through the router, and it must not
+    # raise.
+    it 'charges nothing and does not raise when request_method is absent' do
+      expect { build(request_method: :absent) }.not_to raise_error
+      expect(charged).to be_empty
+    end
+
+    it 'charges nothing and does not raise when request_method is nil' do
+      expect { build(request_method: nil) }.not_to raise_error
+      expect(charged).to be_empty
+    end
+  end
+
+  describe 'wiring' do
+    it 'gives every colonel logic class the four limiter entry points' do
+      expect(described_class.ancestors).to include(Onetime::Security::ColonelRateLimiter)
+      expect(described_class.instance_methods).to include(
+        :enforce_colonel_mutation_limit!,
+        :enforce_colonel_destructive_limit!,
+        :enforce_colonel_handle_resolve_limit!,
+        :enforce_colonel_elevation_limit!,
+      )
+    end
+
+    # The guard-order contract keeps the destructive charge as a SEPARATE call,
+    # the last line of raise_concerns — never folded into the constructor hook.
+    # A destructive verb therefore charges two buckets, which is intended.
+    it 'does not charge the destructive bucket from the constructor' do
+      instance = build
+      expect(instance).to respond_to(:charge_destructive_budget!)
+      expect(charged).to eq(['ur_colonel'])
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/reset_rate_limit_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/reset_rate_limit_spec.rb
@@ -1,0 +1,127 @@
+# apps/api/colonel/spec/logic/colonel/reset_rate_limit_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# POST /api/colonel/ratelimit/reset — removes an active defence, so TIER 2
+# (#4326). The op owns the delete and the single ColonelAuditEvent.
+#
+# The confirmation token is COMPOSED: "<kind>:<subject>". That composition is
+# only safe because the two required-field guards run first — an empty kind and
+# subject would compose the non-blank string ":" and slip past the
+# blank-expected tripwire in require_confirmation!. The unreachability of that
+# case is asserted here explicitly, because it is a property of the ORDER of two
+# statements and nothing else would catch a reordering.
+RSpec.describe ColonelAPI::Logic::Colonel::ResetRateLimit do
+  let(:kind) { Onetime::Operations::RateLimit::Registry::LIMITERS.keys.first }
+  let(:subject_id) { 'ur_target' }
+
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain',
+      role: 'customer', verified?: true, anonymous?: false)
+  end
+
+  let(:op) do
+    instance_double(
+      Onetime::Operations::RateLimit::Reset,
+      call: Onetime::Operations::RateLimit::Reset::Result.new(
+        status: :success, kind: kind, subject: subject_id, keys: ['k'], deleted: 1,
+      ),
+    )
+  end
+
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header — never params.
+  def strategy_result_for(user, confirm_token)
+    double('StrategyResult', session: {}, user: user,
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
+  end
+
+  def logic_for(user = colonel, confirm_token = nil, params = {})
+    described_class.new(
+      strategy_result_for(user, confirm_token || "#{kind}:#{subject_id}"),
+      { 'kind' => kind, 'subject' => subject_id }.merge(params),
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::Operations::RateLimit::Reset).to receive(:new).and_return(op)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  describe 'confirmation (#4326)' do
+    let(:expected_confirm_token) { "#{kind}:#{subject_id}" }
+
+    def confirmed_logic_for(confirm_token)
+      described_class.new(
+        strategy_result_for(colonel, confirm_token),
+        { 'kind' => kind, 'subject' => subject_id },
+      )
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'does not accept either half on its own' do
+      expect { confirmed_logic_for(kind).raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+      expect { confirmed_logic_for(subject_id).raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
+
+    it 'resets nothing when the confirmation is refused' do
+      expect { confirmed_logic_for(nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+      expect(Onetime::Operations::RateLimit::Reset).not_to have_received(:new)
+    end
+  end
+
+  describe 'the composed token can never be a bare ":"' do
+    # Both halves are required BEFORE the guard runs, so `":"` — which is
+    # non-blank and would therefore pass the guard's blank-expected tripwire —
+    # is unreachable. These two examples are what keeps that ordering honest.
+    it 'refuses a blank kind with a 422, before the guard' do
+      expect { logic_for(colonel, ':', 'kind' => '').raise_concerns }
+        .to raise_error(Onetime::FormError, /Limiter kind is required/)
+    end
+
+    it 'refuses a blank subject with a 422, before the guard' do
+      expect { logic_for(colonel, ':', 'subject' => '').raise_concerns }
+        .to raise_error(Onetime::FormError, /Subject is required/)
+    end
+  end
+
+  describe 'guard order (§0.2)' do
+    it 'rejects an unknown limiter kind BEFORE the confirmation gate' do
+      expect { logic_for(colonel, 'nope:ur_target', 'kind' => 'not-a-limiter').raise_concerns }
+        .to raise_error(Onetime::RecordNotFound, /Unknown rate limiter/)
+    end
+
+    it 'rejects a non-colonel before either' do
+      expect { logic_for(customer).raise_concerns }.to raise_error(Onetime::Forbidden)
+    end
+  end
+
+  describe 'the happy path still works' do
+    it 'hands the op the kind, subject and the acting colonel extid' do
+      logic = logic_for
+      logic.raise_concerns
+      data = logic.process
+
+      expect(Onetime::Operations::RateLimit::Reset).to have_received(:new)
+        .with(hash_including(kind: kind, subject: subject_id, actor: 'ur_colonel'))
+      expect(data[:record][:cleared]).to be true
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/reset_rate_limit_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/reset_rate_limit_spec.rb
@@ -113,6 +113,39 @@ RSpec.describe ColonelAPI::Logic::Colonel::ResetRateLimit do
     end
   end
 
+  # A leaked colonel cookie must not clear its OWN colonel_* lockout in a loop
+  # (#4329 review): colonel_elevation is the sole step-up brute-force backstop,
+  # colonel_destructive bounds the audit-cap window. Self-recovery is CLI-only;
+  # peer and non-colonel resets stay reachable over HTTP for operator recovery.
+  describe 'self-reset of a colonel_* limiter is refused over HTTP (#4329 review)' do
+    def reset_logic(reset_kind, reset_subject)
+      described_class.new(
+        strategy_result_for(colonel, "#{reset_kind}:#{reset_subject}"),
+        { 'kind' => reset_kind, 'subject' => reset_subject },
+      )
+    end
+
+    %w[colonel_elevation colonel_destructive colonel_mutation].each do |colonel_kind|
+      it "refuses resetting #{colonel_kind} for the caller's OWN extid" do
+        expect { reset_logic(colonel_kind, 'ur_colonel').raise_concerns }
+          .to raise_error(Onetime::FormError, /clear your own colonel rate limiter/i)
+        expect(Onetime::Operations::RateLimit::Reset).not_to have_received(:new)
+      end
+
+      it "ALLOWS resetting #{colonel_kind} for a PEER colonel (operator recovery)" do
+        expect { reset_logic(colonel_kind, 'ur_peer').raise_concerns }.not_to raise_error
+      end
+    end
+
+    it 'ALLOWS a colonel to reset a NON-colonel limiter for their own extid' do
+      non_colonel = Onetime::Operations::RateLimit::Registry::LIMITERS.keys
+        .reject { |k| k.start_with?('colonel_') }.first
+      skip 'no non-colonel limiter registered' unless non_colonel
+
+      expect { reset_logic(non_colonel, 'ur_colonel').raise_concerns }.not_to raise_error
+    end
+  end
+
   describe 'the happy path still works' do
     it 'hands the op the kind, subject and the acting colonel extid' do
       logic = logic_for

--- a/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
@@ -9,10 +9,11 @@ require 'colonel/logic'
 # EVERY device, so TIER 1 (#4326).
 #
 # This adapter is deliberately thin: Onetime::Operations::Sessions::RevokeAllForCustomer
-# owns the purge and the single ColonelAuditEvent (CONTRACT 4). The account is
-# resolved here ONLY to name the confirmation token — it is not (yet) a 404
-# guard, because the op is idempotent on an unknown custid. P4 (#4328) adds the
-# existence check and the self-target interlock between that resolve and the gate.
+# owns the purge and the single ColonelAuditEvent (CONTRACT 4). Since #4328 the
+# account is resolved as a real 404 guard (an unknown identifier used to return
+# zero counts, which reads as "done" for a typo), and a SELF-TARGET request is
+# routed to RevokeAllForCustomerExceptCurrent rather than refused — killing your
+# own other sessions is the first containment step for a leaked colonel cookie.
 RSpec.describe ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions do
   let(:colonel) do
     instance_double(Onetime::Customer,
@@ -83,13 +84,16 @@ RSpec.describe ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions do
       expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
     end
 
-    # The expected token must never be blank — that is a 500 by design — so an
-    # identifier that resolves to nothing falls back to what the caller sent.
-    it 'falls back to the submitted identifier when the account does not resolve' do
+    # #4328 replaced P2's "fall back to the submitted identifier" with a real
+    # 404: an unresolvable target now stops at guard-order step 2, BEFORE the
+    # confirmation gate, so there is no expected token to name at all.
+    it '404s before the gate when the account does not resolve' do
       allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(nil)
       allow(Onetime::Customer).to receive(:load).and_return(nil)
 
-      expect { logic_for(colonel, 'ur_target').raise_concerns }.not_to raise_error
+      expect { logic_for(colonel, 'ur_target').raise_concerns }
+        .to raise_error(Onetime::RecordNotFound)
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
     end
   end
 
@@ -111,6 +115,96 @@ RSpec.describe ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions do
     it 'refuses a non-colonel and writes NO audit event' do
       expect { logic_for(customer, nil).raise_concerns }.to raise_error(Onetime::Forbidden)
       expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+
+  # ---- Self-target containment (#4328) ---------------------------------------
+  #
+  # Deliberately NOT a refusal (design M-6): "kill all my sessions" is the first
+  # containment step for a leaked colonel cookie, so refusing it would remove
+  # the operator's only in-console remedy for the compromise they are
+  # containing. It routes to the except-current op instead.
+  describe 'self-target' do
+    let(:self_target) do
+      instance_double(Onetime::Customer,
+        objid: 'cust_colonel', extid: 'ur_colonel', email: 'colonel@example.com',
+        exists?: true, anonymous?: false)
+    end
+
+    let(:except_op) do
+      instance_double(
+        Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent,
+        call: Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent::Result.new(
+          revoked: true, blobs_deleted: 3, untracked_deleted: 1, scan_capped: false,
+        ),
+      )
+    end
+
+    # A Rack SessionId: #public_id is the cookie value the ops key on.
+    let(:rack_session_id) { double('SessionId', public_id: 'a' * 64) }
+
+    def self_logic(session_id = rack_session_id)
+      described_class.new(
+        double('StrategyResult',
+          session: double('Session', id: session_id),
+          user: colonel, auth_method: 'sessionauth',
+          metadata: { confirm_token: 'colonel@example.com' }),
+        { 'user_id' => 'ur_colonel' },
+      )
+    end
+
+    before do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(self_target)
+      allow(Onetime::Customer).to receive(:load).and_return(self_target)
+      allow(Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent)
+        .to receive(:new).and_return(except_op)
+    end
+
+    it 'routes to the except-current op, excluding this request session' do
+      logic = self_logic
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent)
+        .to have_received(:new).with(hash_including(
+          custid: 'ur_colonel', except_session_id: 'a' * 64, actor: 'ur_colonel',
+        ))
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
+    end
+
+    it 'tells the operator their current session was kept' do
+      logic = self_logic
+      logic.raise_concerns
+
+      expect(logic.process[:details][:message]).to eq(described_class::SELF_TARGET_MESSAGE)
+    end
+
+    it 'reports zero rodauth rows (the except-current op is Redis-only)' do
+      logic = self_logic
+      logic.raise_concerns
+
+      expect(logic.process[:record][:rodauth_rows_deleted]).to eq(0)
+    end
+
+    # Fail safe: with no identifiable current session the except-current op
+    # would spare nothing and sign the operator out of the console.
+    it '422s rather than self-revoking when the current sid cannot be resolved' do
+      logic = self_logic(nil)
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::FormError, /no identifiable session/)
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent)
+        .not_to have_received(:new)
+    end
+
+    # M-2 oracle guard: the fail-safe 422 must never be reachable without proof.
+    it 'answers 403 (not the 422) when the confirmation is missing' do
+      logic = described_class.new(
+        double('StrategyResult', session: double('Session', id: nil), user: colonel,
+          auth_method: 'sessionauth', metadata: { confirm_token: nil }),
+        { 'user_id' => 'ur_colonel' },
+      )
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
     end
   end
 

--- a/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
@@ -44,8 +44,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions do
 
   # `confirm_token` is where the colonel session auth strategy puts the
   # percent-decoded X-OTS-Confirm header — never params.
-  def strategy_result_for(user, confirm_token = 'victim@example.com')
-    double('StrategyResult', session: {}, user: user,
+  def strategy_result_for(user, confirm_token = 'victim@example.com', session = {})
+    double('StrategyResult', session: session, user: user,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
@@ -91,6 +91,20 @@ RSpec.describe ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions do
 
       expect { logic_for(colonel, 'ur_target').raise_concerns }.not_to raise_error
     end
+  end
+
+  # ---- Step-up (sudo) window (#4327) -----------------------------------------
+  describe 'elevation' do
+    let(:expected_confirm_token) { 'victim@example.com' }
+
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      described_class.new(
+        strategy_result_for(colonel, confirm_token, session),
+        { 'user_id' => 'ur_target' },
+      )
+    end
+
+    it_behaves_like 'an elevated colonel action'
   end
 
   describe 'authorization' do

--- a/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
@@ -1,0 +1,122 @@
+# apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# POST /api/colonel/users/:user_id/sessions/revoke-all — logs a customer out of
+# EVERY device, so TIER 1 (#4326).
+#
+# This adapter is deliberately thin: Onetime::Operations::Sessions::RevokeAllForCustomer
+# owns the purge and the single ColonelAuditEvent (CONTRACT 4). The account is
+# resolved here ONLY to name the confirmation token — it is not (yet) a 404
+# guard, because the op is idempotent on an unknown custid. P4 (#4328) adds the
+# existence check and the self-target interlock between that resolve and the gate.
+RSpec.describe ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions do
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain',
+      role: 'customer', verified?: true, anonymous?: false)
+  end
+
+  let(:target) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_target', extid: 'ur_target', email: 'victim@example.com',
+      exists?: true, anonymous?: false)
+  end
+
+  let(:op) do
+    instance_double(
+      Onetime::Operations::Sessions::RevokeAllForCustomer,
+      call: Onetime::Operations::Sessions::RevokeAllForCustomer::Result.new(
+        revoked: true, blobs_deleted: 2, untracked_deleted: 0,
+        rodauth_rows_deleted: 0, scan_capped: false,
+      ),
+    )
+  end
+
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header — never params.
+  def strategy_result_for(user, confirm_token = 'victim@example.com')
+    double('StrategyResult', session: {}, user: user,
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
+  end
+
+  def logic_for(user = colonel, confirm_token = 'victim@example.com')
+    described_class.new(strategy_result_for(user, confirm_token), { 'user_id' => 'ur_target' })
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(target)
+    allow(Onetime::Customer).to receive(:load).and_return(target)
+    allow(Onetime::Operations::Sessions::RevokeAllForCustomer).to receive(:new).and_return(op)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  describe 'confirmation (#4326)' do
+    let(:expected_confirm_token) { 'victim@example.com' }
+
+    def confirmed_logic_for(confirm_token)
+      logic_for(colonel, confirm_token)
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'does not accept the extid the URL already carried' do
+      expect { logic_for(colonel, 'ur_target').raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
+
+    it 'revokes nothing when the confirmation is refused' do
+      expect { logic_for(colonel, nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
+    end
+
+    # The expected token must never be blank — that is a 500 by design — so an
+    # identifier that resolves to nothing falls back to what the caller sent.
+    it 'falls back to the submitted identifier when the account does not resolve' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(nil)
+      allow(Onetime::Customer).to receive(:load).and_return(nil)
+
+      expect { logic_for(colonel, 'ur_target').raise_concerns }.not_to raise_error
+    end
+  end
+
+  describe 'authorization' do
+    it 'refuses a non-colonel and writes NO audit event' do
+      expect { logic_for(customer, nil).raise_concerns }.to raise_error(Onetime::Forbidden)
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+
+  describe 'the happy path still works' do
+    it 'hands the op the custid and the acting colonel extid' do
+      logic = logic_for
+      logic.raise_concerns
+      data = logic.process
+
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new)
+        .with(hash_including(custid: 'ur_target', actor: 'ur_colonel'))
+      expect(data[:record][:blobs_deleted]).to eq(2)
+    end
+
+    it 'records no audit event of its own (the op owns the trail)' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/revoke_customer_session_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/revoke_customer_session_spec.rb
@@ -1,0 +1,190 @@
+# apps/api/colonel/spec/logic/colonel/revoke_customer_session_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# DELETE /api/colonel/users/:user_id/sessions/:session_handle — the per-customer
+# twin of the global DeleteSession, and TIER 1 like it.
+#
+# This adapter owns HTTP concerns only: it resolves the non-bearer handle back to
+# a sid by recomputing handles over the OWNING customer's own active-session set
+# (so an untrusted handle can only ever name one of that customer's sessions, and
+# the raw sid never leaves the server), then hands the sid to
+# Onetime::Operations::Sessions::RevokeForCustomer, which owns the mutation and
+# the ColonelAuditEvent (CONTRACT 4).
+#
+# The examples here pin the two guards this file gained in the hardening epic:
+# the confirmation + elevation gate (#4326/#4327) and the self-revoke interlock
+# (#4328), which runs AFTER them so its 422 is not a free "is this handle mine?"
+# oracle for a caller holding nothing but the cookie.
+RSpec.describe ColonelAPI::Logic::Colonel::RevokeCustomerSession do
+  let(:target_sid) { 'b' * 64 }
+  let(:own_sid)    { 'c' * 64 }
+  let(:handle)     { Onetime::SessionMetadata.handle_for(target_sid) }
+  let(:own_handle) { Onetime::SessionMetadata.handle_for(own_sid) }
+
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain',
+      role: 'customer', verified?: true, anonymous?: false)
+  end
+
+  let(:owner) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_owner', extid: 'ur_owner', email: 'owner@example.com',
+      exists?: true, anonymous?: false, active_sessions: active_sessions)
+  end
+
+  # Customer#active_sessions is a sorted set; the adapter reads it with
+  # revrange(0, -1) and matches by recomputed handle.
+  let(:active_sessions) { double('SortedSet', revrange: [target_sid, own_sid]) }
+
+  let(:op) do
+    instance_double(
+      Onetime::Operations::Sessions::RevokeForCustomer,
+      call: Onetime::Operations::Sessions::RevokeForCustomer::Result.new(
+        session_id: target_sid, revoked: true, blob_deleted: true,
+      ),
+    )
+  end
+
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header — never params. `session_id` is the
+  # acting colonel's OWN request session (a Rack SessionId; #public_id is the
+  # cookie value), which is what the self-revoke interlock digests.
+  def strategy_result_for(user, confirm_token = 'owner@example.com', session_id: nil, session: nil)
+    sess = session || double('Session', id: session_id && double('SessionId', public_id: session_id))
+    double('StrategyResult', session: sess, user: user,
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
+  end
+
+  def logic_for(user = colonel, confirm_token = 'owner@example.com',
+                target_handle = handle, session_id: nil)
+    described_class.new(
+      strategy_result_for(user, confirm_token, session_id: session_id),
+      { 'user_id' => 'ur_owner', 'session_handle' => target_handle },
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(owner)
+    allow(Onetime::Customer).to receive(:load).and_return(owner)
+    allow(Onetime::Operations::Sessions::RevokeForCustomer).to receive(:new).and_return(op)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  describe 'confirmation (#4326)' do
+    let(:expected_confirm_token) { 'owner@example.com' }
+
+    def confirmed_logic_for(confirm_token)
+      logic_for(colonel, confirm_token)
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'does not accept the opaque handle the URL already carried' do
+      expect { logic_for(colonel, handle).raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
+
+    it 'revokes nothing when the confirmation is refused' do
+      expect { logic_for(colonel, nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+      expect(Onetime::Operations::Sessions::RevokeForCustomer).not_to have_received(:new)
+    end
+  end
+
+  describe 'elevation (#4327)' do
+    let(:expected_confirm_token) { 'owner@example.com' }
+
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      described_class.new(
+        strategy_result_for(colonel, confirm_token, session: session),
+        { 'user_id' => 'ur_owner', 'session_handle' => handle },
+      )
+    end
+
+    it_behaves_like 'an elevated colonel action'
+  end
+
+  describe 'handle resolution' do
+    it 'hands the OP the resolved sid, never the submitted handle' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::Operations::Sessions::RevokeForCustomer).to have_received(:new)
+        .with(custid: 'ur_owner', session_id: target_sid, actor: 'ur_colonel')
+    end
+
+    it '404s before the gate when the handle names none of the customer sessions' do
+      expect { logic_for(colonel, nil, 'f' * 32).raise_concerns }
+        .to raise_error(Onetime::RecordNotFound)
+    end
+
+    it 'echoes the handle and never the sid' do
+      logic = logic_for
+      logic.raise_concerns
+      response = logic.process
+
+      expect(response[:record][:session_handle]).to eq(handle)
+      expect(response.to_s).not_to include(target_sid)
+    end
+  end
+
+  # ---- Self-target interlock (#4328) -----------------------------------------
+  describe 'self-target' do
+    it 'refuses revoking your own active session, naming session_handle' do
+      logic = logic_for(colonel, 'owner@example.com', own_handle, session_id: own_sid)
+
+      expect { logic.raise_concerns }
+        .to raise_error(Onetime::FormError, /Cannot revoke your own active session/)
+      expect(Onetime::Operations::Sessions::RevokeForCustomer).not_to have_received(:new)
+    end
+
+    it 'proceeds for any other handle in the same listing' do
+      logic = logic_for(colonel, 'owner@example.com', handle, session_id: own_sid)
+
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+
+    it 'does not raise when the request session has no resolvable id' do
+      expect { logic_for(colonel, 'owner@example.com', own_handle).raise_concerns }
+        .not_to raise_error
+    end
+
+    # M-2 oracle guard: with no proof the answer must be the 403, never the 422.
+    it 'answers 403 (not the interlock 422) when the confirmation is missing' do
+      logic = logic_for(colonel, nil, own_handle, session_id: own_sid)
+
+      expect { logic.raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+    end
+  end
+
+  describe 'authorization' do
+    it 'refuses a non-colonel, revokes nothing and writes NO audit event' do
+      expect { logic_for(customer, nil).raise_concerns }.to raise_error(Onetime::Forbidden)
+      expect(Onetime::Operations::Sessions::RevokeForCustomer).not_to have_received(:new)
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+
+    it 'records no event of its own on success — the op owns the trail' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/set_user_role_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/set_user_role_spec.rb
@@ -13,7 +13,8 @@ require 'colonel/logic'
 # The role ENUM check is shape validation (guard-order step 2) and therefore
 # still runs before the confirmation gate: the caller supplied the role, so
 # rejecting an unknown one discloses nothing. The self-demotion and last-colonel
-# INTERLOCKS (#4328) land after the gate — P4 extends this file.
+# INTERLOCKS (#4328) land AFTER the gate, so their 422s cannot be used as a free
+# "who is the last colonel" / "is this account me" oracle.
 RSpec.describe ColonelAPI::Logic::Colonel::SetUserRole do
   let(:colonel) do
     instance_double(Onetime::Customer,
@@ -109,6 +110,118 @@ RSpec.describe ColonelAPI::Logic::Colonel::SetUserRole do
     end
   end
 
+  # ---- Interlocks (#4328) ----------------------------------------------------
+  describe 'interlocks' do
+    let(:colonel_target) do
+      instance_double(Onetime::Customer,
+        objid: 'cust_target', extid: 'ur_target', email: 'target@example.com',
+        obscure_email: 't****@example.com', role: 'colonel', verified?: true,
+        updated: 1_700_000_000, exists?: true, anonymous?: false)
+    end
+
+    let(:second_colonel) do
+      instance_double(Onetime::Customer,
+        objid: 'cust_other', role: 'colonel', verified?: true, exists?: true)
+    end
+
+    def stub_roster(*colonels)
+      allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel').and_return(colonels)
+    end
+
+    def demote_logic(confirm_token = 'target@example.com')
+      described_class.new(
+        strategy_result_for(colonel, confirm_token),
+        { 'user_id' => 'ur_target', 'role' => 'customer' },
+      )
+    end
+
+    it 'refuses self-demotion, naming user_id and the CLI remediation' do
+      allow(colonel).to receive_messages(
+        email: 'target@example.com', exists?: true, updated: 1, obscure_email: 't****@example.com',
+      )
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel)
+      allow(Onetime::Customer).to receive(:load).and_return(colonel)
+
+      error = begin
+        demote_logic.raise_concerns
+      rescue Onetime::FormError => ex
+        ex
+      end
+
+      expect(error.message).to match(/Cannot demote your own colonel account/)
+      expect(error.message).to include('bin/ots customers role demote')
+    end
+
+    # The acting colonel's OWN record, resolved as the target. Separate double
+    # from `colonel` only so the role gate keeps reading 'colonel' for the
+    # actor while the target record under test sits at 'admin'.
+    it 'still allows PROMOTING yourself (only demotion is a lockout risk)' do
+      own_record = instance_double(Onetime::Customer,
+        objid: 'cust_colonel', extid: 'ur_colonel', email: 'target@example.com',
+        role: 'admin', exists?: true, anonymous?: false)
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(own_record)
+      allow(Onetime::Customer).to receive(:load).and_return(own_record)
+
+      expect { logic_for.raise_concerns }.not_to raise_error
+    end
+
+    it 'refuses demoting the last remaining verified colonel' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel_target)
+      allow(Onetime::Customer).to receive(:load).and_return(colonel_target)
+      stub_roster(colonel_target)
+
+      expect { demote_logic.raise_concerns }
+        .to raise_error(Onetime::FormError, /last remaining colonel/)
+    end
+
+    it 'allows the demotion once a second active colonel exists' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel_target)
+      allow(Onetime::Customer).to receive(:load).and_return(colonel_target)
+      stub_roster(colonel_target, second_colonel)
+
+      expect { demote_logic.raise_concerns }.not_to raise_error
+    end
+
+    # M-2 oracle guard: with no proof the answer must be the 403, never the 422.
+    it 'answers 403 (not the interlock 422) when the confirmation is missing' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel_target)
+      allow(Onetime::Customer).to receive(:load).and_return(colonel_target)
+      stub_roster(colonel_target)
+
+      expect { demote_logic(nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+    end
+
+    it 'answers 403 (not the interlock 422) when elevation is missing' do
+      stub_colonel_elevation(enabled: true, window: 600)
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel_target)
+      allow(Onetime::Customer).to receive(:load).and_return(colonel_target)
+      stub_roster(colonel_target)
+
+      expect { demote_logic.raise_concerns }.to raise_error(Onetime::ElevationRequired)
+    end
+
+    it 'does not read the colonel roster when the target is not a colonel' do
+      allow(Onetime::Customer).to receive(:find_all_by_role)
+      demote_logic.raise_concerns
+
+      expect(Onetime::Customer).not_to have_received(:find_all_by_role)
+    end
+  end
+
+  # ---- The identifier bug this package fixes ---------------------------------
+  describe 'identifier handling' do
+    it 'resolves an EMAIL user_id (sanitize_identifier used to strip @ and .)' do
+      logic = described_class.new(
+        strategy_result_for(colonel),
+        { 'user_id' => 'Target@Example.com', 'role' => 'colonel' },
+      )
+      logic.raise_concerns
+
+      expect(logic.user_id).to eq('Target@Example.com')
+      expect(Onetime::Customer).to have_received(:load_by_extid_or_email).with('target@example.com')
+    end
+  end
+
   describe 'the happy path still works' do
     it 'hands the op the resolved customer, the role, and the colonel extid' do
       logic = logic_for
@@ -118,6 +231,42 @@ RSpec.describe ColonelAPI::Logic::Colonel::SetUserRole do
       expect(Auth::Operations::Customers::SetRole).to have_received(:new)
         .with(hash_including(customer: target, role: 'colonel', actor: 'ur_colonel'))
       expect(data[:details][:changed]).to be true
+    end
+
+    it 'hands the op the acting colonel objid for the self-demotion backstop' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Auth::Operations::Customers::SetRole).to have_received(:new)
+        .with(hash_including(actor_objid: 'cust_colonel'))
+    end
+
+    # The op is the backstop for a roster that changed under us; its refusal
+    # statuses must become the same 422s, never a reported change.
+    it 'maps each op refusal status to its 422' do
+      {
+        self_demotion: /Cannot demote your own colonel account/,
+        last_colonel: /last remaining colonel/,
+      }.each do |status, message|
+        allow(op).to receive(:call).and_return(
+          instance_double(Auth::Operations::Customers::SetRole::Result, status: status),
+        )
+        logic = logic_for
+        logic.raise_concerns
+
+        expect { logic.process }.to raise_error(Onetime::FormError, message)
+      end
+    end
+
+    it 'raises loudly on a status it does not know' do
+      allow(op).to receive(:call).and_return(
+        instance_double(Auth::Operations::Customers::SetRole::Result, status: :something_new),
+      )
+      logic = logic_for
+      logic.raise_concerns
+
+      expect { logic.process }.to raise_error(Onetime::FormError, /did not complete/)
     end
 
     it 'records no audit event of its own (the op owns the trail)' do

--- a/apps/api/colonel/spec/logic/colonel/set_user_role_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/set_user_role_spec.rb
@@ -1,0 +1,117 @@
+# apps/api/colonel/spec/logic/colonel/set_user_role_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# POST /api/colonel/users/:user_id/role — privilege-granting, so TIER 1 (#4326).
+#
+# This adapter owns HTTP concerns only; Auth::Operations::Customers::SetRole owns
+# the mutation and the ColonelAuditEvent (CONTRACT 4).
+#
+# The role ENUM check is shape validation (guard-order step 2) and therefore
+# still runs before the confirmation gate: the caller supplied the role, so
+# rejecting an unknown one discloses nothing. The self-demotion and last-colonel
+# INTERLOCKS (#4328) land after the gate — P4 extends this file.
+RSpec.describe ColonelAPI::Logic::Colonel::SetUserRole do
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:customer) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_plain', extid: 'ur_plain',
+      role: 'customer', verified?: true, anonymous?: false)
+  end
+
+  let(:target) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_target', extid: 'ur_target', email: 'target@example.com',
+      obscure_email: 't****@example.com', role: 'admin', updated: 1_700_000_000,
+      exists?: true, anonymous?: false)
+  end
+
+  let(:op) do
+    instance_double(Auth::Operations::Customers::SetRole,
+      call: instance_double(Auth::Operations::Customers::SetRole::Result, status: :success))
+  end
+
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header — never params.
+  def strategy_result_for(user, confirm_token = 'target@example.com')
+    double('StrategyResult', session: {}, user: user,
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
+  end
+
+  def logic_for(user = colonel, confirm_token = 'target@example.com', params = {})
+    described_class.new(
+      strategy_result_for(user, confirm_token),
+      { 'user_id' => 'ur_target', 'role' => 'colonel' }.merge(params),
+    )
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(target)
+    allow(Onetime::Customer).to receive(:load).and_return(target)
+    allow(Auth::Operations::Customers::SetRole).to receive(:new).and_return(op)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  describe 'confirmation (#4326)' do
+    let(:expected_confirm_token) { 'target@example.com' }
+
+    def confirmed_logic_for(confirm_token)
+      logic_for(colonel, confirm_token)
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'does not accept the extid the URL already carried' do
+      expect { logic_for(colonel, 'ur_target').raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
+
+    it 'changes no role when the confirmation is refused' do
+      expect { logic_for(colonel, nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+      expect(Auth::Operations::Customers::SetRole).not_to have_received(:new)
+    end
+  end
+
+  describe 'guard order (§0.2)' do
+    it 'rejects an unknown role BEFORE the confirmation gate (shape, not secret)' do
+      expect { logic_for(colonel, nil, 'role' => 'emperor').raise_concerns }
+        .to raise_error(Onetime::FormError, /Invalid role/)
+    end
+
+    it 'rejects a non-colonel before either' do
+      expect { logic_for(customer, nil).raise_concerns }.to raise_error(Onetime::Forbidden)
+    end
+  end
+
+  describe 'the happy path still works' do
+    it 'hands the op the resolved customer, the role, and the colonel extid' do
+      logic = logic_for
+      logic.raise_concerns
+      data = logic.process
+
+      expect(Auth::Operations::Customers::SetRole).to have_received(:new)
+        .with(hash_including(customer: target, role: 'colonel', actor: 'ur_colonel'))
+      expect(data[:details][:changed]).to be true
+    end
+
+    it 'records no audit event of its own (the op owns the trail)' do
+      logic = logic_for
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/set_user_role_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/set_user_role_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::SetUserRole do
 
   # `confirm_token` is where the colonel session auth strategy puts the
   # percent-decoded X-OTS-Confirm header — never params.
-  def strategy_result_for(user, confirm_token = 'target@example.com')
-    double('StrategyResult', session: {}, user: user,
+  def strategy_result_for(user, confirm_token = 'target@example.com', session = {})
+    double('StrategyResult', session: session, user: user,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
@@ -82,6 +82,20 @@ RSpec.describe ColonelAPI::Logic::Colonel::SetUserRole do
       expect { logic_for(colonel, nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
       expect(Auth::Operations::Customers::SetRole).not_to have_received(:new)
     end
+  end
+
+  # ---- Step-up (sudo) window (#4327) -----------------------------------------
+  describe 'elevation' do
+    let(:expected_confirm_token) { 'target@example.com' }
+
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      described_class.new(
+        strategy_result_for(colonel, confirm_token, session),
+        { 'user_id' => 'ur_target', 'role' => 'colonel' },
+      )
+    end
+
+    it_behaves_like 'an elevated colonel action'
   end
 
   describe 'guard order (§0.2)' do

--- a/apps/api/colonel/spec/logic/colonel/set_user_verification_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/set_user_verification_spec.rb
@@ -16,7 +16,8 @@ require 'colonel/logic'
 #
 # The split is `return if verified_target` inside SetUserVerificationBase, which
 # is exactly the asymmetry these examples pin — a refactor that hoists the guard
-# above that line would silently gate the recovery path.
+# above that line would silently gate the recovery path. It now guards the
+# #4328 interlocks too.
 RSpec.describe ColonelAPI::Logic::Colonel::UnverifyUser do
   let(:colonel) do
     instance_double(Onetime::Customer,
@@ -27,8 +28,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::UnverifyUser do
   let(:target) do
     instance_double(Onetime::Customer,
       objid: 'cust_target', extid: 'ur_target', email: 'target@example.com',
-      obscure_email: 't****@example.com', verified?: false, updated: 1_700_000_000,
-      exists?: true, anonymous?: false)
+      obscure_email: 't****@example.com', role: 'customer', verified?: false,
+      updated: 1_700_000_000, exists?: true, anonymous?: false)
   end
 
   let(:op) do
@@ -89,14 +90,103 @@ RSpec.describe ColonelAPI::Logic::Colonel::UnverifyUser do
     end
   end
 
+  # ---- Interlocks (#4328, review B-1) ----------------------------------------
+  #
+  # Unverifying strips colonel eligibility, so an attacker refused a demotion by
+  # RoleSupport.last_colonel? would otherwise just call unverify instead. Both
+  # refusals run at STEP 4 — after the confirmation gate — so their 422s cannot
+  # be used as a "who is the last colonel" oracle by a caller holding only the
+  # cookie.
+  describe 'interlocks' do
+    let(:colonel_target) do
+      instance_double(Onetime::Customer,
+        objid: 'cust_target', extid: 'ur_target', email: 'target@example.com',
+        obscure_email: 't****@example.com', role: 'colonel', verified?: true,
+        updated: 1_700_000_000, exists?: true, anonymous?: false)
+    end
+
+    let(:second_colonel) do
+      instance_double(Onetime::Customer,
+        objid: 'cust_other', role: 'colonel', verified?: true, exists?: true)
+    end
+
+    def stub_roster(*colonels)
+      allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel').and_return(colonels)
+    end
+
+    it 'refuses unverifying your own account, naming user_id' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel)
+      allow(Onetime::Customer).to receive(:load).and_return(colonel)
+      allow(colonel).to receive_messages(email: 'target@example.com', exists?: true)
+      stub_roster(colonel)
+
+      expect { logic_for(described_class, 'target@example.com').raise_concerns }
+        .to raise_error(Onetime::FormError, /Cannot unverify your own account/)
+    end
+
+    it 'refuses unverifying the last remaining verified colonel' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel_target)
+      allow(Onetime::Customer).to receive(:load).and_return(colonel_target)
+      stub_roster(colonel_target)
+
+      expect { logic_for(described_class, 'target@example.com').raise_concerns }
+        .to raise_error(Onetime::FormError, /last remaining colonel/)
+    end
+
+    it 'allows it once a second active colonel exists' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel_target)
+      allow(Onetime::Customer).to receive(:load).and_return(colonel_target)
+      stub_roster(colonel_target, second_colonel)
+
+      expect { logic_for(described_class, 'target@example.com').raise_concerns }.not_to raise_error
+    end
+
+    # M-2 oracle guard: with no confirmation the answer must be the 403, never
+    # the interlock 422 — otherwise the refusal itself discloses the roster.
+    it 'answers 403 (not the interlock 422) when the confirmation is missing' do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(colonel_target)
+      allow(Onetime::Customer).to receive(:load).and_return(colonel_target)
+      stub_roster(colonel_target)
+
+      expect { logic_for(described_class, nil).raise_concerns }
+        .to raise_error(Onetime::ConfirmationRequired)
+    end
+
+    it 'does not run the roster read on the verify arm' do
+      allow(Onetime::Customer).to receive(:find_all_by_role)
+      logic_for(ColonelAPI::Logic::Colonel::VerifyUser, nil).raise_concerns
+
+      expect(Onetime::Customer).not_to have_received(:find_all_by_role)
+    end
+  end
+
   describe 'the happy path still works' do
-    it 'hands the op verified: false and the acting colonel extid' do
+    it 'hands the op verified: false, the acting colonel extid and its objid' do
       logic = logic_for(described_class, 'target@example.com')
       logic.raise_concerns
       logic.process
 
       expect(Auth::Operations::Customers::SetVerification).to have_received(:new)
-        .with(hash_including(verified: false, actor: 'ur_colonel'))
+        .with(hash_including(verified: false, actor: 'ur_colonel', actor_objid: 'cust_colonel'))
+    end
+
+    # The op is the backstop: if the roster changed between raise_concerns and
+    # the write, its refusal status must become the same 422, never a reported
+    # change that did not happen.
+    it 'maps an op-level refusal status to a 422' do
+      allow(op).to receive(:call).and_return(:last_colonel)
+      logic = logic_for(described_class, 'target@example.com')
+      logic.raise_concerns
+
+      expect { logic.process }.to raise_error(Onetime::FormError, /last remaining colonel/)
+    end
+
+    it 'raises loudly on a status it does not know' do
+      allow(op).to receive(:call).and_return(:something_new)
+      logic = logic_for(described_class, 'target@example.com')
+      logic.raise_concerns
+
+      expect { logic.process }.to raise_error(Onetime::FormError, /did not complete/)
     end
   end
 end

--- a/apps/api/colonel/spec/logic/colonel/set_user_verification_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/set_user_verification_spec.rb
@@ -1,0 +1,102 @@
+# apps/api/colonel/spec/logic/colonel/set_user_verification_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# POST /api/colonel/users/:user_id/{verify,unverify} — one shared base, two arms,
+# and only ONE of them is gated (#4326, TIER 2).
+#
+# UNVERIFY strips colonel eligibility: has_system_role? refuses every elevated
+# role to an unverified account ("Defense in depth: System roles require email
+# verification"), so an un-gated unverify is a route to leaving an install with
+# zero working colonels. VERIFY is the restorative arm and stays a one-click
+# operator action.
+#
+# The split is `return if verified_target` inside SetUserVerificationBase, which
+# is exactly the asymmetry these examples pin — a refactor that hoists the guard
+# above that line would silently gate the recovery path.
+RSpec.describe ColonelAPI::Logic::Colonel::UnverifyUser do
+  let(:colonel) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_colonel', extid: 'ur_colonel',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  let(:target) do
+    instance_double(Onetime::Customer,
+      objid: 'cust_target', extid: 'ur_target', email: 'target@example.com',
+      obscure_email: 't****@example.com', verified?: false, updated: 1_700_000_000,
+      exists?: true, anonymous?: false)
+  end
+
+  let(:op) do
+    instance_double(Auth::Operations::Customers::SetVerification, call: :success)
+  end
+
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header — never params.
+  def strategy_result_for(confirm_token = 'target@example.com')
+    double('StrategyResult', session: {}, user: colonel,
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
+  end
+
+  def logic_for(klass, confirm_token)
+    klass.new(strategy_result_for(confirm_token), { 'user_id' => 'ur_target' })
+  end
+
+  before do
+    allow(OT).to receive(:info)
+    allow(OT).to receive(:ld)
+    allow(OT).to receive(:li)
+    allow(OT).to receive(:le)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(target)
+    allow(Onetime::Customer).to receive(:load).and_return(target)
+    allow(Auth::Operations::Customers::SetVerification).to receive(:new).and_return(op)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  describe 'unverify is gated' do
+    let(:expected_confirm_token) { 'target@example.com' }
+
+    def confirmed_logic_for(confirm_token)
+      logic_for(described_class, confirm_token)
+    end
+
+    it_behaves_like 'a confirmed colonel action'
+
+    it 'unverifies nothing when the confirmation is refused' do
+      expect { confirmed_logic_for(nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+      expect(Auth::Operations::Customers::SetVerification).not_to have_received(:new)
+    end
+  end
+
+  describe 'verify is NOT gated (the restorative arm)' do
+    it 'needs no confirmation' do
+      logic = logic_for(ColonelAPI::Logic::Colonel::VerifyUser, nil)
+
+      expect { logic.raise_concerns }.not_to raise_error
+    end
+
+    it 'still reaches the op' do
+      logic = logic_for(ColonelAPI::Logic::Colonel::VerifyUser, nil)
+      logic.raise_concerns
+      logic.process
+
+      expect(Auth::Operations::Customers::SetVerification).to have_received(:new)
+        .with(hash_including(verified: true, actor: 'ur_colonel'))
+    end
+  end
+
+  describe 'the happy path still works' do
+    it 'hands the op verified: false and the acting colonel extid' do
+      logic = logic_for(described_class, 'target@example.com')
+      logic.raise_concerns
+      logic.process
+
+      expect(Auth::Operations::Customers::SetVerification).to have_received(:new)
+        .with(hash_including(verified: false, actor: 'ur_colonel'))
+    end
+  end
+end

--- a/apps/api/colonel/spec/logic/colonel/transfer_organization_ownership_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/transfer_organization_ownership_spec.rb
@@ -35,8 +35,8 @@ RSpec.describe ColonelAPI::Logic::Colonel::TransferOrganizationOwnership do
   # dry_run is pinned false on this surface, so EVERY call is an apply and
   # requires the org's NAME in X-OTS-Confirm (#4326). `confirm_token` is where
   # the colonel session auth strategy puts the percent-decoded header.
-  def strategy_result_for(confirm_token = 'Target Org')
-    double('StrategyResult', session: {}, user: colonel,
+  def strategy_result_for(confirm_token = 'Target Org', session = {})
+    double('StrategyResult', session: session, user: colonel,
       auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
 
@@ -92,6 +92,21 @@ RSpec.describe ColonelAPI::Logic::Colonel::TransferOrganizationOwnership do
     end
 
     it_behaves_like 'a confirmed colonel action'
+  end
+
+  # ---- Step-up (sudo) window (#4327) -----------------------------------------
+  describe 'elevation' do
+    let(:expected_confirm_token) { 'Target Org' }
+
+    def elevated_logic_for(session, confirm_token = expected_confirm_token)
+      allow(op).to receive(:call).and_return(build_result(status: :success))
+      described_class.new(
+        strategy_result_for(confirm_token, session),
+        { 'org_id' => 'or_target', 'new_owner' => 'ur_newowner' },
+      )
+    end
+
+    it_behaves_like 'an elevated colonel action'
   end
 
   describe 'success path' do

--- a/apps/api/colonel/spec/logic/colonel/transfer_organization_ownership_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/transfer_organization_ownership_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ColonelAPI::Logic::Colonel::TransferOrganizationOwnership do
 
   let(:org) do
     instance_double(Onetime::Organization,
-      objid: 'org_internal', extid: 'or_target', exists?: true)
+      objid: 'org_internal', extid: 'or_target', display_name: 'Target Org', exists?: true)
   end
 
   let(:new_owner) do
@@ -32,10 +32,15 @@ RSpec.describe ColonelAPI::Logic::Colonel::TransferOrganizationOwnership do
       objid: 'cust_new', extid: 'ur_newowner', anonymous?: false)
   end
 
-  let(:strategy_result) do
+  # dry_run is pinned false on this surface, so EVERY call is an apply and
+  # requires the org's NAME in X-OTS-Confirm (#4326). `confirm_token` is where
+  # the colonel session auth strategy puts the percent-decoded header.
+  def strategy_result_for(confirm_token = 'Target Org')
     double('StrategyResult', session: {}, user: colonel,
-      auth_method: 'sessionauth', metadata: {})
+      auth_method: 'sessionauth', metadata: { confirm_token: confirm_token })
   end
+
+  let(:strategy_result) { strategy_result_for }
 
   def build_result(status:, **overrides)
     result_class.new(
@@ -71,6 +76,22 @@ RSpec.describe ColonelAPI::Logic::Colonel::TransferOrganizationOwnership do
     allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(new_owner)
     allow(Onetime::Operations::Org::TransferOwnership).to receive(:new).and_return(op)
     allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
+
+  # ---- Server-side confirmation (#4326) --------------------------------------
+
+  describe 'confirmation' do
+    let(:expected_confirm_token) { 'Target Org' }
+
+    def confirmed_logic_for(confirm_token)
+      allow(op).to receive(:call).and_return(build_result(status: :success))
+      described_class.new(
+        strategy_result_for(confirm_token),
+        { 'org_id' => 'or_target', 'new_owner' => 'ur_newowner' },
+      )
+    end
+
+    it_behaves_like 'a confirmed colonel action'
   end
 
   describe 'success path' do

--- a/apps/web/auth/operations/customers/change_email.rb
+++ b/apps/web/auth/operations/customers/change_email.rb
@@ -678,6 +678,11 @@ module Auth
               verified: false,
               actor: @actor,
               verified_by: nil,
+              # A credential-provenance reset, not an administrative unverify:
+              # the address changed and is now unproven. #4328's last-colonel
+              # interlock must not refuse it — leaving a colonel "verified"
+              # against an address nobody controls is worse than the lockout.
+              enforce_interlocks: false,
               db: @db,
             ).call
             return :reset if result == :success

--- a/apps/web/auth/operations/customers/set_role.rb
+++ b/apps/web/auth/operations/customers/set_role.rb
@@ -151,9 +151,18 @@ module Auth
         # can empty the roster — a promotion or an unrelated role change must
         # never be rolled back merely because the roster happens to be empty for
         # another reason, so both edges are guarded before the roster read.
+        #
+        # The target must also have been VERIFIED: active_colonels counts only
+        # verified colonels, so demoting an UNVERIFIED colonel-role account never
+        # removes anyone from the roster. Without this guard the roster is already
+        # empty when no colonel is verified, and the check would roll the demotion
+        # back — making a stale, never-verified (or provenance-reset) colonel role
+        # impossible to remove, the same empty-roster false positive last_colonel?
+        # guards against on the pre-check.
         def demotion_left_no_colonel?
           return false unless @from == 'colonel'
           return false if @role == 'colonel'
+          return false unless @customer.verified?
 
           active_colonels.empty?
         end

--- a/apps/web/auth/operations/customers/set_role.rb
+++ b/apps/web/auth/operations/customers/set_role.rb
@@ -4,6 +4,7 @@
 
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/operations/customers/role_support'
 
 module Auth
   module Operations
@@ -18,9 +19,23 @@ module Auth
       #
       # `VALID_ROLES` is the single source of truth for assignable roles; the CLI
       # and colonel adapters both reference it rather than keeping their own copy.
+      #
+      # ## Interlocks (#4328)
+      #
+      # Two refusals live HERE rather than in the colonel adapter, so
+      # `bin/ots customers role demote` is bound by them too:
+      #
+      #   :self_demotion — the acting colonel demoting their own account
+      #   :last_colonel  — demoting the only remaining active colonel
+      #
+      # Both follow {Onetime::Operations::Memberships::Remove}'s shape: a shared
+      # predicate ({RoleSupport}) so the endpoint and the CLI cannot drift into
+      # different definitions of "the last one", and a single `build` exit point
+      # so no early return can skip the refusal audit.
       class SetRole
         include Onetime::LoggerMethods
         include Onetime::AuditedFailure
+        include Onetime::Operations::Customers::RoleSupport
 
         AUDIT_VERB = 'customer.set_role'
 
@@ -39,8 +54,19 @@ module Auth
         # backstop: adapters should validate up front for good UX.
         class InvalidRole < StandardError; end
 
+        # Statuses that MUTATE nothing but each record one `result: :failure`
+        # event. A refused privileged change is a rare, operator-driven attempt
+        # worth tracing — unlike the confirmation/elevation rejections in
+        # #4326/#4327, which any cookie holder can drive on demand and which
+        # therefore write nothing. That distinction only holds because the
+        # adapter runs these interlocks AFTER elevation and confirmation (the
+        # guard-order contract in colonel/logic/destructive_action.rb); do not
+        # reorder the guards without revisiting this choice.
+        REFUSAL_STATUSES = [:last_colonel, :self_demotion].freeze
+
         # @!attribute status [r]
-        #   @return [Symbol] :success (role changed) or :no_change (already at role)
+        #   @return [Symbol] :success (role changed), :no_change (already at
+        #     role), :self_demotion or :last_colonel (refused, nothing mutated)
         Result = Data.define(:status, :customer, :from, :to)
 
         # @param customer [Onetime::Customer] target (caller ensures non-nil,
@@ -48,10 +74,15 @@ module Auth
         # @param role [String, Symbol] target role; must be in VALID_ROLES
         # @param actor [String, #extid, #email] acting admin's PUBLIC identity
         #   (colonel extid/email, or a CLI sentinel). Never an internal objid.
-        def initialize(customer:, role:, actor:)
-          @customer = customer
-          @role     = role.to_s
-          @actor    = actor
+        # @param actor_objid [String, nil] the acting colonel's INTERNAL id, for
+        #   the self-demotion comparison only (purge_user.rb compares the same
+        #   way; the AUDIT actor stays the public id above). nil for the CLI,
+        #   which has no acting customer and nothing to self-demote.
+        def initialize(customer:, role:, actor:, actor_objid: nil)
+          @customer    = customer
+          @role        = role.to_s
+          @actor       = actor
+          @actor_objid = actor_objid
         end
 
         # @return [Result]
@@ -61,8 +92,13 @@ module Auth
             raise InvalidRole, "Invalid role '#{@role}'. Valid roles: #{VALID_ROLES.join(', ')}"
           end
 
-          from = @customer.role.to_s
-          return Result.new(status: :no_change, customer: @customer, from: from, to: @role) if from == @role
+          @from = @customer.role.to_s
+          return build(:no_change) if @from == @role
+
+          # INTERLOCKS (#4328). Self-demotion first: it is the cheaper check and
+          # the more specific answer when both apply.
+          return build(:self_demotion) if self_demotion?
+          return build(:last_colonel) if last_colonel?(@customer, @role)
 
           @customer.role = @role
           @customer.save
@@ -73,17 +109,49 @@ module Auth
             verb: AUDIT_VERB,
             target: @customer.extid,
             result: :success,
-            detail: { from: from, to: @role },
+            detail: { from: @from, to: @role },
           )
 
           # debug level (not info): the audit event is the durable record, and an
           # info-level line here would surface in CLI stderr and break the CLI's
           # bit-for-bit output contract.
-          auth_logger.debug "[customer.set_role] #{@customer.extid} #{from} -> #{@role} by #{actor_label}"
-          Result.new(status: :success, customer: @customer, from: from, to: @role)
+          auth_logger.debug "[customer.set_role] #{@customer.extid} #{@from} -> #{@role} by #{actor_label}"
+          build(:success)
         end
 
         private
+
+        # Only a DEMOTION of one's own account is refused: a colonel raising
+        # their own role is not a lockout risk, and the CLI (actor_objid nil)
+        # never self-refuses.
+        def self_demotion?
+          return false if @actor_objid.to_s.empty?
+          return false if @role == 'colonel'
+
+          @actor_objid == @customer.objid
+        end
+
+        # Single exit point for every status, so the refusal audit cannot be
+        # forgotten at an early return (Memberships::Remove#build).
+        def build(status)
+          record_refusal(status) if REFUSAL_STATUSES.include?(status)
+
+          Result.new(status: status, customer: @customer, from: @from, to: @role)
+        end
+
+        # Same verb/target/actor as the success event. Best-effort: never break
+        # the op.
+        def record_refusal(status)
+          Onetime::ColonelAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: @customer.extid,
+            result: :failure,
+            detail: { reason: status.to_s, from: @from, to: @role },
+          )
+        rescue StandardError => ex
+          OT.le "[Customers::SetRole] refusal audit failed: #{ex.class}: #{ex.message}"
+        end
 
         # Loggable, non-secret actor label (mirrors the audit actor normalization).
         def actor_label

--- a/apps/web/auth/operations/customers/set_role.rb
+++ b/apps/web/auth/operations/customers/set_role.rb
@@ -103,6 +103,21 @@ module Auth
           @customer.role = @role
           @customer.save
 
+          # POST-WRITE re-validation (#4328). last_colonel? above is a
+          # check-then-act: it is NOT atomic, so two concurrent demotions of the
+          # two distinct last colonels can each pass the pre-check (each still
+          # sees the other) and both write, leaving the install with zero
+          # colonels — recoverable only from the CLI, the exact outcome #4328
+          # exists to prevent. Re-run the roster check AFTER the write; if this
+          # demotion emptied it, roll the role back and refuse through the SAME
+          # build exit, so the :last_colonel failure still audits. Over-preserving
+          # on a concurrent double-rollback is the safe direction.
+          if demotion_left_no_colonel?
+            @customer.role = @from
+            @customer.save
+            return build(:last_colonel)
+          end
+
           # One audit event per successful mutation, emitted from the op layer.
           Onetime::ColonelAuditEvent.record(
             actor: @actor,
@@ -129,6 +144,18 @@ module Auth
           return false if @role == 'colonel'
 
           @actor_objid == @customer.objid
+        end
+
+        # Did the just-applied write demote a colonel and leave the roster
+        # empty? (#4328 post-write re-validation.) Only a demotion FROM colonel
+        # can empty the roster — a promotion or an unrelated role change must
+        # never be rolled back merely because the roster happens to be empty for
+        # another reason, so both edges are guarded before the roster read.
+        def demotion_left_no_colonel?
+          return false unless @from == 'colonel'
+          return false if @role == 'colonel'
+
+          active_colonels.empty?
         end
 
         # Single exit point for every status, so the refusal audit cannot be

--- a/apps/web/auth/operations/customers/set_verification.rb
+++ b/apps/web/auth/operations/customers/set_verification.rb
@@ -120,6 +120,24 @@ module Auth
             db: @db,
           ).call
 
+          # POST-WRITE re-validation (#4328), mirroring SetRole. unverify_refusal
+          # above is a check-then-act and is NOT atomic: two concurrent unverifies
+          # of the two distinct last colonels can each pass the pre-check and both
+          # write, leaving the install with zero verified colonels — recoverable
+          # only from the CLI. Re-run the roster check AFTER the write; if this
+          # unverify emptied it, roll the unverify back (re-verify) and refuse
+          # through the SAME build exit, so the :last_colonel failure still audits.
+          # Over-preserving on a concurrent double-rollback is the safe direction.
+          if result == :success && unverify_left_no_colonel?
+            Auth::Operations::SetCustomerVerification.new(
+              customer: @customer,
+              verified: true,
+              verified_by: @verified_by,
+              db: @db,
+            ).call
+            return build(:last_colonel)
+          end
+
           # Audit only an actual state change; a :no_change mutated nothing.
           if result == :success
             Onetime::ColonelAuditEvent.record(
@@ -145,6 +163,19 @@ module Auth
           return :last_colonel if last_colonel_by_verification?(@customer)
 
           nil
+        end
+
+        # Did the just-applied UNVERIFY remove the last verified colonel? (#4328
+        # post-write re-validation.) Only meaningful for an interlocked unverify
+        # of a colonel — the verify arm and provenance resets can never cause a
+        # lockout, and unverifying a non-colonel cannot empty the roster, so all
+        # three are guarded before the roster read (mirrors the pre-check).
+        def unverify_left_no_colonel?
+          return false if @verified
+          return false unless @enforce_interlocks
+          return false unless @customer.role.to_s == 'colonel'
+
+          active_colonels.empty?
         end
 
         # Single exit point, so the refusal audit cannot be forgotten at an

--- a/apps/web/auth/operations/customers/set_verification.rb
+++ b/apps/web/auth/operations/customers/set_verification.rb
@@ -6,6 +6,7 @@
 # the auth app's autoloader, so require the dependency explicitly.
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/operations/customers/role_support'
 require 'auth/operations/set_customer_verification'
 
 module Auth
@@ -33,10 +34,32 @@ module Auth
       # adapters keep their exact control flow:
       #   :success | :no_change  (symbols, same as the underlying op)
       #   raises SetCustomerVerification::{NoAuthDatabase, AccountNotFound, AccountClosed}
+      #
+      # ## Interlocks (#4328 / review B-1)
+      #
+      # `has_system_role?` refuses every elevated role to an unverified account
+      # ("Defense in depth: System roles require email verification"), so
+      # UNVERIFYING a colonel is a demotion by another name — and it used to be
+      # reachable in one un-gated POST, straight past any last-colonel check on
+      # the role endpoint. Two refusals therefore live here, next to the audit,
+      # so `bin/ots customers unverify` is bound by them too:
+      #
+      #   :self_unverify — the acting colonel unverifying their own account
+      #   :last_colonel  — unverifying the only remaining active colonel
+      #
+      # They join the existing symbol contract rather than introducing a Result
+      # struct, because three adapters already `case` on the returned symbol.
       class SetVerification
         include Onetime::AuditedFailure
+        include Onetime::Operations::Customers::RoleSupport
 
         AUDIT_VERB = 'customer.set_verification'
+
+        # Statuses that MUTATE nothing but each record one `result: :failure`
+        # event. Same rationale as {Customers::SetRole::REFUSAL_STATUSES}: an
+        # authenticated privileged refusal is traceable; an authorization
+        # rejection is not audited at all.
+        REFUSAL_STATUSES = [:last_colonel, :self_unverify].freeze
 
         # This wrapper's whole job is the audit event, and the three documented
         # error classes below are ALL raised by the inner op BEFORE it — so an
@@ -56,19 +79,40 @@ module Auth
         #   (colonel extid/email, or a CLI sentinel). Never an internal objid.
         # @param verified_by [String, nil] provenance tag passed through to the
         #   underlying op ('cli_provision', 'colonel_admin', …); nil when clearing
+        # @param actor_objid [String, nil] the acting colonel's INTERNAL id, for
+        #   the self-unverify comparison only (the AUDIT actor stays the public
+        #   id above). nil for the CLI and for the self-service callers, which
+        #   have no acting colonel.
+        # @param enforce_interlocks [Boolean] apply the #4328 unverify refusals.
+        #   TRUE for every ADMINISTRATIVE unverify (the colonel endpoint, the
+        #   CLI). FALSE only for a CREDENTIAL-PROVENANCE reset — clearing
+        #   verification because the address itself changed and is now unproven
+        #   (Customers::ChangeEmail). Refusing that would be strictly worse than
+        #   the lockout it prevents: it would leave a colonel verified against
+        #   an address nobody has proven they control.
         # @param db [Sequel::Database, nil] injectable, passed through
-        def initialize(customer:, verified:, actor:, verified_by:, db: nil)
-          @customer    = customer
-          @verified    = verified
-          @actor       = actor
-          @verified_by = verified_by
-          @db          = db
+        def initialize(customer:, verified:, actor:, verified_by:, actor_objid: nil,
+                       enforce_interlocks: true, db: nil)
+          @customer           = customer
+          @verified           = verified
+          @actor              = actor
+          @verified_by        = verified_by
+          @actor_objid        = actor_objid
+          @enforce_interlocks = enforce_interlocks
+          @db                 = db
         end
 
-        # @return [Symbol] :success or :no_change (passthrough from the inner op)
+        # @return [Symbol] :success or :no_change (passthrough from the inner
+        #   op), or :self_unverify / :last_colonel when an interlock refused
         # @raise [SetCustomerVerification::NoAuthDatabase, SetCustomerVerification::AccountNotFound,
         #   SetCustomerVerification::AccountClosed]
         def call
+          # INTERLOCKS (#4328) run BEFORE the cross-store write, so a refusal
+          # mutates nothing. Only the UNVERIFY arm is interlocked; verifying is
+          # the restorative direction and can never cause a lockout.
+          refusal = unverify_refusal
+          return build(refusal) if refusal
+
           result = Auth::Operations::SetCustomerVerification.new(
             customer: @customer,
             verified: @verified,
@@ -87,7 +131,42 @@ module Auth
             )
           end
 
-          result
+          build(result)
+        end
+
+        private
+
+        # @return [Symbol, nil] the refusal status, or nil to proceed
+        def unverify_refusal
+          return nil if @verified
+          return nil unless @enforce_interlocks
+
+          return :self_unverify if !@actor_objid.to_s.empty? && @actor_objid == @customer.objid
+          return :last_colonel if last_colonel_by_verification?(@customer)
+
+          nil
+        end
+
+        # Single exit point, so the refusal audit cannot be forgotten at an
+        # early return (Memberships::Remove#build).
+        def build(status)
+          record_refusal(status) if REFUSAL_STATUSES.include?(status)
+
+          status
+        end
+
+        # Same verb/target/actor as the success event. Best-effort: never break
+        # the op.
+        def record_refusal(status)
+          Onetime::ColonelAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: @customer.extid,
+            result: :failure,
+            detail: { reason: status.to_s, verified: @verified },
+          )
+        rescue StandardError => ex
+          OT.le "[Customers::SetVerification] refusal audit failed: #{ex.class}: #{ex.message}"
         end
       end
     end

--- a/apps/web/auth/operations/customers/set_verification.rb
+++ b/apps/web/auth/operations/customers/set_verification.rb
@@ -113,6 +113,21 @@ module Auth
           refusal = unverify_refusal
           return build(refusal) if refusal
 
+          # Provenance to restore if the post-write re-validation below rolls this
+          # unverify back. Read BEFORE the write and ONLY on the unverify-of-a-colonel
+          # path #unverify_left_no_colonel? can trip: SetCustomerVerification#update_customer!
+          # assigns verified_by UNCONDITIONALLY, and the unverify arm passes nil
+          # (SetUserVerification#verified_by_tag returns nil when clearing), so the
+          # write blanks it in memory. The rollback must restore this ORIGINAL tag,
+          # not the nil this op was called with — otherwise a concurrent double-unverify
+          # re-verifies the surviving colonel with verified_by wiped, destroying the
+          # 'sso'/'colonel_admin'/'email' provenance (#4328). Guarded so other callers
+          # (verify arm, non-colonel targets, provenance resets) need not expose it.
+          original_verified_by =
+            if !@verified && @enforce_interlocks && @customer.role.to_s == 'colonel'
+              @customer.verified_by
+            end
+
           result = Auth::Operations::SetCustomerVerification.new(
             customer: @customer,
             verified: @verified,
@@ -132,7 +147,7 @@ module Auth
             Auth::Operations::SetCustomerVerification.new(
               customer: @customer,
               verified: true,
-              verified_by: @verified_by,
+              verified_by: original_verified_by,
               db: @db,
             ).call
             return build(:last_colonel)

--- a/apps/web/auth/operations/sync_session.rb
+++ b/apps/web/auth/operations/sync_session.rb
@@ -296,6 +296,13 @@ module Auth
         # Clear MFA waiting flag - user has completed full authentication
         @session.delete(:awaiting_mfa)
         @session.delete('awaiting_mfa')
+
+        # #4327: an identity change must always land UNELEVATED. Rodauth's
+        # :renew carries the session hash to a new sid (hooks/account.rb after a
+        # password change), so a colonel step-up window could otherwise survive
+        # a rotation — or an identity change — on the same browser. Elevation is
+        # also identity-bound on read; this is the second of two closures.
+        @session.delete('elevated_until')
       end
 
       # Stamps the customer's last_login timestamp on full session sync.

--- a/apps/web/auth/spec/operations/customers/change_email_spec.rb
+++ b/apps/web/auth/spec/operations/customers/change_email_spec.rb
@@ -494,8 +494,13 @@ RSpec.describe Auth::Operations::Customers::ChangeEmail do
       it 'still resets verification, through the same wrapper :success uses' do
         result = op.call
 
+        # enforce_interlocks: false — a credential-provenance reset, not an
+        # administrative unverify (#4328). It must never be refused by the
+        # last-colonel interlock: leaving a colonel "verified" against an
+        # address nobody proved is worse than the lockout that guard prevents.
         expect(Auth::Operations::Customers::SetVerification).to have_received(:new).with(
-          customer: customer, verified: false, actor: 'cli', verified_by: nil, db: db
+          customer: customer, verified: false, actor: 'cli', verified_by: nil,
+          enforce_interlocks: false, db: db
         )
         expect(verifier).to have_received(:call)
         expect(result.verification_reset).to be true
@@ -707,8 +712,11 @@ RSpec.describe Auth::Operations::Customers::ChangeEmail do
     it 'resets verification through SetVerification when require_verification is true' do
       op.call
 
+      # See the note on the :partial example: this reset is a provenance reset,
+      # so it opts out of #4328's administrative unverify interlocks.
       expect(Auth::Operations::Customers::SetVerification).to have_received(:new).with(
-        customer: customer, verified: false, actor: 'cli', verified_by: nil, db: db
+        customer: customer, verified: false, actor: 'cli', verified_by: nil,
+        enforce_interlocks: false, db: db
       )
     end
 

--- a/apps/web/auth/spec/operations/customers/set_role_spec.rb
+++ b/apps/web/auth/spec/operations/customers/set_role_spec.rb
@@ -5,7 +5,13 @@
 # Unit tests for Auth::Operations::Customers::SetRole.
 #
 # Covers: successful change (+ exactly one audit event), idempotent no_change
-# (no save, no audit), and invalid-role rejection.
+# (no save, no audit), invalid-role rejection, and the #4328 interlocks
+# (:self_demotion / :last_colonel).
+#
+# The interlocks live in the OP, not the colonel adapter, so
+# `bin/ots customers role demote` is bound by them too — and each refusal
+# records exactly one result: :failure event through the single `build` exit
+# point, so no early return can skip it (the Memberships::Remove shape).
 #
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/customers/set_role_spec.rb
 
@@ -15,10 +21,14 @@ require 'auth/operations/customers/set_role'
 
 RSpec.describe Auth::Operations::Customers::SetRole do
   let(:customer) do
-    double('Customer', role: 'customer', extid: 'ur_test', :role= => nil, save: true)
+    double('Customer', role: 'customer', extid: 'ur_test', objid: 'cust_test',
+      :role= => nil, save: true)
   end
 
-  before { allow(Onetime::ColonelAuditEvent).to receive(:record) }
+  before do
+    allow(OT).to receive(:le)
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+  end
 
   it 'changes the role, saves, and returns :success with from/to' do
     result = described_class.new(customer: customer, role: 'colonel', actor: 'ur_col').call
@@ -77,5 +87,101 @@ RSpec.describe Auth::Operations::Customers::SetRole do
         detail: hash_including(error: 'Auth::Operations::Customers::SetRole::InvalidRole'),
       ),
     )
+  end
+
+  # ---- Interlocks (#4328) ----------------------------------------------------
+  describe 'interlocks' do
+    let(:colonel_target) do
+      double('Customer', role: 'colonel', extid: 'ur_col', objid: 'cust_col',
+        verified?: true, exists?: true, :role= => nil, save: true)
+    end
+
+    let(:second_colonel) do
+      double('Customer', role: 'colonel', objid: 'cust_other', verified?: true, exists?: true)
+    end
+
+    def stub_roster(*colonels)
+      allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel').and_return(colonels)
+    end
+
+    def demote(target, **extra)
+      described_class.new(customer: target, role: 'customer', actor: 'ur_actor', **extra).call
+    end
+
+    it 'refuses a self-demotion and mutates nothing' do
+      result = demote(colonel_target, actor_objid: 'cust_col')
+
+      expect(result.status).to eq(:self_demotion)
+      expect(colonel_target).not_to have_received(:save)
+    end
+
+    it 'refuses demoting the last active colonel and mutates nothing' do
+      stub_roster(colonel_target)
+
+      result = demote(colonel_target)
+
+      expect(result.status).to eq(:last_colonel)
+      expect(colonel_target).not_to have_received(:save)
+    end
+
+    it 'records exactly one result: :failure event per refusal' do
+      stub_roster(colonel_target)
+      demote(colonel_target)
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+        actor: 'ur_actor',
+        verb: 'customer.set_role',
+        target: 'ur_col',
+        result: :failure,
+        detail: { reason: 'last_colonel', from: 'colonel', to: 'customer' },
+      )
+    end
+
+    it 'proceeds once a second active colonel exists' do
+      stub_roster(colonel_target, second_colonel)
+
+      expect(demote(colonel_target).status).to eq(:success)
+      expect(colonel_target).to have_received(:save)
+    end
+
+    # The roster is authoritative, not the derived role index: the index drifts
+    # UPWARD (add-only partial writes; TTL-expired customer hashes leave members
+    # behind), so counting it would make this guard fail OPEN.
+    it 'ignores drifted index members when counting the remaining colonels' do
+      stub_roster(
+        colonel_target,
+        double('Customer', objid: 'cust_gone', exists?: false, role: 'colonel', verified?: true),
+        double('Customer', objid: 'cust_demoted', exists?: true, role: 'admin', verified?: true),
+        double('Customer', objid: 'cust_unver', exists?: true, role: 'colonel', verified?: false),
+      )
+
+      expect(demote(colonel_target).status).to eq(:last_colonel)
+    end
+
+    # The CLI passes no actor_objid: there is no acting customer in a shell, and
+    # nothing to self-demote. It must keep working unchanged.
+    it 'never self-refuses when actor_objid is nil (the CLI path)' do
+      stub_roster(colonel_target, second_colonel)
+
+      expect(demote(colonel_target).status).to eq(:success)
+    end
+
+    it 'does not refuse a PROMOTION to colonel by the actor themselves' do
+      result = described_class.new(
+        customer: colonel_target, role: 'colonel', actor: 'ur_actor', actor_objid: 'cust_col'
+      ).call
+
+      # Already a colonel, so this is the idempotent arm — the point is that it
+      # is not :self_demotion.
+      expect(result.status).to eq(:no_change)
+    end
+
+    it 'does not read the colonel roster when the target is not a colonel' do
+      allow(Onetime::Customer).to receive(:find_all_by_role)
+
+      demote(customer)
+
+      expect(Onetime::Customer).not_to have_received(:find_all_by_role)
+    end
   end
 end

--- a/apps/web/auth/spec/operations/customers/set_role_spec.rb
+++ b/apps/web/auth/spec/operations/customers/set_role_spec.rb
@@ -183,5 +183,44 @@ RSpec.describe Auth::Operations::Customers::SetRole do
 
       expect(Onetime::Customer).not_to have_received(:find_all_by_role)
     end
+
+    # POST-WRITE re-validation (#4328). The pre-check is not atomic: two
+    # concurrent demotions of the two distinct last colonels can both pass it
+    # and leave zero colonels. Simulate the roster dropping to zero BETWEEN the
+    # pre-check and the post-check (find_all_by_role returns two colonels the
+    # first time, none the second), and assert the demotion is rolled back and a
+    # :last_colonel failure is returned and audited.
+    describe 'the check-then-act race (post-write re-validation)' do
+      before do
+        allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel')
+          .and_return([colonel_target, second_colonel], [])
+      end
+
+      it 'rolls the role back and refuses with :last_colonel' do
+        result = demote(colonel_target)
+
+        expect(result.status).to eq(:last_colonel)
+        # demoted to the target role, then restored to the prior colonel role
+        expect(colonel_target).to have_received(:role=).with('customer')
+        expect(colonel_target).to have_received(:role=).with('colonel')
+        expect(colonel_target).to have_received(:save).twice
+      end
+
+      it 'records the :last_colonel failure and no success event' do
+        demote(colonel_target)
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            verb: 'customer.set_role',
+            target: 'ur_col',
+            result: :failure,
+            detail: hash_including(reason: 'last_colonel'),
+          ),
+        )
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record).with(
+          hash_including(result: :success),
+        )
+      end
+    end
   end
 end

--- a/apps/web/auth/spec/operations/customers/set_role_spec.rb
+++ b/apps/web/auth/spec/operations/customers/set_role_spec.rb
@@ -158,6 +158,22 @@ RSpec.describe Auth::Operations::Customers::SetRole do
       expect(demote(colonel_target).status).to eq(:last_colonel)
     end
 
+    # #4328 review: an UNVERIFIED colonel-role account is not an active colonel, so
+    # demoting it cannot empty the roster — even when NO colonel is verified and
+    # the active roster is already empty. Neither the pre-check (last_colonel?) nor
+    # the post-write check (demotion_left_no_colonel?) may refuse it, or a stale,
+    # never-verified (or provenance-reset via ChangeEmail) colonel role could never
+    # be removed by any surface.
+    it 'allows demoting an unverified colonel even when no colonel is verified' do
+      unverified_colonel = double('Customer', role: 'colonel', extid: 'ur_unver',
+        objid: 'cust_unver', verified?: false, exists?: true, :role= => nil, save: true)
+      # Roster holds only an unverified colonel-role account → active_colonels is empty.
+      stub_roster(unverified_colonel)
+
+      expect(demote(unverified_colonel).status).to eq(:success)
+      expect(unverified_colonel).to have_received(:save)
+    end
+
     # The CLI passes no actor_objid: there is no acting customer in a shell, and
     # nothing to self-demote. It must keep working unchanged.
     it 'never self-refuses when actor_objid is nil (the CLI path)' do

--- a/apps/web/auth/spec/operations/customers/set_verification_spec.rb
+++ b/apps/web/auth/spec/operations/customers/set_verification_spec.rb
@@ -110,7 +110,8 @@ RSpec.describe Auth::Operations::Customers::SetVerification do
   # ---- Unverify interlocks (#4328 / review B-1) ------------------------------
   describe 'unverify interlocks' do
     let(:colonel) do
-      double('Customer', extid: 'ur_col_t', objid: 'cust_col_t', role: 'colonel', verified?: true)
+      double('Customer', extid: 'ur_col_t', objid: 'cust_col_t', role: 'colonel',
+                         verified?: true, verified_by: 'colonel_admin')
     end
 
     let(:second_colonel) do
@@ -213,12 +214,14 @@ RSpec.describe Auth::Operations::Customers::SetVerification do
       it 'rolls the unverify back (re-verifies) and refuses with :last_colonel' do
         expect(unverify(colonel)).to eq(:last_colonel)
 
-        # inner op called twice: the unverify write, then the re-verify rollback
+        # inner op called twice: the unverify write (verified_by nil, the clearing
+        # arm), then the re-verify rollback carrying the ORIGINAL provenance tag
+        # ('colonel_admin') — NOT nil, so the restore does not wipe verified_by (#4328).
         expect(Auth::Operations::SetCustomerVerification).to have_received(:new).with(
           customer: colonel, verified: false, verified_by: nil, db: nil
         )
         expect(Auth::Operations::SetCustomerVerification).to have_received(:new).with(
-          customer: colonel, verified: true, verified_by: nil, db: nil
+          customer: colonel, verified: true, verified_by: 'colonel_admin', db: nil
         )
       end
 

--- a/apps/web/auth/spec/operations/customers/set_verification_spec.rb
+++ b/apps/web/auth/spec/operations/customers/set_verification_spec.rb
@@ -197,5 +197,46 @@ RSpec.describe Auth::Operations::Customers::SetVerification do
 
       expect(unverify(colonel, enforce_interlocks: false)).to eq(:success)
     end
+
+    # POST-WRITE re-validation (#4328), mirroring SetRole. The pre-check is not
+    # atomic: two concurrent unverifies of the two distinct last colonels can
+    # both pass it and leave zero verified colonels. Simulate the roster dropping
+    # to zero BETWEEN the pre-check and the post-check (find_all_by_role returns
+    # two colonels first, none second), and assert the unverify is rolled back
+    # (re-verified) and a :last_colonel failure is returned and audited.
+    describe 'the check-then-act race (post-write re-validation)' do
+      before do
+        allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel')
+          .and_return([colonel, second_colonel], [])
+      end
+
+      it 'rolls the unverify back (re-verifies) and refuses with :last_colonel' do
+        expect(unverify(colonel)).to eq(:last_colonel)
+
+        # inner op called twice: the unverify write, then the re-verify rollback
+        expect(Auth::Operations::SetCustomerVerification).to have_received(:new).with(
+          customer: colonel, verified: false, verified_by: nil, db: nil
+        )
+        expect(Auth::Operations::SetCustomerVerification).to have_received(:new).with(
+          customer: colonel, verified: true, verified_by: nil, db: nil
+        )
+      end
+
+      it 'records the :last_colonel failure and no success event' do
+        unverify(colonel)
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            verb: 'customer.set_verification',
+            target: 'ur_col_t',
+            result: :failure,
+            detail: hash_including(reason: 'last_colonel'),
+          ),
+        )
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record).with(
+          hash_including(result: :success),
+        )
+      end
+    end
   end
 end

--- a/apps/web/auth/spec/operations/customers/set_verification_spec.rb
+++ b/apps/web/auth/spec/operations/customers/set_verification_spec.rb
@@ -9,6 +9,12 @@
 # does not audit on :no_change, and records one result: :failure (then
 # re-raises) when the inner op raises one of its documented error classes.
 #
+# Plus the #4328 unverify interlocks. They live HERE rather than in the colonel
+# adapter so `bin/ots customers unverify` is bound by them too — unverifying a
+# colonel is a demotion by another name (has_system_role? refuses every elevated
+# role to an unverified account), so unverifying the last one would leave the
+# install with no administrator.
+#
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/customers/set_verification_spec.rb
 
 require 'spec_helper'
@@ -16,10 +22,15 @@ require 'onetime/models/colonel_audit_event'
 require 'auth/operations/customers/set_verification'
 
 RSpec.describe Auth::Operations::Customers::SetVerification do
-  let(:customer) { double('Customer', extid: 'ur_v') }
-  let(:inner)    { instance_double(Auth::Operations::SetCustomerVerification) }
+  # A plain (non-colonel) target: role/verified? are what the interlocks read,
+  # and this one short-circuits both of them.
+  let(:customer) do
+    double('Customer', extid: 'ur_v', objid: 'cust_v', role: 'customer', verified?: true)
+  end
+  let(:inner) { instance_double(Auth::Operations::SetCustomerVerification) }
 
   before do
+    allow(OT).to receive(:le)
     allow(Onetime::ColonelAuditEvent).to receive(:record)
     allow(Auth::Operations::SetCustomerVerification).to receive(:new).and_return(inner)
   end
@@ -94,5 +105,97 @@ RSpec.describe Auth::Operations::Customers::SetVerification do
         ),
       ),
     )
+  end
+
+  # ---- Unverify interlocks (#4328 / review B-1) ------------------------------
+  describe 'unverify interlocks' do
+    let(:colonel) do
+      double('Customer', extid: 'ur_col_t', objid: 'cust_col_t', role: 'colonel', verified?: true)
+    end
+
+    let(:second_colonel) do
+      double('Customer', objid: 'cust_other', role: 'colonel', verified?: true, exists?: true)
+    end
+
+    def stub_roster(*colonels)
+      allow(Onetime::Customer).to receive(:find_all_by_role).with('colonel').and_return(colonels)
+    end
+
+    def unverify(target, actor_objid: nil, **extra)
+      described_class.new(
+        customer: target, verified: false, actor: 'ur_col', verified_by: nil,
+        actor_objid: actor_objid, **extra
+      ).call
+    end
+
+    before do
+      allow(inner).to receive(:call).and_return(:success)
+      allow(colonel).to receive(:exists?).and_return(true)
+    end
+
+    it 'refuses a self-unverify and mutates nothing' do
+      expect(unverify(colonel, actor_objid: 'cust_col_t')).to eq(:self_unverify)
+      expect(Auth::Operations::SetCustomerVerification).not_to have_received(:new)
+    end
+
+    it 'refuses unverifying the last active colonel and mutates nothing' do
+      stub_roster(colonel)
+
+      expect(unverify(colonel)).to eq(:last_colonel)
+      expect(Auth::Operations::SetCustomerVerification).not_to have_received(:new)
+    end
+
+    it 'records exactly one result: :failure event per refusal' do
+      stub_roster(colonel)
+      unverify(colonel)
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+        actor: 'ur_col',
+        verb: 'customer.set_verification',
+        target: 'ur_col_t',
+        result: :failure,
+        detail: { reason: 'last_colonel', verified: false },
+      )
+    end
+
+    it 'proceeds once a second active colonel exists' do
+      stub_roster(colonel, second_colonel)
+
+      expect(unverify(colonel)).to eq(:success)
+    end
+
+    # The roster is authoritative, not the derived index: an index member whose
+    # customer hash is gone, whose role field disagrees, or that is unverified
+    # must not count as "another colonel" — otherwise the guard fails open.
+    it 'ignores drifted index members when counting the remaining colonels' do
+      stub_roster(
+        colonel,
+        double('Customer', objid: 'cust_gone', exists?: false, role: 'colonel', verified?: true),
+        double('Customer', objid: 'cust_demoted', exists?: true, role: 'admin', verified?: true),
+        double('Customer', objid: 'cust_unver', exists?: true, role: 'colonel', verified?: false),
+      )
+
+      expect(unverify(colonel)).to eq(:last_colonel)
+    end
+
+    it 'never refuses the VERIFY arm' do
+      stub_roster(colonel)
+
+      result = described_class.new(
+        customer: colonel, verified: true, actor: 'ur_col',
+        verified_by: 'colonel_admin', actor_objid: 'cust_col_t'
+      ).call
+
+      expect(result).to eq(:success)
+    end
+
+    # A credential-provenance reset (Customers::ChangeEmail) clears verification
+    # because the ADDRESS changed and is now unproven. Refusing that would leave
+    # a colonel "verified" against an address nobody controls.
+    it 'skips the interlocks when the caller opts out (enforce_interlocks: false)' do
+      stub_roster(colonel)
+
+      expect(unverify(colonel, enforce_interlocks: false)).to eq(:success)
+    end
   end
 end

--- a/apps/web/core/controllers/authentication.rb
+++ b/apps/web/core/controllers/authentication.rb
@@ -115,6 +115,15 @@ module Core
           session['authenticated']    = true
           session['authenticated_at'] = Familia.now.to_i
 
+          # #4327: an identity change must always land UNELEVATED. This path
+          # deliberately does not clear or renew the session (compare
+          # lib/onetime/helpers/session_helpers.rb, the other authenticate path,
+          # which does both), so without this the colonel step-up window minted
+          # by the previous occupant of this cookie would be inherited by the
+          # account signing in. Elevation is also identity-bound on read, so this
+          # is the second of two independent closures.
+          session.delete('elevated_until')
+
           auth_logger.info 'Session synchronized after authentication',
             {
               user_id: cust_after.custid,

--- a/docs/operations/admin-network-isolation.md
+++ b/docs/operations/admin-network-isolation.md
@@ -82,19 +82,106 @@ changes the auth behavior beneath it.
 
 ### Route-level network requirements
 
-Otto routes can declare `network=admin` when an endpoint must not inherit the
-network gate's opt-in default. Such a route returns `404` unless all of these are
-true:
+Individual routes can require more than the surface-wide posture above. There
+are **two tokens**, and the difference between them is what happens on an
+install that has not configured admin isolation at all.
 
-1. `ADMIN_ALLOWED_HOSTS` explicitly names an enforceable admin hostname.
-2. `ADMIN_ALLOWED_CIDRS` contains at least one parseable range.
-3. The request passes both allowlists.
+| Token | Routes carrying it | Where isolation is **fully configured** | Everywhere else |
+|---|---|---|---|
+| `network=admin` | 1 — `GET /api/colonel/system/proxy-headers` | enforced | **404, always** |
+| `network=admin_if_configured` | 15 — the tier-1 destructive verbs (#4332) | enforced | falls through; the surface-wide gates and the app-layer controls apply |
 
-The canonical-host fallback does not satisfy an explicit route requirement, and
-`ADMIN_ALLOWED_HOSTS=*` disables the host gate, so it does not satisfy one
-either. Routes without `network=admin` retain the general Colonel behavior
-described above. The proxy-header diagnostic is the first route using this
-requirement; see [Proxy header diagnostic](proxy-header-diagnostic.md).
+"Fully configured" means all of:
+
+1. `ADMIN_ALLOWED_HOSTS` explicitly names an enforceable admin hostname
+   (the canonical-host **fallback** does not count — it is not a choice you
+   made — and `ADMIN_ALLOWED_HOSTS=*` turns the host gate off, so it does not
+   count either);
+2. `ADMIN_ALLOWED_CIDRS` contains at least one parseable range;
+3. the request itself passes both allowlists.
+
+Only a posture where **both** hold satisfies a route requirement:
+
+| Posture | `ADMIN_ALLOWED_HOSTS` | `ADMIN_ALLOWED_CIDRS` | Route requirement | Boot line |
+|---|---|---|---|---|
+| A | unset, no routable anchor (stock self-hosted) | unset | advisory | INFO |
+| B | unset — served by the canonical anchor fallback | unset | advisory | INFO |
+| C | set to a real hostname | unset | advisory | **WARN** |
+| D | `*` (host gate off) | set | advisory | **WARN** |
+| — | unset — canonical anchor fallback | set | advisory | **WARN** |
+| E | set to a real hostname | set | **enforced** | none |
+
+The WARN rows are the ones worth an operator's attention: exactly one of the two
+halves is configured, so the posture looks restricted and enforces no route
+requirement. Note that neither the anchor fallback nor `*` counts as the host
+half — the first is not a choice you made, the second turns the gate off.
+
+**Why the destructive routes do not use the strict token.** `network=admin` has
+no fall-through and no opt-out. Annotating the fifteen destructive colonel
+verbs with it would return `404` — to an authenticated colonel, from localhost,
+with no diagnosis beyond a server WARN — on every install in postures A–D, which
+is every install that has not deliberately configured both allowlists. That is a
+breaking change dressed as hardening, so the destructive routes carry
+`network=admin_if_configured` instead.
+
+**What the annotation is worth in posture A.** Honestly: not much on the request
+path, since a request that reaches the route has already passed whatever
+surface-wide gates are active. Its value is (i) it **fails closed** if
+`AdminNetworkIsolation` ever leaves the middleware stack or a route moves
+outside the `/colonel*` prefixes — the requirement is denied when the
+middleware's verdict is missing entirely, not treated as advisory; (ii) it is a
+one-variable hard enforcement option for operators who want it; and (iii) it is
+a machine-readable, testable statement of which routes are destructive, checked
+in CI against `apps/api/colonel/destructive_actions.rb`.
+
+**Which routes carry it.** Exactly the fifteen tier-1 verbs — the irreversible,
+credential-revoking or privilege-granting ones:
+
+| Method | Path (under `/api/colonel`) |
+|---|---|
+| `DELETE` | `/secrets/:secret_id` |
+| `POST` | `/users/:user_id/email` |
+| `POST` | `/users/:user_id/role` |
+| `DELETE` | `/users/:user_id` |
+| `POST` | `/users/:user_id/sessions/revoke-all` |
+| `DELETE` | `/users/:user_id/sessions/:session_handle` |
+| `DELETE` | `/sessions/:session_handle` |
+| `POST` | `/domains/:extid/transfer` |
+| `DELETE` | `/domains/:extid/configs/:kind` |
+| `DELETE` | `/domains/:extid` |
+| `POST` | `/organizations/:org_id/transfer-ownership` |
+| `POST` | `/organizations/:org_id/members/:member_id/role` |
+| `DELETE` | `/organizations/:org_id/members/:member_id` |
+| `DELETE` | `/organizations/:org_id` |
+| `POST` | `/queues/dlq/:queue/purge` |
+
+**Which routes deliberately do not.** The twelve tier-2 routes — unverify,
+suspend, domain repair/override, domain-config upsert, the entitlement-override
+verbs, membership add, DLQ replay, rate-limit reset — are reversible. A network
+requirement is the one control in this area that fails as a **silent 404**, so it
+covers the irreversible set only; widening it trades a real bricking risk for
+little. The tier-2 verbs still require server-side confirmation, and the tier-1
+verbs still require confirmation *and* step-up re-authentication regardless of
+posture (see
+[colonel-admin-guide.md](colonel-admin-guide.md#destructive-actions-what-the-server-now-requires)).
+The tier lists themselves live in `apps/api/colonel/destructive_actions.rb`, and
+a spec fails if a route is annotated that is not tier 1, or a tier-1 route is not
+annotated.
+
+**Two seams worth knowing**, both deliberate and both unchanged by #4332:
+
+- A route-requirement denial is a `404`, not a `403`, and carries no reason. It
+  is indistinguishable from "this endpoint does not exist" — including from an
+  authenticated colonel on the wrong network.
+- That denial body (`{"error":"Not Found"}`) is **not** byte-identical to the
+  colonel router's own not-found body
+  (`{"error":"Not Found","error_type":"NotFound"}`), so a network-gated route is
+  distinguishable from an undefined one by a caller who looks. Closing that seam
+  is not worth a change to the shared error shape.
+
+Which mode is in force is announced once at boot — see [The boot
+log](#the-boot-log). The proxy-header diagnostic is the one route on the strict
+token; see [Proxy header diagnostic](proxy-header-diagnostic.md).
 
 ## Host allowlist (`site.admin.allowed_hosts`)
 
@@ -224,6 +311,34 @@ Partial failures change nothing: as long as **one** entry is enforceable, the
 rest are dropped with a WARN (`Ignoring unusable entries in
 site.admin.allowed_hosts`) and the survivors are enforced.
 
+## The default posture is open — what the allowlists do and do not do
+
+Before the details: **with both allowlists unset — the shipped default — the
+Colonel surfaces are reachable from any network, on any hostname the app serves
+that the host gate's anchor fallback admits.** Nothing on this page is enforcing
+anything on a stock install beyond that fallback.
+
+What is left holding the door in that posture:
+
+- `role=colonel` at the Otto router, on every `/api/colonel` route;
+- `verify_one_of_roles!(colonel: true)` (plus `cust.verified?`) in every colonel
+  logic class;
+- and, since epic #4323: server-side confirmation on 25 verbs, a step-up (sudo)
+  window on the 15 destructive ones, four rate-limit buckets on
+  `/api/colonel/*`, and a shorter idle/absolute session bound on the admin API.
+  See [colonel-admin-guide.md](colonel-admin-guide.md).
+
+That is a deliberate default, not an oversight: a single-container self-hosted
+install cannot require a VPN, and a fail-closed network default would 404
+`/colonel` on every one of them. But it is **a posture to change deliberately,
+not a hardened baseline**. If operators reach your console over a VPN, an office
+range or a bastion, set both allowlists — that is also what promotes the fifteen
+destructive routes from an advisory network requirement to an enforced one (see
+[Route-level network requirements](#route-level-network-requirements)).
+
+Setting only one of the two gives you neither promotion **and** logs a boot WARN
+saying so.
+
 ## Network allowlist (`site.admin.allowed_cidrs`)
 
 ### Default: no-op (self-hosted single-container)
@@ -232,7 +347,9 @@ When `site.admin.allowed_cidrs` is **unset or empty**, the network gate is a
 strict **no-op** — the surfaces stay reachable from any IP and the auth layers
 (plus the host gate above) are the remaining gates. This is the intended default
 for self-hosted single-container installs, which cannot require a VPN. No new
-configuration is required to keep this factor as it was.
+configuration is required to keep this factor as it was — read
+[the section above](#the-default-posture-is-open--what-the-allowlists-do-and-do-not-do)
+for what that leaves in place.
 
 ### Cloud enablement (private CIDRs)
 
@@ -512,6 +629,14 @@ app-layer auth layers fully in force underneath.
   vouched for, never from the private-address heuristic.
 - A percent-encoded admin path (`/%63olonel`, `/colonel%2Fsettings`) returns the
   same 404 as `/colonel` on a denied host or from a denied IP.
+- With **both** allowlists set (posture E): `GET /api/colonel/system/proxy-headers`
+  returns something other than 404 from an allowed host and IP, and the boot log
+  carries **no** advisory line. In every other posture that route is a 404 and
+  the advisory line names the posture — that route is the cheapest probe for
+  which mode you are in.
+- The fifteen destructive routes behave the same in every posture *except* that
+  in posture E they are additionally subject to the two allowlists. They are
+  never taken away by the annotation alone.
 
 ### The boot log
 
@@ -552,6 +677,8 @@ Also emitted at boot, each only in its own case:
 
 | Message | Level | Means |
 |---|---|---|
+| `Admin route network requirement is advisory (admin isolation is not configured)` | INFO | neither half is configured, so `network=admin_if_configured` falls through. Not a misconfiguration |
+| `Admin route network requirement is ADVISORY: admin isolation is half-configured` | WARN | exactly one half is configured — see the posture table under [Route-level network requirements](#route-level-network-requirements). The payload carries both gate states and the fix |
 | ``Admin host allowlist DISABLED by `*` `` | WARN | `ADMIN_ALLOWED_HOSTS` contains `*` — host gate off |
 | ``Ignoring every other entry in site.admin.allowed_hosts: `*` disables the host gate`` | WARN | `*` was listed beside other entries; those entries do nothing |
 | `Ignoring unusable entries in site.admin.allowed_hosts` | WARN | some entries dropped; each named with its reason |

--- a/docs/operations/colonel-admin-guide.md
+++ b/docs/operations/colonel-admin-guide.md
@@ -255,6 +255,65 @@ Configuration lives under `site.admin.elevation` and `site.admin.rate_limit` in
 `etc/defaults/config.defaults.yaml`; every knob has an env var, listed in
 `.env.reference`.
 
+### Rate limits on `/api/colonel/*` (#4329)
+
+Before this, nothing throttled the colonel API at all: a scripted compromise of a
+colonel session could purge at wire speed and, because the operator audit trail
+trims at a 10 000-event count cap with no TTL, evict the evidence of its own
+actions while doing it. Four buckets now bound it. All four are keyed on the
+**acting colonel's `extid`** — the same public id the audit trail records as
+`actor`, never a session id (that value *is* the bearer cookie) — so a second
+stolen session or a parallel tab shares one budget rather than getting a fresh
+one.
+
+| Kind | Limit | What it covers |
+|---|---|---|
+| `colonel_mutation` | 120 / 5 min, 5 min lockout | every mutating colonel verb (POST/PUT/PATCH/DELETE), charged once per request |
+| `colonel_destructive` | 10 / 5 min, **15 min** lockout | the fifteen tier-1 verbs, charged **only when the request is about to execute** |
+| `colonel_handle_resolve` | 60 / 5 min, 5 min lockout | `GET`/`DELETE /sessions/:session_handle`, the two reads that may fall back to a bounded 10 000-key scan |
+| `colonel_elevation` | 5 / 15 min, 15 min lockout | `POST /elevation` (above) |
+
+Over a cap the API answers **429** with the usual body — `error`, `error_type:
+"LimitExceeded"`, `retry_after`, `max_attempts` — plus a `Retry-After` header.
+The console renders the server's message in the confirm dialog and appends the
+wait and the recovery path.
+
+Three things worth knowing:
+
+- **Ordinary reads are deliberately unlimited.** The console fetches several on
+  every screen; throttling them would break the dashboard. The two
+  handle-resolving session reads are the one exception, because each can cost a
+  bounded scan plus as many HMACs.
+- **A refused destructive attempt costs nothing.** The destructive charge is the
+  last step of the guard sequence — after step-up, confirmation and the per-verb
+  interlocks all pass — so the ten are ten *real* actions, not five plus five
+  wasted pre-elevation retries, and nobody holding your cookie can lock you out
+  of incident response with cheap 403s. Volume is still bounded meanwhile by the
+  broad `colonel_mutation` bucket.
+- **A destructive burst is a bulk-work signal.** Ten actions per five minutes is
+  sized for incident response, not for migrations. Bulk work belongs on
+  `bin/ots`, which these limiters do not touch.
+
+**Clearing a lockout.** `POST /api/colonel/ratelimit/reset` with `kind` set to the
+bucket and `subject` set to the colonel's extid; it is a tier-2 verb, so it needs
+no elevation and stays reachable while the destructive, handle-resolve or
+elevation bucket is exhausted. The one bucket it cannot rescue you from is
+`colonel_mutation` — the reset is itself a mutation — so clear that one with the
+valkey-cli commands `bin/ots ratelimit keys colonel_mutation <extid>` prints
+(the CLI only prints them; it never connects). `bin/ots ratelimit inspect
+<kind> <extid>` shows the current counter and lockout TTL.
+
+**Audit.** Only the **cap-reaching** request writes an event, into the security
+collection (`record_security`: 7-day retention, its own cap), never the operator
+trail: `colonel.mutation_throttled`, `colonel.destructive_throttled`,
+`colonel.handle_resolve_throttled`, `colonel.elevate_throttled`. Every subsequent
+429 inside the lockout window writes nothing, which is what keeps a throttled
+attacker from minting events.
+
+**If Redis is unavailable** the limiters fail **closed**: a colonel mutation 500s
+rather than being admitted unthrottled. That matches every other limiter in the
+codebase.
+
 ## 3. Restricting the admin surfaces
 
 Two independent factors restrict which requests reach `/colonel*` and

--- a/docs/operations/colonel-admin-guide.md
+++ b/docs/operations/colonel-admin-guide.md
@@ -142,6 +142,83 @@ Which verbs are gated, and which mutating verbs are deliberately **not**, is
 committed data in `apps/api/colonel/destructive_actions.rb`; a spec fails if a
 new mutating route appears in none of the three lists.
 
+### Step-up (sudo) re-authentication — `POST /api/colonel/elevation`
+
+On top of confirmation, the **tier-1** verbs (the fifteen irreversible,
+credential-revoking or privilege-granting ones — purge, role change, session
+revoke, secret/org/domain/config delete, domain transfer, DLQ purge) also require
+a live **elevation window**. A colonel session alone is no longer sufficient for
+any of them: the operator must have re-proven a credential in the last ten
+minutes. A verb attempted outside a window is refused with **403
+`error_code: elevation_required`**, carrying the window length in seconds.
+
+```
+GET    /api/colonel/elevation   → { record: { elevated, expires_at, seconds_remaining },
+                                    details: { enabled, window, reauth_grace,
+                                               grace_available, password_available, factors } }
+POST   /api/colonel/elevation   → { "factor": "password", "password": "…" }
+DELETE /api/colonel/elevation   → ends the window early
+```
+
+- **The console does this for you.** A 403 opens an in-place sudo prompt, and the
+  refused call is retried **once, after** the operator completes it. It is never
+  retried silently.
+- **The window is per session AND per identity.** A second browser elevates
+  separately, and signing in as a different account in the same browser lands
+  unelevated — the stored value names the account that minted it, and both login
+  paths delete it outright.
+- **Two factors.** `password` re-verifies the account password and is the only
+  factor available by default. `recent_auth` elevates with no credential inside a
+  post-sign-in grace, but ONLY for accounts that cannot satisfy the password
+  factor and ONLY when an operator sets a non-zero
+  `COLONEL_ELEVATION_REAUTH_GRACE` (**default 0 — off**). Giving that grace to
+  password holders would make step-up a no-op for the first N seconds after every
+  colonel sign-in, which is the exact condition this control exists to remove.
+  MFA as a step-up factor is not implemented.
+- **SSO-only fleets must configure one of two things.** A colonel with no password
+  cannot elevate at all otherwise. Either set
+  `COLONEL_ELEVATION_REAUTH_GRACE` to a non-zero number of seconds, or set
+  `COLONEL_ELEVATION_ENABLED=false` (confirmation still applies). In **full auth
+  mode** the password probe is not reachable from the API layer, so every account
+  there counts as password-holding and `recent_auth` is unavailable —
+  a full-mode SSO-only fleet uses `COLONEL_ELEVATION_ENABLED=false`.
+  `GET /api/colonel/elevation` reports `password_available` and `factors` for the
+  calling account, so the console can say which of these applies.
+- **The console does not poll this endpoint**, and must not be made to. Every
+  authenticated request advances the session's `last_activity_at`, so a polling
+  banner would keep an idle admin tab alive forever and disable the admin idle
+  timeout. The countdown you see is computed in the browser from `expires_at`.
+
+**Throttle.** `POST /api/colonel/elevation` is limited to 5 attempts per 15
+minutes per colonel account, then a 15-minute lockout — the password check behind
+it is a Rodauth *internal request*, which does not increment Rodauth's own lockout
+counter, so this limiter is the only backstop against guessing. Clear a stuck
+lockout with `POST /api/colonel/ratelimit/reset` (kind `colonel_elevation`,
+subject the colonel's extid — a tier-2 verb, so it needs no elevation), or with
+the commands `bin/ots ratelimit keys colonel_elevation <extid>` prints.
+
+**Audit.** A successful step-up records `colonel.elevate` on the operator trail
+*carrying the factor used*, so a password-less `recent_auth` window is visible as
+the weaker path. A failed attempt records the same `colonel.elevate` verb with
+`result: failure` into the **security** collection (`record_security`: 7-day
+retention, its own cap), never the operator trail, because a cookie holder can
+drive failures on demand. Reaching the throttle records `colonel.elevate_throttled`
+there too, once per lockout window. Dropping a window records
+`colonel.elevate_drop`. An `ElevationRequired` refusal records **nothing at all**,
+for the same reason as the confirmation gate.
+
+**Residual risk, stated rather than hidden.** Elevation is carried by the session.
+While a window is live, a stolen session cookie is exactly as capable as it was
+before this feature existed. What the window buys is that the capability is
+time-bounded, operator-initiated and audited instead of standing. Binding it to a
+value the cookie does not carry — an elevation nonce echoed as a request header —
+is the follow-up, and is not implemented here. Do not read (or write) release
+notes implying that cookie theft is now bounded by the credential.
+
+Configuration lives under `site.admin.elevation` and `site.admin.rate_limit` in
+`etc/defaults/config.defaults.yaml`; every knob has an env var, listed in
+`.env.reference`.
+
 ## 3. Restricting the admin surfaces
 
 Two independent factors restrict which requests reach `/colonel*` and

--- a/docs/operations/colonel-admin-guide.md
+++ b/docs/operations/colonel-admin-guide.md
@@ -48,6 +48,42 @@ Notes:
 - Add `-f`/`--force` to skip the confirmation prompt in automation.
 - To revoke access, `demote` the account; the role is removed immediately.
 
+### Self-target and last-colonel interlocks (#4328)
+
+The console refuses four things outright, with a 422 naming the remediation:
+
+| Action | Why it is refused |
+|---|---|
+| Demoting **your own** colonel account | Nobody else could undo it from the console. |
+| Demoting the **last remaining** colonel | The install would have no administrator. |
+| **Unverifying** your own account | A system role requires `cust.verified?`, so unverifying is a demotion by another name. |
+| Unverifying the **last remaining** colonel | Same, applied to the whole install. |
+
+The last two matter more than they look: unverifying used to be an un-gated
+POST that stripped colonel eligibility straight past any last-colonel check on
+the role endpoint.
+
+**The CLI is the recovery path, and it is interlocked too.** `bin/ots customers
+role demote` and `bin/ots customers unverify` refuse the last remaining verified
+colonel and exit non-zero — the refusal lives in the shared operation, not in
+the HTTP adapter, so there is no way around it short of editing Redis. To
+actually hand over the last colonel account, promote **and verify** the
+replacement first, then demote.
+
+"Last remaining colonel" is computed from the authoritative `role` field on
+every candidate, not from `customer:role_index:colonel`. That index drifts
+UPWARD (see `bin/ots customers role reconcile`), so counting it would make the
+guard fail open and let you demote the only administrator you have.
+
+Two session verbs carry the same self-target rule:
+
+- Revoking **your own** session, from either the global console or the
+  per-customer panel, is refused — sign out instead.
+- Revoking **all** sessions on your own account is **not** refused. It is the
+  first containment step for a leaked colonel cookie, so it runs the
+  except-current variant: every other session dies and the one you are working
+  in survives.
+
 ## 2. What the console can do
 
 Every capability is enforced by the two-layer authorization invariant (router

--- a/docs/operations/colonel-admin-guide.md
+++ b/docs/operations/colonel-admin-guide.md
@@ -314,6 +314,47 @@ attacker from minting events.
 rather than being admitted unthrottled. That matches every other limiter in the
 codebase.
 
+### Admin session lifetime (#4331)
+
+`/api/colonel*` expires on its own schedule, independently of the session cookie.
+
+| Bound | Default | Source | Env var |
+| --- | --- | --- | --- |
+| Idle | 1 h | `SessionMetadata#last_activity_at` (the per-session sidecar) | `ADMIN_SESSION_IDLE_TIMEOUT` |
+| Absolute | 12 h | `session['authenticated_at']`, stamped at sign-in | `ADMIN_SESSION_ABSOLUTE_TIMEOUT` |
+
+Exceeding either answers **401** with
+`[ADMIN_SESSION_EXPIRED] Admin session <idle|absolute> timeout exceeded; sign in
+again`. Set either to `0` to disable that bound, or
+`ADMIN_SESSION_LIFETIME_ENABLED=false` to restore the pre-#4331 posture.
+
+**What this does NOT do, on purpose.** It does not shorten the `onetime.session`
+cookie: one cookie serves the admin console, the tenant app and the auth app, so
+expiring the object would log a colonel out of the customer app — and on a
+self-hosted install the colonel is frequently the only customer.
+`site.session.expire_after` (24 h rolling) still governs the session itself. It
+also does not gate the `/colonel` SPA shell: the shell loads on a stale session,
+its first API call 401s, and the console renders an expired banner with a
+sign-in link rather than a bare JSON error on an HTML navigation.
+
+**Recovery is sign-in.** There is no refresh endpoint — signing in replaces the
+session, which also drops any step-up window. Nothing else in the console
+changes.
+
+**Two caveats worth understanding before you rely on the idle bound.** The
+sidecar it reads is best-effort: a session that predates the feature or whose
+30-day sidecar TTL lapsed has no record, and a missing record SKIPS the idle
+check rather than failing it (the absolute bound still applies). And that record
+is a **site-wide** activity clock, so a colonel who is browsing the tenant app
+keeps their admin window open too. A request the bound refuses does not stamp
+activity — an expired window stays expired across retries — but per-surface idle
+tracking needs the separate admin session that splitting the cookie would give.
+
+**If you build anything against the console:** the idle bound only bites because
+the admin SPA makes no periodic requests. Any polling added under
+`src/apps/admin/` would refresh `last_activity_at` forever and silently disable
+this control.
+
 ## 3. Restricting the admin surfaces
 
 Two independent factors restrict which requests reach `/colonel*` and

--- a/docs/operations/colonel-admin-guide.md
+++ b/docs/operations/colonel-admin-guide.md
@@ -118,6 +118,51 @@ acting colonel, the verb, the target, and the result — whether it originated
 from the console or the CLI (both go through the same shared operations). This is
 the non-negotiable backstop for privileged actions.
 
+### Destructive actions: what the server now requires
+
+**Read this section when a colonel API call starts returning 403.**
+
+Until epic #4323 every safety interlock on a destructive colonel action lived in
+the browser: typed-confirmation dialogs, danger flags and warnings were all
+Vue-side, and the API executed purge / delete / revoke / role-change on a bare
+authenticated request. A leaked colonel session cookie was unbounded,
+un-throttled destructive capability. It is not any more. Every mutating verb is
+now in exactly one of three tiers, and each tier costs a caller something
+different:
+
+| Tier | Count | What the server requires, on top of a colonel session |
+| --- | --- | --- |
+| **1 — destructive** | 15 routes | `X-OTS-Confirm` **and** a live step-up window **and** the tight `colonel_destructive` bucket **and** `network=admin_if_configured` |
+| **2 — sensitive** | 12 routes | `X-OTS-Confirm` only |
+| **3 — reviewed, un-gated** | the rest | nothing beyond the two authorization layers and the broad `colonel_mutation` bucket |
+
+Tier 1 is the irreversible, credential-revoking or privilege-granting set:
+delete a secret, change or purge an account, change a role, transfer or delete a
+domain or a domain config, transfer or delete an organization, change or remove
+a membership, revoke a session or all of an account's sessions, purge a DLQ.
+Tier 2 is reversible but removes a defence, denies service or grants privilege —
+unverify, suspend, domain repair/override, domain-config upsert, entitlement
+overrides, membership add, DLQ replay, rate-limit reset.
+
+Which verb is in which tier is **committed data**, not prose:
+`apps/api/colonel/destructive_actions.rb`, with a spec that fails if a new
+mutating route appears in none of the three lists.
+
+Two more things changed on the wire and are easy to trip over from a script:
+
+- **Sessions are addressed by an opaque handle, not a session id** (#4330).
+  `GET|DELETE /api/colonel/sessions/:session_handle` takes a 32-hex handle (an
+  HMAC of the session id), never the raw id, and the console never renders a
+  live bearer credential again. Both accept an optional `?user_id=` owner hint,
+  which makes the lookup cheap and exact instead of a bounded scan; without it a
+  read can report `details.scan_capped: true`, meaning "not found, but the scan
+  was truncated" rather than "absent". `bin/ots session` is unaffected.
+- **Four new refusals are 422s, not 403s** (#4328): demoting or unverifying
+  yourself or the last remaining colonel, and revoking your own active session.
+  Revoking *all* of your own sessions still works and keeps the current one.
+
+The rest of this section takes each control in turn.
+
 ### Destructive-action confirmation — `X-OTS-Confirm`
 
 Typed-confirmation used to live only in the browser: past the console, purge,
@@ -355,6 +400,36 @@ the admin SPA makes no periodic requests. Any polling added under
 `src/apps/admin/` would refresh `last_activity_at` forever and silently disable
 this control.
 
+### Network gating on the destructive routes (#4332)
+
+The fifteen tier-1 routes declare `network=admin_if_configured`. In the shipped
+posture — neither `ADMIN_ALLOWED_HOSTS` nor `ADMIN_ALLOWED_CIDRS` set — this
+changes nothing you can observe: the requirement is **advisory** and the routes
+behave exactly as before. Set **both** variables and it becomes **enforced**, so
+those fifteen verbs are additionally bound to the admin hostname and the admin
+network. Setting only one gives you neither, and logs a boot WARN saying so.
+
+There is no third state and no per-route opt-out. The reason the token is
+`_if_configured` rather than the strict `network=admin` used by
+`GET /system/proxy-headers` is that the strict token has no fall-through: it
+would `404` all fifteen destructive verbs for an authenticated colonel on
+localhost, on every install that has not configured both allowlists.
+
+Its value in the advisory posture is narrower than it looks, and worth being
+plain about: a request that reaches one of these routes has already passed
+whatever surface-wide gates are active, so this is belt-and-braces. What it
+genuinely buys is that the requirement **fails closed** — if
+`AdminNetworkIsolation` ever leaves the middleware stack, or one of these routes
+moves outside the `/colonel*` prefixes, the route 404s instead of serving.
+
+A denial here is a bare `404` with no reason, indistinguishable from a route
+that does not exist. If a destructive verb starts 404ing after you set the
+allowlists, that is where to look first — the twelve tier-2 verbs are
+deliberately not annotated, so they will keep working and the contrast is the
+diagnosis. Full detail, including the five postures and the exact route list, is
+in
+[admin-network-isolation.md](admin-network-isolation.md#route-level-network-requirements).
+
 ## 3. Restricting the admin surfaces
 
 Two independent factors restrict which requests reach `/colonel*` and
@@ -389,6 +464,14 @@ client IPs may reach the surfaces. Unset (the default) it is a no-op, the right
 posture for a self-hosted single-container install that cannot require a VPN. Do
 not put public CIDRs in the allowlist — the app-layer auth remains the gate for
 anyone already on the trusted network.
+
+**With both unset — the shipped default — the colonel surfaces are reachable
+from any network on any hostname the anchor fallback admits**, and the controls
+in section 2 are the only ones enforcing. That is deliberate, and it is a
+posture to change deliberately rather than a hardened baseline. Setting both is
+also what promotes the fifteen destructive routes from an advisory network
+requirement to an enforced one (see [Network gating on the destructive
+routes](#network-gating-on-the-destructive-routes-4332)).
 
 Both are a config posture, not a code fork — the same app-layer enforcement runs
 underneath regardless. The full setup (upgrade impact, private CIDRs, the

--- a/docs/operations/colonel-admin-guide.md
+++ b/docs/operations/colonel-admin-guide.md
@@ -273,10 +273,13 @@ DELETE /api/colonel/elevation   → ends the window early
 **Throttle.** `POST /api/colonel/elevation` is limited to 5 attempts per 15
 minutes per colonel account, then a 15-minute lockout — the password check behind
 it is a Rodauth *internal request*, which does not increment Rodauth's own lockout
-counter, so this limiter is the only backstop against guessing. Clear a stuck
-lockout with `POST /api/colonel/ratelimit/reset` (kind `colonel_elevation`,
-subject the colonel's extid — a tier-2 verb, so it needs no elevation), or with
-the commands `bin/ots ratelimit keys colonel_elevation <extid>` prints.
+counter, so this limiter is the only backstop against guessing. Clear your OWN
+stuck lockout with the commands `bin/ots ratelimit keys colonel_elevation
+<extid>` prints — a colonel cannot clear their own `colonel_*` bucket over the
+API (a leaked cookie could otherwise loop out of its own lockout). A SECOND
+colonel can clear it for you with `POST /api/colonel/ratelimit/reset` (kind
+`colonel_elevation`, subject the locked colonel's extid — a tier-2 verb, so it
+needs no elevation).
 
 **Audit.** A successful step-up records `colonel.elevate` on the operator trail
 *carrying the factor used*, so a password-less `recent_auth` window is visible as
@@ -339,14 +342,24 @@ Three things worth knowing:
   sized for incident response, not for migrations. Bulk work belongs on
   `bin/ots`, which these limiters do not touch.
 
-**Clearing a lockout.** `POST /api/colonel/ratelimit/reset` with `kind` set to the
-bucket and `subject` set to the colonel's extid; it is a tier-2 verb, so it needs
-no elevation and stays reachable while the destructive, handle-resolve or
-elevation bucket is exhausted. The one bucket it cannot rescue you from is
-`colonel_mutation` — the reset is itself a mutation — so clear that one with the
-valkey-cli commands `bin/ots ratelimit keys colonel_mutation <extid>` prints
-(the CLI only prints them; it never connects). `bin/ots ratelimit inspect
-<kind> <extid>` shows the current counter and lockout TTL.
+**Clearing a lockout.** A colonel cannot clear their OWN `colonel_*` bucket over
+the API: `POST /api/colonel/ratelimit/reset` refuses with a 422 when `subject` is
+the caller's own extid, because a leaked cookie could otherwise reset its own
+lockout in a loop and defeat the bucket. Two paths remain:
+
+- **Your own lockout** — the valkey-cli commands `bin/ots ratelimit keys <kind>
+  <extid>` prints (the CLI only prints them; it never connects). This is the only
+  path that clears your own bucket — including `colonel_mutation`, which the reset
+  endpoint could never clear anyway (the reset is itself a mutation) — and it
+  needs no second operator.
+- **A peer clears it for you** — a SECOND colonel calls `POST
+  /api/colonel/ratelimit/reset` with `kind` set to the bucket and `subject` set to
+  the locked colonel's extid; it is a tier-2 verb, so it needs no elevation and
+  stays reachable while that colonel's destructive, handle-resolve or elevation
+  bucket is exhausted.
+
+`bin/ots ratelimit inspect <kind> <extid>` shows the current counter and lockout
+TTL.
 
 **Audit.** Only the **cap-reaching** request writes an event, into the security
 collection (`record_security`: 7-day retention, its own cap), never the operator

--- a/docs/operations/colonel-admin-guide.md
+++ b/docs/operations/colonel-admin-guide.md
@@ -82,6 +82,66 @@ acting colonel, the verb, the target, and the result — whether it originated
 from the console or the CLI (both go through the same shared operations). This is
 the non-negotiable backstop for privileged actions.
 
+### Destructive-action confirmation — `X-OTS-Confirm`
+
+Typed-confirmation used to live only in the browser: past the console, purge,
+delete, revoke and DLQ-purge executed on a bare authenticated request. They are
+now checked **server-side**. A gated verb is refused with **403
+`error_code: confirmation_required`** unless the request carries an identifier of
+the target in the `X-OTS-Confirm` request header.
+
+- **A header, not a query or body parameter.** Most of these tokens are an email
+  address, an organization name or a hostname — PII that a query string writes
+  into every access log, proxy log and browser history. `?confirm=…` is ignored;
+  it is not a fallback.
+- **Percent-encoded**, because HTTP header values are ISO-8859-1 by RFC 7230 and
+  an organization display name may not be. A plain ASCII token is unchanged by
+  encoding, so `curl -H 'X-OTS-Confirm: victim@example.com'` works as typed.
+- **Apply only.** A verb with a `dry_run` preview needs no header to preview; the
+  preview writes nothing. `dry_run` defaults to TRUE on the domain and
+  organization verbs and FALSE on the DLQ verbs.
+- **The console sends it for you.** This matters to scripted callers and to the
+  eleven endpoints below that have no UI at all.
+
+Eighteen of the twenty-five gated verbs ask for an identifier the URL does not
+carry, so a scraped-URL replay needs a second fact about the target. The two DLQ
+verbs echo the queue name because a queue has no second identifier.
+
+| Endpoint | `X-OTS-Confirm` must equal | UI? |
+| -------- | -------------------------- | --- |
+| `DELETE /secrets/:secret_id` | the receipt **shortid** | yes |
+| `POST /users/:user_id/email` | the account's **current email** | no |
+| `POST /users/:user_id/role` | the account **email** (its extid when it has none) | yes |
+| `POST /users/:user_id/unverify` | the account **email** | yes |
+| `POST /users/:user_id/suspend` | the account **email** | yes |
+| `DELETE /users/:user_id` | the account **email** | yes |
+| `POST /users/:user_id/sessions/revoke-all` | the account **email** | yes |
+| `DELETE /users/:user_id/sessions/:session_handle` | the session owner's **email** | yes |
+| `DELETE /sessions/:session_handle` | the session owner's **email** (its external id, or the handle for an anonymous session) | yes |
+| `POST /domains/:extid/repair` | the **domain name** | yes |
+| `POST /domains/:extid/override` | the **domain name** | yes |
+| `POST /domains/:extid/transfer` | the **domain name** | yes |
+| `DELETE /domains/:extid` | the **domain name** | yes |
+| `PUT\|DELETE /domains/:extid/configs/:kind` | `"<domain name>:<kind>"` | yes |
+| `POST /organizations/:org_id/transfer-ownership` | the organization **name** (its extid when it has none) | no |
+| `POST /organizations/:org_id/members` | the organization **name** | yes |
+| `POST\|DELETE /organizations/:org_id/entitlements/…` | the organization **name** | yes |
+| `DELETE /organizations/:org_id` | the organization **name** | yes |
+| `POST /organizations/:org_id/members/:member_id/role` | the member's **email** | no |
+| `DELETE /organizations/:org_id/members/:member_id` | the member's **email** | no |
+| `POST\|DELETE /organizations/:org_id/members/:member_id/entitlements/…` | the member's **email** | no |
+| `POST /queues/dlq/:queue/purge` | the **queue name** | no |
+| `POST /queues/dlq/:queue/replay` | the **queue name** | no |
+| `POST /ratelimit/reset` | `"<kind>:<subject>"` | no |
+
+A refusal writes **no audit event** — deliberately. `ConfirmationRequired` is in
+the `Forbidden` family, which the auto-audit path excludes, so hammering the gate
+cannot mint events and flush the count-capped operator trail.
+
+Which verbs are gated, and which mutating verbs are deliberately **not**, is
+committed data in `apps/api/colonel/destructive_actions.rb`; a spec fails if a
+new mutating route appears in none of the three lists.
+
 ## 3. Restricting the admin surfaces
 
 Two independent factors restrict which requests reach `/colonel*` and

--- a/docs/operations/pentest-scope.md
+++ b/docs/operations/pentest-scope.md
@@ -83,8 +83,8 @@ Expected responses for the negative cases (asserted by the BFLA tryout):
 | DELETE | /api/colonel/organizations/:org_id/entitlements/overrides | ColonelAPI::Logic::Colonel::ManageEntitlementOverride |
 | GET    | /api/colonel/usage/export | ColonelAPI::Logic::Colonel::ExportUsage |
 | GET    | /api/colonel/sessions | ColonelAPI::Logic::Colonel::ListSessions |
-| GET    | /api/colonel/sessions/:session_id | ColonelAPI::Logic::Colonel::GetSessionDetail |
-| DELETE | /api/colonel/sessions/:session_id | ColonelAPI::Logic::Colonel::DeleteSession |
+| GET    | /api/colonel/sessions/:session_handle | ColonelAPI::Logic::Colonel::GetSessionDetail |
+| DELETE | /api/colonel/sessions/:session_handle | ColonelAPI::Logic::Colonel::DeleteSession |
 | GET    | /api/colonel/banner | ColonelAPI::Logic::Colonel::GetBanner |
 | POST   | /api/colonel/banner | ColonelAPI::Logic::Colonel::SetBanner |
 | DELETE | /api/colonel/banner | ColonelAPI::Logic::Colonel::ClearBanner |

--- a/docs/operations/pentest-scope.md
+++ b/docs/operations/pentest-scope.md
@@ -131,8 +131,12 @@ Expected responses for the negative cases (asserted by the BFLA tryout):
     it must land in the security collection, not the count-capped operator
     trail. A 429 that mints an operator-trail event is a log-eviction primitive.
   - *Recovery.* `POST /ratelimit/reset` is deliberately tier 2 (no step-up) so a
-    locked-out colonel can clear their own bucket; check it cannot be used to
-    clear another subject's limiter without the confirmation header.
+    PEER colonel can clear a locked-out colonel's bucket while that colonel's own
+    step-up bucket is exhausted. A colonel canNOT clear their OWN `colonel_*`
+    bucket over HTTP — self-reset is refused with a 422 (#4329 review), since a
+    leaked cookie could otherwise loop out of its own lockout. Check that the
+    refusal holds for every `colonel_*` kind, and that no reset lands without the
+    confirmation header.
 - **Admin session lifetime (#4331)** — `/api/colonel*` additionally requires a
   colonel session to be within a 1 h idle and a 12 h absolute bound; the shared
   cookie, the tenant app and the `/colonel` SPA shell are deliberately NOT

--- a/docs/operations/pentest-scope.md
+++ b/docs/operations/pentest-scope.md
@@ -133,6 +133,20 @@ Expected responses for the negative cases (asserted by the BFLA tryout):
   - *Recovery.* `POST /ratelimit/reset` is deliberately tier 2 (no step-up) so a
     locked-out colonel can clear their own bucket; check it cannot be used to
     clear another subject's limiter without the confirmation header.
+- **Admin session lifetime (#4331)** — `/api/colonel*` additionally requires a
+  colonel session to be within a 1 h idle and a 12 h absolute bound; the shared
+  cookie, the tenant app and the `/colonel` SPA shell are deliberately NOT
+  bounded. Worth attacking specifically:
+  - *Sliding the window from the wrong side.* A request the bound REFUSES must
+    not stamp activity. If a 401 lets the next request through, the idle bound is
+    a one-request speed bump; any endpoint that acts as a keep-alive for an
+    already-expired session is a finding.
+  - *Reaching the absolute bound.* `authenticated_at` is stamped at sign-in and
+    only a password change re-stamps it. Any path that lets a request advance it
+    defeats the bound entirely.
+  - *Scope creep in reverse.* A colonel refused on `/api/colonel` must still be
+    served on `/`, `/account/*` and `GET /colonel`. Logging them out of the
+    tenant app is the regression this design exists to prevent, not a hardening.
 - **Bundle isolation** — the admin bundle (`src/admin.ts`) must not ship to the
   customer frontend and the customer bundle must not import `src/apps/admin/*`
   (enforced by `src/tests/apps/admin/admin-isolation.spec.ts`).

--- a/docs/operations/pentest-scope.md
+++ b/docs/operations/pentest-scope.md
@@ -168,3 +168,24 @@ Expected responses for the negative cases (asserted by the BFLA tryout):
     it.
 
   See `docs/operations/admin-network-isolation.md`.
+- **Route-level network requirements (#4332)** — two tokens ride on the same
+  middleware verdict: `network=admin` (strict, one route —
+  `GET /system/proxy-headers`) and `network=admin_if_configured` (the 15 tier-1
+  destructive routes), which enforces only where BOTH allowlists are configured
+  and otherwise falls through. Worth attacking specifically:
+  - *Forging the verdict.* Both strategies read Rack env keys
+    (`onetime.admin_network_requirement_met` / `…_mode`). Any way for a client
+    to inject an env key — a header that survives into env under that name, a
+    middleware that copies headers wholesale — turns the strict route on and
+    the advisory one into a permanent bypass. Nothing may write those keys but
+    `AdminNetworkIsolation`.
+  - *Fail-open on a missing middleware.* An ABSENT mode key must DENY, not read
+    as advisory. Removing `AdminNetworkIsolation` from the stack, or moving an
+    annotated route outside `/colonel*`, must 404 the route rather than serve
+    it.
+  - *Coverage drift.* Exactly the 15 tier-1 routes carry the token, and no
+    tier-2/tier-3 route carries any `network=` token
+    (`spec/unit/onetime/application/colonel_route_annotations_spec.rb`). A
+    destructive route added without a tier entry is a finding.
+  - *Posture confusion.* Setting only one of the two allowlists must not read as
+    configured — it enforces nothing and must log the WARN that says so.

--- a/docs/operations/pentest-scope.md
+++ b/docs/operations/pentest-scope.md
@@ -56,6 +56,9 @@ Expected responses for the negative cases (asserted by the BFLA tryout):
 | GET    | /api/colonel/info | ColonelAPI::Logic::Colonel::GetColonelInfo |
 | GET    | /api/colonel/stats | ColonelAPI::Logic::Colonel::GetColonelStats |
 | GET    | /api/colonel/config | ColonelAPI::Logic::Colonel::GetSystemSettings |
+| GET    | /api/colonel/elevation | ColonelAPI::Logic::Colonel::GetElevationStatus |
+| POST   | /api/colonel/elevation | ColonelAPI::Logic::Colonel::ElevateSession |
+| DELETE | /api/colonel/elevation | ColonelAPI::Logic::Colonel::DropElevation |
 | GET    | /api/colonel/available-plans | ColonelAPI::Logic::Colonel::GetAvailablePlans |
 | POST   | /api/colonel/entitlement-preview | ColonelAPI::Logic::Colonel::SetEntitlementPreview |
 | GET    | /api/colonel/secrets | ColonelAPI::Logic::Colonel::ListSecrets |

--- a/docs/operations/pentest-scope.md
+++ b/docs/operations/pentest-scope.md
@@ -115,6 +115,24 @@ Expected responses for the negative cases (asserted by the BFLA tryout):
 - **Audit trail** — every mutating operation must record exactly one
   `ColonelAuditEvent` (actor / verb / target / result). A mutation that leaves no
   audit event is a finding.
+- **Rate limits (#4329)** — four buckets, all keyed on the acting colonel's
+  `extid`: `colonel_mutation` (120/5 min, every mutating verb),
+  `colonel_destructive` (10/5 min, tier-1 verbs), `colonel_handle_resolve`
+  (60/5 min, the two session-handle reads) and `colonel_elevation` (5/15 min).
+  Worth attacking specifically:
+  - *Budget exhaustion as DoS.* A caller holding the cookie but unable to pass
+    step-up or confirmation must not be able to consume the destructive budget —
+    the charge is the last step of the guard sequence, and a rejected attempt
+    that decrements it is a finding (it would let an attacker lock the real
+    operator out of incident response).
+  - *Key contents.* No limiter key may contain a session id, an objid, or an
+    email; `redis-cli --scan 'colonel:*'` should show only extids.
+  - *Audit amplification.* Only the cap-reaching request may write an event, and
+    it must land in the security collection, not the count-capped operator
+    trail. A 429 that mints an operator-trail event is a log-eviction primitive.
+  - *Recovery.* `POST /ratelimit/reset` is deliberately tier 2 (no step-up) so a
+    locked-out colonel can clear their own bucket; check it cannot be used to
+    clear another subject's limiter without the confirmation header.
 - **Bundle isolation** — the admin bundle (`src/admin.ts`) must not ship to the
   customer frontend and the customer bundle must not import `src/apps/admin/*`
   (enforced by `src/tests/apps/admin/admin-isolation.spec.ts`).

--- a/docs/operations/proxy-header-diagnostic.md
+++ b/docs/operations/proxy-header-diagnostic.md
@@ -16,6 +16,16 @@ For this route, `network=admin` requires explicit, enforceable values for both
 does not admit the request, the endpoint returns `404`. The canonical-host
 fallback used by ordinary Colonel routes does not satisfy this requirement.
 
+`network=admin` is the **strict** of two tokens. Since #4332 there is also
+`network=admin_if_configured`, carried by the 15 destructive colonel routes,
+which enforces the same requirement only where the operator configured admin
+isolation and otherwise falls through — a stock self-hosted install cannot
+satisfy the strict token, and taking those routes away is not an option. This
+route keeps the strict token deliberately: it is a read-only diagnostic that is
+*supposed* to be absent unless both allowlists are set, which also makes it the
+cheapest probe for which mode a deployment is in. See
+[admin-network-isolation.md](admin-network-isolation.md#route-level-network-requirements).
+
 `AdminNetworkIsolation` evaluates the host and CIDR gates before the Otto route
 and its controller run. The endpoint returns only a fixed allowlist of
 proxy-related fields; it does not dump arbitrary request headers.

--- a/docs/specs/colonel-ui/spec-session-gap-analysis.md
+++ b/docs/specs/colonel-ui/spec-session-gap-analysis.md
@@ -106,6 +106,17 @@ the sidecar; accept the plain sid only as _input_ to revoke. `SessionMetadata`
 already exists as the natural home for a display id. Audit rows should carry the
 hashed form (see 5.7).
 
+**Resolved for the global console (#4330).** `Sessions::List` now emits
+`SessionMetadata.handle_for(sid)` and strips `session_id`/`key` unless the caller
+passes `reveal_session_id: true` (only `bin/ots session` does).
+`GET`/`DELETE /api/colonel/sessions/:session_handle` take the handle and resolve
+it server-side via `Sessions::Store.resolve_handle` — owner-hinted first, bounded
+scan second — and `Sessions::Delete` records the handle as its audit target. The
+console renders a truncated handle and gates revoke on the session owner's email.
+Still open here: the raw sid inside `RevokeForCustomer`'s audit **detail** (its
+`target` is the customer), and the "session_id is a public identifier" comment at
+`revoke_for_customer.rb:103`.
+
 ---
 
 ## 2. Termination

--- a/docs/specs/colonel-ui/spec-session-gap-analysis.md
+++ b/docs/specs/colonel-ui/spec-session-gap-analysis.md
@@ -181,6 +181,26 @@ exists. Do not ship the wiring alone.
 | 3.13 | Admin sessions strictly shorter than user sessions               | Same single `onetime.session` cookie, same `expire_after`, for colonel and tenant alike                                                                                                                                               | Absent                                                                                                                                                                                                                                                                                                                                                         | P1       |
 | 3.14 | Admin session must not share a cookie with the tenant-facing app | It does — one cookie name, one store, one TTL                                                                                                                                                                                         | Compensating control exists (`AdminNetworkIsolation` middleware). Not a substitute: a stolen tenant-app session cookie from a colonel's browser is a colonel session                                                                                                                                                                                           | P1       |
 
+**Resolved for the colonel API (#4327): 3.3, and 1.11 with it.** A step-up window
+now exists. `sess['elevated_until']` is a registered session sidecar field holding
+`{extid, exp}` — identity-bound, so a cookie that outlives an identity change
+cannot carry a window across it, and both login paths delete it outright.
+`ColonelAPI::Logic::DestructiveAction#require_elevation!` refuses every TIER 1
+verb outside a live window with 403 `elevation_required`;
+`GET|POST|DELETE /api/colonel/elevation` reads, mints and drops one, and the
+console renders the state (1.11) from that read plus a client-side countdown.
+
+Two factors ship: `password` re-verification (dual-mode), and a `recent_auth`
+grace that is OFF by default and, when enabled, offered only to accounts that
+cannot satisfy the password factor. MFA as a step-up factor is not implemented.
+
+Still open here, and deliberately: **3.11**, session-id rotation ON elevation. The
+window is minted on the existing sid rather than a rotated one, so during a live
+window a stolen cookie is exactly as capable as before — the window bounds and
+audits the capability rather than binding it to the credential. Binding it to a
+value the cookie does not carry (an elevation nonce echoed as a request header,
+or a sid rotation at grant time) is the follow-up.
+
 ### 3.1/3.2 detail — two policy engines, neither covering the request path
 
 There are two independent session-policy mechanisms with non-overlapping

--- a/docs/specs/colonel-ui/spec-session-gap-analysis.md
+++ b/docs/specs/colonel-ui/spec-session-gap-analysis.md
@@ -223,6 +223,35 @@ audits the capability rather than binding it to the credential. Binding it to a
 value the cookie does not carry (an elevation nonce echoed as a request header,
 or a sid rotation at grant time) is the follow-up.
 
+**Bounded for the admin API surface (#4331): 3.1, 3.2, 3.13.** `/api/colonel*`
+now additionally requires a colonel session to satisfy a **1h idle** and a **12h
+absolute** bound
+(`lib/onetime/application/auth_strategies/admin_session_lifetime.rb`, checked in
+`BaseSessionAuthStrategy` after the credential watermark and before
+`additional_checks`; 401 `[ADMIN_SESSION_EXPIRED] …`). Both are configurable
+under `site.admin.session.*`, and `0` disables either.
+
+The bound is on the **surface, not the session object**, which is what the detail
+below argues for but stops short of: expiring the blob would shorten both bounds
+for every user of the site and log a colonel out of the tenant app, and on a
+self-hosted install the colonel is often the only customer. The `/colonel` SPA
+shell is deliberately NOT gated either — the expired-session banner lives inside
+the SPA, so the shell loads, its first API call 401s, and the banner explains.
+
+Two properties the idle bound rests on, both worth knowing before scoring it:
+
+- It reads the **best-effort** `SessionMetadata#last_activity_at` and SKIPS
+  itself when no record exists; a lapsed 30-day sidecar must not log anyone out.
+- That field is a **site-wide** activity clock, so tenant traffic keeps the admin
+  window open. A request the bound REFUSES no longer stamps it (the strategy
+  flags the env and `TrackMetadata` honours the flag), so an expired window stays
+  expired; but a per-surface idle clock needs the separate admin session 3.14
+  asks for.
+
+Still open here, and deliberately: **3.14** — the cookie is still shared, with
+`AdminNetworkIsolation` and now these bounds as compensating controls rather than
+a substitute. Also unchanged: 3.4, 3.5, 3.7, 3.8, 3.9, 3.10, 3.12.
+
 ### 3.1/3.2 detail — two policy engines, neither covering the request path
 
 There are two independent session-policy mechanisms with non-overlapping

--- a/docs/specs/colonel-ui/spec-session-gap-analysis.md
+++ b/docs/specs/colonel-ui/spec-session-gap-analysis.md
@@ -140,6 +140,28 @@ Still open here: the raw sid inside `RevokeForCustomer`'s audit **detail** (its
 | 2.15 | CLI revoke path                                    | `bin/ots session` = `inspect` / `list` / `search` / `delete` / `clean`. `delete` is one sid at a time                                                                                                                                                                                                                  | **No per-user revoke-all in the CLI.** The documented break-glass ("when the web UI is unreachable") is per-sid, or `bin/ots customers suspend` as a side effect. Add `bin/ots session revoke-all --user` over the existing op                                                                                                                                                        | P1       |
 | 2.16 | `session clean` does nothing                       | Its only `del` branch is `ttl == 0` (`session_command.rb:381–393`), which Redis never reports — expired keys are already gone                                                                                                                                                                                          | Dead command that reports "Expired sessions removed: 0" and looks like it worked. Delete it or repurpose it to prune orphaned sidecars and stale index members                                                                                                                                                                                                                        | P2       |
 
+**Resolved for the self-revoke case (#4328).** A colonel could revoke their own
+live session from either console with no warning — the same class of mistake
+`PurgeUser`'s self-target guard already covered for accounts. Both
+`DeleteSession` and `RevokeCustomerSession` now refuse it (422, "use sign-out
+instead"), comparing opaque HANDLES so the bearer sid never enters the
+comparison path, and `ListSessions` publishes `details.current_session_handle`
+so the global console can disable that row the way the per-customer panel
+already did.
+
+`POST /users/:id/sessions/revoke-all` against your **own** account is
+deliberately NOT refused: it is the first containment step for a leaked colonel
+cookie, and refusing it would remove the operator's only in-console remedy for
+the compromise they are containing. It routes to
+`RevokeAllForCustomerExceptCurrent` instead, which keeps the session the request
+arrived on. That op now takes an optional `actor:`, so the colonel-driven call
+still writes the one `session.revoke_all` audit event the trail is owed while
+the self-service credential-change callers stay out of the admin trail (they
+pass none). Revoke-all against an unknown identifier is now a 404 rather than a
+success with zero counts.
+
+Still open here: 2.3, 2.4, 2.5, 2.11, 2.14, 2.15, 2.16.
+
 ### 2.5 detail — the remember-me cascade, and why it is latent
 
 `spec-session-path.md` §4 correctly calls this the most important gap and the

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -765,13 +765,45 @@ site:
     # the acting colonel's extid — the same value the audit trail carries as
     # `actor` — never on a session id.
     #
+    # THREAT: nothing covered /api/colonel/* before #4329. A scripted compromise
+    # of a colonel session could purge at wire speed and, because the operator
+    # audit trail trims at a 10 000-event count cap with NO TTL, evict the
+    # evidence of its own actions while doing it. Every bucket below is sized so
+    # that cap stays unreachable inside one lockout window.
+    #
     # The parent `enabled` flag short-circuits every bucket, which is how the
     # test suites (many endpoints, one process, one actor) opt out wholesale.
     #
     # A locked-out operator clears their own bucket with
-    # `POST /api/colonel/ratelimit/reset` (kind=colonel_elevation, a TIER 2 verb
-    # that needs no elevation), or with the valkey-cli commands
-    # `bin/ots ratelimit keys colonel_elevation <extid>` prints.
+    # `POST /api/colonel/ratelimit/reset` (kind=colonel_elevation /
+    # colonel_destructive / colonel_handle_resolve — a TIER 2 verb that needs no
+    # elevation), or with the valkey-cli commands
+    # `bin/ots ratelimit keys <kind> <extid>` prints. The reset is itself a
+    # mutation, so a `colonel_mutation` lockout is the one the CLI path must
+    # clear.
+    #
+    # SIZING — every bucket is per ACCOUNT (extid), not per session: a session
+    # bucket bounds one cookie, and anyone with a second way in gets a fresh
+    # budget.
+    #
+    #   mutation        120 / 300s  every mutating colonel verb, charged from the
+    #                               base logic constructor. Far above any human
+    #                               operator's rate and above a bulk console
+    #                               session, so it only trips on scripted abuse.
+    #   destructive      10 / 300s  TIER 1 verbs (purge, role change, revoke,
+    #                               delete, DLQ purge), 900s lockout. Charged
+    #                               LAST — after elevation, confirmation and the
+    #                               per-verb interlocks all pass — so a rejected
+    #                               attempt costs nothing and an attacker cannot
+    #                               burn the real operator's budget with cheap
+    #                               403s. 10 REAL incident-response actions per
+    #                               five minutes; bulk work belongs on the CLI.
+    #   handle_resolve   60 / 300s  the two session reads that resolve an opaque
+    #                               handle (#4330) and may fall back to a bounded
+    #                               10 000-key SCAN plus as many HMACs. Every
+    #                               OTHER colonel read is deliberately unlimited
+    #                               — the console fetches them, and a limiter
+    #                               there would break the dashboard.
     rate_limit:
       enabled: <%= ENV['COLONEL_RATE_LIMIT_ENABLED'] != 'false' %>
       elevation:
@@ -779,6 +811,21 @@ site:
         max_attempts: <%= ENV['COLONEL_ELEVATION_MAX_ATTEMPTS'] || 5 %>
         window: <%= ENV['COLONEL_ELEVATION_RATE_WINDOW'] || 900 %>
         lockout: <%= ENV['COLONEL_ELEVATION_LOCKOUT'] || 900 %>
+      mutation:
+        enabled: <%= ENV['COLONEL_MUTATION_RATE_LIMIT_ENABLED'] != 'false' %>
+        max_attempts: <%= ENV['COLONEL_MUTATION_MAX_ATTEMPTS'] || 120 %>
+        window: <%= ENV['COLONEL_MUTATION_RATE_WINDOW'] || 300 %>
+        lockout: <%= ENV['COLONEL_MUTATION_LOCKOUT'] || 300 %>
+      destructive:
+        enabled: <%= ENV['COLONEL_DESTRUCTIVE_RATE_LIMIT_ENABLED'] != 'false' %>
+        max_attempts: <%= ENV['COLONEL_DESTRUCTIVE_MAX_ATTEMPTS'] || 10 %>
+        window: <%= ENV['COLONEL_DESTRUCTIVE_RATE_WINDOW'] || 300 %>
+        lockout: <%= ENV['COLONEL_DESTRUCTIVE_LOCKOUT'] || 900 %>
+      handle_resolve:
+        enabled: <%= ENV['COLONEL_HANDLE_RESOLVE_RATE_LIMIT_ENABLED'] != 'false' %>
+        max_attempts: <%= ENV['COLONEL_HANDLE_RESOLVE_MAX_ATTEMPTS'] || 60 %>
+        window: <%= ENV['COLONEL_HANDLE_RESOLVE_RATE_WINDOW'] || 300 %>
+        lockout: <%= ENV['COLONEL_HANDLE_RESOLVE_LOCKOUT'] || 300 %>
 
     # Which HOSTNAMES serve the Colonel admin surfaces (/colonel shell and
     # /api/colonel API). A request whose validated detected host is not on this

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -753,8 +753,14 @@ site:
     # enabled:false instead. See docs/operations/colonel-admin-guide.md.
     #
     # DISABLING: enabled:false restores pre-#4327 behaviour (confirmation still
-    # applies). An SSO-only fleet must set either reauth_grace > 0 or
-    # enabled:false, or its colonels cannot run tier-1 verbs at all.
+    # applies). An SSO-only (password-less) colonel fleet cannot run tier-1 verbs
+    # at all unless configured, and WHICH knob works depends on the auth mode:
+    #   - SIMPLE mode: set reauth_grace > 0 (recent_auth elevation) OR
+    #     enabled:false.
+    #   - FULL mode: only enabled:false works. recent_auth is never offered in
+    #     full mode (see the reauth_grace note above — the password factor cannot
+    #     be probed there, so every account is treated as password-holding), so
+    #     reauth_grace has NO effect for a full-mode SSO-only fleet.
     elevation:
       enabled: <%= ENV['COLONEL_ELEVATION_ENABLED'] != 'false' %>
       window: <%= ENV['COLONEL_ELEVATION_WINDOW'] || 600 %>

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -720,6 +720,66 @@ site:
   # below are INDEPENDENT: a request must pass every gate that is active, and
   # neither replaces the other.
   admin:
+    # Step-up (sudo) re-authentication for destructive colonel actions (#4327).
+    #
+    # THREAT: a leaked colonel session cookie is otherwise unbounded destructive
+    # capability — purge, role change, session revoke, org delete all execute on
+    # a bare authenticated request. A short elevation window means a stolen
+    # cookie alone cannot destroy anything; the attacker also needs the password.
+    #
+    # RESIDUAL RISK, stated plainly: elevation is bound to the SESSION and the
+    # acting identity, not to a value the cookie lacks. While a window is live, a
+    # stolen cookie is exactly as capable as it was before this feature. What the
+    # window buys is that the capability is time-bounded, operator-initiated and
+    # audited, instead of standing. Binding it to a nonce the cookie does not
+    # carry is the follow-up.
+    #
+    # SIZING: window 600s is long enough for a multi-step triage session and
+    # short enough that an idle console is not a standing capability.
+    #
+    # reauth_grace: seconds after sign-in during which a PASSWORD-LESS (SSO-only)
+    # colonel may elevate with factor=recent_auth and no credential. DEFAULT 0 =
+    # OFF. It is available only to accounts that cannot satisfy the password
+    # factor: handing it to password holders would make step-up a no-op for the
+    # first N seconds after every sign-in, which is exactly the condition this
+    # feature exists to remove. Raise it ONLY for an SSO-only operator fleet, and
+    # understand that you are trading step-up for "signed in recently" for those
+    # accounts. MFA as a step-up factor is not implemented yet.
+    #
+    # In FULL auth mode the password factor cannot be probed from the logic layer
+    # (the Rodauth password-hash table is only reachable inside a Rodauth
+    # instance), so every full-mode account is treated as password-holding and
+    # recent_auth is unavailable there. A full-mode SSO-only fleet sets
+    # enabled:false instead. See docs/operations/colonel-admin-guide.md.
+    #
+    # DISABLING: enabled:false restores pre-#4327 behaviour (confirmation still
+    # applies). An SSO-only fleet must set either reauth_grace > 0 or
+    # enabled:false, or its colonels cannot run tier-1 verbs at all.
+    elevation:
+      enabled: <%= ENV['COLONEL_ELEVATION_ENABLED'] != 'false' %>
+      window: <%= ENV['COLONEL_ELEVATION_WINDOW'] || 600 %>
+      reauth_grace: <%= ENV['COLONEL_ELEVATION_REAUTH_GRACE'] || 0 %>
+
+    # Rate limits for the colonel API surface (#4327 ships the elevation bucket;
+    # #4329 adds the mutation / destructive / handle-resolve buckets). Keyed on
+    # the acting colonel's extid — the same value the audit trail carries as
+    # `actor` — never on a session id.
+    #
+    # The parent `enabled` flag short-circuits every bucket, which is how the
+    # test suites (many endpoints, one process, one actor) opt out wholesale.
+    #
+    # A locked-out operator clears their own bucket with
+    # `POST /api/colonel/ratelimit/reset` (kind=colonel_elevation, a TIER 2 verb
+    # that needs no elevation), or with the valkey-cli commands
+    # `bin/ots ratelimit keys colonel_elevation <extid>` prints.
+    rate_limit:
+      enabled: <%= ENV['COLONEL_RATE_LIMIT_ENABLED'] != 'false' %>
+      elevation:
+        enabled: <%= ENV['COLONEL_ELEVATION_RATE_LIMIT_ENABLED'] != 'false' %>
+        max_attempts: <%= ENV['COLONEL_ELEVATION_MAX_ATTEMPTS'] || 5 %>
+        window: <%= ENV['COLONEL_ELEVATION_RATE_WINDOW'] || 900 %>
+        lockout: <%= ENV['COLONEL_ELEVATION_LOCKOUT'] || 900 %>
+
     # Which HOSTNAMES serve the Colonel admin surfaces (/colonel shell and
     # /api/colonel API). A request whose validated detected host is not on this
     # list receives the same 404 as the CIDR gate below.

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -827,6 +827,40 @@ site:
         window: <%= ENV['COLONEL_HANDLE_RESOLVE_RATE_WINDOW'] || 300 %>
         lockout: <%= ENV['COLONEL_HANDLE_RESOLVE_LOCKOUT'] || 300 %>
 
+    # Session bounds for the ADMIN API SURFACE (/api/colonel) only (#4331).
+    #
+    # SCOPE: these do NOT shorten the session cookie, and they do NOT gate the
+    # /colonel SPA shell. One onetime.session serves the admin console, the
+    # tenant app and the auth app, and site.session.expire_after (24h rolling)
+    # still governs the object. These bounds gate admin API ACCESS, so a colonel
+    # who is also a customer keeps their normal session on the rest of the site,
+    # and a stale admin tab loads the shell and shows an expired banner instead
+    # of a bare 401 on an HTML navigation. Splitting the admin surface onto its
+    # own cookie is the fuller fix.
+    #
+    # THREAT: the general session policy is 24h ROLLING with no absolute cap, so
+    # a colonel session left open in a tab is a standing administrative
+    # capability for as long as anything touches it. AdminNetworkIsolation
+    # compensates at the network layer but is a no-op by default on self-hosted
+    # installs.
+    #
+    # idle_timeout: seconds of inactivity before /api/colonel stops
+    #   authenticating. Sourced from the SessionMetadata sidecar, which is
+    #   best-effort: when no sidecar exists the idle bound is SKIPPED, never
+    #   failed. Two caveats worth knowing before you rely on it. (a) It only
+    #   bites because the admin console makes no periodic requests — adding any
+    #   polling to the admin SPA silently disables this bound. (b) The sidecar is
+    #   a SITE-WIDE activity clock, so touching a tenant route also keeps the
+    #   admin window open; absolute_timeout is the bound nothing can slide.
+    # absolute_timeout: seconds since sign-in, regardless of activity. Sourced
+    #   from session['authenticated_at'], which both auth modes stamp and only a
+    #   password change re-stamps.
+    # Set either to 0 to disable that bound. enabled:false disables both.
+    session:
+      enabled: <%= ENV['ADMIN_SESSION_LIFETIME_ENABLED'] != 'false' %>
+      idle_timeout: <%= ENV['ADMIN_SESSION_IDLE_TIMEOUT'] || 3600 %>
+      absolute_timeout: <%= ENV['ADMIN_SESSION_ABSOLUTE_TIMEOUT'] || 43200 %>
+
     # Which HOSTNAMES serve the Colonel admin surfaces (/colonel shell and
     # /api/colonel API). A request whose validated detected host is not on this
     # list receives the same 404 as the CIDR gate below.

--- a/lib/onetime/application/auth_strategies.rb
+++ b/lib/onetime/application/auth_strategies.rb
@@ -9,6 +9,7 @@
 # Structure:
 #   auth_strategies/
 #     helpers.rb                      - Shared helper methods
+#     admin_session_lifetime.rb       - Admin-surface idle/absolute bounds (#4331)
 #     no_auth_strategy.rb             - Public access (auth=noauth)
 #     base_session_auth_strategy.rb   - Abstract base for session auth
 #     session_auth_strategy.rb        - Authenticated sessions (auth=sessionauth)
@@ -23,6 +24,7 @@
 
 require_relative 'organization_loader'
 require_relative 'auth_strategies/helpers'
+require_relative 'auth_strategies/admin_session_lifetime'
 require_relative 'auth_strategies/no_auth_strategy'
 require_relative 'auth_strategies/base_session_auth_strategy'
 require_relative 'auth_strategies/session_auth_strategy'

--- a/lib/onetime/application/auth_strategies/admin_session_lifetime.rb
+++ b/lib/onetime/application/auth_strategies/admin_session_lifetime.rb
@@ -123,13 +123,22 @@ module Onetime
 
         # 0 legitimately DISABLES a bound, so this cannot use the positive_*
         # setting guard's "fall back to the default" behaviour: a configured 0
-        # must stay 0. A negative or unparseable value falls back.
+        # must stay 0. But it must NOT String#to_i an arbitrary value either —
+        # `raw` arrives as whatever YAML parsed from `<%= ENV[...] || N %>`, so a
+        # typo'd env is a String, and `"off".to_i` / `"none".to_i` is 0 (silently
+        # disabling a security bound) while `"12h".to_i` is 12 (a 12-SECOND
+        # lifetime). Accept only a clean non-negative integer — an Integer, or an
+        # all-digits String; anything else (a non-numeric string, a YAML boolean
+        # from `off`/`no`) falls back to the shipped default. Same intent as
+        # colonel_rate_limiter.rb#positive_colonel_setting.
         def admin_timeout_setting(key, default)
           raw = admin_session_config[key]
-          return default if raw.nil?
 
-          value = raw.to_i
-          value.negative? ? default : value
+          case raw
+          when Integer then raw.negative? ? default : raw
+          when String  then raw.match?(/\A\d+\z/) ? raw.to_i : default
+          else default
+          end
         end
 
         def admin_idle_timeout

--- a/lib/onetime/application/auth_strategies/admin_session_lifetime.rb
+++ b/lib/onetime/application/auth_strategies/admin_session_lifetime.rb
@@ -1,0 +1,145 @@
+# lib/onetime/application/auth_strategies/admin_session_lifetime.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Application
+    module AuthStrategies
+      # Shorter idle + absolute session bounds for the ADMIN API SURFACE only
+      # (#4331).
+      #
+      # SCOPE IS THE SURFACE, NOT THE SESSION. One onetime.session cookie serves
+      # the colonel API, the tenant app and the Rodauth app (Onetime::Session is
+      # mounted once, in the universal middleware stack), so expiring the session
+      # object would log a colonel out of the customer app too — and on a
+      # self-hosted install the colonel often IS the only customer. Bounding the
+      # surface gives the security property (a stale admin session cannot act)
+      # with no tenant-side regression. Splitting the admin surface onto its own
+      # cookie remains the fuller fix.
+      #
+      # /api/colonel ONLY. The /colonel SPA shell is deliberately NOT bounded: a
+      # bare 401 on an HTML navigation has no defined UX, and the expired-session
+      # banner lives inside the SPA. The shell loads, its first API call 401s, the
+      # banner renders. The shell alone can do nothing. This is why the prefix
+      # below is NOT AdminNetworkIsolation::SURFACES (%w[/colonel /api/colonel]) —
+      # the two definitions are intentionally different, so do not "fix" the
+      # divergence by sharing the constant.
+      #
+      # ABSOLUTE bound reads session['authenticated_at'], which both auth modes
+      # stamp at login and which UpdatePassword re-stamps after a password change.
+      # Nothing an attacker holding the cookie can do advances it, so this is the
+      # bound that actually binds.
+      #
+      # IDLE bound reads SessionMetadata#last_activity_at, refreshed on every
+      # authenticated write by Onetime::Operations::Sessions::TrackMetadata.
+      # SessionMetadata is BEST-EFFORT and never authoritative: a session
+      # predating the sidecar, one whose 30-day TTL lapsed, or one whose write was
+      # swallowed has none. A missing sidecar therefore SKIPS the idle check
+      # rather than failing it — hard-failing would log out live sessions for a
+      # reason unrelated to their age.
+      #
+      # Two properties the idle bound depends on, both load-bearing:
+      #
+      #   1. The admin console makes NO periodic requests. TrackMetadata advances
+      #      last_activity_at on every authenticated commit, so any poll would
+      #      refresh it forever. See src/apps/admin/composables/useColonelElevation.ts
+      #      — do not add a timer anywhere under src/apps/admin/.
+      #   2. A REJECTED request is not activity. The caller stamps
+      #      EXPIRED_ENV_KEY into the Rack env on refusal and TrackMetadata skips
+      #      its upsert when it sees it; without that, the very request this
+      #      module just refused would advance last_activity_at on its way out and
+      #      the next one would sail through, making the bound a one-request speed
+      #      bump.
+      #
+      # Residual, stated rather than hidden: last_activity_at is a SITE-WIDE
+      # activity clock, so a colonel (or anyone holding their cookie) who touches
+      # a tenant route keeps the admin idle window open. The absolute bound is
+      # unaffected. Per-surface activity needs the separate admin session this
+      # design deliberately defers.
+      module AdminSessionLifetime
+        DEFAULT_IDLE_TIMEOUT     = 3_600    # 1 hour
+        DEFAULT_ABSOLUTE_TIMEOUT = 43_200   # 12 hours
+
+        ADMIN_API_PREFIX = '/api/colonel'
+
+        # Rack env flag set by the auth strategy when it refuses an admin request
+        # on either bound. Read by Onetime::Operations::Sessions::TrackMetadata.
+        EXPIRED_ENV_KEY = 'onetime.admin_session_expired'
+
+        # @param session [Hash, Rack::Session::Abstract::SessionHash] the raw session
+        # @param cust [Onetime::Customer] the customer this request loaded
+        # @param env [Hash] the Rack environment
+        # @return [Symbol, nil] :absolute, :idle, or nil when the session may proceed
+        def admin_session_expiry_reason(session, cust, env)
+          return nil unless admin_api_request?(env)
+          return nil unless cust.role.to_s == 'colonel'
+          return nil unless admin_session_lifetime_enabled?
+
+          now = Familia.now.to_i
+
+          absolute = admin_absolute_timeout
+          if absolute.positive?
+            stamped = session['authenticated_at'].to_i
+            return :absolute if stamped.positive? && (now - stamped) > absolute
+          end
+
+          idle = admin_idle_timeout
+          return nil unless idle.positive?
+
+          last = admin_last_activity_at(session)
+          return nil if last.nil? # best-effort sidecar missing -> skip, never fail
+          return :idle if (now - last) > idle
+
+          nil
+        end
+
+        private
+
+        def admin_api_request?(env)
+          path = "#{env['SCRIPT_NAME']}#{env['PATH_INFO']}"
+          path == ADMIN_API_PREFIX || path.start_with?("#{ADMIN_API_PREFIX}/")
+        rescue StandardError
+          false
+        end
+
+        def admin_last_activity_at(session)
+          sid = session.respond_to?(:id) ? session.id : nil
+          sid = sid.respond_to?(:public_id) ? sid.public_id : sid&.to_s
+          return nil if sid.to_s.empty?
+
+          Onetime::SessionMetadata.load(sid)&.last_activity_at&.to_i
+        rescue StandardError => ex
+          OT.ld "[AdminSessionLifetime] sidecar read failed: #{ex.message}"
+          nil
+        end
+
+        def admin_session_config
+          OT.conf&.dig('site', 'admin', 'session') || {}
+        end
+
+        def admin_session_lifetime_enabled?
+          admin_session_config.fetch('enabled', true) != false
+        end
+
+        # 0 legitimately DISABLES a bound, so this cannot use the positive_*
+        # setting guard's "fall back to the default" behaviour: a configured 0
+        # must stay 0. A negative or unparseable value falls back.
+        def admin_timeout_setting(key, default)
+          raw = admin_session_config[key]
+          return default if raw.nil?
+
+          value = raw.to_i
+          value.negative? ? default : value
+        end
+
+        def admin_idle_timeout
+          admin_timeout_setting('idle_timeout', DEFAULT_IDLE_TIMEOUT)
+        end
+
+        def admin_absolute_timeout
+          admin_timeout_setting('absolute_timeout', DEFAULT_ABSOLUTE_TIMEOUT)
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/application/auth_strategies/base_session_auth_strategy.rb
+++ b/lib/onetime/application/auth_strategies/base_session_auth_strategy.rb
@@ -11,12 +11,14 @@
 # @see Onetime::Application::AuthStrategies
 
 require_relative 'helpers'
+require_relative 'admin_session_lifetime'
 
 module Onetime
   module Application
     module AuthStrategies
       class BaseSessionAuthStrategy < Otto::Security::AuthStrategy
         include Helpers
+        include AdminSessionLifetime
         include Onetime::Application::OrganizationLoader
 
         @auth_method_name = nil
@@ -65,6 +67,25 @@ module Onetime
           # never-mass-logout semantics.
           if session_predates_credential_change?(session, cust)
             return failure('[SESSION_STALE_CREDENTIALS] Session predates last credential change')
+          end
+
+          # Admin-surface session bounds (#4331). Runs here because this is the
+          # one per-request chokepoint that already has the loaded customer
+          # (hence cust.role) and the raw session. Deliberately AFTER the
+          # watermark and BEFORE additional_checks.
+          #
+          # The session is NOT mutated: an auth strategy runs on read paths and
+          # must stay side-effect-free, and clearing `authenticated` here would
+          # risk a write on a request that should not commit one. Failing is
+          # sufficient — the SPA sees the 401 and routes to sign-in, which
+          # replaces the session. The env flag is not a session write; it tells
+          # TrackMetadata that a REFUSED request is not activity, so the request
+          # we are rejecting cannot slide the idle window forward on its way out.
+          if (reason = admin_session_expiry_reason(session, cust, env))
+            env[AdminSessionLifetime::EXPIRED_ENV_KEY] = reason.to_s
+            return failure(
+              "[ADMIN_SESSION_EXPIRED] Admin session #{reason} timeout exceeded; sign in again",
+            )
           end
 
           # Perform additional checks (role, permissions, etc.)

--- a/lib/onetime/application/network_requirements.rb
+++ b/lib/onetime/application/network_requirements.rb
@@ -11,16 +11,39 @@ module Onetime
   module Application
     # Enforces declarative network requirements from Otto route options.
     #
-    # `network=admin` is stricter than the general Colonel posture: the route is
-    # absent unless both ADMIN_ALLOWED_HOSTS and ADMIN_ALLOWED_CIDRS were
-    # explicitly configured and their gates admitted the request.
+    # Two strengths, both fail-closed when the verdict AdminNetworkIsolation
+    # writes is absent entirely:
+    #
+    #   `network=admin` — the route is absent unless both ADMIN_ALLOWED_HOSTS
+    #     and ADMIN_ALLOWED_CIDRS were explicitly configured and their gates
+    #     admitted the request. Stricter than the general Colonel posture, and
+    #     with no opt-out: a stock install cannot satisfy it.
+    #
+    #   `network=admin_if_configured` (#4332) — the same requirement, enforced
+    #     only where the operator actually configured admin isolation. This is
+    #     what makes the annotation usable on the destructive colonel routes:
+    #     the strict token would 404 all fifteen of them for an authenticated
+    #     colonel on localhost, in every posture except a fully configured one.
     module NetworkRequirements
       extend self
 
-      ADMIN = 'admin'
+      ADMIN               = 'admin'
+      ADMIN_IF_CONFIGURED = 'admin_if_configured'
 
       STRATEGIES = {
         ADMIN => ->(env) {
+          env[Onetime::Middleware::AdminNetworkIsolation::ROUTE_REQUIREMENT_ENV_KEY] == true
+        },
+        # Enforce the route requirement only where the operator configured admin
+        # isolation. An ABSENT mode key — the middleware missing from the stack,
+        # or the route moved outside the /colonel* prefixes it annotates — is
+        # NOT advisory: it falls through to the strict read and denies. That
+        # fail-closed-on-regression property is what this annotation is really
+        # worth on a route the surface-wide gates already cover.
+        ADMIN_IF_CONFIGURED => ->(env) {
+          mode = env[Onetime::Middleware::AdminNetworkIsolation::ROUTE_REQUIREMENT_MODE_ENV_KEY]
+          next true if mode == :advisory
+
           env[Onetime::Middleware::AdminNetworkIsolation::ROUTE_REQUIREMENT_ENV_KEY] == true
         },
       }.freeze

--- a/lib/onetime/application/otto_hooks.rb
+++ b/lib/onetime/application/otto_hooks.rb
@@ -84,6 +84,20 @@ module Onetime
           with_error_correlation(error.to_h, req, error)
         end
 
+        # Step-up (sudo) window for tier-1 colonel verbs (#4327). Two classes,
+        # two registrations: Otto matches by exact class name, so neither is
+        # covered by the Forbidden handler above. ElevationRequired means "no
+        # live window"; ElevationFailed means "the elevation attempt failed".
+        router.register_error_handler(Onetime::ElevationRequired, status: 403, log_level: :warn) do |error, req|
+          Onetime::Application::ErrorResolver.resolve!(error, req)
+          with_error_correlation(error.to_h, req, error)
+        end
+
+        router.register_error_handler(Onetime::ElevationFailed, status: 403, log_level: :warn) do |error, req|
+          Onetime::Application::ErrorResolver.resolve!(error, req)
+          with_error_correlation(error.to_h, req, error)
+        end
+
         # Programming error in a destructive guard (#4326). Registered so it is a
         # deliberate 500 with correlation rather than an unhandled one.
         router.register_error_handler(Onetime::GuardMisconfigured, status: 500, log_level: :error) do |error, req|

--- a/lib/onetime/application/otto_hooks.rb
+++ b/lib/onetime/application/otto_hooks.rb
@@ -76,6 +76,20 @@ module Onetime
           with_error_correlation(body, req, error)
         end
 
+        # Server-side destructive-action confirmation (#4326). Same 403 family as
+        # Forbidden; separate registration because Otto resolves handlers by exact
+        # class name (see the note above).
+        router.register_error_handler(Onetime::ConfirmationRequired, status: 403, log_level: :warn) do |error, req|
+          Onetime::Application::ErrorResolver.resolve!(error, req)
+          with_error_correlation(error.to_h, req, error)
+        end
+
+        # Programming error in a destructive guard (#4326). Registered so it is a
+        # deliberate 500 with correlation rather than an unhandled one.
+        router.register_error_handler(Onetime::GuardMisconfigured, status: 500, log_level: :error) do |error, req|
+          with_error_correlation(error.to_h, req, error)
+        end
+
         # Rate limit exceeded errors return 429 with retry info
         router.register_error_handler(Onetime::LimitExceeded, status: 429, log_level: :warn) do |error, req|
           Onetime::Application::ErrorResolver.resolve!(error, req)

--- a/lib/onetime/cli/customers/role_command.rb
+++ b/lib/onetime/cli/customers/role_command.rb
@@ -113,11 +113,18 @@ module Onetime
           end
         end
 
-        Auth::Operations::Customers::SetRole.new(
+        result = Auth::Operations::Customers::SetRole.new(
           customer: customer,
           role: target_role,
           actor: Customers::Shared::CLI_ACTOR,
         ).call
+
+        # `promote --role admin` on a colonel is a DEMOTION in effect, so it can
+        # hit the last-colonel interlock too. Same handling as demote.
+        unless result.status == :success
+          puts refusal_message(result.status, obscured)
+          exit 1
+        end
 
         puts "#{obscured}: #{old_role} -> #{target_role}"
         OT.info "[role-change] #{customer.objid} promoted: #{old_role} -> #{target_role}"
@@ -144,14 +151,38 @@ module Onetime
           end
         end
 
-        Auth::Operations::Customers::SetRole.new(
+        result = Auth::Operations::Customers::SetRole.new(
           customer: customer,
           role: 'customer',
           actor: Customers::Shared::CLI_ACTOR,
         ).call
 
+        # The op refuses demoting the last remaining colonel (#4328) — the same
+        # interlock the colonel endpoint answers with a 422. The CLI is the
+        # DOCUMENTED recovery path out of that state, so it has to say what
+        # happened and exit non-zero rather than print a change it did not make.
+        # :self_demotion is unreachable here (no acting customer), so it is not
+        # branched on; the else arm would catch it if that ever changed.
+        unless result.status == :success
+          puts refusal_message(result.status, obscured)
+          exit 1
+        end
+
         puts "#{obscured}: #{old_role} -> customer"
         OT.info "[role-change] #{customer.objid} demoted: #{old_role} -> customer"
+      end
+
+      # @param status [Symbol] a non-:success SetRole::Result status
+      # @param obscured [String] the log-safe form of the target's address
+      # @return [String]
+      def refusal_message(status, obscured)
+        case status
+        when :last_colonel
+          "Error: refusing to demote #{obscured}: they are the last remaining verified colonel. " \
+          'Promote and verify another account first (bin/ots customers role promote EMAIL).'
+        else
+          "Error: role change did not complete for #{obscured} (#{status})"
+        end
       end
 
       def list_customers_by_role(target_role)

--- a/lib/onetime/cli/customers/unverify_command.rb
+++ b/lib/onetime/cli/customers/unverify_command.rb
@@ -75,6 +75,17 @@ module Onetime
           puts "#{obscured} is already unverified"
         when :success
           puts "Unverified: #{obscured}"
+        when :last_colonel
+          # #4328: unverifying strips colonel eligibility (has_system_role?
+          # requires a verified email), so this would leave the install with no
+          # administrator. Exit non-zero — a script must not read this as done.
+          puts "Error: refusing to unverify #{obscured}: they are the last remaining verified " \
+               'colonel, and an unverified account cannot hold the colonel role. ' \
+               'Promote and verify another account first.'
+          exit 1
+        else
+          puts "Error: verification change did not complete for #{obscured} (#{result})"
+          exit 1
         end
       rescue Auth::Operations::SetCustomerVerification::NoAuthDatabase => ex
         puts "Error: #{ex.message}. Check AUTH_DATABASE_URL."

--- a/lib/onetime/cli/session_command.rb
+++ b/lib/onetime/cli/session_command.rb
@@ -231,18 +231,26 @@ module Onetime
 
         # Route through the extracted list op (single implementation, bounded
         # scan). `--limit` maps to one page; the op caps a page at its MAX_PER_PAGE.
-        result = Onetime::Operations::Sessions::List.new(page: 1, per_page: limit.to_i).call
+        #
+        # reveal_session_id: the local operator shell is the ONE consumer that
+        # opts in (#4330) — `inspect` and `delete` take a raw sid, so a listing
+        # without one would be useless here. The handle is printed alongside so a
+        # CLI row can be correlated with an admin-console row.
+        result = Onetime::Operations::Sessions::List.new(
+          page: 1, per_page: limit.to_i, reveal_session_id: true,
+        ).call
 
         if result.sessions.empty?
           puts 'No sessions found'
           return
         end
 
-        puts format('%-40s %-25s %-15s', 'Session ID', 'Authenticated As', 'Created')
+        puts format('%-40s %-34s %-25s %-15s', 'Session ID', 'Handle', 'Authenticated As', 'Created')
         puts '-' * 80
 
         result.sessions.each do |session|
           session_id  = session[:session_id]
+          handle      = session[:session_handle] || '<n/a>'
           email       = session[:email] || 'anonymous'
           external_id = session[:external_id] || '<n/a>'
           auth        = session[:authenticated] ? '✓' : '✗'
@@ -255,7 +263,13 @@ module Onetime
           end
 
           display_email = OT::Utils.obscure_email(email)
-          puts format('%-40s %-25s %s', session_id[0..39], "#{auth} #{display_email} #{external_id}", time_str)
+          puts format(
+            '%-40s %-34s %-25s %s',
+            session_id[0..39],
+            handle,
+            "#{auth} #{display_email} #{external_id}",
+            time_str,
+          )
         end
       end
     end
@@ -280,10 +294,13 @@ module Onetime
         puts '-' * 80
 
         # Route through the extracted list op with a search filter (single
-        # implementation, bounded scan).
+        # implementation, bounded scan). reveal_session_id: the operator shell is
+        # the one opted-in consumer of the raw sid (#4330) — the printed id is
+        # what `inspect` / `delete` take next.
         result = Onetime::Operations::Sessions::List.new(
           search: search_term,
           per_page: Onetime::Operations::Sessions::List::MAX_PER_PAGE,
+          reveal_session_id: true,
         ).call
 
         if result.sessions.empty?
@@ -296,6 +313,7 @@ module Onetime
 
         result.sessions.each do |session|
           puts "Session: #{session[:session_id]}"
+          puts "  Handle: #{session[:session_handle]}"
           puts "  Email: #{session[:email]}"
           puts "  External ID: #{session[:external_id]}"
           puts "  Authenticated: #{session[:authenticated]}"

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -363,4 +363,46 @@ module Onetime
       }.compact
     end
   end
+
+  # Raised when a destructive colonel verb was invoked without the matching
+  # server-side confirmation token (#4326). A Forbidden subclass deliberately:
+  # AuditedFailure.authorization_rejection? drops the whole Forbidden family, so a
+  # compromised colonel session cannot mint audit events by hammering a destructive
+  # route (the operator trail is count-capped with NO TTL).
+  class ConfirmationRequired < Forbidden
+    ERROR_CODE = 'confirmation_required'
+
+    attr_reader :field
+
+    def initialize(message = 'Confirmation required', field: nil, error_key: nil, args: {})
+      super(message, error_key: error_key, args: args)
+      @field = field
+    end
+
+    def to_h
+      {
+        error: message,
+        error_type: 'ConfirmationRequired',
+        error_code: ERROR_CODE,
+        field: field,
+        error_key: error_key,
+      }.compact
+    end
+  end
+
+  # A destructive-action guard was called with no expected token — a programming
+  # error in the calling logic class, never a caller-triggerable condition. 500,
+  # never a silent admit. Distinct from a bare Onetime::Problem because Otto
+  # resolves error handlers by EXACT class name and Problem is not registered.
+  class GuardMisconfigured < Problem
+    ERROR_CODE = 'guard_misconfigured'
+
+    def to_h
+      {
+        error: 'Internal configuration error',
+        error_type: 'GuardMisconfigured',
+        error_code: ERROR_CODE,
+      }
+    end
+  end
 end

--- a/lib/onetime/errors.rb
+++ b/lib/onetime/errors.rb
@@ -390,6 +390,60 @@ module Onetime
     end
   end
 
+  # Raised when a TIER 1 colonel verb is invoked outside a live step-up window
+  # (#4327). Forbidden subclass for the same audit-exclusion reason as
+  # {ConfirmationRequired}: whoever holds the cookie can drive this rejection on
+  # demand, and the operator trail is count-capped with no TTL.
+  #
+  # `window` is the configured elevation lifetime in seconds, so the console can
+  # tell the operator how long a fresh window will last before they re-enter a
+  # credential.
+  class ElevationRequired < Forbidden
+    ERROR_CODE = 'elevation_required'
+
+    attr_reader :window
+
+    def initialize(message = 'Step-up authentication required', window: nil, error_key: nil, args: {})
+      super(message, error_key: error_key, args: args)
+      @window = window
+    end
+
+    def to_h
+      {
+        error: message,
+        error_type: 'ElevationRequired',
+        error_code: ERROR_CODE,
+        window: window,
+        error_key: error_key,
+      }.compact
+    end
+  end
+
+  # Raised when a step-up ATTEMPT itself fails (#4327) — a wrong password, or a
+  # factor this account cannot satisfy. Distinct from {ElevationRequired}, which
+  # says "you never elevated": this one says "the elevation you just tried did
+  # not work", and the console renders the server's remediation message.
+  class ElevationFailed < Forbidden
+    ERROR_CODE = 'elevation_failed'
+
+    attr_reader :factor
+
+    def initialize(message = 'Step-up authentication failed', factor: nil, error_key: nil, args: {})
+      super(message, error_key: error_key, args: args)
+      @factor = factor
+    end
+
+    def to_h
+      {
+        error: message,
+        error_type: 'ElevationFailed',
+        error_code: ERROR_CODE,
+        factor: factor,
+        error_key: error_key,
+      }.compact
+    end
+  end
+
   # A destructive-action guard was called with no expected token — a programming
   # error in the calling logic class, never a caller-triggerable condition. 500,
   # never a silent admit. Distinct from a bare Onetime::Problem because Otto

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -37,11 +37,28 @@ module Onetime
     #      rule as the host gate: a list an operator wrote is never silently
     #      disabled.
     #
-    # Routes may additionally declare `network=admin`. Those routes require
-    # BOTH allowlists to be explicitly configured and active; after both gates
-    # admit the request this middleware records that verdict in Rack env for the
-    # Otto route wrapper. This leaves ordinary Colonel routes on the existing
-    # opt-in CIDR posture while sensitive routes can require the stronger one.
+    # Routes may additionally declare a network requirement, in one of two
+    # strengths (Onetime::Application::NetworkRequirements):
+    #
+    #   `network=admin` — strict. The route requires BOTH allowlists to be
+    #      explicitly configured and active; after both gates admit the request
+    #      this middleware records that verdict in Rack env for the Otto route
+    #      wrapper. Anything less is a 404.
+    #
+    #   `network=admin_if_configured` (#4332) — enforced only where the operator
+    #      actually configured admin isolation, advisory otherwise. This is what
+    #      the 15 tier-1 destructive colonel routes carry: annotating them with
+    #      the strict token would 404 every destructive verb on a stock
+    #      self-hosted install, where neither allowlist is set.
+    #
+    # Those two are told apart by the MODE key beside the verdict key — see
+    # ROUTE_REQUIREMENT_MODE_ENV_KEY. Both keys are written for every
+    # admin-surface request this middleware sees, including one it lets through
+    # with both gates inactive; their ABSENCE means the middleware never ran,
+    # which both strategies treat as a denial.
+    #
+    # This leaves ordinary Colonel routes on the existing opt-in CIDR posture
+    # while sensitive routes can require the stronger one.
     #
     # A request that fails EITHER active gate gets a 404 on `/colonel` and
     # `/api/colonel` — indistinguishable-from-absent, NOT a 403, so the admin
@@ -51,8 +68,9 @@ module Onetime
     # true) in each logic class), which still enforce beneath for any request
     # that does pass.
     #
-    # When BOTH gates are inactive the middleware is a strict NO-OP, exactly as
-    # before #4062.
+    # When BOTH gates are inactive the middleware still serves every request
+    # unchanged, exactly as before #4062; the only thing it does on that path is
+    # stamp the two verdict keys on an admin-surface request (#4332).
     #
     # ## Host resolution
     #
@@ -243,6 +261,15 @@ module Onetime
       # cannot supply Rack env keys over HTTP.
       ROUTE_REQUIREMENT_ENV_KEY = 'onetime.admin_network_requirement_met'
 
+      # Tri-state companion to ROUTE_REQUIREMENT_ENV_KEY (#4332). :enforced when
+      # the operator has fully configured admin isolation (explicit enforceable
+      # hosts AND at least one parseable CIDR); :advisory otherwise.
+      # `network=admin_if_configured` falls through on :advisory so annotating
+      # destructive routes cannot brick a stock self-hosted install. ABSENT
+      # means the middleware never ran for this request — the strategy treats
+      # that as a denial, not as advisory.
+      ROUTE_REQUIREMENT_MODE_ENV_KEY = 'onetime.admin_network_requirement_mode'
+
       # @see Onetime::Middleware::ADMIN_NOT_FOUND_HTML
       NOT_FOUND_HTML = ADMIN_NOT_FOUND_HTML
 
@@ -337,12 +364,23 @@ module Onetime
 
       def call(env)
         # Cheapest discriminator first, and it is this one: with both gates
-        # inactive — the pre-#4062 self-hosted default — the middleware is a
-        # strict NO-OP that allocates nothing, and the two app-layer auth
-        # layers are the sole gate. Reconstructing the path first would put a
-        # String allocation on every request of every mounted app to answer a
-        # question two already-computed booleans settle.
-        return @app.call(env) unless host_gate_active? || network_gate_active?
+        # inactive — the pre-#4062 self-hosted default — this middleware denies
+        # nothing and the two app-layer auth layers are the sole gate.
+        # Reconstructing the path first would put a String allocation on every
+        # request of every mounted app to answer a question two already-computed
+        # booleans settle.
+        #
+        # #4332 added ONE thing to that path: the verdict keys are still needed
+        # on admin paths, so `network=admin_if_configured` can distinguish
+        # "advisory" from "the middleware never ran". It is reached through an
+        # allocation-free prefilter (#maybe_admin_surface? reads two strings Rack
+        # already built), so the exact — allocating — check runs only for the
+        # handful of requests that could be admin ones. Every other request
+        # keeps the original no-op fast path.
+        unless host_gate_active? || network_gate_active?
+          annotate_route_requirement(env) if maybe_admin_surface?(env)
+          return @app.call(env)
+        end
 
         full_path = request_path(env)
         return @app.call(env) unless admin_surface?(full_path)
@@ -353,11 +391,49 @@ module Onetime
         return not_found_response(full_path) if host_denied?(env, full_path)
         return not_found_response(full_path) if network_denied?(env, full_path)
 
-        env[ROUTE_REQUIREMENT_ENV_KEY] = route_requirement_met?
+        annotate_route_requirement(env, full_path)
         @app.call(env)
       end
 
       private
+
+      # Record this request's route-requirement verdict for the Otto wrappers.
+      #
+      # Both keys move together — a reader that saw one without the other could
+      # not tell "advisory" from "middleware absent" — and both are written ONLY
+      # on an admin surface, which is the only place the verdict means anything.
+      #
+      # @param env [Hash] the Rack env, mutated in place
+      # @param full_path [String] the normalized path, when the caller has one
+      # @return [void]
+      def annotate_route_requirement(env, full_path = request_path(env))
+        return unless admin_surface?(full_path)
+
+        env[ROUTE_REQUIREMENT_ENV_KEY]      = route_requirement_met?
+        env[ROUTE_REQUIREMENT_MODE_ENV_KEY] = route_requirement_mode
+      end
+
+      # "Could this request possibly be for an admin surface?" — a deliberately
+      # over-broad prefilter that allocates nothing, so it can sit on the
+      # both-gates-inactive fast path that runs for every request of all ~13
+      # mounted apps. #annotate_route_requirement re-checks exactly (and with
+      # normalization) before writing anything.
+      #
+      # SCRIPT_NAME is the mount prefix for a mounted app and PATH_INFO the
+      # remainder, so both are checked rather than concatenated: the colonel API
+      # arrives as SCRIPT_NAME=/api/colonel + PATH_INFO=/info, and the shell as
+      # SCRIPT_NAME='' + PATH_INFO=/colonel.
+      def maybe_admin_surface?(env)
+        script = env['SCRIPT_NAME']
+        return true if script && (script.start_with?('/colonel', '/api/colonel'))
+
+        # A non-empty SCRIPT_NAME that is not an admin mount cannot become one
+        # by appending PATH_INFO.
+        return false unless script.nil? || script.empty?
+
+        path = env['PATH_INFO']
+        !path.nil? && (path.start_with?('/colonel', '/api/colonel'))
+      end
 
       # --- gates ---------------------------------------------------------
 
@@ -375,6 +451,30 @@ module Onetime
       # count as network isolation.
       def route_requirement_met?
         @host_gate_explicit && host_gate_active? && network_gate_active?
+      end
+
+      # Whether a route-level admin requirement is ENFORCEABLE in this posture
+      # (#4332). Process-constant, like #route_requirement_met? itself: it is
+      # the same construction-time decision, read as a tri-state so a route can
+      # opt into "enforce only where the operator configured this".
+      #
+      # :advisory is not a weaker verdict, it is a different question — "is the
+      # operator running admin isolation at all?" — which is why the strict
+      # `network=admin` token never consults it.
+      def route_requirement_mode
+        route_requirement_met? ? :enforced : :advisory
+      end
+
+      # Half-configured: the operator set one of the two knobs in a way that
+      # cannot enforce, which is the posture most likely to be believed working.
+      # Both halves are read the way #route_requirement_met? reads them —
+      # a wildcard host list is explicit but inactive, and therefore not
+      # configured for this purpose.
+      def admin_isolation_half_configured?
+        host_half    = @host_gate_explicit && host_gate_active?
+        network_half = network_gate_active?
+
+        host_half ^ network_half
       end
 
       # Host gate. Fails closed twice over: an active gate with an unresolvable
@@ -972,6 +1072,38 @@ module Onetime
 
         log_once(:posture, posture) do
           @logger.info 'Admin surface isolation posture', posture
+        end
+
+        log_route_requirement_mode
+      end
+
+      # The one line that tells an operator whether the `network=admin_if_configured`
+      # annotation on the 15 destructive colonel routes is doing anything (#4332).
+      #
+      # Level is the whole point. A stock self-hosted install configured neither
+      # allowlist and is not misconfigured — nagging it at WARN would train
+      # operators to ignore this line. A HALF-configured install is different:
+      # someone set one of the two knobs, so they believe a restriction is in
+      # force, and it is not. Through log_once for the usual reason — this
+      # middleware is constructed once per mounted app.
+      def log_route_requirement_mode
+        return if route_requirement_mode == :enforced
+
+        payload = {
+          mode: :advisory,
+          host_gate_explicit: @host_gate_explicit,
+          host_gate: host_gate_active?,
+          network_gate: network_gate_active?,
+          consequence: 'routes marked network=admin_if_configured are NOT network-gated; ' \
+                       'set BOTH ADMIN_ALLOWED_HOSTS (no wildcard) and ADMIN_ALLOWED_CIDRS to enforce',
+        }
+
+        log_once(:admin_route_requirement_advisory, payload) do
+          if admin_isolation_half_configured?
+            @logger.warn 'Admin route network requirement is ADVISORY: admin isolation is half-configured', payload
+          else
+            @logger.info 'Admin route network requirement is advisory (admin isolation is not configured)', payload
+          end
         end
       end
 

--- a/lib/onetime/operations/customers/role_support.rb
+++ b/lib/onetime/operations/customers/role_support.rb
@@ -1,0 +1,87 @@
+# lib/onetime/operations/customers/role_support.rb
+#
+# frozen_string_literal: true
+
+module Onetime
+  module Operations
+    module Customers
+      # Shared predicates for system-role and verification changes (#4328).
+      #
+      # Lives here — not in the colonel adapter — so the definition of "the last
+      # colonel" is IDENTICAL for the HTTP endpoints and for
+      # `bin/ots customers role demote`. Same reasoning as
+      # {Onetime::Operations::Memberships::Support#sole_owner?}, which the
+      # membership ops share with their CLI for exactly this reason.
+      #
+      # `extend self` (not module_function) is the in-repo idiom and what
+      # Style/ModuleFunction enforces: callers may either `include` the module
+      # (the ops do, so the predicates read as plain calls) or address it
+      # directly as `RoleSupport.last_colonel?(...)` (the adapters do).
+      module RoleSupport
+        extend self
+
+        # Every account that is authoritatively a colonel RIGHT NOW.
+        #
+        # Customer.colonel_count / role_index_for read a DERIVED index that is
+        # known to drift UPWARD (reconcile_role_index.rb documents both
+        # mechanisms: familia 2.12 partial writes are add-only and retain the
+        # previous role's bucket member, and a TTL-expired customer hash leaves
+        # its index member behind forever). Counting the index would make a
+        # last-colonel guard FAIL OPEN — the exact failure mode #4328 exists to
+        # prevent — so every member is re-checked against the authoritative
+        # `role` field. `verified?` matches has_system_role?, which refuses the
+        # colonel role to an unverified account; that is also why unverifying
+        # the last colonel is itself an interlocked action.
+        #
+        # Bounded cost: the colonel bucket holds a handful of accounts in every
+        # real install, and this is only reached on a role or verification
+        # CHANGE — never on the read path.
+        #
+        # @return [Array<Onetime::Customer>]
+        def active_colonels
+          Onetime::Customer.find_all_by_role('colonel').select do |candidate|
+            candidate && candidate.exists? && candidate.role.to_s == 'colonel' && candidate.verified?
+          end
+        end
+
+        # Would demoting this customer leave the install with no colonel?
+        #
+        # @param customer [Onetime::Customer] the demotion target
+        # @param to_role [String, Symbol] the role being assigned
+        # @return [Boolean]
+        def last_colonel?(customer, to_role)
+          return false if to_role.to_s == 'colonel'
+          return false unless customer.role.to_s == 'colonel'
+
+          sole_active_colonel?(customer)
+        end
+
+        # Would UNVERIFYING this customer leave the install with no colonel?
+        #
+        # Unverification strips colonel eligibility through has_system_role?'s
+        # verified? check, so it is a demotion by another name — and it was
+        # reachable straight past any last-colonel check on the role endpoint.
+        #
+        # @param customer [Onetime::Customer] the unverify target
+        # @return [Boolean]
+        def last_colonel_by_verification?(customer)
+          return false unless customer.role.to_s == 'colonel'
+          return false unless customer.verified?
+
+          sole_active_colonel?(customer)
+        end
+
+        # True when no OTHER account is an active colonel. Identity is compared
+        # on objid (the internal id), matching purge_user.rb's self-target
+        # comparison; extid would work too but objid is what every other
+        # same-account check in this codebase uses.
+        #
+        # @param customer [Onetime::Customer]
+        # @return [Boolean]
+        def sole_active_colonel?(customer)
+          active_colonels.none? { |candidate| candidate.objid != customer.objid }
+        end
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/customers/role_support.rb
+++ b/lib/onetime/operations/customers/role_support.rb
@@ -46,12 +46,24 @@ module Onetime
 
         # Would demoting this customer leave the install with no colonel?
         #
+        # Symmetric with {#last_colonel_by_verification?}: the target must itself
+        # be an ACTIVE colonel (verified), because only active colonels count
+        # toward the roster this guard protects. Without the verified? gate an
+        # UNVERIFIED colonel-role account trips the guard whenever the roster is
+        # empty — sole_active_colonel? returns true for anyone when active_colonels
+        # is [] ([].none? is true) — so a stale, never-verified (or provenance-
+        # reset, see change_email.rb) colonel role could never be removed by
+        # either surface, and the "last remaining verified colonel" message it
+        # printed was false. An unverified target is not an active colonel, so
+        # demoting it cannot empty the roster.
+        #
         # @param customer [Onetime::Customer] the demotion target
         # @param to_role [String, Symbol] the role being assigned
         # @return [Boolean]
         def last_colonel?(customer, to_role)
           return false if to_role.to_s == 'colonel'
           return false unless customer.role.to_s == 'colonel'
+          return false unless customer.verified?
 
           sole_active_colonel?(customer)
         end

--- a/lib/onetime/operations/ratelimit/registry.rb
+++ b/lib/onetime/operations/ratelimit/registry.rb
@@ -96,6 +96,32 @@ module Onetime
             keys: ['colonel:elevation:attempts:%s', 'colonel:elevation:locked:%s'],
             dbclient: -> { Onetime::Customer.dbclient },
           },
+          # The broad colonel-mutation bucket (#4329): every mutating colonel
+          # verb, charged from ColonelAPI::Logic::Base#initialize. Resetting
+          # THIS one over POST /ratelimit/reset is self-defeating (the reset is
+          # itself a mutation) — clear it with the valkey-cli commands
+          # `bin/ots ratelimit keys colonel_mutation <extid>` prints.
+          'colonel_mutation' => {
+            subject: 'colonel external id (extid)',
+            keys: ['colonel:mutation:attempts:%s', 'colonel:mutation:locked:%s'],
+            dbclient: -> { Onetime::Customer.dbclient },
+          },
+          # The tight TIER 1 bucket (#4329). This row MUST exist: the documented
+          # lockout recovery is POST /ratelimit/reset with kind
+          # colonel_destructive, which is a TIER 2 verb and therefore still
+          # reachable while the destructive bucket is exhausted.
+          'colonel_destructive' => {
+            subject: 'colonel external id (extid)',
+            keys: ['colonel:destructive:attempts:%s', 'colonel:destructive:locked:%s'],
+            dbclient: -> { Onetime::Customer.dbclient },
+          },
+          # The two session reads that resolve an opaque handle and may fall
+          # back to a bounded keyspace scan (#4329 / #4330).
+          'colonel_handle_resolve' => {
+            subject: 'colonel external id (extid)',
+            keys: ['colonel:handle_resolve:attempts:%s', 'colonel:handle_resolve:locked:%s'],
+            dbclient: -> { Onetime::Customer.dbclient },
+          },
           'dns' => {
             subject: 'domain identifier (sanitized)',
             keys: ['dns:ratelimit:%s'],

--- a/lib/onetime/operations/ratelimit/registry.rb
+++ b/lib/onetime/operations/ratelimit/registry.rb
@@ -106,10 +106,12 @@ module Onetime
             keys: ['colonel:mutation:attempts:%s', 'colonel:mutation:locked:%s'],
             dbclient: -> { Onetime::Customer.dbclient },
           },
-          # The tight TIER 1 bucket (#4329). This row MUST exist: the documented
-          # lockout recovery is POST /ratelimit/reset with kind
-          # colonel_destructive, which is a TIER 2 verb and therefore still
-          # reachable while the destructive bucket is exhausted.
+          # The tight TIER 1 bucket (#4329). This row MUST exist so the limiter is
+          # resettable at all. Recovery is a PEER colonel calling POST
+          # /ratelimit/reset (a TIER 2 verb, still reachable while the destructive
+          # bucket is exhausted) or the CLI: ResetRateLimit refuses SELF-reset of
+          # any colonel_* bucket over HTTP (#4329 review), since a leaked cookie
+          # could otherwise clear its own destructive/elevation lockout in a loop.
           'colonel_destructive' => {
             subject: 'colonel external id (extid)',
             keys: ['colonel:destructive:attempts:%s', 'colonel:destructive:locked:%s'],

--- a/lib/onetime/operations/ratelimit/registry.rb
+++ b/lib/onetime/operations/ratelimit/registry.rb
@@ -85,6 +85,17 @@ module Onetime
             keys: ['create_account:attempts:ip:%s', 'create_account:locked:ip:%s'],
             dbclient: -> { Onetime::Customer.dbclient },
           },
+          # Colonel step-up (sudo) attempts (#4327), keyed on the acting
+          # colonel's PUBLIC external id — never an objid, never a session id
+          # (Rack aliases SessionId#to_s to the live bearer cookie). Customer
+          # shard, matching ColonelRateLimiter#colonel_rate_limit_redis. Keep
+          # these templates byte-identical with that module's key builder or the
+          # CLI, Inspect and Reset cannot see the keys.
+          'colonel_elevation' => {
+            subject: 'colonel external id (extid)',
+            keys: ['colonel:elevation:attempts:%s', 'colonel:elevation:locked:%s'],
+            dbclient: -> { Onetime::Customer.dbclient },
+          },
           'dns' => {
             subject: 'domain identifier (sanitized)',
             keys: ['dns:ratelimit:%s'],

--- a/lib/onetime/operations/sessions/delete_session.rb
+++ b/lib/onetime/operations/sessions/delete_session.rb
@@ -4,6 +4,7 @@
 
 require 'onetime/operations/sessions/store'
 require 'onetime/session/sidecar'
+require 'onetime/models/session_metadata'
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
 
@@ -14,7 +15,8 @@ module Onetime
       # implementation of the session-delete verb (epic #40 / D3 / CONTRACT 4).
       #
       # This is the one mutating session verb. The colonel endpoint
-      # (`DELETE /api/colonel/sessions/:session_id`) and the `bin/ots session delete`
+      # (`DELETE /api/colonel/sessions/:session_handle`, which resolves the handle
+      # back to this sid server-side) and the `bin/ots session delete`
       # CLI are thin adapters over it. The model mutation is IDENTICAL to the prior
       # inline CLI call (`dbclient.del(session_key)`); the op adds exactly one thing
       # the inline call lacked: one {Onetime::ColonelAuditEvent} per successful delete.
@@ -34,7 +36,13 @@ module Onetime
 
         # Destructive verb: record the attempt when the delete raises (the
         # success-path record below is unreachable in that case) and re-raise.
-        audit_failures :call, verb: AUDIT_VERB, target: -> { @session_id }
+        #
+        # target is the non-reversible handle, never the sid: the sid IS the
+        # bearer cookie and the operator trail is count-capped with no TTL, so a
+        # sid recorded here is a replayable credential persisted forever (#4330).
+        audit_failures :call,
+          verb: AUDIT_VERB,
+          target: -> { Onetime::SessionMetadata.handle_for(@session_id) }
 
         # @!attribute status [r] Symbol :deleted (removed) or :not_found (no-op)
         Result = Data.define(:status, :session_id, :key)
@@ -68,12 +76,13 @@ module Onetime
           # (find_key resolves several), which would fail purge's sid guard.
           Onetime::SessionSidecar.purge(Store.extract_id(key), dbclient: db)
 
-          # One audit event per successful mutation. The session id is a public
-          # identifier; never put session contents (tokens, etc.) into detail.
+          # One audit event per successful mutation. Never put session contents
+          # (tokens, etc.) into detail — and never the sid itself (see the
+          # audit_failures note above): the trail carries the handle.
           Onetime::ColonelAuditEvent.record(
             actor: @actor,
             verb: AUDIT_VERB,
-            target: @session_id,
+            target: Onetime::SessionMetadata.handle_for(@session_id),
             result: :success,
           )
 

--- a/lib/onetime/operations/sessions/inspect_session.rb
+++ b/lib/onetime/operations/sessions/inspect_session.rb
@@ -8,8 +8,10 @@ module Onetime
   module Operations
     module Sessions
       # Inspect a single session — the SINGLE implementation of the session-inspect
-      # verb (epic #40 / D3). The colonel endpoint (`GET /api/colonel/sessions/:id`)
-      # and the `bin/ots session inspect` CLI are thin adapters over it.
+      # verb (epic #40 / D3). The colonel endpoint
+      # (`GET /api/colonel/sessions/:session_handle`, which resolves the handle to
+      # this sid server-side) and the `bin/ots session inspect` CLI are thin
+      # adapters over it.
       #
       # READ-ONLY: records NO {Onetime::ColonelAuditEvent} (CONTRACT 4).
       #

--- a/lib/onetime/operations/sessions/list_sessions.rb
+++ b/lib/onetime/operations/sessions/list_sessions.rb
@@ -97,7 +97,7 @@ module Onetime
           # The geo join keys on :session_id, so the internal identifiers are
           # stripped only after it — and only when the caller did not opt in.
           page_rows   = attach_geo_country(identified[start_idx, @per_page] || [])
-          page_rows = strip_internal_identifiers(page_rows) unless @reveal_session_id
+          page_rows   = strip_internal_identifiers(page_rows) unless @reveal_session_id
 
           Result.new(
             sessions: page_rows,

--- a/lib/onetime/operations/sessions/list_sessions.rb
+++ b/lib/onetime/operations/sessions/list_sessions.rb
@@ -25,7 +25,10 @@ module Onetime
       class List
         # @!attribute sessions [r] Array<Hash> one page of {Store.summarize} rows,
         #   each decorated with `:geo_country` from the metadata sidecar
-        #   (see {#attach_geo_country}); nil when no sidecar record survives
+        #   (see {#attach_geo_country}); nil when no sidecar record survives.
+        #   Rows identify a session by `:session_handle`; the internal
+        #   `:session_id` / `:key` are present ONLY when the caller passed
+        #   `reveal_session_id: true` (#4330)
         # @!attribute total_count [r] Integer identity sessions matched (pre-pagination)
         # @!attribute scanned [r] Integer session keys examined this scan
         # @!attribute anonymous_count [r] Integer scanned keys with no actor identity (filtered out)
@@ -49,13 +52,22 @@ module Onetime
 
         # @param page [Integer] 1-based page (clamped to >= 1).
         # @param per_page [Integer] page size (clamped to 1..MAX_PER_PAGE).
-        # @param search [String, nil] optional free-text identity filter.
+        # @param search [String, nil] optional free-text identity filter (identity
+        #   fields, or a session-handle prefix).
         # @param dbclient [Object, nil] Redis-like client; defaults to Familia.dbclient.
-        def initialize(page: 1, per_page: DEFAULT_PER_PAGE, search: nil, dbclient: nil)
-          @page     = page.to_i < 1 ? 1 : page.to_i
-          @per_page = clamp_per_page(per_page)
-          @search   = search.to_s.empty? ? nil : search.to_s
-          @dbclient = dbclient
+        # @param reveal_session_id [Boolean] include the INTERNAL `:session_id` and
+        #   `:key` on each row. Defaults FALSE — fail-closed (#4330): the raw sid is
+        #   byte-identical to the `onetime.session` cookie, so only the local
+        #   `bin/ots session` CLI — whose whole purpose is to hand the operator an
+        #   id for `inspect`/`delete` — opts in. Every HTTP consumer gets
+        #   `session_handle` only.
+        def initialize(page: 1, per_page: DEFAULT_PER_PAGE, search: nil, dbclient: nil,
+                       reveal_session_id: false)
+          @page              = page.to_i < 1 ? 1 : page.to_i
+          @per_page          = clamp_per_page(per_page)
+          @search            = search.to_s.empty? ? nil : search.to_s
+          @dbclient          = dbclient
+          @reveal_session_id = reveal_session_id
         end
 
         # @return [Result]
@@ -71,14 +83,21 @@ module Onetime
           # counted so the operator sees the true keyspace shape rather than a
           # list that looks empty for no reason.
           identified, anonymous = rows.partition { |row| Store.identified?(row[:__data]) }
-          identified.select! { |row| Store.matches_search?(row[:__data], @search) } if @search
+          if @search
+            identified.select! do |row|
+              Store.matches_search?(row[:__data], @search, session_id: row[:session_id])
+            end
+          end
           identified.sort_by! { |row| [-(row[:created_at] || 0), row[:session_id].to_s] }
           identified.each { |row| row.delete(:__data) }
 
           total_count = identified.size
           total_pages = @per_page.zero? ? 0 : (total_count.to_f / @per_page).ceil
           start_idx   = (@page - 1) * @per_page
+          # The geo join keys on :session_id, so the internal identifiers are
+          # stripped only after it — and only when the caller did not opt in.
           page_rows   = attach_geo_country(identified[start_idx, @per_page] || [])
+          page_rows = strip_internal_identifiers(page_rows) unless @reveal_session_id
 
           Result.new(
             sessions: page_rows,
@@ -93,6 +112,17 @@ module Onetime
         end
 
         private
+
+        # Drop the bearer-shaped identifiers from the rows that leave this op
+        # (#4330). `:session_id` IS the `onetime.session` cookie value and `:key`
+        # embeds it; `:session_handle` — a non-reversible keyed digest — is the
+        # identifier every consumer routes on instead.
+        def strip_internal_identifiers(rows)
+          rows.each do |row|
+            row.delete(:session_id)
+            row.delete(:key)
+          end
+        end
 
         # Bounded scan → decode → summarize. The parsed session data rides along
         # under `:__data` so the identity partition and the search predicate can

--- a/lib/onetime/operations/sessions/revoke_all_for_customer_except_current.rb
+++ b/lib/onetime/operations/sessions/revoke_all_for_customer_except_current.rb
@@ -5,6 +5,7 @@
 require 'onetime/operations/sessions/store'
 require 'onetime/session/sidecar'
 require 'onetime/models/session_metadata'
+require 'onetime/models/colonel_audit_event'
 
 module Onetime
   module Operations
@@ -85,6 +86,12 @@ module Onetime
       # contract: a missing customer degrades to a zero-count revoke rather than
       # raising (callers wrap it in ErrorHandler.safe_execute regardless).
       class RevokeAllForCustomerExceptCurrent
+        # Audit verb for the ADMIN caller only (see +actor:+). Deliberately the
+        # same verb {RevokeAllForCustomer} writes: to an operator reading the
+        # trail this is the same action, distinguished by `except_current` in
+        # the detail rather than by a second verb they would have to know about.
+        AUDIT_VERB = 'session.revoke_all'
+
         # Session-data identity fields matched against the target's extid during the
         # best-effort untracked sweep. Deliberately the same narrow set
         # {RevokeAllForCustomer} uses (extid only) — never account_id/email — so the
@@ -112,9 +119,18 @@ module Onetime
         #   STRICTLY AFTER `Customer#last_password_update` (see class docs). Default
         #   FALSE. The async sweep worker passes TRUE; with a nil/empty/zero
         #   watermark the flag degrades to the unguarded revoke.
+        # @param actor [String, #extid, nil] acting COLONEL's public identity.
+        #   nil (the default) for every self-service caller, and nil is what
+        #   keeps the colonel trail free of self-service noise — the whole
+        #   reason this op does not audit (see class docs). The colonel
+        #   revoke-all endpoint routes its SELF-TARGET case here (#4328), and
+        #   that IS an admin action, so it passes an actor and one
+        #   {Onetime::ColonelAuditEvent} is written — by the op, never by the
+        #   adapter (CONTRACT 4).
         # @param dbclient [Object, nil] Redis-like client; defaults to Familia.dbclient.
         def initialize(custid:, except_session_id: nil, scan_untracked: true,
-                       honor_credential_watermark: false, dbclient: nil)
+                       honor_credential_watermark: false, actor: nil, dbclient: nil)
+          @actor                      = actor
           @custid                     = custid
           # Normalize to a string so the `sid == @except_session_id` guards are
           # type-stable; nil becomes '' which no real sid ever equals → revoke ALL.
@@ -152,6 +168,12 @@ module Onetime
           #     never the watermark-spared ones — those stay fully tracked).
           tidy_sidecars(customer, tracked, spared)
 
+          record_admin_audit(
+            blobs_deleted: tracked_deleted + untracked_deleted,
+            untracked_deleted: untracked_deleted,
+            scan_capped: scan_capped,
+          )
+
           Result.new(
             revoked: true,
             blobs_deleted: tracked_deleted + untracked_deleted,
@@ -161,6 +183,24 @@ module Onetime
         end
 
         private
+
+        # One admin audit event, and ONLY when an admin actor was named — the
+        # self-service callers pass none and stay out of the colonel trail
+        # (class docs). Best-effort: a broken sink must not fail a containment
+        # revoke that has already happened.
+        def record_admin_audit(**detail)
+          return if @actor.nil?
+
+          Onetime::ColonelAuditEvent.record(
+            actor: @actor,
+            verb: AUDIT_VERB,
+            target: @custid,
+            result: :success,
+            detail: detail.merge(except_current: true),
+          )
+        rescue StandardError => ex
+          OT.le "[Sessions::RevokeAllForCustomerExceptCurrent] audit failed: #{ex.class}: #{ex.message}"
+        end
 
         def zero_result
           Result.new(revoked: true, blobs_deleted: 0, untracked_deleted: 0, scan_capped: false)

--- a/lib/onetime/operations/sessions/store.rb
+++ b/lib/onetime/operations/sessions/store.rb
@@ -5,6 +5,7 @@
 require 'json'
 require 'redis' # for Redis::CommandError in the defensive load_data rescue
 require 'onetime/session/codec' # canonical decryptor injected into load_data
+require 'onetime/models/session_metadata' # handle_for — the non-bearer session id
 
 module Onetime
   module Operations
@@ -44,6 +45,14 @@ module Onetime
 
         # Common prefixes stripped to recover the bare session id from a key.
         KEY_PREFIX_PATTERN = /^(session:|rack:session:)/
+
+        # Shape of Onetime::SessionMetadata.handle_for output (HANDLE_LENGTH = 32).
+        HANDLE_PATTERN = /\A[0-9a-f]{32}\z/
+
+        # Shortest handle prefix {matches_search?} will treat as a handle needle.
+        # Below this a hex-looking term is far more likely to be part of an extid
+        # or an email than a handle the operator copied off a row.
+        HANDLE_SEARCH_PATTERN = /\A[0-9a-f]{4,32}\z/
 
         # The candidate keys a bare session id can live under. Identical to the
         # historic CLI list — order matters (first existing key wins).
@@ -185,12 +194,19 @@ module Onetime
         # shows it anyway); presentation-layer obscuring — e.g. the CLI `list`
         # formatter — stays in the adapter so the op has one canonical shape.
         #
+        # `session_handle` is the ONLY identifier safe to serialize (#4330): the
+        # raw `session_id` is byte-identical to the `onetime.session` cookie and
+        # `key` embeds it, so both are INTERNAL. {List} strips them unless the
+        # caller explicitly opts in (only `bin/ots session` does), and no HTTP
+        # response may carry them.
+        #
         # @param session_id [String]
         # @param key [String]
         # @param data [Hash] parsed session data
         # @return [Hash]
         def summarize(session_id, key, data)
           {
+            session_handle: Onetime::SessionMetadata.handle_for(session_id),
             session_id: session_id,
             key: key,
             authenticated: data['authenticated'] ? true : false,
@@ -204,20 +220,92 @@ module Onetime
         end
 
         # Case-insensitive match of a session against a free-text term across the
-        # identity fields. Identical predicate to the historic CLI `search`.
+        # identity fields, plus the session handle when the caller supplies the
+        # sid it was derived from.
+        #
+        # The console shows operators handles and nothing else (#4330), so a
+        # search box that could not match one would be a regression with no
+        # operator workaround. Handles match on PREFIX because the table renders
+        # a truncated handle — what the operator can copy is the first N chars.
         #
         # @param data [Hash]
         # @param term [String]
+        # @param session_id [String, nil] keyword-optional so the CLI adapter,
+        #   which searches raw rows, keeps working unchanged.
         # @return [Boolean]
-        def matches_search?(data, term)
+        def matches_search?(data, term, session_id: nil)
           needle = term.to_s.downcase
           return false if needle.empty?
+
+          if session_id && needle.match?(HANDLE_SEARCH_PATTERN)
+            handle = Onetime::SessionMetadata.handle_for(session_id)
+            return true if handle&.start_with?(needle)
+          end
 
           [
             data['email'],
             data['external_id'],
             data['account_external_id'],
           ].compact.any? { |field| field.downcase.include?(needle) }
+        end
+
+        # Resolve an opaque session handle back to its raw session id.
+        #
+        # Non-reversible by construction (the handle is a truncated HMAC keyed on
+        # OT.global_secret), so this recomputes handles and compares.
+        #
+        # TWO STAGES, cheap first:
+        #   1. owner hint — when the caller knows which account owns the session
+        #      (the console listing carries external_id on every row), walk only
+        #      that customer's active_sessions ZSET. Single-digit cost, the same
+        #      path RevokeCustomerSession takes.
+        #   2. bounded keyspace SCAN — at most {MAX_SCAN} keys, CONTRACT 6 (never
+        #      a blocking KEYS). Covers untracked/legacy blobs and hint misses.
+        #
+        # @param dbclient [Object]
+        # @param session_handle [String] 32-char lowercase hex
+        # @param owner_hint [String, nil] extid/email/objid of the presumed owner
+        # @return [Array(String, Boolean), Array(nil, Boolean)] `[sid, scan_capped]`.
+        #   scan_capped is true when stage 2 ran AND hit {MAX_SCAN}, i.e. a nil sid
+        #   may mean "not sampled" rather than "does not exist". Callers MUST
+        #   surface it — which is why this returns a pair and not a bare sid.
+        def resolve_handle(dbclient, session_handle, owner_hint: nil)
+          handle = session_handle.to_s.downcase
+          return [nil, false] unless handle.match?(HANDLE_PATTERN)
+
+          if (sid = resolve_handle_via_owner(owner_hint, handle))
+            return [sid, false]
+          end
+
+          keys   = scan_keys(dbclient)
+          capped = keys.size >= MAX_SCAN
+          keys.each do |key|
+            sid = extract_id(key)
+            return [sid, capped] if Onetime::SessionMetadata.handle_for(sid) == handle
+          end
+          [nil, capped]
+        end
+
+        # Stage 1 of {resolve_handle}: match the handle over one customer's own
+        # bounded active_sessions set. The hint is NOT authorization — it only
+        # picks a cheaper search space, and a wrong hint simply misses.
+        #
+        # @param owner_hint [String, nil]
+        # @param handle [String] downcased 32-hex handle
+        # @return [String, nil]
+        def resolve_handle_via_owner(owner_hint, handle)
+          return nil if owner_hint.to_s.empty?
+
+          customer = Onetime::Customer.load_by_extid_or_email(owner_hint) ||
+                     Onetime::Customer.load(owner_hint)
+          return nil unless customer&.exists?
+
+          customer.active_sessions.revrange(0, -1).find do |sid|
+            Onetime::SessionMetadata.handle_for(sid) == handle
+          end
+        rescue StandardError => ex
+          OT.ld "[Sessions::Store] owner-hinted handle resolution failed: #{ex.message}"
+          nil
         end
       end
     end

--- a/lib/onetime/operations/sessions/track_metadata.rb
+++ b/lib/onetime/operations/sessions/track_metadata.rb
@@ -4,6 +4,7 @@
 
 require_relative '../../models/session_metadata'
 require_relative '../../application/organization_loader'
+require_relative '../../application/auth_strategies/admin_session_lifetime'
 
 module Onetime
   module Operations
@@ -63,6 +64,15 @@ module Onetime
           # in session_data (adaptation #3), so both are copied AS-IS.
           return nil unless @session_data['authenticated'] && extid && !@session_id.to_s.empty?
 
+          # A REFUSED request is not activity (#4331). The admin-surface session
+          # bounds read last_activity_at from this very record, so stamping it
+          # here for a request the auth strategy just rejected would slide the
+          # idle window forward and let the next request through — the bound
+          # would only ever cost an attacker one 401. The strategy sets the flag;
+          # this is the only reader. Note it suppresses the whole upsert, the
+          # active_sessions score included, for exactly that one request.
+          return nil if admin_session_expired?
+
           customer = Onetime::Customer.find_by_extid(extid)
           return nil if customer.nil?
 
@@ -109,6 +119,16 @@ module Onetime
         end
 
         private
+
+        # True when this request was refused by the #4331 admin-surface session
+        # bounds. See the call site in #call for why it suppresses the upsert.
+        def admin_session_expired?
+          return false unless @env.respond_to?(:[])
+
+          !@env[Onetime::Application::AuthStrategies::AdminSessionLifetime::EXPIRED_ENV_KEY].nil?
+        rescue StandardError
+          false
+        end
 
         # org_id = the objid of the session's ACTIVE ORGANIZATION.
         #

--- a/lib/onetime/security/colonel_rate_limiter.rb
+++ b/lib/onetime/security/colonel_rate_limiter.rb
@@ -31,14 +31,17 @@ module Onetime
     # a colonel mutation rather than admitting an unthrottled one.
     #
     # CLEARING A STUCK LOCKOUT — the same two paths as every other limiter, over
-    # kind `colonel_elevation`:
+    # kinds `colonel_elevation`, `colonel_mutation`, `colonel_destructive` and
+    # `colonel_handle_resolve`:
     #
-    #   1. `bin/ots ratelimit keys colonel_elevation <extid>` piped to valkey-cli
-    #      (the CLI only PRINTS the commands);
-    #   2. `POST /api/colonel/ratelimit/reset` with kind=colonel_elevation, which
-    #      performs the delete AND records a ColonelAuditEvent. That endpoint is
-    #      TIER 2 — confirmation only, no elevation — so an operator locked out
-    #      of step-up can still clear their own bucket.
+    #   1. `bin/ots ratelimit keys <kind> <extid>` piped to valkey-cli (the CLI
+    #      only PRINTS the commands);
+    #   2. `POST /api/colonel/ratelimit/reset` with that kind, which performs the
+    #      delete AND records a ColonelAuditEvent. That endpoint is TIER 2 —
+    #      confirmation only, no elevation — so an operator locked out of step-up
+    #      or of destructive actions can still clear their own bucket. It is
+    #      itself a mutation, so the one bucket it cannot rescue you from is
+    #      `colonel_mutation`; that is what the valkey-cli path is for.
     #
     # Usage:
     #   include Onetime::Security::ColonelRateLimiter
@@ -56,6 +59,42 @@ module Onetime
       # Namespaced `<resource>.<action>` like every other verb in the trail; the
       # admin console filters on the exact string, so it is a constant.
       ELEVATION_AUDIT_VERB = 'colonel.elevate_throttled'
+
+      # 120 mutating colonel requests per 5 minutes (#4329). Far above any human
+      # operator's rate and above a bulk console session, so this bucket only
+      # trips on scripted abuse. It bounds request VOLUME across all 46 mutating
+      # verbs and is the ONLY bucket charged before the guards run — see
+      # ColonelAPI::Logic::Base#initialize.
+      DEFAULT_MUTATION_MAX     = 120
+      DEFAULT_MUTATION_WINDOW  = 300
+      DEFAULT_MUTATION_LOCKOUT = 300
+      MUTATION_AUDIT_VERB      = 'colonel.mutation_throttled'
+
+      # 10 TIER 1 actions per 5 minutes, then a 15-minute lockout. Permits a real
+      # incident-response burst (revoke a handful of sessions, purge an account)
+      # while capping a scripted purge at 10 before it stalls — which keeps the
+      # audit trail's 10 000-event count cap unreachable inside a lockout window.
+      # That is the whole point of #4329: a purge at wire speed can otherwise
+      # evict the evidence of its own actions.
+      #
+      # These are 10 EXECUTABLE attempts, not 10 requests: the charge is the last
+      # line of raise_concerns, after elevation, confirmation and the interlocks
+      # all pass, so a rejected attempt costs nothing and an attacker holding the
+      # cookie cannot burn the real operator's budget with cheap 403s.
+      DEFAULT_DESTRUCTIVE_MAX     = 10
+      DEFAULT_DESTRUCTIVE_WINDOW  = 300
+      DEFAULT_DESTRUCTIVE_LOCKOUT = 900
+      DESTRUCTIVE_AUDIT_VERB      = 'colonel.destructive_throttled'
+
+      # 60 session-handle lookups per 5 minutes. The two handle-resolving session
+      # reads are the only colonel READS whose cost is not O(1)-ish — each can
+      # fall back to a bounded 10 000-key SCAN plus up to 10 000 HMACs (#4330) —
+      # so they carry a bucket while every other read stays unlimited (the
+      # console fetches those, and a limiter there would break the dashboard).
+      DEFAULT_HANDLE_RESOLVE_MAX     = 60
+      DEFAULT_HANDLE_RESOLVE_WINDOW  = 300
+      DEFAULT_HANDLE_RESOLVE_LOCKOUT = 300
+      HANDLE_RESOLVE_AUDIT_VERB      = 'colonel.handle_resolve_throttled'
 
       # Check the lockout AND record the attempt in one atomic round trip — the
       # same contract as every sibling limiter: Redis serializes script
@@ -103,6 +142,66 @@ module Onetime
           enabled: colonel_elevation_limit_enabled?,
           message: 'Too many step-up attempts. Try again later.',
           audit_verb: ELEVATION_AUDIT_VERB,
+        )
+      end
+
+      # Throttle every mutating colonel request for one colonel account (#4329).
+      # Charged from ColonelAPI::Logic::Base#initialize, so all 46 mutating verbs
+      # are covered without editing 46 files.
+      #
+      # @param subject [String, nil] the acting colonel's extid.
+      # @raise [Onetime::LimitExceeded] 429 once the account is locked out.
+      # @return [void]
+      def enforce_colonel_mutation_limit!(subject)
+        enforce_colonel_bucket!(
+          prefix: 'colonel:mutation',
+          subject: subject,
+          max_attempts: colonel_mutation_max,
+          window: colonel_mutation_window,
+          lockout: colonel_mutation_lockout,
+          enabled: colonel_mutation_limit_enabled?,
+          message: 'Too many admin actions. Please slow down and try again shortly.',
+          audit_verb: MUTATION_AUDIT_VERB,
+        )
+      end
+
+      # Throttle TIER 1 (destructive) colonel actions for one colonel account.
+      # Charged as the LAST line of raise_concerns — see
+      # ColonelAPI::Logic::DestructiveAction#charge_destructive_budget!.
+      #
+      # @param subject [String, nil] the acting colonel's extid.
+      # @raise [Onetime::LimitExceeded] 429 once the account is locked out.
+      # @return [void]
+      def enforce_colonel_destructive_limit!(subject)
+        enforce_colonel_bucket!(
+          prefix: 'colonel:destructive',
+          subject: subject,
+          max_attempts: colonel_destructive_max,
+          window: colonel_destructive_window,
+          lockout: colonel_destructive_lockout,
+          enabled: colonel_destructive_limit_enabled?,
+          message: 'Too many destructive admin actions. This is a safety limit; ' \
+                   'try again shortly or use the CLI for bulk work.',
+          audit_verb: DESTRUCTIVE_AUDIT_VERB,
+        )
+      end
+
+      # Throttle the two session reads that resolve an opaque handle (#4330) and
+      # may fall back to a bounded keyspace scan.
+      #
+      # @param subject [String, nil] the acting colonel's extid.
+      # @raise [Onetime::LimitExceeded] 429 once the account is locked out.
+      # @return [void]
+      def enforce_colonel_handle_resolve_limit!(subject)
+        enforce_colonel_bucket!(
+          prefix: 'colonel:handle_resolve',
+          subject: subject,
+          max_attempts: colonel_handle_resolve_max,
+          window: colonel_handle_resolve_window,
+          lockout: colonel_handle_resolve_lockout,
+          enabled: colonel_handle_resolve_limit_enabled?,
+          message: 'Too many session lookups. Try again shortly.',
+          audit_verb: HANDLE_RESOLVE_AUDIT_VERB,
         )
       end
 
@@ -184,6 +283,18 @@ module Onetime
         colonel_bucket_enabled?('elevation')
       end
 
+      def colonel_mutation_limit_enabled?
+        colonel_bucket_enabled?('mutation')
+      end
+
+      def colonel_destructive_limit_enabled?
+        colonel_bucket_enabled?('destructive')
+      end
+
+      def colonel_handle_resolve_limit_enabled?
+        colonel_bucket_enabled?('handle_resolve')
+      end
+
       def colonel_bucket_enabled?(section)
         return false if colonel_rate_limit_config.fetch('enabled', true) == false
 
@@ -210,6 +321,42 @@ module Onetime
 
       def colonel_elevation_lockout
         positive_colonel_setting('elevation', 'lockout', DEFAULT_ELEVATION_LOCKOUT)
+      end
+
+      def colonel_mutation_max
+        positive_colonel_setting('mutation', 'max_attempts', DEFAULT_MUTATION_MAX)
+      end
+
+      def colonel_mutation_window
+        positive_colonel_setting('mutation', 'window', DEFAULT_MUTATION_WINDOW)
+      end
+
+      def colonel_mutation_lockout
+        positive_colonel_setting('mutation', 'lockout', DEFAULT_MUTATION_LOCKOUT)
+      end
+
+      def colonel_destructive_max
+        positive_colonel_setting('destructive', 'max_attempts', DEFAULT_DESTRUCTIVE_MAX)
+      end
+
+      def colonel_destructive_window
+        positive_colonel_setting('destructive', 'window', DEFAULT_DESTRUCTIVE_WINDOW)
+      end
+
+      def colonel_destructive_lockout
+        positive_colonel_setting('destructive', 'lockout', DEFAULT_DESTRUCTIVE_LOCKOUT)
+      end
+
+      def colonel_handle_resolve_max
+        positive_colonel_setting('handle_resolve', 'max_attempts', DEFAULT_HANDLE_RESOLVE_MAX)
+      end
+
+      def colonel_handle_resolve_window
+        positive_colonel_setting('handle_resolve', 'window', DEFAULT_HANDLE_RESOLVE_WINDOW)
+      end
+
+      def colonel_handle_resolve_lockout
+        positive_colonel_setting('handle_resolve', 'lockout', DEFAULT_HANDLE_RESOLVE_LOCKOUT)
       end
     end
   end

--- a/lib/onetime/security/colonel_rate_limiter.rb
+++ b/lib/onetime/security/colonel_rate_limiter.rb
@@ -1,0 +1,216 @@
+# lib/onetime/security/colonel_rate_limiter.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/models/colonel_audit_event'
+
+module Onetime
+  module Security
+    # Rate limits for the colonel (admin) API surface — the first limiter in the
+    # repo that keys on an AUTHENTICATED identity rather than a perimeter IP.
+    #
+    # #4327 ships the elevation bucket only. #4329 adds the broad mutation
+    # bucket, the tight destructive bucket and the handle-resolve bucket to the
+    # same module, through the same {#enforce_colonel_bucket!} body.
+    #
+    # KEYED ON cust.extid, the acting colonel's PUBLIC id — the same value every
+    # colonel op already passes as its audit `actor:`. Per-ACCOUNT rather than
+    # per-session because a per-session bucket is strictly weaker: it bounds one
+    # cookie's activity, and an attacker with any second way in (a second stolen
+    # session, a parallel tab, the CLI) gets a fresh budget, while the account
+    # bucket bounds the identity as a whole and lines up with the audit actor.
+    # Issue #4329 asks for "a modest per-session limiter"; this deliberately
+    # goes stronger, and the PR says so.
+    #
+    # NEVER interpolate sess.id — Rack aliases SessionId#to_s to #public_id, i.e.
+    # the live bearer cookie, which would leak credentials into
+    # `ratelimit inspect`, `bin/ots ratelimit keys`, `redis-cli --scan` and the
+    # audit target field (#4330).
+    #
+    # Fail-closed on Redis errors, matching every sibling limiter: an outage 500s
+    # a colonel mutation rather than admitting an unthrottled one.
+    #
+    # CLEARING A STUCK LOCKOUT — the same two paths as every other limiter, over
+    # kind `colonel_elevation`:
+    #
+    #   1. `bin/ots ratelimit keys colonel_elevation <extid>` piped to valkey-cli
+    #      (the CLI only PRINTS the commands);
+    #   2. `POST /api/colonel/ratelimit/reset` with kind=colonel_elevation, which
+    #      performs the delete AND records a ColonelAuditEvent. That endpoint is
+    #      TIER 2 — confirmation only, no elevation — so an operator locked out
+    #      of step-up can still clear their own bucket.
+    #
+    # Usage:
+    #   include Onetime::Security::ColonelRateLimiter
+    #   enforce_colonel_elevation_limit!(cust.extid)
+    module ColonelRateLimiter
+      # Five step-up attempts per 15 minutes, then a 15-minute lockout. Tight on
+      # purpose: Auth::Config.valid_login_and_password? is an INTERNAL REQUEST,
+      # so it is not a login (no after_login hook, no auth audit) and it does not
+      # increment Rodauth's own lockout counter — this limiter is the only
+      # backstop against password guessing through POST /api/colonel/elevation.
+      DEFAULT_ELEVATION_MAX     = 5
+      DEFAULT_ELEVATION_WINDOW  = 900
+      DEFAULT_ELEVATION_LOCKOUT = 900
+
+      # Namespaced `<resource>.<action>` like every other verb in the trail; the
+      # admin console filters on the exact string, so it is a constant.
+      ELEVATION_AUDIT_VERB = 'colonel.elevate_throttled'
+
+      # Check the lockout AND record the attempt in one atomic round trip — the
+      # same contract as every sibling limiter: Redis serializes script
+      # executions, the increment that reaches max_attempts sets the lockout flag
+      # and clears the counter, and every later execution sees the flag and is
+      # denied before incrementing, so concurrent bursts cannot overshoot.
+      # Returns {1, current_count} when allowed, {0, lockout_ttl} when denied.
+      CHECK_AND_RECORD_SCRIPT = <<~LUA
+        local attempts_key = KEYS[1]
+        local lockout_key = KEYS[2]
+        local attempt_window = tonumber(ARGV[1])
+        local max_attempts = tonumber(ARGV[2])
+        local lockout_duration = tonumber(ARGV[3])
+
+        if redis.call('EXISTS', lockout_key) == 1 then
+          return {0, redis.call('TTL', lockout_key)}
+        end
+
+        local current = redis.call('INCR', attempts_key)
+
+        if current == 1 then
+          redis.call('EXPIRE', attempts_key, attempt_window)
+        end
+
+        if current >= max_attempts then
+          redis.call('SETEX', lockout_key, lockout_duration, '1')
+          redis.call('DEL', attempts_key)
+        end
+
+        return {1, current}
+      LUA
+
+      # Throttle step-up attempts for one colonel account.
+      #
+      # @param subject [String, nil] the acting colonel's extid.
+      # @raise [Onetime::LimitExceeded] 429 once the account is locked out.
+      # @return [void]
+      def enforce_colonel_elevation_limit!(subject)
+        enforce_colonel_bucket!(
+          prefix: 'colonel:elevation',
+          subject: subject,
+          max_attempts: colonel_elevation_max,
+          window: colonel_elevation_window,
+          lockout: colonel_elevation_lockout,
+          enabled: colonel_elevation_limit_enabled?,
+          message: 'Too many step-up attempts. Try again later.',
+          audit_verb: ELEVATION_AUDIT_VERB,
+        )
+      end
+
+      private
+
+      # Shared body for every colonel bucket.
+      #
+      # Skips entirely on a blank subject rather than building one shared
+      # blank-suffixed key: the first few subject-less callers would lock that
+      # bucket and every later one would be denied — a colonel-wide outage driven
+      # by whatever made the extid unresolvable. Same rationale as
+      # CreateAccountRateLimiter#create_account_ip_keys. On this surface the
+      # router has already enforced role=colonel, so an authenticated caller with
+      # no extid is not a reachable state.
+      def enforce_colonel_bucket!(prefix:, subject:, max_attempts:, window:, lockout:,
+                                  enabled:, message:, audit_verb:)
+        return unless enabled
+        return if subject.to_s.empty?
+
+        allowed, detail = colonel_rate_limit_redis.eval(
+          CHECK_AND_RECORD_SCRIPT,
+          keys: ["#{prefix}:attempts:#{subject}", "#{prefix}:locked:#{subject}"],
+          argv: [window, max_attempts, lockout],
+        )
+
+        if allowed.to_i != 1
+          raise Onetime::LimitExceeded.new(
+            message,
+            retry_after: detail.to_i.positive? ? detail.to_i : lockout,
+            max_attempts: max_attempts,
+          )
+        end
+
+        return unless detail.to_i >= max_attempts
+
+        # This cap-reaching request was itself ALLOWED (the Lua script locks
+        # after incrementing); the lockout applies to the next one.
+        OT.le "[ColonelRateLimiter] #{prefix} subject #{subject} hit cap " \
+              "(#{detail.to_i}/#{max_attempts}); locked for #{lockout}s"
+        record_colonel_throttle_audit(audit_verb, subject, detail.to_i, max_attempts, window, lockout)
+      end
+
+      # Cap-reaching request only — one event per colonel per lockout window.
+      #
+      # record_security (1k cap + 7d retention), never .record: the #4327/#4329
+      # threat model is a COMPROMISED COLONEL SESSION, i.e. exactly an actor who
+      # can mint authenticated events on demand, and the operator trail .record
+      # writes to is count-capped with no TTL.
+      #
+      # Best-effort, matching every other audit call site: a throttle must never
+      # fail because its event could not be assembled.
+      def record_colonel_throttle_audit(verb, subject, count, max, window, lockout)
+        Onetime::ColonelAuditEvent.record_security(
+          actor: subject,
+          verb: verb,
+          target: subject,
+          result: :failure,
+          detail: { count: count, max_attempts: max, window: window, lockout: lockout },
+        )
+      rescue StandardError => ex
+        OT.le('[ColonelRateLimiter] audit record failed', exception: ex)
+      end
+
+      # Co-located with the Customer shard because the subject is a Customer
+      # extid (matches login / reset / create_account).
+      def colonel_rate_limit_redis
+        Onetime::Customer.dbclient
+      end
+
+      def colonel_rate_limit_config
+        OT.conf.dig('site', 'admin', 'rate_limit') || {}
+      end
+
+      # Every bucket consults the PARENT flag as well as its own, so
+      # `site.admin.rate_limit.enabled: false` (what spec/config.test.yaml sets)
+      # short-circuits all of them — otherwise the colonel suites, which drive
+      # many endpoints from one process as one actor, would throttle themselves.
+      def colonel_elevation_limit_enabled?
+        colonel_bucket_enabled?('elevation')
+      end
+
+      def colonel_bucket_enabled?(section)
+        return false if colonel_rate_limit_config.fetch('enabled', true) == false
+
+        colonel_rate_limit_config.dig(section, 'enabled') != false
+      end
+
+      # Fall back to the default unless the configured value coerces to a
+      # POSITIVE integer. A zero/garbage value (a typo'd env var: `to_i` turns
+      # "abc" into 0) would otherwise invert enforcement — a zero cap locks on
+      # the first attempt, and a non-positive lockout makes the Lua SETEX fail,
+      # turning every step-up into a 500 instead of a throttle.
+      def positive_colonel_setting(section, key, default)
+        value = colonel_rate_limit_config.dig(section, key).to_i
+        value.positive? ? value : default
+      end
+
+      def colonel_elevation_max
+        positive_colonel_setting('elevation', 'max_attempts', DEFAULT_ELEVATION_MAX)
+      end
+
+      def colonel_elevation_window
+        positive_colonel_setting('elevation', 'window', DEFAULT_ELEVATION_WINDOW)
+      end
+
+      def colonel_elevation_lockout
+        positive_colonel_setting('elevation', 'lockout', DEFAULT_ELEVATION_LOCKOUT)
+      end
+    end
+  end
+end

--- a/lib/onetime/security/colonel_rate_limiter.rb
+++ b/lib/onetime/security/colonel_rate_limiter.rb
@@ -30,18 +30,20 @@ module Onetime
     # Fail-closed on Redis errors, matching every sibling limiter: an outage 500s
     # a colonel mutation rather than admitting an unthrottled one.
     #
-    # CLEARING A STUCK LOCKOUT — the same two paths as every other limiter, over
-    # kinds `colonel_elevation`, `colonel_mutation`, `colonel_destructive` and
-    # `colonel_handle_resolve`:
+    # CLEARING A STUCK LOCKOUT, over kinds `colonel_elevation`, `colonel_mutation`,
+    # `colonel_destructive` and `colonel_handle_resolve`. A colonel may NOT clear
+    # their OWN colonel_* bucket over HTTP — ResetRateLimit#refuse_self_colonel_reset!
+    # refuses (422) when the subject is the caller's own extid, because a leaked
+    # cookie could otherwise reset its own lockout in a loop and defeat the bucket.
+    # So the two recovery paths are asymmetric:
     #
-    #   1. `bin/ots ratelimit keys <kind> <extid>` piped to valkey-cli (the CLI
-    #      only PRINTS the commands);
-    #   2. `POST /api/colonel/ratelimit/reset` with that kind, which performs the
-    #      delete AND records a ColonelAuditEvent. That endpoint is TIER 2 —
-    #      confirmation only, no elevation — so an operator locked out of step-up
-    #      or of destructive actions can still clear their own bucket. It is
-    #      itself a mutation, so the one bucket it cannot rescue you from is
-    #      `colonel_mutation`; that is what the valkey-cli path is for.
+    #   1. YOUR OWN lockout, any of the four kinds: `bin/ots ratelimit keys <kind>
+    #      <extid>` piped to valkey-cli (the CLI only PRINTS the commands). This is
+    #      the only path that clears your own bucket, and it needs no second operator.
+    #   2. A PEER's lockout: a SECOND colonel calls `POST /api/colonel/ratelimit/reset`
+    #      with that kind and the locked colonel's extid, which performs the delete
+    #      AND records a ColonelAuditEvent. That endpoint is TIER 2 — confirmation
+    #      only, no elevation — so a peer need not elevate to free you.
     #
     # Usage:
     #   include Onetime::Security::ColonelRateLimiter

--- a/lib/onetime/session/sidecar.rb
+++ b/lib/onetime/session/sidecar.rb
@@ -189,6 +189,36 @@ module Onetime
       # Redis-writing attacker from replaying one session's pending bind under
       # another sid.
       'link_sso_pending_bind' => { ttl: 900, encrypted: true, merge_on_read: false, externalize: false, destroy_warn: true },
+      # #4327: the colonel step-up (sudo) window. Value is an object
+      #   { "extid" => <acting colonel's public id>, "exp" => <unix seconds> }
+      # NOT a bare epoch: one onetime.session cookie can outlive an identity
+      # change (simple-mode login does not clear or renew the session; full-mode
+      # :renew carries the hash to a new sid), so a bare epoch would let identity
+      # B inherit identity A's live elevation. ColonelAPI::Logic::Colonel::
+      # Elevation#elevated? compares the stored extid against the CURRENT cust
+      # and ignores a mismatch — the codec's sid/field binding closes the other
+      # half (replay under a different sid).
+      #
+      # Absence is the safe state (admission rule): a miss means not elevated,
+      # and every tier-1 colonel verb refuses. Externalized so the capability
+      # carries its own short TTL instead of riding the 24h blob — the stored
+      # exp is AUTHORITATIVE and the TTL is only a backstop, because commit
+      # re-externalizes (and so re-stamps the TTL) on every write. The TTL sits
+      # well above the default 600s window so the sidecar itself can never drop
+      # a live elevation mid-window. absent_when_falsy converges a dropped
+      # elevation to absent instead of parking an empty object refreshed on
+      # every commit. Encrypted: it is a capability bound to a sid.
+      #
+      # No destroy_warn: elevation is not an in-flight hand-off — destroying an
+      # elevated session simply ends the window, which is the safe direction.
+      'elevated_until' => {
+        ttl: 1_800,
+        encrypted: true,
+        merge_on_read: true,
+        externalize: true,
+        absent_when_falsy: true,
+        destroy_warn: false,
+      },
     }.freeze
 
     # Deterministic key derivation — no stored key names needed, which is what

--- a/locales/content/en/admin-customers.json
+++ b/locales/content/en/admin-customers.json
@@ -706,5 +706,25 @@
   "web.admin.customers.detail.diagnostics.auditLog.unavailable": {
     "text": "Authentication log could not be read: {reason}",
     "content_hash": "ab18af57"
+  },
+  "web.admin.customers.actions.role.selfDemote": {
+    "text": "You cannot demote your own colonel account. Ask another colonel to do it, or run `bin/ots customers role demote`.",
+    "content_hash": "3e75d01b"
+  },
+  "web.admin.customers.actions.role.lastColonel": {
+    "text": "You cannot demote the last remaining colonel — the install would have no administrator. Promote and verify another account first.",
+    "content_hash": "9c59c731"
+  },
+  "web.admin.customers.actions.unverify.selfUnverify": {
+    "text": "You cannot unverify your own account: a verified email is required to hold the colonel role.",
+    "content_hash": "8ab024fe"
+  },
+  "web.admin.customers.actions.unverify.lastColonel": {
+    "text": "You cannot unverify the last remaining colonel — an unverified account cannot hold the colonel role. Promote and verify another account first.",
+    "content_hash": "fc404616"
+  },
+  "web.admin.customers.detail.sessions.revokeAll.selfDescription": {
+    "text": "This signs you out of every other device and browser, including sessions not shown in this list. The session you are working in right now is kept.",
+    "content_hash": "ae350040"
   }
 }

--- a/locales/content/en/admin-customers.json
+++ b/locales/content/en/admin-customers.json
@@ -319,13 +319,17 @@
     "text": "Apply",
     "content_hash": "31e392d1"
   },
+  "web.admin.customers.actions.role.button": {
+    "text": "Change role",
+    "content_hash": "a43a8d8c"
+  },
   "web.admin.customers.actions.role.confirmTitle": {
     "text": "Change role?",
     "content_hash": "227f57d7"
   },
   "web.admin.customers.actions.role.confirmDescription": {
-    "text": "Change {email} to the {role} role.",
-    "content_hash": "9ba063c6"
+    "text": "Changes {email} to the {role} role. The colonel role grants full administrative access to every account, secret and organization on this install. Type the account email address below to confirm.",
+    "content_hash": "0ed85b97"
   },
   "web.admin.customers.actions.role.success": {
     "text": "Role updated.",
@@ -440,8 +444,8 @@
     "content_hash": "62ed2854"
   },
   "web.admin.customers.actions.unverify.confirmDescription": {
-    "text": "Mark {email} as not verified.",
-    "content_hash": "592ffd27"
+    "text": "Marks {email} as not verified. An unverified account cannot hold the colonel, admin or staff role, so this also strips any elevated role it has. Type the account email address below to confirm.",
+    "content_hash": "601f7382"
   },
   "web.admin.customers.actions.unverify.success": {
     "text": "Customer unverified.",

--- a/locales/content/en/admin-elevation.json
+++ b/locales/content/en/admin-elevation.json
@@ -1,0 +1,46 @@
+{
+  "web.admin.elevation.banner.active": {
+    "text": "Elevated access active — {remaining} remaining",
+    "content_hash": "3e446719"
+  },
+  "web.admin.elevation.banner.activeRecentAuth": {
+    "text": "Elevated WITHOUT a password (recent sign-in) — {remaining} remaining",
+    "content_hash": "6bc7f4ca"
+  },
+  "web.admin.elevation.banner.drop": {
+    "text": "Drop elevation",
+    "content_hash": "b4960d01"
+  },
+  "web.admin.elevation.prompt.title": {
+    "text": "Confirm it's you",
+    "content_hash": "6176eec2"
+  },
+  "web.admin.elevation.prompt.description": {
+    "text": "This action is destructive. Re-enter your password to unlock destructive actions for the next {minutes} minutes.",
+    "content_hash": "2e85bbdd"
+  },
+  "web.admin.elevation.prompt.confirm": {
+    "text": "Unlock",
+    "content_hash": "4ac709aa"
+  },
+  "web.admin.elevation.prompt.confirmItsYou": {
+    "text": "Confirm it's me",
+    "content_hash": "f718279a"
+  },
+  "web.admin.elevation.prompt.confirmItsYouDescription": {
+    "text": "Your account has no password. Confirm to unlock destructive actions for the next {minutes} minutes.",
+    "content_hash": "d8d63a3a"
+  },
+  "web.admin.elevation.errors.noPassword": {
+    "text": "This account has no password, so it cannot complete step-up authentication.",
+    "content_hash": "ba0d40e8"
+  },
+  "web.admin.elevation.errors.noGrace": {
+    "text": "Ask an administrator to set COLONEL_ELEVATION_REAUTH_GRACE, or to disable step-up with COLONEL_ELEVATION_ENABLED=false.",
+    "content_hash": "ac501a95"
+  },
+  "web.admin.elevation.errors.failed": {
+    "text": "Step-up authentication failed. Destructive actions stay locked.",
+    "content_hash": "f17909ec"
+  }
+}

--- a/locales/content/en/admin-kit.json
+++ b/locales/content/en/admin-kit.json
@@ -66,5 +66,13 @@
   "web.admin.kit.revealEmail.copy": {
     "text": "Copy email address",
     "content_hash": "61b94846"
+  },
+  "web.admin.errors.rateLimited": {
+    "text": "You can try again in about {minutes} minutes.",
+    "content_hash": "27f2d054"
+  },
+  "web.admin.errors.rateLimitedRecovery": {
+    "text": "If you must act sooner, clear the limiter with POST /api/colonel/ratelimit/reset for your own account, or run `bin/ots ratelimit keys <kind> <extid>`.",
+    "content_hash": "b77e1388"
   }
 }

--- a/locales/content/en/admin-session.json
+++ b/locales/content/en/admin-session.json
@@ -1,0 +1,10 @@
+{
+  "web.admin.session.expired": {
+    "text": "Your admin session has expired. Sign in again to continue.",
+    "content_hash": "e970de7c"
+  },
+  "web.admin.session.signIn": {
+    "text": "Sign in",
+    "content_hash": "bfd402b2"
+  }
+}

--- a/locales/content/en/admin-sessions.json
+++ b/locales/content/en/admin-sessions.json
@@ -7,10 +7,6 @@
     "text": "Inspect, search and revoke active sessions for incident response.",
     "content_hash": "784a3a44"
   },
-  "web.admin.sessions.columns.sessionId": {
-    "text": "Session ID",
-    "content_hash": "cb9ac5c5"
-  },
   "web.admin.sessions.columns.authenticated": {
     "text": "Auth",
     "content_hash": "8eb3ea9b"
@@ -40,8 +36,8 @@
     "content_hash": "ff8059dc"
   },
   "web.admin.sessions.search.placeholder": {
-    "text": "Search by email or external ID",
-    "content_hash": "f2dc5c06"
+    "text": "Search by email, external ID or session handle",
+    "content_hash": "4894dec4"
   },
   "web.admin.sessions.list.loadError": {
     "text": "Could not load sessions.",
@@ -76,8 +72,8 @@
     "content_hash": "0c6605c1"
   },
   "web.admin.sessions.revoke.confirmDescription": {
-    "text": "This logs the user out immediately by deleting session {id}. Type the session ID to confirm.",
-    "content_hash": "9e08b1b8"
+    "text": "This logs the user out immediately by revoking session {id}. Type {token} to confirm.",
+    "content_hash": "80578692"
   },
   "web.admin.sessions.revoke.success": {
     "text": "Session revoked",
@@ -110,14 +106,6 @@
   "web.admin.sessions.sections.raw": {
     "text": "Raw session data",
     "content_hash": "c9f11eb4"
-  },
-  "web.admin.sessions.fields.sessionId": {
-    "text": "Session ID",
-    "content_hash": "cb9ac5c5"
-  },
-  "web.admin.sessions.fields.key": {
-    "text": "Redis Key",
-    "content_hash": "0b196725"
   },
   "web.admin.sessions.fields.ttl": {
     "text": "TTL",
@@ -208,7 +196,19 @@
     "content_hash": "34cb67a4"
   },
   "web.admin.sessions.scan.capped": {
-    "text": "Scan capped at the first {scanned} keys — authenticated sessions beyond this window aren't listed. Inspect a specific session by ID to reach it.",
-    "content_hash": "fa418b4e"
+    "text": "Scan capped at the first {scanned} keys — authenticated sessions beyond this window aren't listed. Narrow the search to reach them.",
+    "content_hash": "7a8d6fd5"
+  },
+  "web.admin.sessions.columns.sessionHandle": {
+    "text": "Session handle",
+    "content_hash": "2f08034d"
+  },
+  "web.admin.sessions.fields.sessionHandle": {
+    "text": "Session handle",
+    "content_hash": "2f08034d"
+  },
+  "web.admin.sessions.errors.scanCapped": {
+    "text": "This session was not found in the sampled keyspace. Open it from its row in the list so the owner can be used to look it up.",
+    "content_hash": "67b73f7f"
   }
 }

--- a/locales/content/en/admin-sessions.json
+++ b/locales/content/en/admin-sessions.json
@@ -210,5 +210,9 @@
   "web.admin.sessions.errors.scanCapped": {
     "text": "This session was not found in the sampled keyspace. Open it from its row in the list so the owner can be used to look it up.",
     "content_hash": "67b73f7f"
+  },
+  "web.admin.sessions.revoke.ownSession": {
+    "text": "This is your own session. Revoking it would sign you out — use sign-out instead.",
+    "content_hash": "a6762292"
   }
 }

--- a/spec/cli/customers_command_role_spec.rb
+++ b/spec/cli/customers_command_role_spec.rb
@@ -1,0 +1,134 @@
+# spec/cli/customers_command_role_spec.rb
+#
+# frozen_string_literal: true
+
+# `bin/ots customers role promote|demote` and `bin/ots customers unverify`
+# against the #4328 interlocks.
+#
+# The CLI is the DOCUMENTED recovery path out of a last-colonel lockout: the
+# HTTP endpoints refuse a colonel demoting or unverifying themselves, and tell
+# the operator to use these commands instead. That makes it the one adapter
+# whose refusal handling has to be verified rather than assumed — a command that
+# printed "colonel -> customer" and exited 0 while the op refused would send an
+# operator away believing they had done something they had not.
+#
+# The interlocks themselves live in the shared ops and are unit-tested there
+# (apps/web/auth/spec/operations/customers/{set_role,set_verification}_spec.rb);
+# these examples own only the CLI's contract: message + exit status.
+#
+# Run: bundle exec rspec spec/cli/customers_command_role_spec.rb
+
+require_relative 'cli_spec_helper'
+
+require 'auth/operations/customers/set_role'
+require 'auth/operations/customers/set_verification'
+require 'auth/operations/set_customer_verification'
+
+RSpec.describe 'Customers Role Command interlocks', type: :cli do
+  let(:customer) do
+    double('Customer',
+      email: 'colonel@example.com', objid: 'cust_col', extid: 'ur_col',
+      role: 'colonel', verified?: true, anonymous?: false)
+  end
+
+  before do
+    allow(Onetime::Customer).to receive(:email_exists?).and_return(true)
+    allow(Onetime::Customer).to receive(:find_by_email).and_return(customer)
+  end
+
+  def stub_set_role(status)
+    result = instance_double(Auth::Operations::Customers::SetRole::Result, status: status)
+    allow(Auth::Operations::Customers::SetRole).to receive(:new).and_return(
+      instance_double(Auth::Operations::Customers::SetRole, call: result),
+    )
+  end
+
+  describe 'role demote' do
+    it 'prints the refusal and exits non-zero for the last remaining colonel' do
+      stub_set_role(:last_colonel)
+
+      output = run_cli_command_quietly('customers', 'role', 'demote', 'colonel@example.com', '--force')
+
+      expect(output[:stdout]).to include('last remaining verified colonel')
+      expect(output[:stdout]).to include('bin/ots customers role promote')
+      expect(output[:stdout]).not_to include('-> customer')
+      expect(last_exit_code).to eq(1)
+    end
+
+    it 'succeeds and exits zero for a colonel who is not the last one' do
+      stub_set_role(:success)
+
+      output = run_cli_command_quietly('customers', 'role', 'demote', 'colonel@example.com', '--force')
+
+      expect(output[:stdout]).to match(/-> customer/)
+      expect(last_exit_code).to eq(0)
+    end
+
+    it 'exits non-zero on a status it does not recognize' do
+      stub_set_role(:something_new)
+
+      output = run_cli_command_quietly('customers', 'role', 'demote', 'colonel@example.com', '--force')
+
+      expect(output[:stdout]).to include('did not complete')
+      expect(last_exit_code).to eq(1)
+    end
+  end
+
+  # `promote --role admin` on a colonel is a DEMOTION in effect, so it reaches
+  # the same interlock.
+  describe 'role promote' do
+    it 'refuses a sideways move that would demote the last colonel' do
+      stub_set_role(:last_colonel)
+
+      output = run_cli_command_quietly(
+        'customers', 'role', 'promote', 'colonel@example.com', '--role', 'admin', '--force'
+      )
+
+      expect(output[:stdout]).to include('last remaining verified colonel')
+      expect(last_exit_code).to eq(1)
+    end
+
+    it 'still promotes normally' do
+      stub_set_role(:success)
+
+      output = run_cli_command_quietly(
+        'customers', 'role', 'promote', 'colonel@example.com', '--role', 'admin', '--force'
+      )
+
+      expect(output[:stdout]).to include('-> admin')
+      expect(last_exit_code).to eq(0)
+    end
+  end
+
+  describe 'unverify' do
+    def stub_set_verification(result)
+      allow(Auth::Operations::Customers::SetVerification).to receive(:new).and_return(
+        instance_double(Auth::Operations::Customers::SetVerification, call: result),
+      )
+    end
+
+    before do
+      allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(customer)
+      allow(Onetime::Customer).to receive(:load).and_return(customer)
+    end
+
+    it 'prints the refusal and exits non-zero for the last verified colonel' do
+      stub_set_verification(:last_colonel)
+
+      output = run_cli_command_quietly('customers', 'unverify', 'colonel@example.com')
+
+      expect(output[:stdout]).to include('last remaining verified colonel')
+      expect(output[:stdout]).not_to include('Unverified:')
+      expect(last_exit_code).to eq(1)
+    end
+
+    it 'succeeds and exits zero otherwise' do
+      stub_set_verification(:success)
+
+      output = run_cli_command_quietly('customers', 'unverify', 'colonel@example.com')
+
+      expect(output[:stdout]).to include('Unverified:')
+      expect(last_exit_code).to eq(0)
+    end
+  end
+end

--- a/spec/cli/customers_command_spec.rb
+++ b/spec/cli/customers_command_spec.rb
@@ -75,11 +75,15 @@ RSpec.describe 'Customers Command', type: :cli do
   # state-change lives in
   # apps/web/auth/spec/operations/set_customer_verification_spec.rb.
   # These specs cover only the CLI translation layer.
+  # `role` / `verified?` are read by the #4328 unverify interlocks; a plain
+  # customer short-circuits both without touching the role index.
   let(:target_customer) do
     double('Customer',
       email: 'target@example.com',
       objid: 'cust_target',
       extid: 'cust_ext_target',
+      role: 'customer',
+      verified?: true,
       anonymous?: false,
     )
   end

--- a/spec/cli/session_command_security_spec.rb
+++ b/spec/cli/session_command_security_spec.rb
@@ -249,4 +249,57 @@ RSpec.describe 'Session deserialization security (issue #3498 item 1)', type: :c
       end
     end
   end
+
+  # --------------------------------------------------------------------------
+  # #4330 — the CLI is the ONE opted-in consumer of the raw session id.
+  #
+  # `Sessions::List` strips `:session_id` / `:key` from its rows by default: the
+  # sid is byte-identical to the user's `onetime.session` cookie, so no HTTP
+  # response may carry it. The local operator shell is the deliberate exception
+  # — `ots session inspect` / `delete` take a sid — and it opts in explicitly.
+  # These examples pin BOTH halves of that: the id survives here, and the
+  # non-bearer handle (what the admin console shows) is printed next to it so an
+  # operator can correlate the two surfaces.
+  # --------------------------------------------------------------------------
+  describe 'bin/ots session list — the raw-sid opt-in (#4330)' do
+    let(:redis) { mock_redis_client }
+    # Short enough to survive the list formatter's 40-char id column.
+    let(:cli_session_id) { 'c0ffeec0ffeec0ff' }
+    let(:session_payload) do
+      JSON.generate(
+        'authenticated' => true,
+        'email' => 'operator@example.com',
+        'external_id' => 'ur_cli_1',
+        'authenticated_at' => 1_700_000_000,
+      )
+    end
+
+    before do
+      allow(redis).to receive(:scan_each).and_return(["session:#{cli_session_id}"].each)
+      allow(redis).to receive(:get).and_return(session_payload)
+    end
+
+    it 'still prints the raw session id — the CLI passes reveal_session_id' do
+      output = run_cli_command_quietly('session', 'list')
+
+      expect(output[:stdout]).to include(cli_session_id)
+    end
+
+    it 'prints the console-facing handle alongside it' do
+      output = run_cli_command_quietly('session', 'list')
+
+      expect(output[:stdout]).to include('Handle')
+      expect(output[:stdout]).to include(
+        Onetime::SessionMetadata.handle_for(cli_session_id),
+      )
+    end
+
+    it 'is the ONLY way to get an id out of the op: the default listing has none' do
+      rows = Onetime::Operations::Sessions::List.new(dbclient: redis).call.sessions
+
+      expect(rows.first).to include(:session_handle)
+      expect(rows.first).not_to include(:session_id)
+      expect(rows.first).not_to include(:key)
+    end
+  end
 end

--- a/spec/config.test.yaml
+++ b/spec/config.test.yaml
@@ -92,6 +92,19 @@ site:
     # create_account_rate_limiter.rb.
     create_account_rate_limit:
       enabled: false
+  admin:
+    # Disabled under test so the colonel spec + tryout suites (which hit many
+    # destructive endpoints from one process, as one actor) are not gated; the
+    # #4327 elevation specs enable it in-process. See
+    # apps/api/colonel/logic/colonel/elevation.rb.
+    #
+    # The SHIPPED defaults are asserted separately by
+    # spec/unit/onetime/config/admin_defaults_spec.rb — do not let this file
+    # become the only posture under test.
+    elevation:
+      enabled: false
+    rate_limit:
+      enabled: false
 
 features:
   regions:

--- a/spec/config.test.yaml
+++ b/spec/config.test.yaml
@@ -105,6 +105,13 @@ site:
       enabled: false
     rate_limit:
       enabled: false
+    # Disabled under test so a long-running suite cannot cut its own colonel
+    # session off mid-run (the idle bound reads a sidecar the suite rarely
+    # writes, and the absolute bound would bite any fixture that back-dates
+    # authenticated_at); the #4331 lifetime specs enable it in-process. See
+    # lib/onetime/application/auth_strategies/admin_session_lifetime.rb.
+    session:
+      enabled: false
 
 features:
   regions:

--- a/spec/integration/all/colonel_customer_support_spec.rb
+++ b/spec/integration/all/colonel_customer_support_spec.rb
@@ -23,12 +23,15 @@ RSpec.describe 'Colonel customer support features', type: :integration do
   # Build the StrategyResult double Logic::Base expects (mirrors
   # entitlement_preview_spec.rb). The colonel is a REAL verified customer so
   # verify_one_of_roles!(colonel: true) exercises the actual policy.
-  def strategy_result_for(user, session: {})
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header (#4326) — never params. The gated verbs
+  # exercised below refuse without it.
+  def strategy_result_for(user, session: {}, confirm_token: nil)
     double(
       'StrategyResult',
       session: session,
       user: user,
-      metadata: { ip: '127.0.0.1' },
+      metadata: { ip: '127.0.0.1', confirm_token: confirm_token },
       auth_method: 'sessionauth',
     )
   end
@@ -384,8 +387,10 @@ RSpec.describe 'Colonel customer support features', type: :integration do
   describe 'SuspendUser / UnsuspendUser' do
     let(:target) { create_customer(email: "target-#{SecureRandom.hex(4)}@example.com") }
 
-    def run_logic(klass, params)
-      logic = klass.new(strategy_result_for(colonel), params)
+    # SUSPEND is confirmation-gated (#4326) on the account email; UNSUSPEND is
+    # the restorative arm and ignores the token.
+    def run_logic(klass, params, confirm: target.email)
+      logic = klass.new(strategy_result_for(colonel, confirm_token: confirm), params)
       logic.raise_concerns
       logic.process
     end
@@ -450,8 +455,17 @@ RSpec.describe 'Colonel customer support features', type: :integration do
       )
       audit_before = Onetime::ColonelAuditEvent.count
 
-      logic = ColonelAPI::Logic::Colonel::SuspendUser.new(
+      # The privilege guard is an INTERLOCK, so it runs AFTER the confirmation
+      # gate (§0.2): a caller who has not named the target correctly must not
+      # learn from a 422 that the account holds the colonel role.
+      unconfirmed = ColonelAPI::Logic::Colonel::SuspendUser.new(
         strategy_result_for(colonel), { 'user_id' => other_colonel.extid },
+      )
+      expect { unconfirmed.raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+
+      logic = ColonelAPI::Logic::Colonel::SuspendUser.new(
+        strategy_result_for(colonel, confirm_token: other_colonel.email),
+        { 'user_id' => other_colonel.extid },
       )
       expect { logic.raise_concerns }.to raise_error(OT::FormError, /cannot be suspended/i)
 

--- a/spec/integration/all/colonel_host_allowlist_spec.rb
+++ b/spec/integration/all/colonel_host_allowlist_spec.rb
@@ -1158,7 +1158,153 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
   end
 
   # ===========================================================================
-  # 11. The boot posture line reports the trusted-proxy mode ACTUALLY IN FORCE
+  # 11. Route-level network requirements — the two tokens (#4332)
+  # ===========================================================================
+  #
+  # Two tokens ride on this middleware's verdict, and their behaviours diverge
+  # in exactly the postures below:
+  #
+  #   `network=admin`               — strict, one route (GET /system/proxy-headers).
+  #                                   404 unless BOTH allowlists are configured.
+  #   `network=admin_if_configured` — the 15 tier-1 destructive routes. Enforced
+  #                                   where isolation is configured, advisory
+  #                                   where it is not, so annotating them cannot
+  #                                   brick a stock self-hosted install.
+  #
+  # "Reachable" is asserted as a 403 `elevation_required` rather than a 200:
+  # DELETE /users/:id is a tier-1 verb, so a guard refusal FROM THE LOGIC LAYER
+  # proves the request got all the way past the network gate, the router and the
+  # role check. A 404 would be the gate; a bare 403 `Forbidden` with no
+  # error_code would be the role check. `elevation_required` specifically (not
+  # `confirmation_required`) because elevation runs first in the guard order
+  # (design §0.2), and because configure_admin! REPLACES site.admin wholesale —
+  # which drops spec/config.test.yaml's `elevation.enabled: false` and leaves
+  # the shipped default, i.e. enabled, in force for these examples.
+  describe 'route-level network requirements (#4332)' do
+    # A tier-1 route with a real target, so its refusal comes from the guard and
+    # not from a not-found. `purge` is the canonical destructive verb.
+    def destructive_path
+      "/api/colonel/users/#{regular.extid}"
+    end
+
+    # The stack hands the CSRF token back on any colonel GET. It has to be
+    # fetched from the same vantage as the DELETE, or the CIDR gate denies the
+    # fetch and the DELETE fails for the wrong reason.
+    def csrf_token_from(host, rack_env)
+      header 'Host', host
+      header 'Accept', 'application/json'
+      header 'Content-Type', nil
+      header 'Content-Length', nil
+      header 'X-CSRF-Token', nil
+      get '/api/colonel/info', {}, rack_env
+      last_response.headers['X-CSRF-Token']
+    end
+
+    # DELETE the target, carrying CSRF but deliberately NO X-OTS-Confirm.
+    def attempt_destructive(host, rack_env = {})
+      token = csrf_token_from(host, rack_env)
+      header 'Host', host
+      header 'Accept', 'application/json'
+      header 'X-CSRF-Token', token
+      delete destructive_path, {}, rack_env
+      last_response
+    end
+
+    def get_strict_route(host, rack_env = {})
+      header 'Host', host
+      header 'Accept', 'application/json'
+      get '/api/colonel/system/proxy-headers', {}, rack_env
+      last_response
+    end
+
+    # Posture A: neither allowlist configured, and no routable hostname to
+    # anchor on — the stock single-container install, where the host gate
+    # self-disables and the CIDR gate was never opt-ed into.
+    context 'in posture A (stock self-hosted: neither allowlist configured)' do
+      before do
+        configure_admin!(allowed_hosts: [], allowed_cidrs: [], site_host: '127.0.0.1:3000',
+                         default_domain: nil)
+      end
+
+      it 'leaves a destructive route reachable — the annotation is advisory' do
+        # The whole reason `network=admin_if_configured` exists. With the strict
+        # token these fifteen routes would 404 for an authenticated colonel on
+        # localhost, with nothing in the response to diagnose it.
+        signed_in_as(colonel)
+        response = attempt_destructive('localhost')
+
+        expect(response.status).to eq(403), "expected the guard, got #{response.status}: #{response.body}"
+        expect(json_body['error_code']).to eq('elevation_required')
+      end
+
+      it 'still 404s the strict network=admin route' do
+        # Unchanged behaviour, and the control that says the verdict keys really
+        # are being read: same posture, same request shape, different token.
+        signed_in_as(colonel)
+
+        expect(get_strict_route('localhost').status).to eq(404)
+      end
+    end
+
+    context 'in posture B (canonical anchor only — no explicit ADMIN_ALLOWED_HOSTS)' do
+      before { configure_admin!(default_domain: 'example.com', site_host: 'example.com') }
+
+      it 'leaves a destructive route reachable: the anchor fallback is not an explicit choice' do
+        signed_in_as(colonel)
+        response = attempt_destructive('example.com')
+
+        expect(response.status).to eq(403), "expected the guard, got #{response.status}: #{response.body}"
+        expect(json_body['error_code']).to eq('elevation_required')
+      end
+
+      it 'still 404s the strict network=admin route' do
+        signed_in_as(colonel)
+
+        expect(get_strict_route('example.com').status).to eq(404)
+      end
+    end
+
+    context 'in posture E (both allowlists configured — enforced)' do
+      let(:inside)  { { 'REMOTE_ADDR' => '203.0.113.9' } }
+      let(:outside) { { 'REMOTE_ADDR' => '198.51.100.4' } }
+
+      before do
+        configure_admin!(
+          allowed_hosts: ['admin.example.com'],
+          allowed_cidrs: ['203.0.113.9/32'],
+          default_domain: 'example.com',
+          site_host: 'example.com',
+        )
+      end
+
+      it 'serves a destructive route from an allowed host and CIDR' do
+        signed_in_as(colonel)
+        response = attempt_destructive('admin.example.com', inside)
+
+        expect(response.status).to eq(403), "expected the guard, got #{response.status}: #{response.body}"
+        expect(json_body['error_code']).to eq('elevation_required')
+      end
+
+      it '404s the same route from outside the CIDR' do
+        signed_in_as(colonel)
+        response = attempt_destructive('admin.example.com', outside)
+
+        expect(response.status).to eq(404)
+        expect(response.body).to eq('{"error":"Not Found"}')
+      end
+
+      it 'serves the strict network=admin route too, from the same vantage' do
+        # Posture E is the only one that satisfies the strict token, which is
+        # what made it unusable on the console's own routes.
+        signed_in_as(colonel)
+
+        expect(get_strict_route('admin.example.com', inside).status).to eq(200)
+      end
+    end
+  end
+
+  # ===========================================================================
+  # 12. The boot posture line reports the trusted-proxy mode ACTUALLY IN FORCE
   # ===========================================================================
   #
   # #4087. `trusted_proxy` rides on the posture line because it qualifies the

--- a/spec/integration/all/colonel_membership_entitlement_override_spec.rb
+++ b/spec/integration/all/colonel_membership_entitlement_override_spec.rb
@@ -22,12 +22,15 @@ require 'colonel/application'
 # colonel_customer_support_spec.rb) so the assertions reach the REAL op, the
 # REAL membership model writes, and the REAL audit trail — no HTTP layer.
 RSpec.describe 'Colonel membership entitlement overrides', type: :integration do
-  def strategy_result_for(user, session: {})
+  # `confirm_token` is where the colonel session auth strategy puts the
+  # percent-decoded X-OTS-Confirm header (#4326) — never params. The gated verbs
+  # exercised below refuse without it.
+  def strategy_result_for(user, session: {}, confirm_token: nil)
     double(
       'StrategyResult',
       session: session,
       user: user,
-      metadata: { ip: '127.0.0.1' },
+      metadata: { ip: '127.0.0.1', confirm_token: confirm_token },
       auth_method: 'sessionauth',
     )
   end
@@ -54,9 +57,11 @@ RSpec.describe 'Colonel membership entitlement overrides', type: :integration do
     Onetime::Organization.create!("Member Override Org #{SecureRandom.hex(4)}", owner, owner.email)
   end
 
-  def run_logic(params, actor: colonel)
+  # Every arm of this endpoint is confirmation-gated (#4326) on the MEMBER's
+  # email, so the token defaults to the member these examples target.
+  def run_logic(params, actor: colonel, confirm: owner.email)
     logic = ColonelAPI::Logic::Colonel::ManageMembershipEntitlementOverride.new(
-      strategy_result_for(actor), params,
+      strategy_result_for(actor, confirm_token: confirm), params,
     )
     logic.raise_concerns
     logic.process
@@ -198,6 +203,7 @@ RSpec.describe 'Colonel membership entitlement overrides', type: :integration do
         run_logic(
           { 'org_id' => org.extid, 'member_id' => outsider.extid,
             'entitlement' => 'custom_branding', 'action' => 'grant' },
+          confirm: outsider.email,
         )
       end.to raise_error(Onetime::RecordNotFound, /membership not found/i)
 

--- a/spec/integration/all/colonel_rate_limit_spec.rb
+++ b/spec/integration/all/colonel_rate_limit_spec.rb
@@ -30,9 +30,11 @@
 # (try/unit/security/colonel_rate_limiter_try.rb).
 #
 # What only THIS file can prove: that the charge survives the whole stack, that
-# the 429 reaches the client in the documented shape, and that the documented
-# lockout recovery — POST /ratelimit/reset, a TIER 2 verb that needs no
-# elevation precisely so it stays reachable — actually clears the bucket.
+# the 429 reaches the client in the documented shape, and that lockout recovery
+# behaves over the wire — POST /ratelimit/reset is a TIER 2 verb that needs no
+# elevation, so it stays reachable while locked out, but a colonel may NOT clear
+# their OWN colonel_* bucket over HTTP (a leaked cookie could loop out of its own
+# lockout); a PEER colonel's reset is what clears it end to end.
 #
 # spec/config.test.yaml ships site.admin.rate_limit.enabled:false so the colonel
 # suites (many endpoints, one process, ONE acting colonel) do not throttle
@@ -252,9 +254,14 @@ RSpec.describe 'Colonel API rate limiting (#4329)', type: :integration do
       expect(revoke_all.status).to eq(429)
     end
 
-    # The documented recovery. POST /ratelimit/reset is TIER 2 — confirmation
-    # but no step-up — precisely so a locked-out operator can still reach it.
-    it 'is cleared by POST /ratelimit/reset for kind colonel_destructive' do
+    # SELF-RESET IS REFUSED (#4329 review). POST /ratelimit/reset is TIER 2 —
+    # confirmation but no step-up — so it stays reachable while locked out, but a
+    # colonel may NOT clear their OWN colonel_* bucket over HTTP: a leaked cookie
+    # could otherwise reset its own lockout in a loop and defeat the bucket. The
+    # confirmation token here (kind:subject) is caller-supplied and proves nothing,
+    # so the interlock — not the token — is what stops the loop. Recovery of one's
+    # own lockout is CLI-only; a peer colonel over HTTP is the other path (below).
+    it 'refuses a colonel clearing their OWN colonel_destructive bucket, and the lockout holds' do
       enable_buckets(destructive: { 'max_attempts' => 2 })
 
       2.times { revoke_all }
@@ -265,9 +272,35 @@ RSpec.describe 'Colonel API rate limiting (#4329)', type: :integration do
         { kind: 'colonel_destructive', subject: colonel.extid },
         confirm: "colonel_destructive:#{colonel.extid}",
       )
-      expect(reset.status).to eq(200), "reset should be reachable while locked out: #{reset.body}"
+      expect(reset.status).to eq(422), "self-reset must be refused: #{reset.body}"
+      expect(error_body['error']).to match(/clear your own colonel rate limiter/i)
+
+      # The lockout is untouched: the operator is still throttled.
+      expect(revoke_all.status).to eq(429),
+        "the refused self-reset must not have cleared the bucket: #{last_response.body}"
+    end
+
+    # PEER RECOVERY, end to end. A SECOND colonel can clear the locked-out
+    # colonel's destructive bucket — the operator-recovery case the self-reset
+    # refusal deliberately leaves open — and the reset does clear the bucket.
+    it 'lets a PEER colonel clear the locked-out colonel destructive bucket' do
+      enable_buckets(destructive: { 'max_attempts' => 2 })
+
+      2.times { revoke_all }
+      expect(revoke_all.status).to eq(429)
+
+      peer = create_customer(role: 'colonel')
+      signed_in_as(peer)
+      reset = colonel_post(
+        '/api/colonel/ratelimit/reset',
+        { kind: 'colonel_destructive', subject: colonel.extid },
+        confirm: "colonel_destructive:#{colonel.extid}",
+      )
+      expect(reset.status).to eq(200), "a peer reset should be reachable: #{reset.body}"
       expect(JSON.parse(reset.body).dig('record', 'cleared')).to be true
 
+      # Back as the freed colonel: the bucket is clear, so the operator can act.
+      signed_in_as(colonel)
       expect(revoke_all.status).to eq(200), "the operator should be able to act again: #{last_response.body}"
     end
   end

--- a/spec/integration/all/colonel_rate_limit_spec.rb
+++ b/spec/integration/all/colonel_rate_limit_spec.rb
@@ -1,0 +1,324 @@
+# spec/integration/all/colonel_rate_limit_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — rate limiting on the colonel API surface (#4329)
+# =============================================================================
+#
+# FINDING: the rate-limiter registry was perimeter-only (login, feedback, reset,
+# signup). Nothing — no middleware, no `limit_action`, no `RateLimit.incr` —
+# covered /api/colonel/*. A scripted compromise of a colonel session could purge
+# at wire speed and, because the operator audit trail trims at a 10 000-event
+# count cap with NO TTL, evict the evidence of its own actions while doing it.
+#
+# CODE PATH under test, end to end through the real Rack::URLMap:
+#
+#   ColonelAPI::AuthStrategies::SessionAuthStrategy#build_metadata
+#     -> ColonelAPI::Logic::Base#initialize        (colonel:mutation, every verb)
+#     -> <verb>#raise_concerns, LAST line          (colonel:destructive, TIER 1)
+#     -> GetSessionDetail/DeleteSession            (colonel:handle_resolve)
+#     -> Onetime::Security::ColonelRateLimiter     (the Lua CHECK_AND_RECORD)
+#     -> Onetime::LimitExceeded -> 429 + Retry-After (RetryAfterHeader)
+#
+# The unit-level siblings own the pieces this file cannot see: which requests
+# are charged and with what subject
+# (apps/api/colonel/spec/logic/colonel/rate_limit_hook_spec.rb), the guard-order
+# guarantee that a REJECTED destructive attempt costs nothing
+# (.../destructive_budget_order_spec.rb), and the limiter body itself — key
+# shapes, TTLs, lockout, the single audit write
+# (try/unit/security/colonel_rate_limiter_try.rb).
+#
+# What only THIS file can prove: that the charge survives the whole stack, that
+# the 429 reaches the client in the documented shape, and that the documented
+# lockout recovery — POST /ratelimit/reset, a TIER 2 verb that needs no
+# elevation precisely so it stays reachable — actually clears the bucket.
+#
+# spec/config.test.yaml ships site.admin.rate_limit.enabled:false so the colonel
+# suites (many endpoints, one process, ONE acting colonel) do not throttle
+# themselves; every example here enables the buckets it needs in-process with a
+# small cap and restores the config afterwards.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2163: pnpm run test:database:start
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec \
+#     spec/integration/all/colonel_rate_limit_spec.rb
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require_relative '../integration_spec_helper'
+require 'colonel/application'
+
+RSpec.describe 'Colonel API rate limiting (#4329)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
+    # Without this, Rack::URLMap has no /api/* entries and every request 404s at
+    # the map level — which would look exactly like a limiter denial.
+    Onetime::Application::Registry.prepare_application_registry
+  end
+
+  # Memoized: repeated generate_rack_url_map calls corrupt middleware state.
+  def app
+    @app ||= Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  # The counters live on the Customer shard (ColonelRateLimiter's own client),
+  # which is not necessarily the logical DB the integration helper flushes.
+  let(:rl_redis) { Onetime::Customer.dbclient }
+
+  def clear_colonel_limiter_keys
+    stale = rl_redis.keys('colonel:*:attempts:*') + rl_redis.keys('colonel:*:locked:*')
+    rl_redis.del(*stale) unless stale.empty?
+  end
+
+  before do
+    @saved_conf = YAML.load(YAML.dump(OT.conf))
+    clear_colonel_limiter_keys
+  end
+
+  after do
+    OT.send(:conf=, @saved_conf) if @saved_conf
+    clear_colonel_limiter_keys
+  end
+
+  # Enable exactly the buckets an example needs. Anything not named is left
+  # DISABLED, so one bucket's 429 can never be mistaken for another's.
+  def enable_buckets(**buckets)
+    new_conf = YAML.load(YAML.dump(OT.conf))
+    admin    = ((new_conf['site'] ||= {})['admin'] ||= {})
+
+    admin['rate_limit'] = { 'enabled' => true }.merge(
+      buckets.to_h do |section, settings|
+        [section.to_s, { 'enabled' => true, 'window' => 300, 'lockout' => 300 }.merge(
+          settings.to_h { |key, value| [key.to_s, value] },
+        ),]
+      end,
+    )
+    OT.send(:conf=, new_conf)
+  end
+
+  def create_customer(role: 'customer')
+    cust          = Onetime::Customer.create!(email: "#{role}-#{SecureRandom.hex(6)}@example.com")
+    cust.role     = role
+    cust.verified = 'true'
+    cust.save
+    cust
+  end
+
+  let(:colonel) { create_customer(role: 'colonel') }
+  let(:target)  { create_customer }
+
+  # Otto's session auth strategy reads env['rack.session']; injecting the hash is
+  # the established pattern here (colonel_host_allowlist_spec.rb).
+  def signed_in_as(user)
+    env 'rack.session', {
+      'external_id' => user.extid,
+      'authenticated' => true,
+      'session_id' => SecureRandom.hex(16),
+    }
+  end
+
+  # Setup failure must be LOUD: a nil CSRF token draws a 403 from the CSRF
+  # middleware and would surface as a misleading status assertion further down.
+  def csrf_token
+    # Clear the body headers a previous POST left behind, or rack-test sends
+    # this GET with a JSON content type and no body and the multipart validator
+    # raises on the nil input stream.
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+    header 'X-OTS-Confirm', nil
+    header 'Accept', 'application/json'
+    get '/api/colonel/info'
+    token = last_response.headers['X-CSRF-Token']
+    raise "CSRF setup failed: GET /api/colonel/info returned #{last_response.status}" if token.to_s.empty?
+
+    token
+  end
+
+  def colonel_get(path)
+    header 'Content-Type', nil
+    header 'Content-Length', nil
+    header 'X-OTS-Confirm', nil
+    header 'Accept', 'application/json'
+    get path
+    last_response
+  end
+
+  # POST with the CSRF token the stack just handed us and the #4326 confirmation
+  # header. `confirm: nil` sends no header, i.e. an unconfirmed attempt.
+  def colonel_post(path, body = {}, confirm: nil)
+    token = csrf_token
+    header 'Content-Type', 'application/json'
+    header 'X-CSRF-Token', token
+    header 'X-OTS-Confirm', confirm
+    post path, JSON.generate(body.merge(shrimp: token))
+    raise "CSRF rejected by the stack (403): #{last_response.body}" if last_response.status == 403 &&
+                                                                      last_response.body.to_s == 'Forbidden'
+
+    last_response
+  end
+
+  # A TIER 1 verb that is idempotent and needs no per-call fixture: revoking all
+  # of a session-less account's sessions succeeds and revokes nothing, so a burst
+  # of them isolates the limiter from every other moving part.
+  def revoke_all(confirm: target.email)
+    colonel_post("/api/colonel/users/#{target.extid}/sessions/revoke-all", {}, confirm: confirm)
+  end
+
+  def error_body
+    JSON.parse(last_response.body)
+  end
+
+  before { signed_in_as(colonel) }
+
+  describe 'the broad colonel:mutation bucket' do
+    it 'throttles a burst of mutating requests and reports the documented 429 shape' do
+      enable_buckets(mutation: { 'max_attempts' => 3 }, destructive: { 'max_attempts' => 1000 })
+
+      3.times do |i|
+        expect(revoke_all.status).to eq(200), "call #{i + 1} should pass: #{last_response.body}"
+      end
+
+      response = revoke_all
+      expect(response.status).to eq(429), "the over-cap call should be throttled: #{response.body}"
+      expect(error_body['error_type']).to eq('LimitExceeded')
+      expect(error_body['error']).to match(/Too many admin actions/)
+      expect(error_body['max_attempts']).to eq(3)
+      expect(error_body['retry_after']).to be_a(Integer)
+      # RetryAfterHeader (#3956) turns the body field into the RFC 9110 header
+      # for every LimitExceeded, this limiter included.
+      expect(response.headers['Retry-After'].to_i).to be_positive
+    end
+
+    it 'keys the bucket on the acting colonel PUBLIC extid, never on a session id' do
+      enable_buckets(mutation: { 'max_attempts' => 2 }, destructive: { 'max_attempts' => 1000 })
+
+      2.times { revoke_all }
+      expect(revoke_all.status).to eq(429)
+
+      # The exact key, not merely "something locked": a session-keyed bucket
+      # would put the live bearer credential in a Redis key name (#4330), and a
+      # global bucket would let one colonel throttle every other one.
+      expect(rl_redis.keys('colonel:mutation:locked:*'))
+        .to eq(["colonel:mutation:locked:#{colonel.extid}"])
+    end
+
+    # The console fetches several reads on every screen; a limiter there would
+    # break the dashboard, so only mutations are charged here.
+    it 'never charges an ordinary colonel READ' do
+      enable_buckets(mutation: { 'max_attempts' => 1 })
+
+      5.times { expect(colonel_get('/api/colonel/info').status).to eq(200) }
+      expect(rl_redis.keys('colonel:mutation:*')).to be_empty
+    end
+  end
+
+  describe 'the tight colonel:destructive bucket' do
+    it 'caps TIER 1 verbs independently of the broad bucket' do
+      enable_buckets(destructive: { 'max_attempts' => 3, 'lockout' => 900 })
+
+      3.times do |i|
+        expect(revoke_all.status).to eq(200), "call #{i + 1} should pass: #{last_response.body}"
+      end
+
+      response = revoke_all
+      expect(response.status).to eq(429)
+      expect(error_body['error']).to match(/Too many destructive admin actions/)
+      expect(error_body['max_attempts']).to eq(3)
+      expect(response.headers['Retry-After'].to_i).to be_positive
+    end
+
+    # The M-1 guarantee, over the wire: the charge is the LAST line of
+    # raise_concerns, so an attempt refused for a missing/wrong confirmation
+    # consumes nothing. Otherwise anyone holding the cookie could impose a
+    # 15-minute destructive lockout on the operator with cheap 403s.
+    it 'does not charge a request the confirmation gate refused' do
+      enable_buckets(destructive: { 'max_attempts' => 2 })
+
+      3.times do
+        expect(revoke_all(confirm: nil).status).to eq(403)
+      end
+      expect(error_body['error_code']).to eq('confirmation_required')
+      expect(rl_redis.keys('colonel:destructive:*')).to be_empty
+
+      # The budget is intact: two real actions still land.
+      2.times { expect(revoke_all.status).to eq(200) }
+      expect(revoke_all.status).to eq(429)
+    end
+
+    # The documented recovery. POST /ratelimit/reset is TIER 2 — confirmation
+    # but no step-up — precisely so a locked-out operator can still reach it.
+    it 'is cleared by POST /ratelimit/reset for kind colonel_destructive' do
+      enable_buckets(destructive: { 'max_attempts' => 2 })
+
+      2.times { revoke_all }
+      expect(revoke_all.status).to eq(429)
+
+      reset = colonel_post(
+        '/api/colonel/ratelimit/reset',
+        { kind: 'colonel_destructive', subject: colonel.extid },
+        confirm: "colonel_destructive:#{colonel.extid}",
+      )
+      expect(reset.status).to eq(200), "reset should be reachable while locked out: #{reset.body}"
+      expect(JSON.parse(reset.body).dig('record', 'cleared')).to be true
+
+      expect(revoke_all.status).to eq(200), "the operator should be able to act again: #{last_response.body}"
+    end
+  end
+
+  describe 'the colonel:handle_resolve bucket' do
+    # The one exception to "colonel reads are never limited": resolving an
+    # opaque session handle can fall back to a bounded 10 000-key SCAN plus as
+    # many HMACs (#4330).
+    it 'caps session-handle lookups, including the ones that 404' do
+      enable_buckets(handle_resolve: { 'max_attempts' => 3 })
+      handle = '0123456789abcdef0123456789abcdef'
+
+      3.times do |i|
+        expect(colonel_get("/api/colonel/sessions/#{handle}").status).to eq(404),
+          "lookup #{i + 1} should reach the resolver: #{last_response.body}"
+      end
+
+      response = colonel_get("/api/colonel/sessions/#{handle}")
+      expect(response.status).to eq(429)
+      expect(error_body['error']).to match(/Too many session lookups/)
+      expect(error_body['max_attempts']).to eq(3)
+    end
+
+    it 'leaves every other colonel read unthrottled' do
+      enable_buckets(handle_resolve: { 'max_attempts' => 1 })
+      handle = '0123456789abcdef0123456789abcdef'
+
+      colonel_get("/api/colonel/sessions/#{handle}")
+      expect(colonel_get("/api/colonel/sessions/#{handle}").status).to eq(429)
+
+      expect(colonel_get('/api/colonel/info').status).to eq(200)
+      expect(colonel_get('/api/colonel/sessions').status).to eq(200)
+    end
+  end
+
+  describe 'when the limiters are disabled' do
+    it 'writes no keys and never throttles (the spec/config.test.yaml posture)' do
+      # The parent flag off, every bucket nominally on: this is what the rest of
+      # the colonel suite relies on to avoid throttling itself.
+      new_conf = YAML.load(YAML.dump(OT.conf))
+      admin    = ((new_conf['site'] ||= {})['admin'] ||= {})
+      admin['rate_limit'] = {
+        'enabled' => false,
+        'mutation' => { 'enabled' => true, 'max_attempts' => 1 },
+        'destructive' => { 'enabled' => true, 'max_attempts' => 1 },
+        'handle_resolve' => { 'enabled' => true, 'max_attempts' => 1 },
+      }
+      OT.send(:conf=, new_conf)
+
+      4.times { expect(revoke_all.status).to eq(200) }
+      expect(rl_redis.keys('colonel:*')).to be_empty
+    end
+  end
+end

--- a/spec/integration/all/colonel_session_lifetime_spec.rb
+++ b/spec/integration/all/colonel_session_lifetime_spec.rb
@@ -1,0 +1,259 @@
+# spec/integration/all/colonel_session_lifetime_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Integration — admin-surface session lifetime (#4331)
+# =============================================================================
+#
+# FINDING: one onetime.session cookie served colonel and customer alike on a 24h
+# ROLLING TTL. Onetime::Session#write_session re-applies expire_after on every
+# commit and Rack commits on essentially every request, so a colonel session left
+# open in a tab was a standing administrative capability with no absolute cap and
+# no idle timeout.
+#
+# CODE PATH under test, end to end through the real Rack::URLMap:
+#
+#   Onetime::Session (universal mount)
+#     -> BaseSessionAuthStrategy#authenticate       (after the credential watermark)
+#     -> AdminSessionLifetime#admin_session_expiry_reason
+#     -> 401 [ADMIN_SESSION_EXPIRED] ...            (JSON, via Otto's ResponseBuilder)
+#   ... and on the way out:
+#   Onetime::Session#write_session -> Sessions::TrackMetadata (SKIPPED when refused)
+#
+# What only THIS file can prove, and what the design exists to guarantee:
+#
+#   1. The bound is on the SURFACE, not the session. The SAME cookie that is
+#      refused by /api/colonel still works on a tenant route and still loads the
+#      /colonel SPA shell — a colonel who is also the site's only customer must
+#      not be logged out of the customer app.
+#   2. A refused request does not slide its own idle window forward. Without the
+#      TrackMetadata suppression the bound would cost an attacker exactly one
+#      401 (the M-5 shape: no endpoint, the elevation status read included, may
+#      act as a keep-alive for a session that is already over the bound).
+#
+# The decision table itself is the unit spec
+# (spec/unit/onetime/application/auth_strategies/admin_session_lifetime_spec.rb);
+# the wiring/order is base_session_auth_strategy_spec.rb.
+#
+# spec/config.test.yaml ships site.admin.session.enabled:false so a long suite
+# cannot cut its own colonel session off mid-run; every example here enables the
+# bounds it needs in-process and restores the config afterwards.
+#
+# REQUIREMENTS:
+# - Valkey running on port 2163: pnpm run test:database:start
+#
+# RUN:
+#   RACK_ENV=test AUTHENTICATION_MODE=simple bundle exec rspec \
+#     spec/integration/all/colonel_session_lifetime_spec.rb
+#
+# =============================================================================
+
+require_relative '../../spec_helper'
+require_relative '../integration_spec_helper'
+require 'colonel/application'
+
+RSpec.describe 'Admin-surface session lifetime (#4331)', type: :integration do
+  include Rack::Test::Methods
+
+  before(:all) do
+    require 'onetime'
+    Onetime.boot! :test
+    # Without this, Rack::URLMap has no /api/* entries and every request 404s at
+    # the map level — which would look exactly like an expired session.
+    Onetime::Application::Registry.prepare_application_registry
+  end
+
+  # Memoized: repeated generate_rack_url_map calls corrupt middleware state.
+  def app
+    @app ||= Onetime::Application::Registry.generate_rack_url_map
+  end
+
+  let(:now) { Familia.now.to_i }
+
+  before do
+    @saved_conf = YAML.load(YAML.dump(OT.conf))
+  end
+
+  after { OT.send(:conf=, @saved_conf) if @saved_conf }
+
+  def configure_bounds(**settings)
+    conf = YAML.load(YAML.dump(OT.conf))
+    ((conf['site'] ||= {})['admin'] ||= {})['session'] =
+      { 'enabled' => true }.merge(settings.transform_keys(&:to_s))
+    OT.send(:conf=, conf)
+  end
+
+  def create_customer(role: 'customer')
+    cust          = Onetime::Customer.create!(email: "#{role}-#{SecureRandom.hex(6)}@example.com")
+    cust.role     = role
+    cust.verified = 'true'
+    cust.save
+    cust
+  end
+
+  let(:colonel) { create_customer(role: 'colonel') }
+
+  # Otto's session auth strategy reads env['rack.session']; injecting the hash is
+  # the established pattern here (colonel_host_allowlist_spec.rb). Rack's
+  # prepare_session MERGES it into the real SessionHash, so the session still has
+  # a live sid and still commits — which is what lets this file drive the sidecar
+  # and the rolling-TTL behaviour rather than mocking them.
+  def signed_in_as(user, authenticated_at: now)
+    env 'rack.session', {
+      'external_id' => user.extid,
+      'authenticated' => true,
+      'authenticated_at' => authenticated_at,
+      'role' => user.role,
+    }
+  end
+
+  def json_get(path)
+    header 'Accept', 'application/json'
+    get path
+    last_response
+  end
+
+  def html_get(path)
+    header 'Accept', 'text/html'
+    get path
+    last_response
+  end
+
+  # The sid the stack actually minted for this rack-test session — the key both
+  # the session blob and the SessionMetadata sidecar are stored under.
+  def current_sid
+    rack_mock_session.cookie_jar['onetime.session']
+  end
+
+  def backdate_sidecar(seconds_ago)
+    record = Onetime::SessionMetadata.load(current_sid)
+    raise "no sidecar for #{current_sid.inspect}; TrackMetadata did not run" if record.nil?
+
+    record.last_activity_at = now - seconds_ago
+    record.save
+    record
+  end
+
+  describe 'the absolute bound' do
+    before { configure_bounds(absolute_timeout: 43_200, idle_timeout: 0) }
+
+    it 'lets a fresh colonel session through' do
+      signed_in_as(colonel)
+
+      expect(json_get('/api/colonel/info').status).to eq(200)
+    end
+
+    it 'refuses /api/colonel once the sign-in is older than the bound' do
+      signed_in_as(colonel, authenticated_at: now - 43_201)
+
+      response = json_get('/api/colonel/info')
+      expect(response.status).to eq(401)
+      # The marker the console branches on to render its expired banner. It rides
+      # Otto's JSON auth-failure `message`; the `error` field is Otto's generic
+      # "Authentication Required".
+      expect(JSON.parse(response.body)['message'])
+        .to match(/\A\[ADMIN_SESSION_EXPIRED\] Admin session absolute timeout exceeded/)
+    end
+
+    # THE regression this design exists to prevent. Expiring the session object
+    # would log a colonel out of the customer app too, and on a self-hosted
+    # install the colonel is often the only customer.
+    it 'leaves the SAME session working on a tenant route' do
+      signed_in_as(colonel, authenticated_at: now - 43_201)
+      expect(json_get('/api/colonel/info').status).to eq(401)
+
+      expect(json_get('/api/v2/status').status).to eq(200)
+      expect(html_get('/').status).to eq(200)
+    end
+
+    # Rev-2 scope narrowing: a bare 401 on an HTML navigation has no defined UX,
+    # and the expired banner lives INSIDE the SPA. The shell loads; its first API
+    # call is what 401s.
+    it 'still serves the /colonel SPA shell' do
+      signed_in_as(colonel, authenticated_at: now - 43_201)
+
+      expect(html_get('/colonel').status).to eq(200)
+    end
+
+    it 'is disabled by absolute_timeout: 0' do
+      configure_bounds(absolute_timeout: 0, idle_timeout: 0)
+      signed_in_as(colonel, authenticated_at: now - 200_000)
+
+      expect(json_get('/api/colonel/info').status).to eq(200)
+    end
+
+    it 'is disabled wholesale by enabled: false (the suite-hygiene posture)' do
+      configure_bounds(enabled: false)
+      signed_in_as(colonel, authenticated_at: now - 200_000)
+
+      expect(json_get('/api/colonel/info').status).to eq(200)
+    end
+  end
+
+  describe 'the idle bound' do
+    before { configure_bounds(idle_timeout: 3_600, absolute_timeout: 0) }
+
+    it 'refuses a colonel whose sidecar activity is older than the bound' do
+      signed_in_as(colonel)
+      expect(json_get('/api/colonel/info').status).to eq(200)
+
+      backdate_sidecar(3_601)
+
+      response = json_get('/api/colonel/info')
+      expect(response.status).to eq(401)
+      expect(JSON.parse(response.body)['message'])
+        .to match(/\A\[ADMIN_SESSION_EXPIRED\] Admin session idle timeout exceeded/)
+    end
+
+    # The M-5 regression, and the reason TrackMetadata honours the env flag: a
+    # session that only ever calls the cheap elevation-status read must still be
+    # expired by the idle bound. If a refused request stamped activity, the bound
+    # would be a one-request speed bump — 401, then straight back in.
+    it 'stays expired across repeated attempts, elevation status included' do
+      signed_in_as(colonel)
+      expect(json_get('/api/colonel/info').status).to eq(200)
+
+      backdate_sidecar(3_601)
+
+      expect(json_get('/api/colonel/elevation').status).to eq(401)
+      expect(json_get('/api/colonel/elevation').status).to eq(401)
+      expect(json_get('/api/colonel/info').status).to eq(401)
+    end
+
+    # Best-effort by contract: a session predating the sidecar, or one whose
+    # 30-day TTL lapsed, has no record. Refusing it would log out live sessions
+    # for a reason unrelated to their age.
+    it 'SKIPS itself when the sidecar record is gone' do
+      signed_in_as(colonel)
+      expect(json_get('/api/colonel/info').status).to eq(200)
+
+      Onetime::SessionMetadata.load(current_sid)&.destroy!
+
+      expect(json_get('/api/colonel/info').status).to eq(200)
+    end
+
+    it 'leaves the SAME session working on a tenant route' do
+      signed_in_as(colonel)
+      expect(json_get('/api/colonel/info').status).to eq(200)
+
+      backdate_sidecar(3_601)
+
+      expect(json_get('/api/colonel/info').status).to eq(401)
+      expect(html_get('/').status).to eq(200)
+    end
+  end
+
+  describe 'a non-colonel account' do
+    it 'is unaffected on every surface' do
+      configure_bounds(absolute_timeout: 1, idle_timeout: 1)
+      customer = create_customer
+      signed_in_as(customer, authenticated_at: now - 200_000)
+
+      expect(html_get('/').status).to eq(200)
+      # Still 403/404 for lacking the role — never 401 for an expired admin
+      # window, which is a bound this account is not subject to.
+      expect(json_get('/api/colonel/info').status).not_to eq(401)
+    end
+  end
+end

--- a/spec/integration/full/admin_interface_spec.rb
+++ b/spec/integration/full/admin_interface_spec.rb
@@ -95,6 +95,21 @@ RSpec.describe 'Admin Interface', type: :integration do
     { receipt: receipt, secret: secret }
   end
 
+  # The server-side confirmation token DELETE /api/colonel/secrets/:secret_id now
+  # requires (#4326). It is the RECEIPT shortid — deliberately NOT the secret
+  # shortid, which is only :secret_id[0,8] and so derivable from the URL. Mirror
+  # DeleteSecret#confirmation_token: prefer the secret's stored receipt_shortid,
+  # fall back to the receipt object, so the header matches whichever the record
+  # carries.
+  #
+  # Elevation, the colonel rate limiter and the admin session-lifetime bound are
+  # all disabled in spec/config.test.yaml, so confirmation is the one server-side
+  # guard this HTTP path exercises; the colonel unit specs cover the rest.
+  def delete_secret_confirm_token(pair)
+    token = pair[:secret].receipt_shortid.to_s.strip
+    token.empty? ? pair[:receipt].shortid.to_s : token
+  end
+
   describe 'Authentication & Authorization' do
     context 'when not authenticated' do
       it 'returns 401 for colonel endpoints' do
@@ -219,6 +234,7 @@ RSpec.describe 'Admin Interface', type: :integration do
 
       it 'deletes the secret' do
         header 'X-CSRF-Token', admin_csrf_token
+        header 'X-OTS-Confirm', delete_secret_confirm_token(secret_pair)
         delete "/api/colonel/secrets/#{secret_pair[:secret].objid}"
         expect(last_response.status).to eq(200)
 
@@ -230,6 +246,7 @@ RSpec.describe 'Admin Interface', type: :integration do
         secret_id = secret_pair[:secret].objid
 
         header 'X-CSRF-Token', admin_csrf_token
+        header 'X-OTS-Confirm', delete_secret_confirm_token(secret_pair)
         delete "/api/colonel/secrets/#{secret_id}"
 
         # Verify secret is gone
@@ -242,6 +259,7 @@ RSpec.describe 'Admin Interface', type: :integration do
         receipt_id = secret_pair[:receipt].objid
 
         header 'X-CSRF-Token', admin_csrf_token
+        header 'X-OTS-Confirm', delete_secret_confirm_token(secret_pair)
         delete "/api/colonel/secrets/#{secret_id}"
 
         # Verify metadata is also gone
@@ -488,6 +506,7 @@ RSpec.describe 'Admin Interface', type: :integration do
 
       # Delete through admin panel
       header 'X-CSRF-Token', admin_csrf_token
+      header 'X-OTS-Confirm', delete_secret_confirm_token(secret_pair)
       delete "/api/colonel/secrets/#{secret_id}"
       expect(last_response.status).to eq(200)
 

--- a/spec/support/helpers/colonel_elevation_helpers.rb
+++ b/spec/support/helpers/colonel_elevation_helpers.rb
@@ -1,0 +1,57 @@
+# spec/support/helpers/colonel_elevation_helpers.rb
+#
+# frozen_string_literal: true
+
+# Drive the colonel step-up (sudo) window from a unit spec (#4327).
+#
+# spec/config.test.yaml ships `site.admin.elevation.enabled: false` so the
+# colonel suites — which hit many destructive endpoints from one process as one
+# actor — are not gated. Every spec that wants the gate ON therefore turns it on
+# in-process, which is what {#stub_colonel_elevation} does.
+#
+# It stubs `OT.conf` with a DEEP COPY rather than mutating the live hash: the
+# global after(:each) restores `@conf` only when `OT.conf != @__original_ot_conf`,
+# and an in-place mutation compares equal to itself, so the change would leak
+# into every later example in the process.
+module ColonelElevationHelpers
+  # Replace OT.conf for this example with one whose site.admin.elevation block
+  # says what the caller asked for. Everything else in the config is preserved.
+  #
+  # @param enabled [Boolean]
+  # @param window [Integer] elevation lifetime in seconds
+  # @param reauth_grace [Integer] 0 = the password-less grace is OFF (shipped default)
+  # @return [Hash] the stubbed config
+  def stub_colonel_elevation(enabled: true, window: 600, reauth_grace: 0)
+    conf = deep_dup_conf(OT.conf)
+    conf['site'] ||= {}
+    conf['site']['admin'] ||= {}
+    conf['site']['admin']['elevation'] = {
+      'enabled' => enabled,
+      'window' => window,
+      'reauth_grace' => reauth_grace,
+    }
+    allow(OT).to receive(:conf).and_return(conf)
+    conf
+  end
+
+  # A session hash carrying a live, identity-bound elevation record — the exact
+  # shape ColonelAPI::Logic::Colonel::Elevation#grant_elevation! writes.
+  #
+  # @param extid [String] the acting colonel's PUBLIC id; a record naming any
+  #   other identity must be ignored, which is what the B-2 cases assert.
+  # @param expires_in [Integer] seconds from now; pass a negative value for an
+  #   expired window.
+  def elevated_session(extid, expires_in: 600)
+    { 'elevated_until' => { 'extid' => extid.to_s, 'exp' => Familia.now.to_i + expires_in } }
+  end
+
+  private
+
+  def deep_dup_conf(conf)
+    YAML.load(YAML.dump(conf))
+  end
+end
+
+RSpec.configure do |config|
+  config.include ColonelElevationHelpers
+end

--- a/spec/support/helpers/colonel_rate_limit_helpers.rb
+++ b/spec/support/helpers/colonel_rate_limit_helpers.rb
@@ -1,0 +1,56 @@
+# spec/support/helpers/colonel_rate_limit_helpers.rb
+#
+# frozen_string_literal: true
+
+# Drive the colonel API rate limiters from a unit spec (#4329).
+#
+# spec/config.test.yaml ships `site.admin.rate_limit.enabled: false` so the
+# colonel suites — many endpoints, one process, ONE acting colonel — do not
+# throttle themselves. Every spec that wants a bucket ON therefore turns it on
+# in-process, which is what {#stub_colonel_rate_limit} does.
+#
+# Like {ColonelElevationHelpers#stub_colonel_elevation} it stubs `OT.conf` with a
+# DEEP COPY rather than mutating the live hash (the global after(:each) restores
+# `@conf` only when `OT.conf != @__original_ot_conf`, and an in-place mutation
+# compares equal to itself). It deep-copies whatever `OT.conf` currently returns,
+# so calling it AFTER `stub_colonel_elevation` composes rather than clobbers.
+module ColonelRateLimitHelpers
+  # Replace OT.conf for this example with one whose site.admin.rate_limit block
+  # says what the caller asked for. Everything else in the config is preserved.
+  #
+  # @param buckets [Hash{String,Symbol=>Hash}] per-bucket overrides keyed by
+  #   section name ('mutation', 'destructive', 'handle_resolve', 'elevation').
+  #   Values are string-keyed setting hashes, e.g. `{ 'max_attempts' => 2 }`.
+  # @param enabled [Boolean] the PARENT flag, which short-circuits every bucket.
+  # @return [Hash] the stubbed config
+  def stub_colonel_rate_limit(enabled: true, **buckets)
+    conf = YAML.load(YAML.dump(OT.conf))
+    conf['site'] ||= {}
+    conf['site']['admin'] ||= {}
+    conf['site']['admin']['rate_limit'] = buckets
+      .to_h { |section, settings| [section.to_s, stringify(settings)] }
+      .merge('enabled' => enabled)
+    allow(OT).to receive(:conf).and_return(conf)
+    conf
+  end
+
+  # Delete every key of one colonel bucket for one subject. Call it before AND
+  # after an example that writes real counters: the buckets live on the Customer
+  # shard, which the integration flush hook does not necessarily reach.
+  #
+  # @param prefix [String] e.g. 'colonel:destructive'
+  # @param subject [String] the acting colonel's extid
+  def clear_colonel_bucket(prefix, subject)
+    Onetime::Customer.dbclient.del("#{prefix}:attempts:#{subject}", "#{prefix}:locked:#{subject}")
+  end
+
+  private
+
+  def stringify(settings)
+    settings.to_h { |key, value| [key.to_s, value] }
+  end
+end
+
+RSpec.configure do |config|
+  config.include ColonelRateLimitHelpers
+end

--- a/spec/support/shared_examples/colonel_destructive_action_examples.rb
+++ b/spec/support/shared_examples/colonel_destructive_action_examples.rb
@@ -1,0 +1,85 @@
+# spec/support/shared_examples/colonel_destructive_action_examples.rb
+#
+# frozen_string_literal: true
+
+# Server-side destructive-action confirmation (#4326) — the contract every gated
+# colonel logic class shares.
+#
+# The host spec supplies two things:
+#
+#   let(:expected_confirm_token) { 'victim@example.com' }
+#
+#   def confirmed_logic_for(confirm_token)
+#     described_class.new(strategy_result_for(colonel, confirm_token), params)
+#   end
+#
+# `confirm_token` reaches the logic class through StrategyResult#metadata
+# (`{ confirm_token: … }`) because that is where the colonel session auth
+# strategy puts the percent-decoded `X-OTS-Confirm` header — never params. Pass
+# nil for "no header sent".
+#
+# Rejections must stay in the Onetime::Forbidden family: AuditedFailure drops
+# that family, so a compromised colonel session cannot mint audit events by
+# hammering the gate and flush the count-capped operator trail.
+RSpec.shared_examples 'a confirmed colonel action' do
+  # Stubbed here rather than assumed of the host spec: the "no event on a
+  # rejection" assertion is the point, and a host that never audits at all has
+  # no reason to have stubbed the sink.
+  before { allow(Onetime::ColonelAuditEvent).to receive(:record) }
+
+  it 'refuses when no confirmation header was sent' do
+    logic = confirmed_logic_for(nil)
+    expect { logic.raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+  end
+
+  it 'refuses a wrong token with the identical message (no oracle on which half was wrong)' do
+    missing = begin
+      confirmed_logic_for(nil).raise_concerns
+    rescue Onetime::ConfirmationRequired => ex
+      ex
+    end
+    wrong = begin
+      confirmed_logic_for('not-the-token').raise_concerns
+    rescue Onetime::ConfirmationRequired => ex
+      ex
+    end
+
+    expect(wrong.message).to eq(missing.message)
+  end
+
+  it 'refuses a prefix of the expected token' do
+    logic = confirmed_logic_for(expected_confirm_token[0..-2])
+    expect { logic.raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+  end
+
+  it 'accepts the exact token' do
+    logic = confirmed_logic_for(expected_confirm_token)
+    expect { logic.raise_concerns }.not_to raise_error
+  end
+
+  it 'tolerates surrounding whitespace on the supplied token' do
+    logic = confirmed_logic_for("  #{expected_confirm_token}\n")
+    expect { logic.raise_concerns }.not_to raise_error
+  end
+
+  it 'answers 403 Forbidden with error_code confirmation_required' do
+    logic = confirmed_logic_for(nil)
+    error = begin
+      logic.raise_concerns
+    rescue Onetime::ConfirmationRequired => ex
+      ex
+    end
+
+    expect(error).to be_a(Onetime::Forbidden)
+    expect(error.to_h).to include(
+      error_type: 'ConfirmationRequired',
+      error_code: 'confirmation_required',
+    )
+  end
+
+  it 'writes NO audit event when the confirmation is missing or wrong' do
+    expect { confirmed_logic_for(nil).raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+    expect { confirmed_logic_for('nope').raise_concerns }.to raise_error(Onetime::ConfirmationRequired)
+    expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+  end
+end

--- a/spec/support/shared_examples/colonel_destructive_action_examples.rb
+++ b/spec/support/shared_examples/colonel_destructive_action_examples.rb
@@ -83,3 +83,99 @@ RSpec.shared_examples 'a confirmed colonel action' do
     expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
   end
 end
+
+# The step-up (sudo) window (#4327) — the contract every TIER 1 colonel logic
+# class shares, on top of the confirmation contract above.
+#
+# The host spec supplies one method (and inherits `expected_confirm_token` from
+# the confirmation examples):
+#
+#   def elevated_logic_for(session, confirm_token = expected_confirm_token)
+#     described_class.new(strategy_result_for(colonel, confirm_token, session), params)
+#   end
+#
+# `session` is the Rack session hash the strategy hands the logic class — the
+# same place ColonelAPI::Logic::Colonel::Elevation reads and writes
+# `elevated_until`. Build a live one with {ColonelElevationHelpers#elevated_session}.
+#
+# `acting_extid` defaults to the host's `colonel` double's public id; override it
+# only if the host names its acting colonel something else.
+#
+# Elevation is DISABLED in spec/config.test.yaml, so these examples turn it on
+# in-process — which also means the confirmation examples above keep exercising
+# the un-elevated path, exactly as they did before #4327.
+RSpec.shared_examples 'an elevated colonel action' do
+  let(:acting_extid) { colonel.extid }
+
+  before do
+    allow(Onetime::ColonelAuditEvent).to receive(:record)
+    allow(Onetime::ColonelAuditEvent).to receive(:record_security)
+    stub_colonel_elevation(enabled: true, window: 600)
+  end
+
+  it 'refuses when the session holds no elevation record' do
+    expect { elevated_logic_for({}).raise_concerns }.to raise_error(Onetime::ElevationRequired)
+  end
+
+  it 'refuses an expired window' do
+    session = elevated_session(acting_extid, expires_in: -1)
+    expect { elevated_logic_for(session).raise_concerns }.to raise_error(Onetime::ElevationRequired)
+  end
+
+  # B-2: one onetime.session cookie can outlive an identity change, so a record
+  # naming a different account must never be honoured.
+  it 'ignores a window minted by a different identity' do
+    session = elevated_session('ur_someone_else')
+    expect { elevated_logic_for(session).raise_concerns }.to raise_error(Onetime::ElevationRequired)
+  end
+
+  it 'ignores a bare-epoch value (the shape an earlier draft would have stored)' do
+    session = { 'elevated_until' => Familia.now.to_i + 600 }
+    expect { elevated_logic_for(session).raise_concerns }.to raise_error(Onetime::ElevationRequired)
+  end
+
+  it 'ignores an unparseable value' do
+    session = { 'elevated_until' => '{not json' }
+    expect { elevated_logic_for(session).raise_concerns }.to raise_error(Onetime::ElevationRequired)
+  end
+
+  it 'accepts a live, identity-matched window' do
+    session = elevated_session(acting_extid)
+    expect { elevated_logic_for(session).raise_concerns }.not_to raise_error
+  end
+
+  # Guard order §0.2 step 3: elevation BEFORE confirmation. An unelevated caller
+  # must never learn whether their confirmation-token guess was right.
+  it 'answers the elevation refusal, not the confirmation refusal, when both apply' do
+    expect { elevated_logic_for({}, 'not-the-token').raise_concerns }
+      .to raise_error(Onetime::ElevationRequired)
+  end
+
+  it 'answers 403 Forbidden with error_code elevation_required and the window' do
+    error = begin
+      elevated_logic_for({}).raise_concerns
+    rescue Onetime::ElevationRequired => ex
+      ex
+    end
+
+    expect(error).to be_a(Onetime::Forbidden)
+    expect(error.to_h).to include(
+      error_type: 'ElevationRequired',
+      error_code: 'elevation_required',
+      window: 600,
+    )
+  end
+
+  # Same reason as the confirmation gate: a cookie holder can drive this
+  # rejection on demand, and the operator trail is count-capped with no TTL.
+  it 'writes NO audit event when elevation is refused' do
+    expect { elevated_logic_for({}).raise_concerns }.to raise_error(Onetime::ElevationRequired)
+    expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    expect(Onetime::ColonelAuditEvent).not_to have_received(:record_security)
+  end
+
+  it 'is a no-op when elevation is disabled by config' do
+    stub_colonel_elevation(enabled: false)
+    expect { elevated_logic_for({}).raise_concerns }.not_to raise_error
+  end
+end

--- a/spec/unit/colonel/destructive_actions_spec.rb
+++ b/spec/unit/colonel/destructive_actions_spec.rb
@@ -1,0 +1,139 @@
+# spec/unit/colonel/destructive_actions_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative File.join(Onetime::HOME, 'spec', 'spec_helper')
+require 'colonel/logic'
+
+# The #4326 tier registry, asserted against the source it classifies.
+#
+# This spec exists so the destructive-action classification is TESTABLE data
+# rather than prose in a design doc. Three things it pins, each of which failed
+# silently before it existed:
+#
+#   1. Every listed name resolves to a real logic class (a rename cannot leave a
+#      dangling entry behind).
+#   2. Every TIER 1 class calls guard_destructive_action! WITH tier: :destructive
+#      AND charge_destructive_budget!; every TIER 2 class calls it with
+#      tier: :sensitive and does NOT charge the destructive budget. Asserting
+#      only that the guard "appears" would let a TIER 1 class typo'd to
+#      :sensitive lose step-up (#4327) and the tight bucket (#4329) with every
+#      test green.
+#   3. Every mutating route in routes.txt maps to a class in exactly one of the
+#      three lists. This is what stops the next feature from shipping an
+#      un-triaged destructive route.
+#
+# It reads SOURCE, not behaviour, on purpose: the per-class specs prove the
+# guard works; this proves nobody forgot to call it.
+RSpec.describe ColonelAPI::DestructiveActions do
+  LOGIC_DIR = File.join(Onetime::HOME, 'apps', 'api', 'colonel', 'logic', 'colonel').freeze
+  ROUTES_FILE = File.join(Onetime::HOME, 'apps', 'api', 'colonel', 'routes.txt').freeze
+
+  # Several classes share a file (VerifyUser/UnverifyUser, SuspendUser/
+  # UnsuspendUser, the two entitlement-override arms), and the gate lives in the
+  # shared base class, so the search is per-FILE, not per-class.
+  def source_for(class_name)
+    klass = ColonelAPI::Logic::Colonel.const_get(class_name)
+    path  = Object.const_source_location(klass.name)&.first
+    raise "no source location for #{class_name}" unless path
+
+    File.read(path)
+  end
+
+  describe 'the lists name real classes' do
+    (described_class::TIER1 + described_class::TIER2 +
+      described_class::TIER3_REVIEWED.keys).each do |name|
+      it "#{name} resolves to a logic class" do
+        expect(ColonelAPI::Logic::Colonel.const_get(name)).to be < ColonelAPI::Logic::Base
+      end
+    end
+
+    it 'lists no class twice across the three tiers' do
+      all = described_class::TIER1 + described_class::TIER2 +
+            described_class::TIER3_REVIEWED.keys
+      expect(all).to eq(all.uniq)
+    end
+
+    it 'gives every deliberately un-gated class a stated reason' do
+      expect(described_class::TIER3_REVIEWED.values).to all(satisfy { |r| r.to_s.strip.length > 10 })
+    end
+  end
+
+  describe 'TIER 1 — confirmation + elevation + the tight bucket' do
+    described_class::TIER1.each do |name|
+      it "#{name} calls guard_destructive_action! with tier: :destructive" do
+        expect(source_for(name)).to match(/guard_destructive_action!\([^)]*tier:\s*:destructive/m)
+      end
+
+      it "#{name} charges the destructive budget" do
+        expect(source_for(name)).to include('charge_destructive_budget!')
+      end
+    end
+  end
+
+  describe 'TIER 2 — confirmation only' do
+    described_class::TIER2.each do |name|
+      it "#{name} calls guard_destructive_action! with tier: :sensitive" do
+        expect(source_for(name)).to match(/guard_destructive_action!\([^)]*tier:\s*:sensitive/m)
+      end
+
+      # The tight bucket is the tier-1 ceiling; charging it here would throttle
+      # reversible verbs against the wrong budget.
+      it "#{name} does NOT charge the destructive budget" do
+        expect(source_for(name)).not_to include('charge_destructive_budget!')
+      end
+    end
+  end
+
+  describe 'TIER 3 — reviewed and deliberately un-gated' do
+    described_class::TIER3_REVIEWED.each_key do |name|
+      it "#{name} calls no destructive guard" do
+        # Read the class's OWN file only where it has one to itself; the shared
+        # bases (verify/unverify, suspend/unsuspend) do carry a guard, gated on
+        # the destructive arm, so their restorative twin is exempt from this.
+        next if %w[VerifyUser UnsuspendUser].include?(name)
+
+        expect(source_for(name)).not_to include('guard_destructive_action!')
+      end
+    end
+  end
+
+  describe 'every mutating route is classified' do
+    # POST/PUT/PATCH/DELETE lines in routes.txt, mapped to their handler class.
+    let(:mutating_handlers) do
+      File.readlines(ROUTES_FILE).filter_map do |line|
+        next unless line.match?(/\A(POST|PUT|PATCH|DELETE)\s/)
+
+        line.split[2]
+      end.uniq
+    end
+
+    it 'finds the mutating routes (guards against a parse that silently matches nothing)' do
+      expect(mutating_handlers.size).to be >= 40
+    end
+
+    it 'classifies every one of them' do
+      unclassified = mutating_handlers.reject { |handler| described_class.classified?(handler) }
+      expect(unclassified).to be_empty,
+        "un-triaged mutating colonel routes: #{unclassified.join(', ')}. Add each to TIER1, " \
+        'TIER2, or TIER3_REVIEWED (with a reason) in apps/api/colonel/destructive_actions.rb.'
+    end
+  end
+
+  describe 'the predicates' do
+    it 'accepts a class or a name, qualified or not' do
+      expect(described_class.tier1?(ColonelAPI::Logic::Colonel::PurgeUser)).to be true
+      expect(described_class.tier1?('ColonelAPI::Logic::Colonel::PurgeUser')).to be true
+      expect(described_class.tier1?('PurgeUser')).to be true
+    end
+
+    it 'separates the tiers' do
+      expect(described_class.tier1?('SuspendUser')).to be false
+      expect(described_class.tier2?('SuspendUser')).to be true
+      expect(described_class.gated?('SuspendUser')).to be true
+      expect(described_class.gated?('SetBanner')).to be false
+      expect(described_class.classified?('SetBanner')).to be true
+      expect(described_class.classified?('NoSuchThing')).to be false
+    end
+  end
+end

--- a/spec/unit/onetime/application/auth_strategies/admin_session_lifetime_spec.rb
+++ b/spec/unit/onetime/application/auth_strategies/admin_session_lifetime_spec.rb
@@ -1,0 +1,228 @@
+# spec/unit/onetime/application/auth_strategies/admin_session_lifetime_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/application/auth_strategies/admin_session_lifetime'
+
+# Unit coverage for the #4331 admin-surface session bounds, driven directly
+# against the module rather than through a strategy.
+#
+# What THIS layer owns: the decision — given a session, a customer and a Rack
+# env, may this request touch /api/colonel? The wiring (where the check runs in
+# BaseSessionAuthStrategy, and the 401 message shape) is
+# base_session_auth_strategy_spec.rb; the end-to-end proof that a colonel keeps
+# their TENANT session while the admin surface refuses them is
+# spec/integration/all/colonel_session_lifetime_spec.rb.
+#
+# The bounds are DISABLED in spec/config.test.yaml, so every example here opts in
+# explicitly via `configure_bounds` — which is also what keeps the "enabled:false
+# is a real off switch" example honest.
+RSpec.describe Onetime::Application::AuthStrategies::AdminSessionLifetime do
+  # The module is a mixin for an auth strategy; a bare host exercises it without
+  # dragging in Otto, a Rack env stack or a customer load.
+  let(:host_class) do
+    Class.new do
+      include Onetime::Application::AuthStrategies::AdminSessionLifetime
+    end
+  end
+
+  let(:host) { host_class.new }
+  let(:now) { 1_800_000_000 }
+
+  let(:colonel) { instance_double(Onetime::Customer, role: 'colonel') }
+  let(:customer) { instance_double(Onetime::Customer, role: 'customer') }
+
+  # A Rack SessionHash responds to #id with a Rack::SessionId; a plain Hash does
+  # not. Both shapes reach this code (Basic-auth and JSON paths carry a Hash), so
+  # the sid-bearing case is modelled explicitly.
+  def session_with_sid(sid, **fields)
+    hash = { 'authenticated' => true }.merge(fields)
+    hash.define_singleton_method(:id) { Struct.new(:public_id).new(sid) }
+    hash
+  end
+
+  def env_for(script_name: '/api/colonel', path_info: '/sessions')
+    { 'SCRIPT_NAME' => script_name, 'PATH_INFO' => path_info }
+  end
+
+  def configure_bounds(**settings)
+    conf = YAML.load(YAML.dump(OT.conf))
+    ((conf['site'] ||= {})['admin'] ||= {})['session'] =
+      { 'enabled' => true }.merge(settings.transform_keys(&:to_s))
+    allow(OT).to receive(:conf).and_return(conf)
+  end
+
+  def stub_sidecar(last_activity_at)
+    record = instance_double(Onetime::SessionMetadata, last_activity_at: last_activity_at)
+    allow(Onetime::SessionMetadata).to receive(:load).and_return(record)
+  end
+
+  before do
+    allow(Familia).to receive(:now).and_return(now)
+    allow(Onetime::SessionMetadata).to receive(:load).and_return(nil)
+    allow(OT).to receive(:ld)
+    configure_bounds
+  end
+
+  describe 'the absolute bound' do
+    it 'expires a colonel whose sign-in is older than the bound' do
+      session = session_with_sid('sid1', 'authenticated_at' => now - 43_201)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:absolute)
+    end
+
+    it 'lets a sign-in exactly at the bound through (the comparison is strict)' do
+      session = session_with_sid('sid1', 'authenticated_at' => now - 43_200)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to be_nil
+    end
+
+    # Nothing an attacker holding the cookie can do advances authenticated_at, so
+    # this is the bound that always binds — but only when the field is present.
+    # A session that never stamped one is not treated as infinitely old.
+    it 'skips a session with no authenticated_at rather than failing it' do
+      session = session_with_sid('sid1')
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to be_nil
+    end
+
+    it 'is disabled by absolute_timeout: 0 while the idle bound still applies' do
+      configure_bounds(absolute_timeout: 0)
+      stub_sidecar(now - 10)
+      session = session_with_sid('sid1', 'authenticated_at' => now - 100_000)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to be_nil
+    end
+  end
+
+  describe 'the idle bound' do
+    it 'expires a colonel whose last activity is older than the bound' do
+      stub_sidecar(now - 3_601)
+      session = session_with_sid('sid1', 'authenticated_at' => now - 60)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:idle)
+    end
+
+    it 'lets a recently active session through' do
+      stub_sidecar(now - 60)
+      session = session_with_sid('sid1', 'authenticated_at' => now - 60)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to be_nil
+    end
+
+    # THE fail-open-on-purpose case. SessionMetadata is best-effort: a session
+    # predating the sidecar, one whose 30-day TTL lapsed, or one whose write was
+    # swallowed has no record. Hard-failing here would log out live sessions for
+    # a reason unrelated to their age.
+    it 'SKIPS itself when no sidecar record exists' do
+      session = session_with_sid('sid1', 'authenticated_at' => now - 60)
+
+      expect(Onetime::SessionMetadata).to receive(:load).with('sid1').and_return(nil)
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to be_nil
+    end
+
+    it 'skips itself when the session carries no resolvable sid' do
+      expect(Onetime::SessionMetadata).not_to receive(:load)
+      expect(host.admin_session_expiry_reason({ 'authenticated' => true }, colonel, env_for))
+        .to be_nil
+    end
+
+    it 'skips itself when the sidecar read raises' do
+      allow(Onetime::SessionMetadata).to receive(:load).and_raise(StandardError, 'redis down')
+      session = session_with_sid('sid1')
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to be_nil
+    end
+
+    it 'is disabled by idle_timeout: 0 while the absolute bound still applies' do
+      configure_bounds(idle_timeout: 0)
+      stub_sidecar(now - 100_000)
+      session = session_with_sid('sid1', 'authenticated_at' => now - 43_201)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:absolute)
+    end
+
+    it 'reports :absolute first when both bounds are exceeded' do
+      stub_sidecar(now - 100_000)
+      session = session_with_sid('sid1', 'authenticated_at' => now - 100_000)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:absolute)
+    end
+  end
+
+  describe 'scope' do
+    let(:stale) { session_with_sid('sid1', 'authenticated_at' => now - 100_000) }
+
+    it 'bounds /api/colonel itself and everything under it' do
+      expect(host.admin_session_expiry_reason(stale, colonel, env_for(path_info: '')))
+        .to eq(:absolute)
+      expect(host.admin_session_expiry_reason(stale, colonel, env_for(path_info: '/users/ur_1')))
+        .to eq(:absolute)
+    end
+
+    # The rev-2 scope narrowing. A bare 401 on an HTML navigation has no defined
+    # UX and the expired-session banner lives INSIDE the SPA, so the shell must
+    # load; its first API call is what 401s.
+    it 'does NOT bound the /colonel SPA shell' do
+      env = env_for(script_name: '', path_info: '/colonel')
+
+      expect(host.admin_session_expiry_reason(stale, colonel, env)).to be_nil
+    end
+
+    it 'does NOT bound a path that merely starts with the prefix string' do
+      env = env_for(script_name: '', path_info: '/api/colonelish/thing')
+
+      expect(host.admin_session_expiry_reason(stale, colonel, env)).to be_nil
+    end
+
+    # The regression this whole design exists to prevent: a colonel who is also
+    # the site's only customer must keep their normal 24h session on the tenant
+    # app.
+    it 'does NOT bound a tenant route' do
+      env = env_for(script_name: '', path_info: '/account')
+
+      expect(host.admin_session_expiry_reason(stale, colonel, env)).to be_nil
+    end
+
+    it 'does NOT bound a non-colonel account' do
+      expect(host.admin_session_expiry_reason(stale, customer, env_for)).to be_nil
+    end
+  end
+
+  describe 'configuration' do
+    it 'is a no-op when enabled is false' do
+      configure_bounds(enabled: false)
+      stub_sidecar(now - 100_000)
+      session = session_with_sid('sid1', 'authenticated_at' => now - 100_000)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to be_nil
+    end
+
+    it 'applies the shipped defaults when the block is absent entirely' do
+      conf = YAML.load(YAML.dump(OT.conf))
+      conf['site']['admin'].delete('session')
+      allow(OT).to receive(:conf).and_return(conf)
+      session = session_with_sid('sid1', 'authenticated_at' => now - 43_201)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:absolute)
+    end
+
+    # 0 disables a bound and must survive as 0; a NEGATIVE value is operator
+    # error and falls back to the default rather than disabling the bound
+    # silently (the inverse of the positive_*_setting trap #4329 documents).
+    it 'falls back to the default on a negative value' do
+      configure_bounds(absolute_timeout: -1)
+      session = session_with_sid('sid1', 'authenticated_at' => now - 43_201)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:absolute)
+    end
+
+    it 'reads a string value from ERB-rendered YAML' do
+      configure_bounds(absolute_timeout: '60')
+      session = session_with_sid('sid1', 'authenticated_at' => now - 61)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:absolute)
+    end
+  end
+end

--- a/spec/unit/onetime/application/auth_strategies/admin_session_lifetime_spec.rb
+++ b/spec/unit/onetime/application/auth_strategies/admin_session_lifetime_spec.rb
@@ -224,5 +224,42 @@ RSpec.describe Onetime::Application::AuthStrategies::AdminSessionLifetime do
 
       expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:absolute)
     end
+
+    # #4331 review: raw arrives as whatever YAML parsed from `<%= ENV[...] || N %>`,
+    # and String#to_i silently coerces garbage — "off"/"none" -> 0 (disabling a
+    # security bound) and "12h" -> 12 (a 12-second lifetime). A value that is not a
+    # clean non-negative integer must fall back to the shipped default: never
+    # disable, never drastically shorten.
+    it 'falls back to the default on a non-numeric string (does NOT disable the bound)' do
+      configure_bounds(absolute_timeout: 'off')
+      session = session_with_sid('sid1', 'authenticated_at' => now - 43_201)
+
+      # 'off' must not become 0; the default 12h bound still fires.
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:absolute)
+    end
+
+    it 'falls back to the default on a malformed duration string (not a 12-second lifetime)' do
+      configure_bounds(absolute_timeout: '12h')
+      # 30 minutes old: '12h' must fall back to the 12h default, not "12h".to_i == 12s.
+      session = session_with_sid('sid1', 'authenticated_at' => now - 1_800)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to be_nil
+    end
+
+    it 'falls back to the default on a YAML boolean (off/no parsed as false)' do
+      configure_bounds(absolute_timeout: false)
+      session = session_with_sid('sid1', 'authenticated_at' => now - 43_201)
+
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to eq(:absolute)
+    end
+
+    it 'still honours an explicit 0 (a disabled bound) as a string' do
+      configure_bounds(absolute_timeout: '0')
+      stub_sidecar(now - 10) # keep the idle bound satisfied
+      session = session_with_sid('sid1', 'authenticated_at' => now - 100_000)
+
+      # "0" is a clean integer: the absolute bound is genuinely disabled.
+      expect(host.admin_session_expiry_reason(session, colonel, env_for)).to be_nil
+    end
   end
 end

--- a/spec/unit/onetime/application/auth_strategies/base_session_auth_strategy_spec.rb
+++ b/spec/unit/onetime/application/auth_strategies/base_session_auth_strategy_spec.rb
@@ -1,0 +1,121 @@
+# spec/unit/onetime/application/auth_strategies/base_session_auth_strategy_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/application/auth_strategies'
+
+# The ORDER of the checks in BaseSessionAuthStrategy#authenticate, and what the
+# #4331 admin-surface bound does when it refuses.
+#
+# The bound's own decision table is
+# spec/unit/onetime/application/auth_strategies/admin_session_lifetime_spec.rb.
+# What is asserted here is only what the wiring owns: that the check runs AFTER
+# the credential watermark and BEFORE additional_checks, that the failure carries
+# the [ADMIN_SESSION_EXPIRED] marker the console branches on, and that a refused
+# request stamps the env flag that stops TrackMetadata from counting it as
+# activity.
+RSpec.describe Onetime::Application::AuthStrategies::BaseSessionAuthStrategy do
+  let(:lifetime) { Onetime::Application::AuthStrategies::AdminSessionLifetime }
+
+  # A concrete subclass: the base class is abstract (auth_method_name is nil) and
+  # `additional_checks` is the hook whose ORDERING relative to the new bound is
+  # the point of this file.
+  let(:strategy_class) do
+    Class.new(described_class) do
+      @auth_method_name = 'sessionauth'
+
+      attr_reader :additional_checks_ran
+
+      def additional_checks(_cust, _env)
+        @additional_checks_ran = true
+        nil
+      end
+    end
+  end
+
+  let(:strategy) { strategy_class.new }
+
+  let(:cust) do
+    instance_double(
+      Onetime::Customer,
+      objid: 'cust_1',
+      extid: 'ur_abc',
+      role: 'colonel',
+      suspended?: false,
+      last_password_update: nil,
+    )
+  end
+
+  let(:session) { { 'authenticated' => true, 'external_id' => 'ur_abc' } }
+  let(:env) do
+    {
+      'rack.session' => session,
+      'SCRIPT_NAME' => '/api/colonel',
+      'PATH_INFO' => '/sessions',
+    }
+  end
+
+  before do
+    allow(OT).to receive(:ld)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email).with('ur_abc').and_return(cust)
+    # OrganizationLoader reaches for real models otherwise; this strategy's org
+    # context is not what this file is about.
+    allow(strategy).to receive(:load_organization_context).and_return(nil)
+  end
+
+  context 'when the admin session bound refuses the request' do
+    before do
+      allow(strategy).to receive(:admin_session_expiry_reason).and_return(:absolute)
+    end
+
+    it 'fails with the [ADMIN_SESSION_EXPIRED] marker and the reason' do
+      result = strategy.authenticate(env, 'authenticated')
+
+      expect(result).to be_a(Otto::Security::Authentication::AuthFailure)
+      expect(result.failure_reason)
+        .to eq('[ADMIN_SESSION_EXPIRED] Admin session absolute timeout exceeded; sign in again')
+    end
+
+    it 'stamps the env flag so a REFUSED request is not counted as activity' do
+      strategy.authenticate(env, 'authenticated')
+
+      expect(env[lifetime::EXPIRED_ENV_KEY]).to eq('absolute')
+    end
+
+    # The bound runs BEFORE additional_checks, which is where role/permission
+    # checks live: an expired admin session must not reach them.
+    it 'never reaches additional_checks' do
+      strategy.authenticate(env, 'authenticated')
+
+      expect(strategy.additional_checks_ran).to be_nil
+    end
+  end
+
+  context 'when the credential watermark already rejects the session' do
+    # AFTER the watermark: a session that predates a password change is stale for
+    # every surface, and that is the more fundamental refusal. The admin bound
+    # must not run at all, so it cannot mask it with a different message.
+    it 'reports the stale-credential failure and never consults the bound' do
+      allow(strategy).to receive(:session_predates_credential_change?).and_return(true)
+      expect(strategy).not_to receive(:admin_session_expiry_reason)
+
+      result = strategy.authenticate(env, 'authenticated')
+
+      expect(result.failure_reason).to match(/SESSION_STALE_CREDENTIALS/)
+      expect(env).not_to have_key(lifetime::EXPIRED_ENV_KEY)
+    end
+  end
+
+  context 'when the bound allows the request' do
+    it 'authenticates, runs additional_checks and leaves no env flag' do
+      allow(strategy).to receive(:admin_session_expiry_reason).and_return(nil)
+
+      result = strategy.authenticate(env, 'authenticated')
+
+      expect(result).to be_a(Otto::Security::Authentication::StrategyResult)
+      expect(strategy.additional_checks_ran).to be true
+      expect(env).not_to have_key(lifetime::EXPIRED_ENV_KEY)
+    end
+  end
+end

--- a/spec/unit/onetime/application/colonel_route_annotations_spec.rb
+++ b/spec/unit/onetime/application/colonel_route_annotations_spec.rb
@@ -1,0 +1,153 @@
+# spec/unit/onetime/application/colonel_route_annotations_spec.rb
+#
+# frozen_string_literal: true
+
+# =============================================================================
+# TEST TYPE: Unit (parses apps/api/colonel/routes.txt as data; boots nothing)
+# =============================================================================
+#
+# #4332. The colonel route table is the only place the tier-1 network
+# annotation exists, and NOTHING checks it at boot: Otto's
+# validate_handler_wrappers! runs lazily on the first request and is skipped
+# entirely under RSpec, so a misspelled `network=` token is a runtime 500 on a
+# destructive verb rather than a boot failure.
+#
+# These examples are that missing check, plus the coverage guarantee:
+#
+#   (a) every ColonelAPI::DestructiveActions::TIER1 class has exactly one route
+#       and it carries `network=admin_if_configured`;
+#   (b) no tier-2 or tier-3 route carries a `network=` token at all, except the
+#       one strict `network=admin` route the annotation predates;
+#   (c) every `network=` token in the file spells a key that
+#       Application::NetworkRequirements::STRATEGIES actually implements.
+#
+# (a) is deliberately TIER1-only: two tier-2 classes (ManageEntitlementOverride,
+# ManageMembershipEntitlementOverride) serve two routes each, so "exactly one
+# route per class" is not a property of the other tiers.
+# =============================================================================
+
+require 'spec_helper'
+require 'onetime/application/network_requirements'
+
+require_relative '../../../../apps/api/colonel/destructive_actions'
+
+RSpec.describe 'colonel route network annotations (#4332)' do
+  ROUTES_FILE = File.expand_path('../../../../apps/api/colonel/routes.txt', __dir__)
+
+  # One parsed route line: the HTTP verb, the path, the unqualified handler
+  # class name, and whatever `network=` token it carries (nil for most).
+  Route = Struct.new(:verb, :path, :handler, :network, :line_number, keyword_init: true)
+
+  # The strict token is grandfathered on exactly one route — a GET debug
+  # endpoint that is SUPPOSED to be absent unless admin isolation is fully
+  # configured. Widening it is a breaking change, so it is pinned by path here.
+  STRICT_TOKEN_ROUTE = '/system/proxy-headers'
+
+  def parse_routes
+    File.readlines(ROUTES_FILE, encoding: 'UTF-8').each_with_index.filter_map do |line, index|
+      next unless line =~ /\A(GET|POST|PUT|PATCH|DELETE)\s/
+
+      tokens = line.split(/\s+/)
+      network = tokens.find { |token| token.start_with?('network=') }
+
+      Route.new(
+        verb: tokens[0],
+        path: tokens[1],
+        handler: tokens[2].to_s.split('::').last,
+        network: network&.split('=', 2)&.last,
+        line_number: index + 1,
+      )
+    end
+  end
+
+  let(:routes) { parse_routes }
+  let(:tier1)  { ColonelAPI::DestructiveActions::TIER1 }
+
+  it 'parses a route table that is actually there' do
+    # Guards every other example in this file: a rename or a parser regression
+    # would otherwise turn all of them into assertions about an empty list.
+    expect(routes.size).to be > 80
+  end
+
+  describe 'tier-1 coverage' do
+    it 'gives every TIER1 class exactly one route' do
+      counts = tier1.to_h { |name| [name, routes.count { |route| route.handler == name }] }
+
+      expect(counts.reject { |_, count| count == 1 }).to be_empty
+    end
+
+    it 'annotates every TIER1 route with network=admin_if_configured' do
+      unannotated = routes
+        .select { |route| tier1.include?(route.handler) }
+        .reject { |route| route.network == Onetime::Application::NetworkRequirements::ADMIN_IF_CONFIGURED }
+        .map { |route| "#{route.verb} #{route.path} (line #{route.line_number})" }
+
+      expect(unannotated).to be_empty
+    end
+
+    it 'annotates exactly the tier-1 set and nothing else' do
+      # The inverse of the example above. Together they make the annotation and
+      # the committed tier list one fact rather than two that can drift.
+      annotated = routes
+        .select { |route| route.network == Onetime::Application::NetworkRequirements::ADMIN_IF_CONFIGURED }
+        .map(&:handler)
+
+      expect(annotated.sort).to eq(tier1.sort)
+    end
+  end
+
+  describe 'the strict network=admin token' do
+    it 'is applied to exactly one route, the proxy-header diagnostic' do
+      strict = routes.select { |route| route.network == Onetime::Application::NetworkRequirements::ADMIN }
+
+      expect(strict.map(&:path)).to eq([STRICT_TOKEN_ROUTE])
+    end
+
+    it 'is never applied to a mutating route' do
+      # The strict token has no fall-through: on a stock self-hosted install it
+      # is an unconditional 404. On a read that is a documented diagnostic
+      # posture; on a mutation it is an outage with no diagnosis.
+      strict_mutations = routes.select do |route|
+        route.network == Onetime::Application::NetworkRequirements::ADMIN && route.verb != 'GET'
+      end
+
+      expect(strict_mutations).to be_empty
+    end
+  end
+
+  describe 'tier-2 and tier-3 routes' do
+    it 'carry no network requirement' do
+      # Deliberate scoping, not an oversight: a network requirement is the one
+      # control in this epic that fails as a silent 404, so it covers the
+      # irreversible set only. Changing this means changing the docs too.
+      annotated = routes
+        .reject { |route| tier1.include?(route.handler) }
+        .reject { |route| route.path == STRICT_TOKEN_ROUTE }
+        .select(&:network)
+        .map { |route| "#{route.verb} #{route.path} (line #{route.line_number})" }
+
+      expect(annotated).to be_empty
+    end
+  end
+
+  it 'spells every network token as a strategy that exists' do
+    # The check Otto cannot give us: validate_handler_wrappers! runs on the
+    # first request and is skipped under RSpec, so a typo here reaches
+    # production as a 500 on a destructive verb.
+    unknown = routes
+      .select(&:network)
+      .reject { |route| Onetime::Application::NetworkRequirements::STRATEGIES.key?(route.network) }
+      .map { |route| "#{route.network.inspect} on line #{route.line_number}" }
+
+    expect(unknown).to be_empty
+  end
+
+  it 'keeps every route on the two app-layer authorization tokens' do
+    # The #4332 edit rewrote 15 route lines. Nothing about a network annotation
+    # may weaken the authorization that runs beneath it (design §9.2 invariant 1).
+    lines = File.readlines(ROUTES_FILE, encoding: 'UTF-8').select { |line| line =~ /\A(GET|POST|PUT|PATCH|DELETE)\s/ }
+    missing = lines.reject { |line| line.include?('auth=sessionauth') && line.include?('role=colonel') }
+
+    expect(missing).to be_empty
+  end
+end

--- a/spec/unit/onetime/application/network_requirements_spec.rb
+++ b/spec/unit/onetime/application/network_requirements_spec.rb
@@ -52,6 +52,47 @@ RSpec.describe Onetime::Application::NetworkRequirements do
     )
   end
 
+  # #4332. The strict token above cannot be applied to a route a console calls:
+  # route_requirement_met? is false in every posture except a fully configured
+  # one, so it would 404 the destructive verbs on a stock install. This second
+  # token falls through on :advisory — and ONLY on :advisory.
+  describe 'network=admin_if_configured' do
+    let(:met_key)  { Onetime::Middleware::AdminNetworkIsolation::ROUTE_REQUIREMENT_ENV_KEY }
+    let(:mode_key) { Onetime::Middleware::AdminNetworkIsolation::ROUTE_REQUIREMENT_MODE_ENV_KEY }
+
+    subject(:wrapper) do
+      factory.call(route('Object.to_s response=json network=admin_if_configured'), inner_handler)
+    end
+
+    it 'falls through in an advisory posture even though the verdict is false' do
+      # The stock self-hosted install: the surface-wide gates are the control,
+      # and this annotation must not take the route away.
+      expect(wrapper.call(mode_key => :advisory, met_key => false).first).to eq(200)
+    end
+
+    it 'allows an enforced posture that admitted the request' do
+      expect(wrapper.call(mode_key => :enforced, met_key => true).first).to eq(200)
+    end
+
+    it 'returns the route-shaped 404 in an enforced posture that did not admit the request' do
+      expect(wrapper.call(mode_key => :enforced, met_key => false)).to eq(
+        [404, { 'Content-Type' => 'application/json' }, ['{"error":"Not Found"}']],
+      )
+    end
+
+    it 'fails closed when the mode key is absent entirely' do
+      # ABSENT is not advisory: it means AdminNetworkIsolation never ran for
+      # this request — it left the stack, or the route moved outside the
+      # /colonel* prefixes. That regression must take the route away, which is
+      # the security value the annotation carries on an already-gated surface.
+      expect(wrapper.call({}).first).to eq(404)
+    end
+
+    it 'fails closed when the mode key carries an unrecognized value' do
+      expect(wrapper.call(mode_key => 'advisory', met_key => false).first).to eq(404)
+    end
+  end
+
   it 'fails closed on an unknown network strategy' do
     definition = route('Object.to_s response=json network=unknown')
 

--- a/spec/unit/onetime/config/admin_defaults_spec.rb
+++ b/spec/unit/onetime/config/admin_defaults_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe 'etc/defaults/config.defaults.yaml — admin defaults' do
     COLONEL_DESTRUCTIVE_RATE_WINDOW COLONEL_DESTRUCTIVE_LOCKOUT
     COLONEL_HANDLE_RESOLVE_RATE_LIMIT_ENABLED COLONEL_HANDLE_RESOLVE_MAX_ATTEMPTS
     COLONEL_HANDLE_RESOLVE_RATE_WINDOW COLONEL_HANDLE_RESOLVE_LOCKOUT
+    ADMIN_SESSION_LIFETIME_ENABLED ADMIN_SESSION_IDLE_TIMEOUT ADMIN_SESSION_ABSOLUTE_TIMEOUT
   ].freeze
 
   let(:admin) do
@@ -106,13 +107,40 @@ RSpec.describe 'etc/defaults/config.defaults.yaml — admin defaults' do
     end
   end
 
+  describe 'admin-surface session bounds (#4331)' do
+    it 'ships ENABLED' do
+      expect(admin.dig('session', 'enabled')).to be true
+    end
+
+    # The numbers are the control. A default quietly raised to 86 400 would
+    # restore the 24h rolling posture #4331 exists to bound, with every example
+    # still green.
+    it 'ships a 1-hour idle bound' do
+      expect(admin.dig('session', 'idle_timeout').to_i).to eq(3_600)
+    end
+
+    it 'ships a 12-hour absolute bound' do
+      expect(admin.dig('session', 'absolute_timeout').to_i).to eq(43_200)
+    end
+
+    # Both bounds must be shorter than the session object's own rolling TTL, or
+    # the admin surface would outlive the cookie and the feature would be inert.
+    it 'ships both bounds shorter than site.session.expire_after' do
+      expire_after = Onetime::Initializers::SESSION_DEFAULTS['expire_after']
+
+      expect(admin.dig('session', 'idle_timeout').to_i).to be < expire_after
+      expect(admin.dig('session', 'absolute_timeout').to_i).to be < expire_after
+    end
+  end
+
   describe 'the test config deliberately differs' do
     # Stated as an assertion so the divergence is visible rather than surprising:
     # if someone "fixes" the test config to match the shipped one, the colonel
     # suites start gating themselves and this spec explains why they must not.
-    it 'disables both in spec/config.test.yaml' do
+    it 'disables all three in spec/config.test.yaml' do
       expect(OT.conf.dig('site', 'admin', 'elevation', 'enabled')).to be false
       expect(OT.conf.dig('site', 'admin', 'rate_limit', 'enabled')).to be false
+      expect(OT.conf.dig('site', 'admin', 'session', 'enabled')).to be false
     end
   end
 end

--- a/spec/unit/onetime/config/admin_defaults_spec.rb
+++ b/spec/unit/onetime/config/admin_defaults_spec.rb
@@ -5,6 +5,7 @@
 require 'spec_helper'
 require 'erb'
 require 'yaml'
+require 'onetime/operations/ratelimit/registry'
 
 # The SHIPPED posture of the colonel hardening switches, read from
 # etc/defaults/config.defaults.yaml itself.
@@ -26,6 +27,12 @@ RSpec.describe 'etc/defaults/config.defaults.yaml — admin defaults' do
     COLONEL_ELEVATION_ENABLED COLONEL_ELEVATION_WINDOW COLONEL_ELEVATION_REAUTH_GRACE
     COLONEL_RATE_LIMIT_ENABLED COLONEL_ELEVATION_RATE_LIMIT_ENABLED
     COLONEL_ELEVATION_MAX_ATTEMPTS COLONEL_ELEVATION_RATE_WINDOW COLONEL_ELEVATION_LOCKOUT
+    COLONEL_MUTATION_RATE_LIMIT_ENABLED COLONEL_MUTATION_MAX_ATTEMPTS
+    COLONEL_MUTATION_RATE_WINDOW COLONEL_MUTATION_LOCKOUT
+    COLONEL_DESTRUCTIVE_RATE_LIMIT_ENABLED COLONEL_DESTRUCTIVE_MAX_ATTEMPTS
+    COLONEL_DESTRUCTIVE_RATE_WINDOW COLONEL_DESTRUCTIVE_LOCKOUT
+    COLONEL_HANDLE_RESOLVE_RATE_LIMIT_ENABLED COLONEL_HANDLE_RESOLVE_MAX_ATTEMPTS
+    COLONEL_HANDLE_RESOLVE_RATE_WINDOW COLONEL_HANDLE_RESOLVE_LOCKOUT
   ].freeze
 
   let(:admin) do
@@ -60,18 +67,42 @@ RSpec.describe 'etc/defaults/config.defaults.yaml — admin defaults' do
     end
   end
 
-  describe 'colonel API rate limits (#4327 elevation bucket; #4329 adds the rest)' do
+  describe 'colonel API rate limits (#4327 elevation bucket; #4329 the other three)' do
     it 'ships ENABLED at the parent flag' do
       expect(admin.dig('rate_limit', 'enabled')).to be true
     end
 
-    it 'ships the elevation bucket enabled with its documented sizing' do
-      bucket = admin.dig('rate_limit', 'elevation')
+    # Sizing, not just the flag: the numbers ARE the control. A default quietly
+    # raised to 10 000 would leave every example green while restoring the
+    # unbounded posture #4329 exists to remove.
+    {
+      'elevation' => { max: 5, window: 900, lockout: 900 },
+      'mutation' => { max: 120, window: 300, lockout: 300 },
+      'destructive' => { max: 10, window: 300, lockout: 900 },
+      'handle_resolve' => { max: 60, window: 300, lockout: 300 },
+    }.each do |name, sizing|
+      it "ships the #{name} bucket enabled with its documented sizing" do
+        bucket = admin.dig('rate_limit', name)
 
-      expect(bucket['enabled']).to be true
-      expect(bucket['max_attempts'].to_i).to eq(5)
-      expect(bucket['window'].to_i).to eq(900)
-      expect(bucket['lockout'].to_i).to eq(900)
+        expect(bucket).to be_a(Hash), "site.admin.rate_limit.#{name} is missing from the shipped defaults"
+        expect(bucket['enabled']).to be true
+        expect(bucket['max_attempts'].to_i).to eq(sizing[:max])
+        expect(bucket['window'].to_i).to eq(sizing[:window])
+        expect(bucket['lockout'].to_i).to eq(sizing[:lockout])
+      end
+    end
+
+    # The registry rows are what make `bin/ots ratelimit`, GET
+    # /ratelimit/inspect and POST /ratelimit/reset able to see these keys, and
+    # POST /ratelimit/reset is the documented recovery for an operator who locks
+    # themselves out of destructive actions. A shipped bucket with no row is a
+    # limiter no operator can clear.
+    it 'has a registry row for every shipped bucket' do
+      kinds = Onetime::Operations::RateLimit::Registry.kinds
+
+      expect(kinds).to include(
+        'colonel_elevation', 'colonel_mutation', 'colonel_destructive', 'colonel_handle_resolve'
+      )
     end
   end
 

--- a/spec/unit/onetime/config/admin_defaults_spec.rb
+++ b/spec/unit/onetime/config/admin_defaults_spec.rb
@@ -1,0 +1,87 @@
+# spec/unit/onetime/config/admin_defaults_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'erb'
+require 'yaml'
+
+# The SHIPPED posture of the colonel hardening switches, read from
+# etc/defaults/config.defaults.yaml itself.
+#
+# Why this file exists: spec/config.test.yaml disables step-up and the colonel
+# rate limits so the suites (many destructive endpoints, one process, one actor)
+# are not gated. Without a counter-spec, the DISABLED posture would be the only
+# one under test, and a regression that flipped a shipped default to `false`
+# would pass every example except the two that opt in — i.e. it would ship.
+#
+# It renders the defaults file the way boot does (ERB, then YAML) with the
+# relevant env vars cleared, so what is asserted is what an operator who set
+# nothing actually gets.
+RSpec.describe 'etc/defaults/config.defaults.yaml — admin defaults' do
+  DEFAULTS_PATH = File.join(Onetime::HOME, 'etc', 'defaults', 'config.defaults.yaml')
+
+  # Env vars that could otherwise mask a changed default in a developer shell.
+  ADMIN_ENV_KEYS = %w[
+    COLONEL_ELEVATION_ENABLED COLONEL_ELEVATION_WINDOW COLONEL_ELEVATION_REAUTH_GRACE
+    COLONEL_RATE_LIMIT_ENABLED COLONEL_ELEVATION_RATE_LIMIT_ENABLED
+    COLONEL_ELEVATION_MAX_ATTEMPTS COLONEL_ELEVATION_RATE_WINDOW COLONEL_ELEVATION_LOCKOUT
+  ].freeze
+
+  let(:admin) do
+    saved = ADMIN_ENV_KEYS.to_h { |key| [key, ENV.fetch(key, nil)] }
+    ADMIN_ENV_KEYS.each { |key| ENV.delete(key) }
+    begin
+      rendered = ERB.new(File.read(DEFAULTS_PATH), trim_mode: '-').result(binding)
+      YAML.unsafe_load(rendered).dig('site', 'admin')
+    ensure
+      saved.each { |key, value| value.nil? ? ENV.delete(key) : ENV[key] = value }
+    end
+  end
+
+  it 'parses (a broken ERB/YAML default would break boot, not just this spec)' do
+    expect(admin).to be_a(Hash)
+  end
+
+  describe 'step-up (sudo) re-authentication (#4327)' do
+    it 'ships ENABLED' do
+      expect(admin.dig('elevation', 'enabled')).to be true
+    end
+
+    it 'ships a 10-minute window' do
+      expect(admin.dig('elevation', 'window').to_i).to eq(600)
+    end
+
+    # The B-3 lock. A non-zero default would make step-up a no-op for the first
+    # N seconds after every colonel sign-in, which is the exact condition #4327
+    # exists to remove.
+    it 'ships the password-less grace OFF' do
+      expect(admin.dig('elevation', 'reauth_grace').to_i).to eq(0)
+    end
+  end
+
+  describe 'colonel API rate limits (#4327 elevation bucket; #4329 adds the rest)' do
+    it 'ships ENABLED at the parent flag' do
+      expect(admin.dig('rate_limit', 'enabled')).to be true
+    end
+
+    it 'ships the elevation bucket enabled with its documented sizing' do
+      bucket = admin.dig('rate_limit', 'elevation')
+
+      expect(bucket['enabled']).to be true
+      expect(bucket['max_attempts'].to_i).to eq(5)
+      expect(bucket['window'].to_i).to eq(900)
+      expect(bucket['lockout'].to_i).to eq(900)
+    end
+  end
+
+  describe 'the test config deliberately differs' do
+    # Stated as an assertion so the divergence is visible rather than surprising:
+    # if someone "fixes" the test config to match the shipped one, the colonel
+    # suites start gating themselves and this spec explains why they must not.
+    it 'disables both in spec/config.test.yaml' do
+      expect(OT.conf.dig('site', 'admin', 'elevation', 'enabled')).to be false
+      expect(OT.conf.dig('site', 'admin', 'rate_limit', 'enabled')).to be false
+    end
+  end
+end

--- a/spec/unit/onetime/session/elevation_dropped_on_login_spec.rb
+++ b/spec/unit/onetime/session/elevation_dropped_on_login_spec.rb
@@ -1,0 +1,132 @@
+# spec/unit/onetime/session/elevation_dropped_on_login_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'auth/operations/sync_session'
+
+# An identity change must always land UNELEVATED (#4327).
+#
+# The finding, stated as the scenario it fixes: sign in as account B on a
+# browser that already held account A's ELEVATED colonel session, and B must not
+# inherit A's live step-up window.
+#
+# It is a real risk in this codebase because one `onetime.session` cookie can
+# outlive an identity change on BOTH paths:
+#
+#   - simple mode — Core::Controllers::Authentication#perform_authentication
+#     assigns the new identity into the session and calls neither `session.clear`
+#     nor `request.session_options[:renew] = true`. (Compare
+#     lib/onetime/helpers/session_helpers.rb, the OTHER authenticate path, which
+#     does both; the controller does not use it. Fixing that omission is out of
+#     this epic's charter — see the epic's non-goals — so #4327 only ensures
+#     elevation cannot survive it.)
+#   - full mode — Rodauth's :renew after a password change carries the session
+#     hash to a new sid, where it is re-externalized.
+#
+# Elevation is ALSO identity-bound on read (see
+# apps/api/colonel/spec/logic/colonel/elevation_identity_binding_spec.rb). These
+# two closures are deliberately independent: the read-side binding holds if a
+# third identity-change path is ever added, and this deletion holds if a future
+# refactor changes the stored shape.
+RSpec.describe 'elevation is dropped on every identity change' do
+  let(:elevated) { { 'extid' => 'ur_alice', 'exp' => Familia.now.to_i + 600 } }
+
+  describe 'simple mode — Core::Controllers::Authentication#perform_authentication' do
+    subject(:controller) { Core::Controllers::Authentication.new(req, res) }
+
+    let(:session_data) { { 'elevated_until' => elevated } }
+
+    let(:rack_session) do
+      session = double('RackSession')
+      allow(session).to receive(:id).and_return(double('SessionId', public_id: 'sess_abc'))
+      allow(session).to receive(:[]) { |key| session_data[key] }
+      allow(session).to receive(:[]=) { |key, value| session_data[key] = value }
+      allow(session).to receive(:delete) { |key| session_data.delete(key) }
+      session
+    end
+
+    let(:env) do
+      {
+        'rack.session' => rack_session,
+        'rack.session.options' => {},
+        'HTTP_ACCEPT' => 'application/json',
+        'REMOTE_ADDR' => '127.0.0.1',
+      }
+    end
+
+    let(:req) do
+      request = double('Request')
+      allow(request).to receive_messages(env: env, ip: '127.0.0.1', locale: 'en', params: {})
+      allow(request).to receive(:app_path) { |path| path }
+      request
+    end
+
+    let(:res) do
+      response = double('Response', do_not_cache!: nil, redirect: nil)
+      allow(response).to receive(:status=)
+      response
+    end
+
+    let(:signing_in) do
+      double('Customer', extid: 'ur_bob', email: 'bob@example.com', custid: 'bob@example.com',
+        role: 'customer', obscure_email: 'b***@example.com')
+    end
+
+    before do
+      allow(controller).to receive(:auth_logger).and_return(double('Logger', debug: nil, info: nil))
+      allow(controller).to receive(:strategy_result).and_return(nil)
+      allow(controller).to receive(:json_requested?).and_return(true)
+      allow(controller).to receive(:json_success)
+      allow(Core::Logic::Authentication::AuthenticateSession).to receive(:new)
+        .and_return(double('Logic', cust: signing_in))
+      allow(signing_in).to receive(:role?).with(:colonel).and_return(false)
+      # The controller's own error-handling wrapper yields the success block;
+      # what is under test is what that block writes to the session.
+      allow(controller).to receive(:execute_with_error_handling) { |_logic, **_opts, &block| block.call }
+    end
+
+    it 'deletes the previous occupant\'s step-up window' do
+      controller.send(:perform_authentication)
+
+      expect(session_data).not_to have_key('elevated_until')
+    end
+
+    it 'still establishes the new identity (the deletion is additive)' do
+      controller.send(:perform_authentication)
+
+      expect(session_data).to include('external_id' => 'ur_bob', 'authenticated' => true)
+    end
+  end
+
+  describe 'full mode — Auth::Operations::SyncSession#populate_session' do
+    let(:session) { { 'elevated_until' => elevated } }
+
+    let(:op) do
+      Auth::Operations::SyncSession.new(
+        account: { email: 'bob@example.com', external_id: 'ur_bob', status_id: 2 },
+        account_id: 42,
+        session: session,
+        request: double('Request', ip: '203.0.113.7', user_agent: 'rspec'),
+        correlation_id: 'corr_1',
+        db: double('Sequel::Database'),
+      )
+    end
+
+    let(:customer) do
+      double('Customer', extid: 'ur_bob', email: 'bob@example.com', role: 'customer', locale: 'en')
+    end
+
+    it 'deletes the previous occupant\'s step-up window' do
+      op.send(:populate_session, customer)
+
+      expect(session).not_to have_key('elevated_until')
+    end
+
+    it 'still establishes the new identity (the deletion is additive)' do
+      op.send(:populate_session, customer)
+
+      expect(session).to include('external_id' => 'ur_bob', 'authenticated' => true)
+    end
+  end
+end

--- a/src/apps/admin/components/AdminCustomerSessionsSection.vue
+++ b/src/apps/admin/components/AdminCustomerSessionsSection.vue
@@ -4,7 +4,7 @@
 
   import { AdminConfirmDialog, DataTable } from '@/apps/admin/components/kit';
   import type { DataTableColumn } from '@/apps/admin/components/kit';
-  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useAdminDestructiveMutation } from '@/apps/admin/composables/useAdminDestructiveMutation';
   import { useAdminCustomerSessions } from '@/apps/admin/stores/useAdminCustomerSessions';
   import type { AdminCustomerSession } from '@/schemas/api/internal/responses/colonel-customer-sessions';
   import OIcon from '@/shared/components/icons/OIcon.vue';
@@ -98,7 +98,7 @@
     error: revokeError,
     run: runRevoke,
     reset: resetRevoke,
-  } = useAdminMutation(async () => {
+  } = useAdminDestructiveMutation(async () => {
     if (!revokeTarget.value) throw new Error('No session selected');
     // The store optimistically drops the row on a 2xx; a failure throws before
     // the drop, so useAdminMutation captures it and the row stays for retry.
@@ -138,7 +138,7 @@
     error: revokeAllError,
     run: runRevokeAll,
     reset: resetRevokeAll,
-  } = useAdminMutation(async () => {
+  } = useAdminDestructiveMutation(async () => {
     // run() only returns a boolean, so stash the server's counts for the toast.
     const record = await store.revokeAll(props.userId, props.confirmToken);
     lastRevokedCount.value = record.blobs_deleted;

--- a/src/apps/admin/components/AdminCustomerSessionsSection.vue
+++ b/src/apps/admin/components/AdminCustomerSessionsSection.vue
@@ -27,6 +27,12 @@
   const props = defineProps<{
     /** The customer's public id (extid, 'ur…'), forwarded from the detail view. */
     userId: string;
+    /**
+     * The account identifier the server gates both revoke verbs on (#4326) —
+     * the customer's email, its public id when it has none. Resolved by the
+     * detail view, which is the only surface here that holds the record.
+     */
+    confirmToken: string;
   }>();
 
   const { t } = useI18n();
@@ -96,7 +102,7 @@
     if (!revokeTarget.value) throw new Error('No session selected');
     // The store optimistically drops the row on a 2xx; a failure throws before
     // the drop, so useAdminMutation captures it and the row stays for retry.
-    await store.revoke(props.userId, revokeTarget.value);
+    await store.revoke(props.userId, revokeTarget.value, props.confirmToken);
   });
 
   function requestRevoke(sessionHandle: string): void {
@@ -134,7 +140,7 @@
     reset: resetRevokeAll,
   } = useAdminMutation(async () => {
     // run() only returns a boolean, so stash the server's counts for the toast.
-    const record = await store.revokeAll(props.userId);
+    const record = await store.revokeAll(props.userId, props.confirmToken);
     lastRevokedCount.value = record.blobs_deleted;
     lastScanCapped.value = record.scan_capped;
   });

--- a/src/apps/admin/components/AdminCustomerSessionsSection.vue
+++ b/src/apps/admin/components/AdminCustomerSessionsSection.vue
@@ -33,6 +33,15 @@
      * detail view, which is the only surface here that holds the record.
      */
     confirmToken: string;
+    /**
+     * True when this customer IS the acting colonel (#4328). Revoke-all is then
+     * a CONTAINMENT action rather than an offboarding one: the server routes it
+     * to the except-current op and keeps the session the operator is working
+     * in, so the confirm copy has to say so instead of promising a full logout.
+     * Per-row self-revoke is refused server-side and already disabled here by
+     * `currentSessionHandle`.
+     */
+    isSelf?: boolean;
   }>();
 
   const { t } = useI18n();
@@ -144,6 +153,17 @@
     lastRevokedCount.value = record.blobs_deleted;
     lastScanCapped.value = record.scan_capped;
   });
+
+  /**
+   * Confirm copy for revoke-all. On the acting colonel's OWN account the server
+   * keeps this session (it routes to the except-current op, #4328), so promising
+   * a full logout would be a lie the operator acts on during an incident.
+   */
+  const revokeAllDescription = computed(() =>
+    props.isSelf
+      ? t('web.admin.customers.detail.sessions.revokeAll.selfDescription')
+      : t('web.admin.customers.detail.sessions.revokeAll.confirmDescription')
+  );
 
   function requestRevokeAll(): void {
     resetRevokeAll();
@@ -292,7 +312,7 @@
     <AdminConfirmDialog
       v-model:open="revokeAllDialogOpen"
       :title="t('web.admin.customers.detail.sessions.revokeAll.confirmTitle')"
-      :description="t('web.admin.customers.detail.sessions.revokeAll.confirmDescription')"
+      :description="revokeAllDescription"
       variant="danger"
       :confirm-token="props.userId"
       :confirm-text="t('web.admin.customers.detail.sessions.revokeAll.button')"

--- a/src/apps/admin/components/ElevationBanner.vue
+++ b/src/apps/admin/components/ElevationBanner.vue
@@ -6,7 +6,7 @@
   import { useI18n } from 'vue-i18n';
 
   import { useColonelElevation } from '../composables/useColonelElevation';
-  import { ADMIN_SIGN_IN_PATH } from '../utils/adminSessionExpiry';
+  import { recoverAdminSession } from '../utils/adminSessionExpiry';
 
   /**
    * A live step-up (sudo) window, shown while one is open (#4327), and the
@@ -78,12 +78,18 @@
       <span class="truncate">{{ t('web.admin.session.expired') }}</span>
     </span>
 
-    <a
-      :href="ADMIN_SIGN_IN_PATH"
+    <!--
+      Recovery CLEARS the session before sign-in (#4331): a bare link to /signin
+      is a no-op in simple mode while the cookie still reads authenticated. See
+      recoverAdminSession.
+    -->
+    <button
+      type="button"
       class="shrink-0 rounded px-2 py-1 font-semibold underline underline-offset-2 hover:bg-black/5 dark:hover:bg-white/10"
-      data-testid="admin-session-signin">
+      data-testid="admin-session-signin"
+      @click="recoverAdminSession">
       {{ t('web.admin.session.signIn') }}
-    </a>
+    </button>
   </div>
 
   <div

--- a/src/apps/admin/components/ElevationBanner.vue
+++ b/src/apps/admin/components/ElevationBanner.vue
@@ -6,9 +6,11 @@
   import { useI18n } from 'vue-i18n';
 
   import { useColonelElevation } from '../composables/useColonelElevation';
+  import { ADMIN_SIGN_IN_PATH } from '../utils/adminSessionExpiry';
 
   /**
-   * A live step-up (sudo) window, shown while one is open (#4327).
+   * A live step-up (sudo) window, shown while one is open (#4327), and the
+   * expired-admin-session notice (#4331).
    *
    * Mounted once in AdminLayout. Renders NOTHING when elevation is disabled by
    * config or when no window is live — the console's ordinary state is
@@ -24,18 +26,31 @@
    * A window minted with `recent_auth` is labelled DIFFERENTLY: that path
    * elevates without a credential, so it must be visible while it is live rather
    * than indistinguishable from a password step-up.
+   *
+   * The EXPIRED state (#4331) takes priority over both elevation states, and is
+   * the reason this component renders at all on a dead session: the admin API
+   * surface has its own idle/absolute bounds, but the /colonel shell is
+   * deliberately NOT gated, so the SPA loads, its first API call 401s, and this
+   * is where the operator learns why nothing works. An elevation window is
+   * meaningless once the surface itself refuses the session, so it is not shown
+   * alongside.
    */
   const { t } = useI18n();
 
   const elevation = useColonelElevation();
 
   // The one status fetch the console makes on entry. Everything after this is
-  // triggered by an operator action or a 403.
+  // triggered by an operator action or a 403. It is also, on a stale tab, the
+  // request that discovers the expired admin window.
   onMounted(() => {
     void elevation.refresh();
   });
 
-  const visible = computed(() => elevation.enabled.value && elevation.elevated.value);
+  const expired = computed(() => elevation.adminSessionExpired.value);
+
+  const visible = computed(
+    () => !expired.value && elevation.enabled.value && elevation.elevated.value
+  );
 
   const viaRecentAuth = computed(() => elevation.activeFactor.value === 'recent_auth');
 
@@ -50,7 +65,29 @@
 
 <template>
   <div
-    v-if="visible"
+    v-if="expired"
+    class="flex items-center justify-between gap-3 border-b border-red-300 bg-red-50 px-5 py-2 text-sm text-red-900 sm:px-8 dark:border-red-700 dark:bg-red-950/50 dark:text-red-200"
+    role="alert"
+    data-testid="admin-session-expired-banner">
+    <span class="flex min-w-0 items-center gap-2">
+      <OIcon
+        collection="heroicons"
+        name="exclamation-triangle"
+        size="4"
+        aria-hidden="true" />
+      <span class="truncate">{{ t('web.admin.session.expired') }}</span>
+    </span>
+
+    <a
+      :href="ADMIN_SIGN_IN_PATH"
+      class="shrink-0 rounded px-2 py-1 font-semibold underline underline-offset-2 hover:bg-black/5 dark:hover:bg-white/10"
+      data-testid="admin-session-signin">
+      {{ t('web.admin.session.signIn') }}
+    </a>
+  </div>
+
+  <div
+    v-else-if="visible"
     class="flex items-center justify-between gap-3 border-b px-5 py-2 text-sm sm:px-8"
     :class="
       viaRecentAuth

--- a/src/apps/admin/components/ElevationBanner.vue
+++ b/src/apps/admin/components/ElevationBanner.vue
@@ -1,0 +1,85 @@
+<!-- src/apps/admin/components/ElevationBanner.vue -->
+
+<script setup lang="ts">
+  import OIcon from '@/shared/components/icons/OIcon.vue';
+  import { computed, onMounted } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { useColonelElevation } from '../composables/useColonelElevation';
+
+  /**
+   * A live step-up (sudo) window, shown while one is open (#4327).
+   *
+   * Mounted once in AdminLayout. Renders NOTHING when elevation is disabled by
+   * config or when no window is live — the console's ordinary state is
+   * unelevated, and a permanent "you are not elevated" bar would train operators
+   * to ignore the bar that matters.
+   *
+   * The countdown is driven entirely by {@link useColonelElevation}'s local
+   * timer: this component issues NO HTTP of its own, ever, and the composable's
+   * doc block explains why that is a shipped security property rather than a
+   * style choice (a poll would re-stamp last_activity_at and make #4331's idle
+   * timeout unreachable while an admin tab is open).
+   *
+   * A window minted with `recent_auth` is labelled DIFFERENTLY: that path
+   * elevates without a credential, so it must be visible while it is live rather
+   * than indistinguishable from a password step-up.
+   */
+  const { t } = useI18n();
+
+  const elevation = useColonelElevation();
+
+  // The one status fetch the console makes on entry. Everything after this is
+  // triggered by an operator action or a 403.
+  onMounted(() => {
+    void elevation.refresh();
+  });
+
+  const visible = computed(() => elevation.enabled.value && elevation.elevated.value);
+
+  const viaRecentAuth = computed(() => elevation.activeFactor.value === 'recent_auth');
+
+  /** mm:ss, computed locally from the expiry — no request per tick. */
+  const remaining = computed(() => {
+    const total = Math.max(0, elevation.secondsRemaining.value);
+    const minutes = Math.floor(total / 60);
+    const seconds = total % 60;
+    return `${minutes}:${String(seconds).padStart(2, '0')}`;
+  });
+</script>
+
+<template>
+  <div
+    v-if="visible"
+    class="flex items-center justify-between gap-3 border-b px-5 py-2 text-sm sm:px-8"
+    :class="
+      viaRecentAuth
+        ? 'border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/50 dark:text-amber-200'
+        : 'border-brand-200 bg-brand-50 text-brand-900 dark:border-brand-800 dark:bg-brand-950/50 dark:text-brand-200'
+    "
+    data-testid="elevation-banner">
+    <span class="flex min-w-0 items-center gap-2">
+      <OIcon
+        collection="heroicons"
+        :name="viaRecentAuth ? 'exclamation-triangle' : 'lock-open'"
+        size="4"
+        aria-hidden="true" />
+      <span class="truncate">
+        {{
+          viaRecentAuth
+            ? t('web.admin.elevation.banner.activeRecentAuth', { remaining })
+            : t('web.admin.elevation.banner.active', { remaining })
+        }}
+      </span>
+    </span>
+
+    <button
+      type="button"
+      class="shrink-0 rounded px-2 py-1 font-semibold underline underline-offset-2 hover:bg-black/5 disabled:opacity-50 dark:hover:bg-white/10"
+      :disabled="elevation.loading.value"
+      data-testid="elevation-drop"
+      @click="elevation.drop()">
+      {{ t('web.admin.elevation.banner.drop') }}
+    </button>
+  </div>
+</template>

--- a/src/apps/admin/components/ElevationPrompt.vue
+++ b/src/apps/admin/components/ElevationPrompt.vue
@@ -1,0 +1,155 @@
+<!-- src/apps/admin/components/ElevationPrompt.vue -->
+
+<script setup lang="ts">
+  import PasswordConfirmModal from '@/shared/components/modals/PasswordConfirmModal.vue';
+  import { computed, watch } from 'vue';
+  import { useI18n } from 'vue-i18n';
+
+  import { useColonelElevation } from '../composables/useColonelElevation';
+
+  /**
+   * The step-up (sudo) prompt (#4327).
+   *
+   * Mounted ONCE, in AdminLayout, and driven by the module-level state in
+   * {@link useColonelElevation}: a destructive mutation anywhere in the console
+   * calls `requestElevation()`, this opens, and the promise resolves when the
+   * operator finishes or dismisses.
+   *
+   * ## It always requires an explicit operator gesture
+   *
+   * There is no grace-first auto-elevation. The rejected first draft called
+   * `elevate('recent_auth')` silently on open and retried the failed verb when
+   * it succeeded, which made step-up a no-op for the first N seconds after every
+   * colonel sign-in. Three forks, all operator-initiated:
+   *
+   *   1. the account has a password (the normal case) — re-enter it;
+   *   2. the account has none and an operator configured a grace — ONE deliberate
+   *      "confirm it's you" click, never fired on mount;
+   *   3. the account has none and no grace is configured — nothing the operator
+   *      can do from the browser, so render the remediation and no input at all,
+   *      rather than looping on an unsatisfiable prompt.
+   *
+   * Imports from `@/shared/*` only. `src/apps/session/*` is banned here: the
+   * admin bundle is code-split-free, so one session import would drag the whole
+   * customer auth graph into it (admin-isolation.spec.ts).
+   */
+  const { t } = useI18n();
+
+  const elevation = useColonelElevation();
+
+  const usePasswordFork = computed(
+    () => elevation.passwordAvailable.value && elevation.factors.value.includes('password')
+  );
+  const useGraceFork = computed(
+    () => !elevation.passwordAvailable.value && elevation.factors.value.includes('recent_auth')
+  );
+
+  const windowMinutes = computed(() => Math.max(1, Math.round(elevation.window.value / 60)));
+
+  // Refresh the per-account capability the moment the prompt opens, so the fork
+  // below is decided on current server state rather than whatever was last seen.
+  watch(
+    () => elevation.promptOpen.value,
+    (open) => {
+      if (open) void elevation.refresh();
+      else elevation.error.value = null;
+    }
+  );
+
+  async function onPassword(password: string): Promise<void> {
+    if (await elevation.elevate('password', password)) elevation.resolvePrompt(true);
+  }
+
+  async function onGrace(): Promise<void> {
+    if (await elevation.elevate('recent_auth')) elevation.resolvePrompt(true);
+  }
+
+  function onCancel(): void {
+    elevation.resolvePrompt(false);
+  }
+</script>
+
+<template>
+  <!-- Fork 1: the account has a password. The shared modal already owns the
+       input, visibility toggle, focus management and the confirm/cancel emits. -->
+  <PasswordConfirmModal
+    v-if="usePasswordFork"
+    :open="elevation.promptOpen.value"
+    :title="t('web.admin.elevation.prompt.title')"
+    :description="t('web.admin.elevation.prompt.description', { minutes: windowMinutes })"
+    :confirm-text="t('web.admin.elevation.prompt.confirm')"
+    :loading="elevation.loading.value"
+    :error="elevation.error.value"
+    variant="danger"
+    data-testid="elevation-prompt-password"
+    @confirm="onPassword"
+    @cancel="onCancel"
+    @update:open="(value: boolean) => { if (!value) onCancel(); }" />
+
+  <!-- Forks 2 and 3 share a plain panel: neither takes a credential, and the
+       shared password modal cannot render without its input. -->
+  <div
+    v-else-if="elevation.promptOpen.value"
+    class="fixed inset-0 z-50 flex items-center justify-center bg-gray-500/75 p-4 dark:bg-gray-900/80"
+    role="dialog"
+    aria-modal="true"
+    :aria-label="t('web.admin.elevation.prompt.title')">
+    <div
+      class="w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-gray-900"
+      data-testid="elevation-prompt-alt">
+      <h2 class="font-brand text-lg font-bold text-gray-900 dark:text-gray-100">
+        {{ t('web.admin.elevation.prompt.title') }}
+      </h2>
+
+      <template v-if="useGraceFork">
+        <p class="mt-2 text-sm text-gray-600 dark:text-gray-300">
+          {{ t('web.admin.elevation.prompt.confirmItsYouDescription', { minutes: windowMinutes }) }}
+        </p>
+        <p
+          v-if="elevation.error.value"
+          class="mt-3 text-sm text-red-600 dark:text-red-400"
+          data-testid="elevation-prompt-error">
+          {{ elevation.error.value }}
+        </p>
+        <div class="mt-5 flex justify-end gap-3">
+          <button
+            type="button"
+            class="rounded-md px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+            @click="onCancel">
+            {{ t('web.COMMON.word_cancel') }}
+          </button>
+          <!-- ONE deliberate click. Never fired on mount, never on a watcher. -->
+          <button
+            type="button"
+            class="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:bg-red-700 disabled:opacity-50"
+            :disabled="elevation.loading.value"
+            data-testid="elevation-confirm-its-you"
+            @click="onGrace">
+            {{ t('web.admin.elevation.prompt.confirmItsYou') }}
+          </button>
+        </div>
+      </template>
+
+      <!-- Fork 3: password-less account, no grace configured. There is no input
+           to render — only the remediation an administrator must apply. -->
+      <template v-else>
+        <p
+          class="mt-2 text-sm text-gray-600 dark:text-gray-300"
+          data-testid="elevation-prompt-unsatisfiable">
+          {{ t('web.admin.elevation.errors.noPassword') }}
+        </p>
+        <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          {{ t('web.admin.elevation.errors.noGrace') }}
+        </p>
+        <div class="mt-5 flex justify-end">
+          <button
+            type="button"
+            class="rounded-md bg-gray-200 px-4 py-2 text-sm font-semibold text-gray-800 hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600"
+            @click="onCancel">
+            {{ t('web.LABELS.close') }}
+          </button>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/src/apps/admin/components/domains/DomainConfigsSection.vue
+++ b/src/apps/admin/components/domains/DomainConfigsSection.vue
@@ -58,6 +58,16 @@
   const notifications = useNotificationsStore();
   const store = useAdminDomains();
 
+  /**
+   * What the server requires in X-OTS-Confirm for the per-config verbs (#4326):
+   * "<display_domain>:<kind>". The URL carries the extid and the kind, so the
+   * hostname is the half a scraped-URL replay does not have. `ensure` is
+   * un-gated (an idempotent backfill of missing rows) and sends nothing.
+   */
+  function configConfirmToken(kind: DomainConfigKind): string {
+    return `${props.displayDomain}:${kind}`;
+  }
+
   // ---- Fetch (three failure modes kept distinct) -----------------------------
 
   const configs = ref<ColonelDomainConfigsMap | null>(null);
@@ -242,7 +252,11 @@
       }
       case 'delete': {
         if (!deleteKind.value) throw new Error('No config kind selected');
-        const ack = await store.deleteConfig(props.extid, deleteKind.value);
+        const ack = await store.deleteConfig(
+          props.extid,
+          deleteKind.value,
+          configConfirmToken(deleteKind.value)
+        );
         if (!ack) {
           // Null ack = 2xx whose payload failed the Zod contract. The DELETE
           // itself succeeded (a failure would have rejected), so keep the
@@ -313,7 +327,12 @@
     reset: resetUpsert,
   } = useAdminMutation(async (payload: Record<string, unknown>) => {
     if (!editKind.value) throw new Error('No config kind selected');
-    const ack = await store.upsertConfig(props.extid, editKind.value, payload);
+    const ack = await store.upsertConfig(
+      props.extid,
+      editKind.value,
+      payload,
+      configConfirmToken(editKind.value)
+    );
     if (!ack) {
       // Null ack = 2xx whose payload failed the Zod contract. The PUT itself
       // succeeded (a failure would have rejected), so keep the success flow —

--- a/src/apps/admin/components/domains/DomainConfigsSection.vue
+++ b/src/apps/admin/components/domains/DomainConfigsSection.vue
@@ -9,6 +9,7 @@
     DomainConfigAction,
     DomainConfigStatus,
   } from '@/apps/admin/components/domains/domainConfigTypes';
+  import { useAdminDestructiveMutation } from '@/apps/admin/composables/useAdminDestructiveMutation';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useAdminDomains } from '@/apps/admin/stores/useAdminDomains';
   import {
@@ -232,7 +233,7 @@
     error: mutationError,
     run: runMutation,
     reset: resetMutation,
-  } = useAdminMutation(async () => {
+  } = useAdminDestructiveMutation(async () => {
     switch (activeAction.value) {
       case 'ensure': {
         // The ack is LOAD-BEARING here: it is the only proof the run was

--- a/src/apps/admin/composables/useAdminDestructiveMutation.ts
+++ b/src/apps/admin/composables/useAdminDestructiveMutation.ts
@@ -1,11 +1,14 @@
 // src/apps/admin/composables/useAdminDestructiveMutation.ts
 
+import { useI18n } from 'vue-i18n';
+
 import { useAdminMutation, type UseAdminMutation } from './useAdminMutation';
 import { useColonelElevation } from './useColonelElevation';
 
 /**
  * A TIER 1 (destructive) admin mutation — the same surface as
- * {@link useAdminMutation}, plus the #4327 step-up loop.
+ * {@link useAdminMutation}, plus the #4327 step-up loop and the #4329
+ * rate-limit copy.
  *
  * Drop-in: `useAdminMutation(fn)` becomes `useAdminDestructiveMutation(fn)` and
  * the view keeps binding `loading` / `error` / `run` / `reset` exactly as before.
@@ -25,6 +28,20 @@ import { useColonelElevation } from './useColonelElevation';
  * Only ONE retry, and only when the retry itself is not another
  * elevation_required — otherwise a server that keeps refusing would loop the
  * operator through the prompt indefinitely.
+ *
+ * ## Rate limiting (#4329)
+ *
+ * A 429 already reaches the operator: the shared classifier renders any 4xx
+ * carrying an `error` string verbatim, so the server's per-bucket message shows
+ * up in the dialog with no frontend change. What this adds is the two things the
+ * server message cannot say on its own — HOW LONG the wait is (from
+ * `retry_after`) and HOW TO CLEAR IT. A colonel limiter is always keyed on the
+ * ACTING colonel's extid, so an `error_type: 'LimitExceeded'` from this API is
+ * always about the person reading the dialog; that is what makes the recovery
+ * hint safe to append unconditionally.
+ *
+ * No global 429 interceptor: `errorInterceptor` deliberately does no
+ * gate-keeping, and changing that would affect every app.
  */
 
 /** Minimal shape of an Axios-like error's carried response body. */
@@ -45,19 +62,55 @@ export const BACKEND_CODE_MAP = {
   elevation_failed: 'elevation_failed',
 } as const;
 
-export type AdminGuardCode = (typeof BACKEND_CODE_MAP)[keyof typeof BACKEND_CODE_MAP] | null;
+/**
+ * The status families that need a branch of their own. `Onetime::LimitExceeded`
+ * carries no `error_code` — it predates the convention and is raised by a dozen
+ * perimeter limiters — so 429 is recognised by status.
+ */
+export const STATUS_CODE_MAP = {
+  429: 'rate_limited',
+} as const;
+
+export type AdminGuardCode =
+  | (typeof BACKEND_CODE_MAP)[keyof typeof BACKEND_CODE_MAP]
+  | (typeof STATUS_CODE_MAP)[keyof typeof STATUS_CODE_MAP]
+  | null;
+
+function responseOf(error: unknown): ErrorResponseLike | undefined {
+  return (error as { response?: ErrorResponseLike } | null)?.response;
+}
 
 /**
  * @param error the raw thrown value from a failed mutation
  * @returns the typed guard failure, or null when the error is something else
  */
 export function resolveGuardCode(error: unknown): AdminGuardCode {
-  const response = (error as { response?: ErrorResponseLike } | null)?.response;
+  const response = responseOf(error);
   const code = response?.data?.error_code;
   if (typeof code === 'string' && code in BACKEND_CODE_MAP) {
     return BACKEND_CODE_MAP[code as keyof typeof BACKEND_CODE_MAP];
   }
+  const status = response?.status;
+  if (typeof status === 'number' && status in STATUS_CODE_MAP) {
+    return STATUS_CODE_MAP[status as keyof typeof STATUS_CODE_MAP];
+  }
   return null;
+}
+
+/**
+ * Whole minutes the operator must wait, rounded UP so the console never tells
+ * them to retry a second before the lockout expires. Null when the server sent
+ * no usable `retry_after` — the server message then stands alone.
+ */
+export function retryAfterMinutes(error: unknown): number | null {
+  const seconds = Number(responseOf(error)?.data?.retry_after);
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return Math.max(1, Math.ceil(seconds / 60));
+}
+
+/** True for a 429 raised by an OTS limiter, as opposed to any upstream 429. */
+function isOtsLimiterRejection(error: unknown): boolean {
+  return responseOf(error)?.data?.error_type === 'LimitExceeded';
 }
 
 export function useAdminDestructiveMutation<TArgs extends unknown[]>(
@@ -65,17 +118,37 @@ export function useAdminDestructiveMutation<TArgs extends unknown[]>(
 ): UseAdminMutation<TArgs> {
   const mutation = useAdminMutation(perform);
   const elevation = useColonelElevation();
+  const { t } = useI18n();
+
+  /** Append the wait and the recovery path to the server's own message. */
+  function describeRateLimit(): void {
+    const parts = [mutation.error.value];
+    const minutes = retryAfterMinutes(mutation.lastError.value);
+    if (minutes !== null) parts.push(t('web.admin.errors.rateLimited', { minutes }));
+    if (isOtsLimiterRejection(mutation.lastError.value)) {
+      parts.push(t('web.admin.errors.rateLimitedRecovery'));
+    }
+    mutation.error.value = parts.filter(Boolean).join(' ');
+  }
 
   async function run(...args: TArgs): Promise<boolean> {
     if (await mutation.run(...args)) return true;
-    if (resolveGuardCode(mutation.lastError.value) !== 'needs_elevation') return false;
+
+    const code = resolveGuardCode(mutation.lastError.value);
+    if (code === 'rate_limited') {
+      describeRateLimit();
+      return false;
+    }
+    if (code !== 'needs_elevation') return false;
 
     // The server refreshes what the console knows about this account's factors
     // on the same fetch that opens the prompt.
     if (!(await elevation.requestElevation())) return false;
 
     // Exactly one retry, after the operator's gesture.
-    return mutation.run(...args);
+    if (await mutation.run(...args)) return true;
+    if (resolveGuardCode(mutation.lastError.value) === 'rate_limited') describeRateLimit();
+    return false;
   }
 
   return { ...mutation, run };

--- a/src/apps/admin/composables/useAdminDestructiveMutation.ts
+++ b/src/apps/admin/composables/useAdminDestructiveMutation.ts
@@ -1,0 +1,82 @@
+// src/apps/admin/composables/useAdminDestructiveMutation.ts
+
+import { useAdminMutation, type UseAdminMutation } from './useAdminMutation';
+import { useColonelElevation } from './useColonelElevation';
+
+/**
+ * A TIER 1 (destructive) admin mutation — the same surface as
+ * {@link useAdminMutation}, plus the #4327 step-up loop.
+ *
+ * Drop-in: `useAdminMutation(fn)` becomes `useAdminDestructiveMutation(fn)` and
+ * the view keeps binding `loading` / `error` / `run` / `reset` exactly as before.
+ * The sudo prompt is mounted ONCE in AdminLayout and driven through the shared
+ * elevation state, so no view has to render or own it.
+ *
+ * ## The loop
+ *
+ *   attempt → 403 elevation_required → prompt → operator acts → retry ONCE
+ *
+ * The retry happens only AFTER the operator completes the prompt. It is never
+ * silent: an automatic elevate-and-retry would put the whole flow back where the
+ * security review found it, with a colonel session alone sufficient for a
+ * destructive verb. If the operator cancels, the ORIGINAL error is surfaced
+ * unchanged, and nothing is retried.
+ *
+ * Only ONE retry, and only when the retry itself is not another
+ * elevation_required — otherwise a server that keeps refusing would loop the
+ * operator through the prompt indefinitely.
+ */
+
+/** Minimal shape of an Axios-like error's carried response body. */
+interface ErrorResponseLike {
+  status?: number;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * The backend error codes this console branches on. Resolved from the BACKEND
+ * CODE FIRST and the status family second (the useLinkSso idiom): 403 is shared
+ * by "not a colonel", "no elevation", "wrong confirmation" and "elevation
+ * attempt failed", so a status-first resolver would shadow every one of them.
+ */
+export const BACKEND_CODE_MAP = {
+  elevation_required: 'needs_elevation',
+  confirmation_required: 'needs_confirmation',
+  elevation_failed: 'elevation_failed',
+} as const;
+
+export type AdminGuardCode = (typeof BACKEND_CODE_MAP)[keyof typeof BACKEND_CODE_MAP] | null;
+
+/**
+ * @param error the raw thrown value from a failed mutation
+ * @returns the typed guard failure, or null when the error is something else
+ */
+export function resolveGuardCode(error: unknown): AdminGuardCode {
+  const response = (error as { response?: ErrorResponseLike } | null)?.response;
+  const code = response?.data?.error_code;
+  if (typeof code === 'string' && code in BACKEND_CODE_MAP) {
+    return BACKEND_CODE_MAP[code as keyof typeof BACKEND_CODE_MAP];
+  }
+  return null;
+}
+
+export function useAdminDestructiveMutation<TArgs extends unknown[]>(
+  perform: (...args: TArgs) => Promise<unknown>
+): UseAdminMutation<TArgs> {
+  const mutation = useAdminMutation(perform);
+  const elevation = useColonelElevation();
+
+  async function run(...args: TArgs): Promise<boolean> {
+    if (await mutation.run(...args)) return true;
+    if (resolveGuardCode(mutation.lastError.value) !== 'needs_elevation') return false;
+
+    // The server refreshes what the console knows about this account's factors
+    // on the same fetch that opens the prompt.
+    if (!(await elevation.requestElevation())) return false;
+
+    // Exactly one retry, after the operator's gesture.
+    return mutation.run(...args);
+  }
+
+  return { ...mutation, run };
+}

--- a/src/apps/admin/composables/useAdminMutation.ts
+++ b/src/apps/admin/composables/useAdminMutation.ts
@@ -4,6 +4,8 @@ import { ref, type Ref } from 'vue';
 
 import { classifyError } from '@/schemas/errors';
 
+import { noteAdminSessionExpiry } from '../utils/adminSessionExpiry';
+
 export interface UseAdminMutation<TArgs extends unknown[]> {
   /** True while the mutation is in flight. Wire to AdminConfirmDialog `:loading`. */
   loading: Ref<boolean>;
@@ -70,6 +72,10 @@ export function useAdminMutation<TArgs extends unknown[]>(
       // kept alongside it so callers can branch on the backend's error_code.
       error.value = classifyError(err).message;
       lastError.value = err;
+      // An expired admin window (#4331) is not a per-action failure: it ends the
+      // console session, so it also raises the shared flag the banner reads. The
+      // dialog still shows the server's message.
+      noteAdminSessionExpiry(err);
       return false;
     } finally {
       loading.value = false;

--- a/src/apps/admin/composables/useAdminMutation.ts
+++ b/src/apps/admin/composables/useAdminMutation.ts
@@ -14,6 +14,14 @@ export interface UseAdminMutation<TArgs extends unknown[]> {
    */
   error: Ref<string | null>;
   /**
+   * The raw thrown value from the last failure, or null. `error` is the
+   * user-facing string; this is what a caller needs to BRANCH on — specifically
+   * the backend's `error_code` inside the Axios response body, which is how
+   * {@link useAdminDestructiveMutation} recognises a 403 `elevation_required`
+   * (#4327) and turns it into a sudo prompt rather than a dead-end message.
+   */
+  lastError: Ref<unknown>;
+  /**
    * Run the mutation. Resolves `true` on success and `false` on failure (the
    * message is captured in {@link error}) — it never throws, so the caller can
    * branch on the boolean to close the dialog + refresh only on success.
@@ -47,17 +55,21 @@ export function useAdminMutation<TArgs extends unknown[]>(
 ): UseAdminMutation<TArgs> {
   const loading = ref(false);
   const error = ref<string | null>(null);
+  const lastError = ref<unknown>(null);
 
   async function run(...args: TArgs): Promise<boolean> {
     loading.value = true;
     error.value = null;
+    lastError.value = null;
     try {
       await perform(...args);
       return true;
     } catch (err) {
       // classifyError extracts the backend's user-facing `error` message for
-      // 4xx (form/validation) and a safe generic for the rest.
+      // 4xx (form/validation) and a safe generic for the rest. The raw value is
+      // kept alongside it so callers can branch on the backend's error_code.
       error.value = classifyError(err).message;
+      lastError.value = err;
       return false;
     } finally {
       loading.value = false;
@@ -67,7 +79,8 @@ export function useAdminMutation<TArgs extends unknown[]>(
   function reset(): void {
     loading.value = false;
     error.value = null;
+    lastError.value = null;
   }
 
-  return { loading, error, run, reset };
+  return { loading, error, lastError, run, reset };
 }

--- a/src/apps/admin/composables/useColonelElevation.ts
+++ b/src/apps/admin/composables/useColonelElevation.ts
@@ -11,6 +11,12 @@ import { classifyError } from '@/schemas/errors';
 import { useApi } from '@/shared/composables/useApi';
 import { gracefulParse } from '@/utils/schemaValidation';
 
+import {
+  adminSessionExpired,
+  clearAdminSessionExpired,
+  noteAdminSessionExpiry,
+} from '../utils/adminSessionExpiry';
+
 const ELEVATION_URL = '/api/colonel/elevation';
 
 /**
@@ -146,6 +152,9 @@ async function refresh(): Promise<void> {
     passwordAvailable.value = details.password_available;
     factors.value = details.factors;
   } catch (err) {
+    // This is the FIRST request the console makes on entry, so it is usually
+    // where an expired admin window (#4331) is discovered.
+    noteAdminSessionExpiry(err);
     error.value = classifyError(err).message;
   } finally {
     loading.value = false;
@@ -244,6 +253,13 @@ export interface UseColonelElevation {
   error: Ref<string | null>;
   /** True when the operator has no factor they can satisfy from the browser. */
   unsatisfiable: ComputedRef<boolean>;
+  /**
+   * The admin API surface has expired this session (#4331). Re-exported here,
+   * not re-implemented: the banner needs ONE object holding every reason the
+   * console is currently unable to act, and an expired window outranks every
+   * elevation state.
+   */
+  adminSessionExpired: Ref<boolean>;
   promptOpen: Ref<boolean>;
   refresh: () => Promise<void>;
   elevate: (factor: string, password?: string) => Promise<boolean>;
@@ -273,6 +289,7 @@ export function useColonelElevation(): UseColonelElevation {
     loading,
     error,
     unsatisfiable,
+    adminSessionExpired,
     promptOpen,
     refresh,
     elevate,
@@ -300,4 +317,5 @@ export function __resetColonelElevationState(): void {
   activeFactor.value = null;
   loading.value = false;
   error.value = null;
+  clearAdminSessionExpired();
 }

--- a/src/apps/admin/composables/useColonelElevation.ts
+++ b/src/apps/admin/composables/useColonelElevation.ts
@@ -1,0 +1,303 @@
+// src/apps/admin/composables/useColonelElevation.ts
+
+import type { AxiosInstance } from 'axios';
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
+
+import {
+  colonelElevationGrantResponseSchema,
+  colonelElevationStatusResponseSchema,
+} from '@/schemas/api/internal/responses/colonel-elevation';
+import { classifyError } from '@/schemas/errors';
+import { useApi } from '@/shared/composables/useApi';
+import { gracefulParse } from '@/utils/schemaValidation';
+
+const ELEVATION_URL = '/api/colonel/elevation';
+
+/**
+ * The colonel step-up (sudo) window, as the console sees it (#4327).
+ *
+ * MODULE-LEVEL state, deliberately: the banner in AdminLayout, the sudo prompt,
+ * and every destructive mutation across the console must share ONE view of
+ * elevation. A per-component composable would let a mutation believe it is
+ * unelevated while the banner counts down beside it.
+ *
+ * ## It does not poll, and nothing here may start a timer that makes a request
+ *
+ * `Onetime::Operations::Sessions::TrackMetadata` runs from
+ * `Onetime::Session#write_session` on essentially every authenticated request
+ * and unconditionally advances `last_activity_at` — which is exactly the value
+ * the admin idle timeout (#4331) reads. A banner polling GET /api/colonel/elevation
+ * would re-stamp it forever, so the idle timeout could never fire while an admin
+ * tab was open: dead on arrival in the only configuration that matters.
+ *
+ * So: {@link refresh} runs on admin mount, after every elevate/drop, and when a
+ * 403 `elevation_required` arrives. The countdown between those is computed
+ * CLIENT-SIDE from `expiresAt` by a `setInterval` that issues NO HTTP and, at
+ * zero, flips `elevated` to false locally.
+ *
+ * There is no other timer anywhere under `src/apps/admin/`, so an idle admin tab
+ * genuinely makes no requests. That is a load-bearing property of a shipped
+ * security control, not a style preference. Do not add one.
+ */
+
+// ─── Module-level singleton state ────────────────────────────────────────────
+
+const elevated = ref(false);
+const expiresAt = ref<number | null>(null);
+const secondsRemaining = ref(0);
+const enabled = ref(true);
+const window_ = ref(600);
+const reauthGrace = ref(0);
+const graceAvailable = ref(false);
+const passwordAvailable = ref(true);
+const factors = ref<string[]>(['password']);
+/** The factor the LIVE window was minted with, when this tab minted it. */
+const activeFactor = ref<string | null>(null);
+const loading = ref(false);
+const error = ref<string | null>(null);
+
+/** Prompt state, shared so ONE ElevationPrompt instance can serve the console. */
+const promptOpen = ref(false);
+let promptResolve: ((elevated: boolean) => void) | null = null;
+
+let countdownTimer: ReturnType<typeof setInterval> | null = null;
+let api: AxiosInstance | null = null;
+
+function stopCountdown(): void {
+  if (countdownTimer === null) return;
+  clearInterval(countdownTimer);
+  countdownTimer = null;
+}
+
+/**
+ * Recompute `secondsRemaining` from `expiresAt` locally. Issues no HTTP — see
+ * the module doc block for why that is mandatory rather than an optimisation.
+ */
+function tick(): void {
+  if (expiresAt.value === null) {
+    secondsRemaining.value = 0;
+    elevated.value = false;
+    stopCountdown();
+    return;
+  }
+  const remaining = Math.max(0, expiresAt.value - Math.floor(Date.now() / 1000));
+  secondsRemaining.value = remaining;
+  if (remaining === 0) {
+    elevated.value = false;
+    expiresAt.value = null;
+    activeFactor.value = null;
+    stopCountdown();
+  }
+}
+
+function startCountdown(): void {
+  stopCountdown();
+  if (!elevated.value || expiresAt.value === null) return;
+  countdownTimer = setInterval(tick, 1000);
+}
+
+interface ElevationRecordLike {
+  elevated: boolean;
+  expires_at: number | null;
+  seconds_remaining: number;
+}
+
+function applyRecord(record: ElevationRecordLike): void {
+  elevated.value = record.elevated;
+  expiresAt.value = record.expires_at;
+  secondsRemaining.value = record.seconds_remaining;
+  if (record.elevated) startCountdown();
+  else {
+    stopCountdown();
+    activeFactor.value = null;
+  }
+}
+
+/**
+ * The Axios instance, injected once by the first {@link useColonelElevation}
+ * call inside a component. Module-level like the state it serves.
+ */
+function client(): AxiosInstance {
+  if (!api) throw new Error('useColonelElevation(): call it from a component before using it.');
+  return api;
+}
+
+/** GET the current window and this account's capability. */
+async function refresh(): Promise<void> {
+  loading.value = true;
+  error.value = null;
+  try {
+    const response = await client().get(ELEVATION_URL);
+    const parsed = gracefulParse(
+      colonelElevationStatusResponseSchema,
+      response.data,
+      'ColonelElevationStatusResponse'
+    );
+    if (!parsed.ok) return;
+
+    const { record, details } = parsed.data;
+    if (record) applyRecord(record);
+    if (!details) return;
+
+    enabled.value = details.enabled;
+    window_.value = details.window;
+    reauthGrace.value = details.reauth_grace;
+    graceAvailable.value = details.grace_available;
+    passwordAvailable.value = details.password_available;
+    factors.value = details.factors;
+  } catch (err) {
+    error.value = classifyError(err).message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+/**
+ * Mint a window. Returns false on failure with the server's remediation message
+ * in {@link error} — that message distinguishes "wrong password" from "this
+ * account cannot use that factor", which is what the prompt renders.
+ */
+async function elevate(factor: string, password?: string): Promise<boolean> {
+  loading.value = true;
+  error.value = null;
+  try {
+    const response = await client().post(ELEVATION_URL, { factor, password: password ?? '' });
+    const parsed = gracefulParse(
+      colonelElevationGrantResponseSchema,
+      response.data,
+      'ColonelElevationGrantResponse'
+    );
+    if (parsed.ok) {
+      if (parsed.data.record) applyRecord(parsed.data.record);
+      activeFactor.value = parsed.data.details?.factor ?? factor;
+    }
+    return true;
+  } catch (err) {
+    error.value = classifyError(err).message;
+    return false;
+  } finally {
+    loading.value = false;
+    // A 2xx already told us the truth, but schema drift must not leave a stale
+    // window on screen. No refresh on the failure path: nothing changed.
+    if (!error.value) await refresh();
+  }
+}
+
+async function drop(): Promise<boolean> {
+  loading.value = true;
+  error.value = null;
+  try {
+    await client().delete(ELEVATION_URL);
+    applyRecord({ elevated: false, expires_at: null, seconds_remaining: 0 });
+    return true;
+  } catch (err) {
+    error.value = classifyError(err).message;
+    return false;
+  } finally {
+    loading.value = false;
+    await refresh();
+  }
+}
+
+/**
+ * Open the sudo prompt and wait for the operator.
+ *
+ * ALWAYS requires an explicit gesture — there is no silent grace-first
+ * auto-elevation, even when the server would accept `recent_auth`. Resolves true
+ * once a window is live, false if the operator cancelled.
+ */
+function requestElevation(): Promise<boolean> {
+  if (elevated.value) return Promise.resolve(true);
+
+  promptOpen.value = true;
+  return new Promise<boolean>((resolve) => {
+    promptResolve = resolve;
+  });
+}
+
+/** Called by the prompt when the operator finishes or dismisses it. */
+function resolvePrompt(didElevate: boolean): void {
+  promptOpen.value = false;
+  const resolve = promptResolve;
+  promptResolve = null;
+  resolve?.(didElevate);
+}
+
+// Nothing the operator can do from the browser: no password to re-enter and no
+// grace configured. The prompt renders the remediation, not an input.
+const unsatisfiable = computed(
+  () => !passwordAvailable.value && !factors.value.includes('recent_auth')
+);
+
+export interface UseColonelElevation {
+  elevated: Ref<boolean>;
+  expiresAt: Ref<number | null>;
+  secondsRemaining: Ref<number>;
+  enabled: Ref<boolean>;
+  window: Ref<number>;
+  reauthGrace: Ref<number>;
+  graceAvailable: Ref<boolean>;
+  passwordAvailable: Ref<boolean>;
+  factors: Ref<string[]>;
+  activeFactor: Ref<string | null>;
+  loading: Ref<boolean>;
+  error: Ref<string | null>;
+  /** True when the operator has no factor they can satisfy from the browser. */
+  unsatisfiable: ComputedRef<boolean>;
+  promptOpen: Ref<boolean>;
+  refresh: () => Promise<void>;
+  elevate: (factor: string, password?: string) => Promise<boolean>;
+  drop: () => Promise<boolean>;
+  /** Open the sudo prompt and resolve once the operator elevates or cancels. */
+  requestElevation: () => Promise<boolean>;
+  /** Called by the prompt when the operator finishes or dismisses it. */
+  resolvePrompt: (didElevate: boolean) => void;
+}
+
+export function useColonelElevation(): UseColonelElevation {
+  // Injected lazily: useApi() needs an active component instance, and this
+  // module's state outlives any one of them.
+  if (!api) api = useApi();
+
+  return {
+    elevated,
+    expiresAt,
+    secondsRemaining,
+    enabled,
+    window: window_,
+    reauthGrace,
+    graceAvailable,
+    passwordAvailable,
+    factors,
+    activeFactor,
+    loading,
+    error,
+    unsatisfiable,
+    promptOpen,
+    refresh,
+    elevate,
+    drop,
+    requestElevation,
+    resolvePrompt,
+  };
+}
+
+/** Test seam: reset the module-level singleton between specs. */
+export function __resetColonelElevationState(): void {
+  stopCountdown();
+  api = null;
+  promptResolve = null;
+  promptOpen.value = false;
+  elevated.value = false;
+  expiresAt.value = null;
+  secondsRemaining.value = 0;
+  enabled.value = true;
+  window_.value = 600;
+  reauthGrace.value = 0;
+  graceAvailable.value = false;
+  passwordAvailable.value = true;
+  factors.value = ['password'];
+  activeFactor.value = null;
+  loading.value = false;
+  error.value = null;
+}

--- a/src/apps/admin/composables/usePaginatedFetch.ts
+++ b/src/apps/admin/composables/usePaginatedFetch.ts
@@ -6,6 +6,8 @@ import { ref, type Ref } from 'vue';
 import { useApi } from '@/shared/composables/useApi';
 import { gracefulParse } from '@/utils/schemaValidation';
 
+import { noteAdminSessionExpiry } from '../utils/adminSessionExpiry';
+
 /**
  * Canonical pagination envelope every admin list endpoint returns.
  *
@@ -168,6 +170,10 @@ export function usePaginatedFetch<TResponse, TItem>(
       return selected;
     } catch (err) {
       const wrapped = err instanceof Error ? err : new Error(String(err));
+      // Raised even for a superseded request: an expired admin window (#4331)
+      // is a property of the session, not of this one fetch, and every later
+      // request would fail the same way.
+      noteAdminSessionExpiry(err);
       if (requestId === requestSeq) error.value = wrapped;
       throw wrapped;
     } finally {

--- a/src/apps/admin/composables/useResourceFetch.ts
+++ b/src/apps/admin/composables/useResourceFetch.ts
@@ -6,6 +6,8 @@ import { ref, type Ref } from 'vue';
 import { useApi } from '@/shared/composables/useApi';
 import { gracefulParse } from '@/utils/schemaValidation';
 
+import { noteAdminSessionExpiry } from '../utils/adminSessionExpiry';
+
 /** Query params for a single-resource GET (filters, expansions, …). */
 export type ResourceFetchParams = Record<string, string | number | boolean | undefined | null>;
 
@@ -109,6 +111,9 @@ export function useResourceFetch<TResponse>(
       data.value = result.data;
       return result.data;
     } catch (err) {
+      // An expired admin window (#4331) ends the console session; the banner
+      // reads the shared flag while this view still renders its own error.
+      noteAdminSessionExpiry(err);
       notFound.value = httpStatusOf(err) === 404;
       error.value = err instanceof Error ? err : new Error(String(err));
       data.value = null;

--- a/src/apps/admin/layouts/AdminLayout.vue
+++ b/src/apps/admin/layouts/AdminLayout.vue
@@ -10,6 +10,8 @@
   import { useI18n } from 'vue-i18n';
   import { useRoute } from 'vue-router';
 
+  import ElevationBanner from '../components/ElevationBanner.vue';
+  import ElevationPrompt from '../components/ElevationPrompt.vue';
   import { CONSOLE_GROUPS, CONSOLE_SECTIONS } from '../sections';
 
   // App.vue passes the customer chrome layout props via v-bind; this console
@@ -228,9 +230,17 @@
         </div>
       </header>
 
+      <!-- The step-up (sudo) window (#4327). The banner renders only while a
+           window is live; the prompt is mounted ONCE here and opened through the
+           shared elevation state, so every destructive mutation in the console
+           gets a sudo prompt without any view owning one. Neither polls. -->
+      <ElevationBanner />
+
       <main class="flex-1 overflow-x-auto p-5 sm:p-8">
         <slot></slot>
       </main>
+
+      <ElevationPrompt />
     </div>
   </div>
 </template>

--- a/src/apps/admin/stores/useAdminCustomerSessions.ts
+++ b/src/apps/admin/stores/useAdminCustomerSessions.ts
@@ -1,8 +1,10 @@
 // src/apps/admin/stores/useAdminCustomerSessions.ts
 
+import type { AxiosInstance } from 'axios';
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
 
+import { confirmHeaders } from '@/apps/admin/utils/confirmHeader';
 import { useApi } from '@/shared/composables/useApi';
 import {
   colonelCustomerSessionsResponseSchema,
@@ -25,8 +27,12 @@ import { gracefulParse } from '@/utils/schemaValidation';
  * can appear because none exists on the model.
  *
  *   - fetchForCustomer(userId) → GET    /api/colonel/users/:user_id/sessions
- *   - revoke(userId, sessionHandle) → DELETE /api/colonel/users/:user_id/sessions/:session_handle
- *   - revokeAll(userId) → POST /api/colonel/users/:user_id/sessions/revoke-all
+ *   - revoke(userId, handle, confirm) → DELETE …/sessions/:session_handle
+ *   - revokeAll(userId, confirm) → POST …/sessions/revoke-all
+ *
+ * Both revoke verbs are TIER 1 destructive (#4326): the server refuses them
+ * unless the request carries the account identifier (email, public id when it
+ * has none) in X-OTS-Confirm.
  *
  * Sessions are identified by session_handle, a non-reversible digest of the raw
  * session id (finding F-01) — the raw sid (a live cookie value) never reaches
@@ -59,6 +65,46 @@ function parseSessionsResponse(data: unknown) {
     data,
     'ColonelCustomerSessionsResponse'
   );
+}
+
+/**
+ * DELETE one session. The account identifier rides X-OTS-Confirm (#4326) — the
+ * server refuses this verb without it. The ack is schema-checked as a live
+ * tripwire; drift never fails the action, because a 2xx means it already
+ * happened server-side.
+ */
+async function requestRevoke(
+  $api: AxiosInstance,
+  userId: string,
+  sessionHandle: string,
+  confirm: string
+): Promise<void> {
+  const response = await $api.delete(
+    `${sessionsUrl(userId)}/${encodeURIComponent(sessionHandle)}`,
+    { headers: confirmHeaders(confirm) }
+  );
+  gracefulParse(
+    colonelCustomerSessionRevokeResponseSchema,
+    response.data,
+    'ColonelCustomerSessionRevokeResponse'
+  );
+}
+
+/** POST the bulk revoke; ack drift degrades to the zero-count fallback. */
+async function requestRevokeAll(
+  $api: AxiosInstance,
+  userId: string,
+  confirm: string
+): Promise<ColonelCustomerSessionRevokeAllRecord> {
+  const response = await $api.post(`${sessionsUrl(userId)}/revoke-all`, undefined, {
+    headers: confirmHeaders(confirm),
+  });
+  const result = gracefulParse(
+    colonelCustomerSessionRevokeAllResponseSchema,
+    response.data,
+    'ColonelCustomerSessionRevokeAllResponse'
+  );
+  return result.ok ? result.data.record : EMPTY_REVOKE_ALL;
 }
 
 export const useAdminCustomerSessions = defineStore('adminCustomerSessions', () => {
@@ -119,28 +165,21 @@ export const useAdminCustomerSessions = defineStore('adminCustomerSessions', () 
    * Revoke one of the customer's sessions (logs that user out mid-flight, so the
    * view gates it behind a confirm dialog). Drops the row ONLY after a 2xx — the
    * drop is sequenced after the awaited DELETE, so a failure throws before it and
-   * the row stays. The ack is schema-checked as a live tripwire (never fails the
-   * action on drift). Throws the network/HTTP error for useAdminMutation to catch.
+   * the row stays. Throws the network/HTTP error for useAdminMutation to catch.
    */
-  async function revoke(userId: string, sessionHandle: string): Promise<void> {
-    const response = await $api.delete(
-      `${sessionsUrl(userId)}/${encodeURIComponent(sessionHandle)}`
-    );
-    gracefulParse(
-      colonelCustomerSessionRevokeResponseSchema,
-      response.data,
-      'ColonelCustomerSessionRevokeResponse'
-    );
-    sessions.value = sessions.value.filter((s) => s.session_handle !== sessionHandle);
+  async function revoke(userId: string, handle: string, confirm: string): Promise<void> {
+    await requestRevoke($api, userId, handle, confirm);
+    sessions.value = sessions.value.filter((s) => s.session_handle !== handle);
   }
 
   /** Revoke ALL sessions (offboarding/takeover); clears the list, returns kill counts. */
-  async function revokeAll(userId: string): Promise<ColonelCustomerSessionRevokeAllRecord> {
-    const response = await $api.post(`${sessionsUrl(userId)}/revoke-all`);
-    const schema = colonelCustomerSessionRevokeAllResponseSchema;
-    const result = gracefulParse(schema, response.data, 'ColonelCustomerSessionRevokeAllResponse');
+  async function revokeAll(
+    userId: string,
+    confirm: string
+  ): Promise<ColonelCustomerSessionRevokeAllRecord> {
+    const record = await requestRevokeAll($api, userId, confirm);
     sessions.value = []; // every session is gone regardless of ack shape
-    return result.ok ? result.data.record : EMPTY_REVOKE_ALL;
+    return record;
   }
 
   /** Explicit manual reset — setup stores have no built-in $reset. */

--- a/src/apps/admin/stores/useAdminCustomers.ts
+++ b/src/apps/admin/stores/useAdminCustomers.ts
@@ -1,5 +1,6 @@
 // src/apps/admin/stores/useAdminCustomers.ts
 
+import type { AxiosInstance } from 'axios';
 import { defineStore } from 'pinia';
 import type { z } from 'zod';
 import { ref } from 'vue';
@@ -13,6 +14,7 @@ import {
   colonelUsersResponseSchema,
 } from '@/schemas/api/internal/responses/colonel';
 import type { ColonelUser } from '@/schemas/api/internal/responses/colonel';
+import { confirmHeaders } from '@/apps/admin/utils/confirmHeader';
 import { useApi } from '@/shared/composables/useApi';
 import { gracefulParse } from '@/utils/schemaValidation';
 
@@ -71,6 +73,33 @@ function replaceRow(
  * `src/shared/stores/colonelInfoStore.ts` (enforced by an architecture test),
  * so it never drags the retiring legacy tree into the admin bundle.
  */
+/**
+ * POST verify/unverify. UNVERIFY is gated server-side (#4326): it strips colonel
+ * eligibility, so it must carry the account identifier in X-OTS-Confirm. VERIFY
+ * is the restorative arm and sends nothing.
+ */
+async function requestVerification(
+  $api: AxiosInstance,
+  userId: string,
+  verified: boolean,
+  confirm?: string
+): Promise<void> {
+  const verb = verified ? 'verify' : 'unverify';
+  const config = verified || !confirm ? undefined : { headers: confirmHeaders(confirm) };
+  const response = await $api.post(`${userUrl(userId)}/${verb}`, {}, config);
+  parseMutationAck(response.data);
+}
+
+/** DELETE one account, carrying the confirmation token the server requires. */
+async function requestPurge(
+  $api: AxiosInstance,
+  userId: string,
+  confirm: string
+): Promise<void> {
+  const response = await $api.delete(userUrl(userId), { headers: confirmHeaders(confirm) });
+  parseMutationAck(response.data);
+}
+
 export const useAdminCustomers = defineStore('adminCustomers', () => {
   /** Rows for the current page only (one server page — never accumulated). */
   const customers = ref<ColonelUser[]>([]);
@@ -134,16 +163,17 @@ export const useAdminCustomers = defineStore('adminCustomers', () => {
    *
    * @param userId the customer's public id (extid, 'ur…' — `row.user_id`).
    * @param verified the target state.
+   * @param confirm the account identifier for X-OTS-Confirm; required by the
+   *   server on the UNVERIFY arm only (#4326).
    * @returns the patched row, or null when it is not on the current page.
    * @throws the network/HTTP error, for `useAdminMutation` to classify.
    */
   async function setVerification(
     userId: string,
-    verified: boolean
+    verified: boolean,
+    confirm?: string
   ): Promise<ColonelUser | null> {
-    const verb = verified ? 'verify' : 'unverify';
-    const response = await $api.post(`${userUrl(userId)}/${verb}`, {});
-    parseMutationAck(response.data);
+    await requestVerification($api, userId, verified, confirm);
     const patched = replaceRow(customers.value, userId, { verified });
     customers.value = patched.rows;
     return patched.updated;
@@ -158,11 +188,12 @@ export const useAdminCustomers = defineStore('adminCustomers', () => {
    * refetch the page afterwards (totals/pagination move server-side).
    *
    * @param userId the customer's public id (extid, 'ur…').
+   * @param confirm the account identifier (email, extid when it has none) the
+   *   server requires in X-OTS-Confirm (#4326).
    * @throws the network/HTTP error, for `useAdminMutation` to classify.
    */
-  async function purge(userId: string): Promise<void> {
-    const response = await $api.delete(userUrl(userId));
-    parseMutationAck(response.data);
+  async function purge(userId: string, confirm: string): Promise<void> {
+    await requestPurge($api, userId, confirm);
     customers.value = customers.value.filter((row) => row.user_id !== userId);
   }
 

--- a/src/apps/admin/stores/useAdminDomains.ts
+++ b/src/apps/admin/stores/useAdminDomains.ts
@@ -36,6 +36,7 @@ import {
   type ColonelDomainRepairDetails,
   type ColonelDomainTransferDetails,
 } from '@/schemas/api/internal/responses/colonel-domaintoolbox';
+import { confirmHeaders } from '@/apps/admin/utils/confirmHeader';
 import { useApi } from '@/shared/composables/useApi';
 import { gracefulParse } from '@/utils/schemaValidation';
 import type { AxiosInstance } from 'axios';
@@ -115,6 +116,11 @@ export interface DomainRepairOptions {
   /** Target org for the ORPHANED case (objid or extid). Omitted when blank. */
   orgId?: string;
   dryRun: boolean;
+  /**
+   * The domain's hostname, required in X-OTS-Confirm on the APPLY path (#4326).
+   * A preview needs none — it writes nothing.
+   */
+  confirm?: string;
 }
 
 /** Options for the transfer verb. `dryRun` is explicit — never defaulted here. */
@@ -124,6 +130,8 @@ export interface DomainTransferOptions {
   /** Optional ownership assertion; a mismatch is a 4xx on field `from_org`. */
   fromOrg?: string;
   dryRun: boolean;
+  /** The domain's hostname, required in X-OTS-Confirm on the APPLY path (#4326). */
+  confirm?: string;
 }
 
 /** Options for the configs-ensure verb. `dryRun` is explicit — never defaulted here. */
@@ -135,6 +143,11 @@ export interface DomainConfigsEnsureOptions {
 export interface DomainOverrideOptions {
   verified?: boolean;
   resolving?: boolean;
+  /**
+   * The domain's hostname, required in X-OTS-Confirm (#4326): this verb bypasses
+   * DNS proof of ownership and has no preview arm.
+   */
+  confirm?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +167,15 @@ export interface DomainOverrideOptions {
 /** Path for a single domain, resolved by PUBLIC id (extid) only. */
 function domainPath(extid: string): string {
   return `/api/colonel/domains/${encodeURIComponent(extid)}`;
+}
+
+/**
+ * Axios config carrying the destructive-action confirmation (#4326), or
+ * undefined when there is nothing to send — a dry-run preview is exempt
+ * server-side, so it must NOT send a token it does not need.
+ */
+function headersFor(confirm?: string) {
+  return confirm ? { headers: confirmHeaders(confirm) } : undefined;
 }
 
 /** Read one domain's full record + the deployment's proxy cluster. READ-ONLY. */
@@ -203,7 +225,7 @@ async function overrideDomain(
   if (options.verified !== undefined) body.verified = options.verified;
   if (options.resolving !== undefined) body.resolving = options.resolving;
 
-  const response = await $api.post(`${domainPath(extid)}/override`, body);
+  const response = await $api.post(`${domainPath(extid)}/override`, body, headersFor(options.confirm));
   const parsed = gracefulParse(
     colonelDomainOverrideResponseSchema,
     response.data,
@@ -245,7 +267,7 @@ async function repairDomain(
   const body: Record<string, unknown> = { dry_run: options.dryRun };
   if (options.orgId) body.org_id = options.orgId;
 
-  const response = await $api.post(`${domainPath(extid)}/repair`, body);
+  const response = await $api.post(`${domainPath(extid)}/repair`, body, headersFor(options.confirm));
   const parsed = gracefulParse(
     colonelDomainRepairResponseSchema,
     response.data,
@@ -269,7 +291,7 @@ async function transferDomain(
   };
   if (options.fromOrg) body.from_org = options.fromOrg;
 
-  const response = await $api.post(`${domainPath(extid)}/transfer`, body);
+  const response = await $api.post(`${domainPath(extid)}/transfer`, body, headersFor(options.confirm));
   const parsed = gracefulParse(
     colonelDomainTransferResponseSchema,
     response.data,
@@ -289,9 +311,13 @@ async function transferDomain(
 async function removeDomain(
   $api: AxiosInstance,
   extid: string,
-  dryRun: boolean
+  dryRun: boolean,
+  confirm?: string
 ): Promise<ColonelDomainRemoveDetails | null> {
-  const response = await $api.delete(`${domainPath(extid)}?dry_run=${dryRun}`);
+  const response = await $api.delete(
+    `${domainPath(extid)}?dry_run=${dryRun}`,
+    headersFor(confirm)
+  );
   const parsed = gracefulParse(
     colonelDomainRemoveResponseSchema,
     response.data,
@@ -340,11 +366,13 @@ async function upsertDomainConfig(
   $api: AxiosInstance,
   extid: string,
   kind: EditableDomainConfigKind,
-  body: Record<string, unknown>
+  body: Record<string, unknown>,
+  confirm?: string
 ): Promise<ColonelDomainConfigUpsertDetails | null> {
   const response = await $api.put(
     `${domainConfigsPath(extid)}/${encodeURIComponent(kind)}`,
-    body
+    body,
+    headersFor(confirm)
   );
   const parsed = gracefulParse(
     colonelDomainConfigUpsertResponseSchema,
@@ -358,10 +386,12 @@ async function upsertDomainConfig(
 async function deleteDomainConfig(
   $api: AxiosInstance,
   extid: string,
-  kind: DomainConfigKind
+  kind: DomainConfigKind,
+  confirm?: string
 ): Promise<ColonelDomainConfigDeleteDetails | null> {
   const response = await $api.delete(
-    `${domainConfigsPath(extid)}/${encodeURIComponent(kind)}`
+    `${domainConfigsPath(extid)}/${encodeURIComponent(kind)}`,
+    headersFor(confirm)
   );
   const parsed = gracefulParse(
     colonelDomainConfigDeleteResponseSchema,
@@ -405,12 +435,17 @@ function bindOperations($api: AxiosInstance) {
       repairDomain($api, extid, options),
     transfer: (extid: string, options: DomainTransferOptions) =>
       transferDomain($api, extid, options),
-    remove: (extid: string, dryRun: boolean) => removeDomain($api, extid, dryRun),
+    remove: (extid: string, dryRun: boolean, confirm?: string) =>
+      removeDomain($api, extid, dryRun, confirm),
     fetchConfigs: (extid: string) => fetchDomainConfigs($api, extid),
-    upsertConfig: (extid: string, kind: EditableDomainConfigKind, body: Record<string, unknown>) =>
-      upsertDomainConfig($api, extid, kind, body),
-    deleteConfig: (extid: string, kind: DomainConfigKind) =>
-      deleteDomainConfig($api, extid, kind),
+    upsertConfig: (
+      extid: string,
+      kind: EditableDomainConfigKind,
+      body: Record<string, unknown>,
+      confirm?: string
+    ) => upsertDomainConfig($api, extid, kind, body, confirm),
+    deleteConfig: (extid: string, kind: DomainConfigKind, confirm?: string) =>
+      deleteDomainConfig($api, extid, kind, confirm),
     ensureConfigs: (extid: string, options: DomainConfigsEnsureOptions) =>
       ensureDomainConfigs($api, extid, options),
   };

--- a/src/apps/admin/stores/useAdminSessions.ts
+++ b/src/apps/admin/stores/useAdminSessions.ts
@@ -37,6 +37,12 @@ export const useAdminSessions = defineStore('adminSessions', () => {
    * capped — so a short list never silently reads as "few sessions."
    */
   const scan = ref<ColonelSessionScan | null>(null);
+  /**
+   * The acting colonel's OWN session, as the non-bearer handle (#4328). The
+   * view badges that row and disables its revoke; the server refuses it too.
+   * Null when the server cannot identify the request session.
+   */
+  const currentSessionHandle = ref<string | null>(null);
 
   const pager = usePaginatedFetch<ColonelSessionsResponse, ColonelSession>({
     url: '/api/colonel/sessions',
@@ -46,6 +52,7 @@ export const useAdminSessions = defineStore('adminSessions', () => {
     // so it is the natural place to keep `scan` in lockstep with the page.
     select: (data) => {
       scan.value = data.details?.scan ?? null;
+      currentSessionHandle.value = data.details?.current_session_handle ?? null;
       return {
         items: data.details?.sessions ?? [],
         pagination: data.details?.pagination ?? null,
@@ -78,6 +85,7 @@ export const useAdminSessions = defineStore('adminSessions', () => {
         sessions.value = [];
         pagination.value = null;
         scan.value = null;
+        currentSessionHandle.value = null;
       }
       return result;
     } catch (err) {
@@ -85,6 +93,7 @@ export const useAdminSessions = defineStore('adminSessions', () => {
       sessions.value = [];
       pagination.value = null;
       scan.value = null;
+      currentSessionHandle.value = null;
       throw err;
     }
   }
@@ -94,6 +103,7 @@ export const useAdminSessions = defineStore('adminSessions', () => {
     sessions.value = [];
     pagination.value = null;
     scan.value = null;
+    currentSessionHandle.value = null;
     pager.reset();
   }
 
@@ -102,6 +112,7 @@ export const useAdminSessions = defineStore('adminSessions', () => {
     sessions,
     pagination,
     scan,
+    currentSessionHandle,
     // Fetch state (owned by the shared composable)
     loading: pager.loading,
     error: pager.error,

--- a/src/apps/admin/utils/adminSessionExpiry.ts
+++ b/src/apps/admin/utils/adminSessionExpiry.ts
@@ -1,0 +1,81 @@
+// src/apps/admin/utils/adminSessionExpiry.ts
+
+import { ref, type Ref } from 'vue';
+
+/**
+ * The console's one view of "this admin session is over" (#4331).
+ *
+ * The server bounds the ADMIN API SURFACE (/api/colonel) with an idle and an
+ * absolute timeout while leaving the shared onetime.session cookie alone. So the
+ * /colonel shell keeps loading, the tenant app keeps working, and the only
+ * signal the console gets is a 401 on its own API calls carrying the
+ * {@link ADMIN_SESSION_EXPIRED_PREFIX} marker.
+ *
+ * ## Why a module-level ref and not a store
+ *
+ * Every admin request path — the paginated list fetch, the detail loader, every
+ * mutation, and the elevation status read the console makes on entry — funnels
+ * its catch through {@link noteAdminSessionExpiry}, and ONE banner in
+ * AdminLayout renders the result. A per-component flag would let a list view
+ * know the session is gone while a detail view beside it kept retrying.
+ *
+ * ## Why not a global Axios interceptor
+ *
+ * `errorInterceptor` is shared by every app and deliberately does no
+ * gate-keeping; teaching it about an admin-only header would put admin policy in
+ * everyone's request path. The four admin call sites are the whole surface.
+ *
+ * Nothing here polls. The flag is set by traffic the operator already caused,
+ * which is the same reason the elevation composable has no timer: any periodic
+ * request would refresh the server-side activity clock the idle bound reads and
+ * silently disable it.
+ */
+
+/**
+ * The server-side marker, from
+ * `lib/onetime/application/auth_strategies/base_session_auth_strategy.rb`. Keep
+ * the two in sync — this string IS the contract.
+ */
+export const ADMIN_SESSION_EXPIRED_PREFIX = '[ADMIN_SESSION_EXPIRED]';
+
+/** True once any admin request has been refused for an expired admin window. */
+export const adminSessionExpired: Ref<boolean> = ref(false);
+
+/** Where to send the operator to replace the session. */
+export const ADMIN_SIGN_IN_PATH = '/signin?redirect=/colonel';
+
+interface ErrorBodyLike {
+  status?: number;
+  data?: { error?: unknown; message?: unknown };
+}
+
+function responseOf(error: unknown): ErrorBodyLike | undefined {
+  return (error as { response?: ErrorBodyLike } | null)?.response;
+}
+
+/**
+ * Flip the shared flag when `error` is the admin-session-expired 401.
+ *
+ * Otto renders an auth failure as `{error: 'Authentication Required', message:
+ * '<reason>'}`, so the marker arrives in `message`; `error` is checked too so a
+ * future handler that promotes the reason to the top-level field still matches.
+ *
+ * @returns true when this error was the expired-admin-session 401
+ */
+export function noteAdminSessionExpiry(error: unknown): boolean {
+  const response = responseOf(error);
+  if (response?.status !== 401) return false;
+
+  const carriesMarker = [response.data?.message, response.data?.error].some(
+    (value) => typeof value === 'string' && value.startsWith(ADMIN_SESSION_EXPIRED_PREFIX)
+  );
+  if (!carriesMarker) return false;
+
+  adminSessionExpired.value = true;
+  return true;
+}
+
+/** Test seam, and the reset a future re-authentication flow would call. */
+export function clearAdminSessionExpired(): void {
+  adminSessionExpired.value = false;
+}

--- a/src/apps/admin/utils/adminSessionExpiry.ts
+++ b/src/apps/admin/utils/adminSessionExpiry.ts
@@ -41,8 +41,39 @@ export const ADMIN_SESSION_EXPIRED_PREFIX = '[ADMIN_SESSION_EXPIRED]';
 /** True once any admin request has been refused for an expired admin window. */
 export const adminSessionExpired: Ref<boolean> = ref(false);
 
-/** Where to send the operator to replace the session. */
+/** Where to send the operator to replace the session, after it is cleared. */
 export const ADMIN_SIGN_IN_PATH = '/signin?redirect=/colonel';
+
+/**
+ * Recover from an expired admin window (#4331).
+ *
+ * A bare link to {@link ADMIN_SIGN_IN_PATH} does NOT clear the window in simple
+ * mode: while the shared `onetime.session` cookie still reads `authenticated`,
+ * `GET /signin` short-circuits to "already logged in" WITHOUT re-stamping
+ * `authenticated_at`
+ * (`apps/web/core/controllers/authentication.rb#handle_already_authenticated`),
+ * so the admin idle/absolute bound stays tripped and every `/api/colonel` call
+ * keeps 401ing. The session must be CLEARED first; only then does the sign-in
+ * actually re-authenticate and re-stamp. Full mode re-runs login regardless, but
+ * routing both modes through logout is correct and keeps ONE recovery path.
+ *
+ * Best-effort logout (`GET /auth/logout` clears the session and renews the sid
+ * server-side), then a HARD navigation to sign-in — deliberately not the SPA
+ * router — so the sign-in page loads under the freshly cleared cookie.
+ */
+export async function recoverAdminSession(): Promise<void> {
+  try {
+    await fetch('/auth/logout', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    });
+  } catch {
+    // Even if logout fails (offline, blocked), still send them onward: the worst
+    // case is the same dead-end they are already in, never worse.
+  }
+  window.location.assign(ADMIN_SIGN_IN_PATH);
+}
 
 interface ErrorBodyLike {
   status?: number;

--- a/src/apps/admin/utils/adminSessionExpiry.ts
+++ b/src/apps/admin/utils/adminSessionExpiry.ts
@@ -54,16 +54,20 @@ export const ADMIN_SIGN_IN_PATH = '/signin?redirect=/colonel';
  * (`apps/web/core/controllers/authentication.rb#handle_already_authenticated`),
  * so the admin idle/absolute bound stays tripped and every `/api/colonel` call
  * keeps 401ing. The session must be CLEARED first; only then does the sign-in
- * actually re-authenticate and re-stamp. Full mode re-runs login regardless, but
- * routing both modes through logout is correct and keeps ONE recovery path.
+ * actually re-authenticate and re-stamp (in full mode too: if the session were
+ * left intact the router's isAuthenticated guard would bounce /signin straight
+ * back to /colonel without ever reaching a login form).
  *
- * Best-effort logout (`GET /auth/logout` clears the session and renews the sid
- * server-side), then a HARD navigation to sign-in — deliberately not the SPA
- * router — so the sign-in page loads under the freshly cleared cookie.
+ * Best-effort `GET /logout` — the CORE app's logout, which does session.clear +
+ * sid renew and is served in BOTH modes (`apps/web/core/routes.txt`). NOT
+ * `/auth/logout`: in full mode the Rodauth app owns the `/auth` prefix and its
+ * logout only destroys the session on POST, so a GET there clears nothing. Then
+ * a HARD navigation to sign-in — deliberately not the SPA router — so the
+ * sign-in page loads under the freshly cleared cookie.
  */
 export async function recoverAdminSession(): Promise<void> {
   try {
-    await fetch('/auth/logout', {
+    await fetch('/logout', {
       method: 'GET',
       credentials: 'same-origin',
       headers: { Accept: 'application/json' },

--- a/src/apps/admin/utils/confirmHeader.ts
+++ b/src/apps/admin/utils/confirmHeader.ts
@@ -1,0 +1,48 @@
+// src/apps/admin/utils/confirmHeader.ts
+
+/**
+ * Server-side destructive-action confirmation (#4326).
+ *
+ * The colonel API rejects a destructive verb unless the request carries an
+ * identifier of the target in X-OTS-Confirm. A HEADER, not a query parameter:
+ * these tokens are frequently PII (a target's email, an org name) and a query
+ * string is logged by every default access-log format, kept in browser history,
+ * and is a Referer-leak candidate. Percent-encoded so a non-ASCII token (an org
+ * display name) survives the ISO-8859-1 header charset; the server decodes with
+ * Rack::Utils.unescape.
+ *
+ * A `confirm` query or body parameter is NOT a fallback server-side. Sending one
+ * would leak the token into logs and change nothing.
+ */
+export const CONFIRM_HEADER = 'X-OTS-Confirm';
+
+/** Request headers carrying the confirmation token for one gated call. */
+export function confirmHeaders(token: string): Record<string, string> {
+  return { [CONFIRM_HEADER]: encodeURIComponent(token) };
+}
+
+/**
+ * The confirmation token for an ACCOUNT-scoped verb: the email address, falling
+ * back to the public id when the account has none.
+ *
+ * Mirrors `ColonelAPI::Logic::DestructiveAction#account_confirm_token` exactly —
+ * the two must agree or every such call 403s. Returns undefined when neither is
+ * available (an unloaded record), which callers treat as "do not open the
+ * dialog" rather than sending a blank token.
+ */
+export function accountConfirmToken(
+  account: { email?: string | null; extid?: string | null } | null | undefined
+): string | undefined {
+  return account?.email?.trim() || account?.extid?.trim() || undefined;
+}
+
+/**
+ * The confirmation token for an ORGANIZATION-scoped verb: the display name,
+ * falling back to the public id. Mirrors
+ * `ColonelAPI::Logic::DestructiveAction#org_confirm_token`.
+ */
+export function orgConfirmToken(
+  org: { display_name?: string | null; extid?: string | null } | null | undefined
+): string | undefined {
+  return org?.display_name?.trim() || org?.extid?.trim() || undefined;
+}

--- a/src/apps/admin/views/AdminCustomerDetail.vue
+++ b/src/apps/admin/views/AdminCustomerDetail.vue
@@ -6,7 +6,7 @@
   import { AdminConfirmDialog, DataTable, StatCard } from '@/apps/admin/components/kit';
   import type { DataTableColumn } from '@/apps/admin/components/kit';
   import RevealEmail from '@/apps/admin/components/RevealEmail.vue';
-  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useAdminDestructiveMutation } from '@/apps/admin/composables/useAdminDestructiveMutation';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
   import { accountConfirmToken, confirmHeaders } from '@/apps/admin/utils/confirmHeader';
   import type {
@@ -125,7 +125,7 @@
     error: mutationError,
     run: runMutation,
     reset: resetMutation,
-  } = useAdminMutation(async () => {
+  } = useAdminDestructiveMutation(async () => {
     // Every DANGER action is gated server-side (#4326) on the SAME token the
     // dialog asks the operator to retype. A missing one is a bug, not a
     // fallback: sending no header is a 403 the operator cannot act on.

--- a/src/apps/admin/views/AdminCustomerDetail.vue
+++ b/src/apps/admin/views/AdminCustomerDetail.vue
@@ -19,6 +19,7 @@
   } from '@/schemas/api/internal/responses/colonel';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import { useApi } from '@/shared/composables/useApi';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useNotificationsStore } from '@/shared/stores/notificationsStore';
   import { formatDisplayDateTime } from '@/utils/format';
   import { gracefulParse } from '@/utils/schemaValidation';
@@ -52,6 +53,7 @@
   const router = useRouter();
   const $api = useApi();
   const notifications = useNotificationsStore();
+  const bootstrapStore = useBootstrapStore();
 
   const publicId = computed(() => props.id);
   const userUrl = (): string => `/api/colonel/users/${encodeURIComponent(publicId.value)}`;
@@ -205,6 +207,53 @@
   const purgeBlocked = computed(() => !confirmTokenFor('purge'));
 
   /**
+   * Is the record on screen the acting colonel's own account? (#4328)
+   *
+   * Compared on the PUBLIC id the bootstrap payload already carries. This is
+   * defence in depth, exactly like {@link purgeBlocked} — the server refuses
+   * self-demotion, self-unverify and self-revoke with a 422 whatever the
+   * browser does; disabling here just keeps the operator from typing a
+   * confirmation token for an action that cannot succeed.
+   */
+  const isSelf = computed(
+    () => !!record.value?.extid && record.value.extid === bootstrapStore.cust?.extid
+  );
+
+  /**
+   * A DEMOTION of your own account: the one role change the server refuses.
+   * Raising your own role is not a lockout risk and stays available.
+   */
+  const selfDemoteBlocked = computed(
+    () => isSelf.value && !!pendingRole.value && pendingRole.value !== 'colonel'
+  );
+
+  /** Unverifying yourself strips your own colonel eligibility — also refused. */
+  const selfUnverifyBlocked = computed(() => isSelf.value);
+
+  /** Why the role apply button is disabled, when it is for this reason. */
+  const selfDemoteReason = computed(() =>
+    t('web.admin.customers.actions.role.selfDemote')
+  );
+
+  /**
+   * Advisory (not a gate): demoting or unverifying SOMEONE ELSE'S colonel
+   * account can still be refused server-side when they are the last remaining
+   * one. The console cannot know the roster — that answer is deliberately not
+   * exposed, because it would be an oracle — so this warns rather than blocks.
+   */
+  const demotingAnotherColonel = computed(
+    () =>
+      !isSelf.value &&
+      record.value?.role === 'colonel' &&
+      !!pendingRole.value &&
+      pendingRole.value !== 'colonel'
+  );
+
+  const unverifyingAnotherColonel = computed(
+    () => !isSelf.value && record.value?.role === 'colonel' && !!record.value?.verified
+  );
+
+  /**
    * The token the session-revoke verbs are gated on (#4326) — the same account
    * identifier, resolved here because the sessions section only knows the
    * route's public id. Falls back to that id, which is what the server resolves
@@ -273,6 +322,8 @@
     // Fail closed: never open a danger dialog whose typed token is blank —
     // AdminConfirmDialog runs an empty token as a one-click simple confirm.
     if (DANGER_ACTIONS.includes(key) && !confirmTokenFor(key)) return;
+    // ...nor one the server's self-target interlocks will refuse (#4328).
+    if (key === 'unverify' && selfUnverifyBlocked.value) return;
     activeAction.value = key;
     resetMutation();
     dialogOpen.value = true;
@@ -281,6 +332,8 @@
   function requestSetRole(): void {
     // No-op guard: ignore if the role is unchanged (nothing to confirm).
     if (!pendingRole.value || pendingRole.value === record.value?.role) return;
+    // Fail closed on the interlocks the server enforces (#4328).
+    if (selfDemoteBlocked.value) return;
     requestAction('setRole');
   }
 
@@ -620,12 +673,29 @@
                 <button
                   type="button"
                   data-testid="role-apply"
-                  :disabled="pendingRole === record.role"
+                  :disabled="pendingRole === record.role || selfDemoteBlocked"
+                  :aria-describedby="selfDemoteBlocked ? 'self-demote-reason' : undefined"
                   class="inline-flex shrink-0 items-center rounded-md bg-brand-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-brand-700 focus:ring-2 focus:ring-brand-500 focus:ring-offset-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-brand-500 dark:hover:bg-brand-600"
                   @click="requestSetRole">
                   {{ t('web.admin.customers.actions.role.apply') }}
                 </button>
               </div>
+              <!-- Client-side mirror of the server interlock (#4328): a colonel
+                   cannot demote their own account. Stated, not just disabled —
+                   a dead button with no explanation reads as a bug. -->
+              <p
+                v-if="selfDemoteBlocked"
+                id="self-demote-reason"
+                class="mt-2 text-xs text-amber-700 dark:text-amber-400"
+                data-testid="self-demote-reason">
+                {{ selfDemoteReason }}
+              </p>
+              <p
+                v-else-if="demotingAnotherColonel"
+                class="mt-2 text-xs text-amber-700 dark:text-amber-400"
+                data-testid="last-colonel-warning">
+                {{ t('web.admin.customers.actions.role.lastColonel') }}
+              </p>
             </div>
 
             <!-- Verify / unverify -->
@@ -641,18 +711,36 @@
                 size="4" />
               {{ t('web.admin.customers.actions.verify.button') }}
             </button>
-            <button
-              v-else
-              type="button"
-              data-testid="unverify-button"
-              class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
-              @click="requestAction('unverify')">
-              <OIcon
-                collection="heroicons"
-                name="x-circle"
-                size="4" />
-              {{ t('web.admin.customers.actions.unverify.button') }}
-            </button>
+            <div v-else>
+              <button
+                type="button"
+                data-testid="unverify-button"
+                :disabled="selfUnverifyBlocked"
+                :aria-describedby="selfUnverifyBlocked ? 'self-unverify-reason' : undefined"
+                class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:ring-2 focus:ring-brand-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                @click="requestAction('unverify')">
+                <OIcon
+                  collection="heroicons"
+                  name="x-circle"
+                  size="4" />
+                {{ t('web.admin.customers.actions.unverify.button') }}
+              </button>
+              <!-- Verification is a prerequisite for the colonel role, so
+                   unverifying yourself is a self-demotion (#4328). -->
+              <p
+                v-if="selfUnverifyBlocked"
+                id="self-unverify-reason"
+                class="mt-2 text-xs text-amber-700 dark:text-amber-400"
+                data-testid="self-unverify-reason">
+                {{ t('web.admin.customers.actions.unverify.selfUnverify') }}
+              </p>
+              <p
+                v-else-if="unverifyingAnotherColonel"
+                class="mt-2 text-xs text-amber-700 dark:text-amber-400"
+                data-testid="unverify-last-colonel-warning">
+                {{ t('web.admin.customers.actions.unverify.lastColonel') }}
+              </p>
+            </div>
 
             <!-- Suspend / unsuspend (reversible trust & safety pause).
                  Colonel accounts cannot be suspended (privilege guard); the
@@ -872,7 +960,8 @@
            payload can appear). Guarded per-row revoke logs the user out. -->
       <AdminCustomerSessionsSection
         :user-id="publicId"
-        :confirm-token="sessionsConfirmToken" />
+        :confirm-token="sessionsConfirmToken"
+        :is-self="isSelf" />
 
       <!-- Account auth diagnostics (READ-ONLY) — why can't this user log in /
            sign up. Same read-out as `bin/ots customers diagnose`. -->

--- a/src/apps/admin/views/AdminCustomerDetail.vue
+++ b/src/apps/admin/views/AdminCustomerDetail.vue
@@ -8,6 +8,7 @@
   import RevealEmail from '@/apps/admin/components/RevealEmail.vue';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import { accountConfirmToken, confirmHeaders } from '@/apps/admin/utils/confirmHeader';
   import type {
     ColonelUserDetailReceipt,
     ColonelUserDetailSecret,
@@ -108,10 +109,14 @@
   async function callMutation(
     method: 'post' | 'delete',
     path: string,
-    body?: unknown
+    body?: unknown,
+    headers?: Record<string, string>
   ): Promise<void> {
+    const config = headers ? { headers } : undefined;
     const response =
-      method === 'delete' ? await $api.delete(path) : await $api.post(path, body ?? {});
+      method === 'delete'
+        ? await $api.delete(path, config)
+        : await $api.post(path, body ?? {}, config);
     gracefulParse(colonelUserMutationResponseSchema, response.data, 'ColonelUserMutationResponse');
   }
 
@@ -121,18 +126,25 @@
     run: runMutation,
     reset: resetMutation,
   } = useAdminMutation(async () => {
+    // Every DANGER action is gated server-side (#4326) on the SAME token the
+    // dialog asks the operator to retype. A missing one is a bug, not a
+    // fallback: sending no header is a 403 the operator cannot act on.
+    const confirm = confirmTokenFor(activeAction.value ?? 'verify');
+    const headers = confirm ? confirmHeaders(confirm) : undefined;
+
     switch (activeAction.value) {
       case 'setRole':
-        return callMutation('post', `${userUrl()}/role`, { role: pendingRole.value });
+        return callMutation('post', `${userUrl()}/role`, { role: pendingRole.value }, headers);
       case 'verify':
         return callMutation('post', `${userUrl()}/verify`);
       case 'unverify':
-        return callMutation('post', `${userUrl()}/unverify`);
+        return callMutation('post', `${userUrl()}/unverify`, {}, headers);
       case 'suspend':
         return callMutation(
           'post',
           `${userUrl()}/suspend`,
-          suspendReason.value.trim() ? { reason: suspendReason.value.trim() } : {}
+          suspendReason.value.trim() ? { reason: suspendReason.value.trim() } : {},
+          headers
         );
       case 'unsuspend':
         return callMutation('post', `${userUrl()}/unsuspend`);
@@ -140,7 +152,7 @@
         // Last line of the fail-closed gate: no typed token, no DELETE — even
         // if the dialog were somehow reached with a blank one.
         if (purgeBlocked.value) throw new Error(purgeBlockedReason.value);
-        return callMutation('delete', userUrl());
+        return callMutation('delete', userUrl(), undefined, headers);
       default:
         throw new Error('No active action');
     }
@@ -159,29 +171,48 @@
     purge: 'purge',
   };
 
-  /** Destructive actions gate confirm behind a typed-confirmation token. */
-  const DANGER_ACTIONS: readonly ActionKey[] = ['purge', 'suspend'];
+  /**
+   * Destructive actions gate confirm behind a typed-confirmation token.
+   *
+   * `setRole` and `unverify` joined this list with #4326. Promotion to colonel
+   * is privilege-granting, and unverifying an account STRIPS colonel
+   * eligibility (system roles require a verified email) — neither belongs
+   * behind a one-click confirm.
+   */
+  const DANGER_ACTIONS: readonly ActionKey[] = ['purge', 'suspend', 'setRole', 'unverify'];
 
   /**
-   * The exact string the operator must retype, or undefined for a one-click
-   * confirm. PURGE is irreversible, so it asks for the account's EMAIL — the
-   * identifier the operator can check against the ticket they are working,
-   * rather than an id they just copied off this page. Suspend is reversible and
-   * keeps the public id.
+   * The exact string the operator must retype, AND the token sent in
+   * X-OTS-Confirm — one value, so the gate cannot ask for one thing while
+   * accepting another.
    *
-   * FAILS CLOSED: a record with a blank email yields undefined, and purge is
-   * then UNAVAILABLE (disabled button + a stated reason) rather than silently
-   * dropping AdminConfirmDialog into one-click simple-confirm mode — or asking
-   * for the email while accepting some substitute identifier.
+   * It is the account's EMAIL (its public id only when the account has none),
+   * mirroring the server's `account_confirm_token` for all four danger actions.
+   * That is the identifier an operator can check against the ticket they are
+   * working, rather than an id they just copied off this page — and it is not
+   * the id the URL already carries.
+   *
+   * FAILS CLOSED: an unloaded record yields undefined, and the action is then
+   * UNAVAILABLE rather than silently dropping AdminConfirmDialog into one-click
+   * simple-confirm mode.
    */
   function confirmTokenFor(action: ActionKey): string | undefined {
     if (!DANGER_ACTIONS.includes(action)) return undefined;
-    if (action !== 'purge') return publicId.value;
-    return record.value?.email?.trim() || undefined;
+    return accountConfirmToken(record.value);
   }
 
-  /** True when purge must be unavailable: no email to type as confirmation. */
+  /** True when purge must be unavailable: no token to type as confirmation. */
   const purgeBlocked = computed(() => !confirmTokenFor('purge'));
+
+  /**
+   * The token the session-revoke verbs are gated on (#4326) — the same account
+   * identifier, resolved here because the sessions section only knows the
+   * route's public id. Falls back to that id, which is what the server resolves
+   * an account with no email to.
+   */
+  const sessionsConfirmToken = computed(
+    () => accountConfirmToken(record.value) ?? publicId.value
+  );
 
   /** Why purge is unavailable — rendered beside the disabled button. */
   const purgeBlockedReason = computed(() =>
@@ -839,7 +870,9 @@
 
       <!-- Active sessions (SIDECAR view — SessionMetadata safe_dump, no token/
            payload can appear). Guarded per-row revoke logs the user out. -->
-      <AdminCustomerSessionsSection :user-id="publicId" />
+      <AdminCustomerSessionsSection
+        :user-id="publicId"
+        :confirm-token="sessionsConfirmToken" />
 
       <!-- Account auth diagnostics (READ-ONLY) — why can't this user log in /
            sign up. Same read-out as `bin/ots customers diagnose`. -->

--- a/src/apps/admin/views/AdminCustomers.vue
+++ b/src/apps/admin/views/AdminCustomers.vue
@@ -14,6 +14,7 @@
   import type { DataTableColumn, FilterConfig } from '@/apps/admin/components/kit';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useAdminCustomers } from '@/apps/admin/stores/useAdminCustomers';
+  import { accountConfirmToken } from '@/apps/admin/utils/confirmHeader';
   import type { ColonelUser } from '@/schemas/api/internal/responses/colonel';
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import { useNotificationsStore } from '@/shared/stores/notificationsStore';
@@ -228,6 +229,16 @@
     return email ? email : null;
   }
 
+  /**
+   * The identifier the SERVER gates a row-scoped verb on (#4326): the email,
+   * its public id when the account has none. `purgeTokenFor` stays stricter —
+   * an emailless account has no purge confirmation an operator can meaningfully
+   * check against a ticket, so purge stays unavailable there.
+   */
+  function confirmTokenFor(row: ColonelUser): string | undefined {
+    return accountConfirmToken({ email: row.email, extid: row.extid });
+  }
+
   /** True when the drawer's row has no token to confirm a purge against. */
   const purgeBlocked = computed(() => purgeTokenFor(selectedCustomer.value) === null);
 
@@ -251,14 +262,22 @@
 
     if (action === 'purge') {
       // Last line of the fail-closed gate: no token, no DELETE — even if the
-      // dialog were somehow reached with a blank one.
-      if (!purgeTokenFor(target)) throw new Error(purgeBlockedReason.value);
-      await store.purge(target.user_id);
+      // dialog were somehow reached with a blank one. The same token the
+      // operator retyped is what rides in X-OTS-Confirm (#4326).
+      const token = purgeTokenFor(target);
+      if (!token) throw new Error(purgeBlockedReason.value);
+      await store.purge(target.user_id, token);
       return;
     }
     // The store patches the row in place on a 2xx; re-point the drawer at the
-    // new object so the verification state flips with no page reload.
-    const updated = await store.setVerification(target.user_id, action === 'verify');
+    // new object so the verification state flips with no page reload. Unverify
+    // is gated server-side and carries the same account identifier; verify is
+    // the restorative arm and carries nothing.
+    const updated = await store.setVerification(
+      target.user_id,
+      action === 'verify',
+      confirmTokenFor(target)
+    );
     if (!updated) return;
     actionTarget.value = updated;
     if (selectedCustomer.value?.user_id === updated.user_id) {

--- a/src/apps/admin/views/AdminCustomers.vue
+++ b/src/apps/admin/views/AdminCustomers.vue
@@ -12,7 +12,7 @@
     StatCard,
   } from '@/apps/admin/components/kit';
   import type { DataTableColumn, FilterConfig } from '@/apps/admin/components/kit';
-  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useAdminDestructiveMutation } from '@/apps/admin/composables/useAdminDestructiveMutation';
   import { useAdminCustomers } from '@/apps/admin/stores/useAdminCustomers';
   import { accountConfirmToken } from '@/apps/admin/utils/confirmHeader';
   import type { ColonelUser } from '@/schemas/api/internal/responses/colonel';
@@ -255,7 +255,7 @@
     error: mutationError,
     run: runMutation,
     reset: resetMutation,
-  } = useAdminMutation(async () => {
+  } = useAdminDestructiveMutation(async () => {
     const target = actionTarget.value;
     const action = activeAction.value;
     if (!target || !action) throw new Error('No customer selected');

--- a/src/apps/admin/views/AdminDomainDetail.vue
+++ b/src/apps/admin/views/AdminDomainDetail.vue
@@ -7,6 +7,7 @@
   import DomainProbeResult from '@/apps/admin/components/domains/DomainProbeResult.vue';
   import DomainStateBadge from '@/apps/admin/components/domains/DomainStateBadge.vue';
   import { AdminConfirmDialog, StatCard } from '@/apps/admin/components/kit';
+  import { useAdminDestructiveMutation } from '@/apps/admin/composables/useAdminDestructiveMutation';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
   import { useAdminDomains } from '@/apps/admin/stores/useAdminDomains';
@@ -301,7 +302,7 @@
     error: mutationError,
     run: runMutation,
     reset: resetMutation,
-  } = useAdminMutation(async () => {
+  } = useAdminDestructiveMutation(async () => {
     switch (activeAction.value) {
       case 'verify':
         verifyResult.value = await store.verify(publicId.value);

--- a/src/apps/admin/views/AdminDomainDetail.vue
+++ b/src/apps/admin/views/AdminDomainDetail.vue
@@ -277,6 +277,16 @@
    */
   const removeApplicable = computed(() => removePlan.value?.status === 'planned');
 
+  /**
+   * The identifier the server gates every applying domain verb on (#4326): the
+   * domain's HOSTNAME, not the extid the URL already carries. The record is
+   * loaded before any apply button exists, so the fallback is only reachable if
+   * the read failed — in which case the call 403s and says what to send.
+   */
+  function applyConfirmToken(): string {
+    return record.value?.display_domain ?? publicId.value;
+  }
+
   // ---- The single guarded-action dialog --------------------------------------
 
   type ActionKey = 'verify' | 'repair' | 'transfer' | 'remove';
@@ -300,6 +310,7 @@
         await store.repair(publicId.value, {
           orgId: repairOrgId.value.trim() || undefined,
           dryRun: false,
+          confirm: applyConfirmToken(),
         });
         return;
       case 'transfer':
@@ -307,6 +318,7 @@
           toOrg: transferToOrg.value.trim(),
           fromOrg: transferFromOrg.value.trim() || undefined,
           dryRun: false,
+          confirm: applyConfirmToken(),
         });
         return;
       case 'remove': {
@@ -317,7 +329,7 @@
         // drift) means the server only PREVIEWED — reporting success would
         // toast "removed", drop the cached row and navigate away while the
         // domain still exists.
-        const removeAck = await store.remove(publicId.value, false);
+        const removeAck = await store.remove(publicId.value, false, applyConfirmToken());
         if (!removeAck || removeAck.dry_run !== false) {
           throw new Error(t('web.admin.domains.actions.remove.notApplied'));
         }
@@ -461,7 +473,7 @@
       return;
     }
 
-    await store.override(publicId.value, options);
+    await store.override(publicId.value, { ...options, confirm: applyConfirmToken() });
   });
 
   function openOverride(): void {

--- a/src/apps/admin/views/AdminDomainToolbox.vue
+++ b/src/apps/admin/views/AdminDomainToolbox.vue
@@ -9,6 +9,7 @@
     KitPagination,
   } from '@/apps/admin/components/kit';
   import type { DataTableColumn } from '@/apps/admin/components/kit';
+  import { useAdminDestructiveMutation } from '@/apps/admin/composables/useAdminDestructiveMutation';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useAdminDomainToolbox } from '@/apps/admin/stores/useAdminDomainToolbox';
   import { confirmHeaders } from '@/apps/admin/utils/confirmHeader';
@@ -310,7 +311,7 @@
     error: transferApplyError,
     run: runTransferApply,
     reset: resetTransferApply,
-  } = useAdminMutation(async (extid: string) => {
+  } = useAdminDestructiveMutation(async (extid: string) => {
     const response = await $api.post(
       `/api/colonel/domains/${encodeURIComponent(extid)}/transfer`,
       transferBody(false),

--- a/src/apps/admin/views/AdminDomainToolbox.vue
+++ b/src/apps/admin/views/AdminDomainToolbox.vue
@@ -11,6 +11,7 @@
   import type { DataTableColumn } from '@/apps/admin/components/kit';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useAdminDomainToolbox } from '@/apps/admin/stores/useAdminDomainToolbox';
+  import { confirmHeaders } from '@/apps/admin/utils/confirmHeader';
   import { colonelDomainVerifyResponseSchema } from '@/schemas/api/internal/responses/colonel-domains';
   import type { ColonelOrphanedDomain } from '@/schemas/api/internal/responses/colonel-domaintoolbox';
   import type {
@@ -165,6 +166,13 @@
   const repairOrgId = ref('');
   const repairPlan = ref<ColonelDomainRepairDetails | null>(null);
   const repairDialogOpen = ref(false);
+  /**
+   * The domain's HOSTNAME, captured off the preview's `record` — the toolbox is
+   * driven by extid alone, and the server requires the hostname in
+   * X-OTS-Confirm on the apply (#4326). The apply button only exists behind a
+   * `planned` preview, so this is always populated by the time it is read.
+   */
+  const repairDomainName = ref('');
 
   /** Build the repair request body; org_id only when supplied. */
   function repairBody(dryRun: boolean): Record<string, unknown> {
@@ -190,7 +198,10 @@
       response.data,
       'ColonelDomainRepairResponse'
     );
-    if (parsed.ok) repairPlan.value = parsed.data.details ?? null;
+    if (parsed.ok) {
+      repairPlan.value = parsed.data.details ?? null;
+      repairDomainName.value = parsed.data.record.display_domain;
+    }
   });
 
   const {
@@ -201,7 +212,8 @@
   } = useAdminMutation(async (extid: string) => {
     const response = await $api.post(
       `/api/colonel/domains/${encodeURIComponent(extid)}/repair`,
-      repairBody(false)
+      repairBody(false),
+      { headers: confirmHeaders(repairDomainName.value) }
     );
     gracefulParse(
       colonelDomainRepairResponseSchema,
@@ -258,6 +270,8 @@
   const transferFromOrg = ref('');
   const transferPlan = ref<ColonelDomainTransferDetails | null>(null);
   const transferDialogOpen = ref(false);
+  /** As {@link repairDomainName}: the hostname X-OTS-Confirm needs on the apply. */
+  const transferDomainName = ref('');
 
   function transferBody(dryRun: boolean): Record<string, unknown> {
     const body: Record<string, unknown> = {
@@ -285,7 +299,10 @@
       response.data,
       'ColonelDomainTransferResponse'
     );
-    if (parsed.ok) transferPlan.value = parsed.data.details ?? null;
+    if (parsed.ok) {
+      transferPlan.value = parsed.data.details ?? null;
+      transferDomainName.value = parsed.data.record.display_domain;
+    }
   });
 
   const {
@@ -296,7 +313,8 @@
   } = useAdminMutation(async (extid: string) => {
     const response = await $api.post(
       `/api/colonel/domains/${encodeURIComponent(extid)}/transfer`,
-      transferBody(false)
+      transferBody(false),
+      { headers: confirmHeaders(transferDomainName.value) }
     );
     gracefulParse(
       colonelDomainTransferResponseSchema,

--- a/src/apps/admin/views/AdminDomains.vue
+++ b/src/apps/admin/views/AdminDomains.vue
@@ -307,7 +307,9 @@
       return;
     }
 
-    await store.override(domain.extid, options);
+    // The server requires the domain's HOSTNAME in X-OTS-Confirm (#4326) —
+    // overriding verification bypasses DNS proof of ownership.
+    await store.override(domain.extid, { ...options, confirm: domain.display_domain });
   });
 
   function openOverride(): void {

--- a/src/apps/admin/views/AdminOrganizationDetail.vue
+++ b/src/apps/admin/views/AdminOrganizationDetail.vue
@@ -11,6 +11,7 @@
   import type { AddMembershipRequest } from '@/apps/admin/components/organizations/membershipSchemas';
   import { colonelAddMembershipResponseSchema } from '@/apps/admin/components/organizations/membershipSchemas';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { confirmHeaders, orgConfirmToken } from '@/apps/admin/utils/confirmHeader';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
   import type { InvestigateOrganizationResult } from '@/schemas/api/internal/responses/colonel';
   import {
@@ -88,6 +89,14 @@
   });
 
   const record = computed(() => orgData.value?.record ?? null);
+
+  /**
+   * The identifier the server gates every org-scoped destructive verb on
+   * (#4326): the organization's NAME, its public id when it has none. Mirrors
+   * `ColonelAPI::Logic::DestructiveAction#org_confirm_token`; the two must agree
+   * or the call 403s.
+   */
+  const orgToken = computed(() => orgConfirmToken(record.value) ?? props.id);
   const details = computed(() => orgData.value?.details ?? null);
   const entitlements = computed(() => details.value?.entitlements ?? null);
 
@@ -332,8 +341,12 @@
     const base = `${orgUrl()}/entitlements`;
     const response =
       action === 'clear'
-        ? await $api.delete(`${base}/overrides`)
-        : await $api.post(`${base}/${action}`, { entitlement: pendingEntitlement.value });
+        ? await $api.delete(`${base}/overrides`, { headers: confirmHeaders(orgToken.value) })
+        : await $api.post(
+            `${base}/${action}`,
+            { entitlement: pendingEntitlement.value },
+            { headers: confirmHeaders(orgToken.value) }
+          );
 
     // Tripwire only: a 2xx means the mutation succeeded regardless of ack shape;
     // the panel is driven by the refreshed detail GET, not this ack.
@@ -766,7 +779,11 @@
     // the operator reads the reason instead of a generic request failure.
     if (deleteBlockedReason.value) throw new Error(deleteBlockedReason.value);
 
-    const response = await $api.delete(deleteUrl(false));
+    // The preview above is EXEMPT (it writes nothing); only the apply carries
+    // the organization's name in X-OTS-Confirm (#4326).
+    const response = await $api.delete(deleteUrl(false), {
+      headers: confirmHeaders(orgToken.value),
+    });
     const parsed = gracefulParse(
       colonelDeleteOrganizationResponseSchema,
       response.data,
@@ -877,13 +894,18 @@
 
     let response;
     try {
-      response = await $api.post(`${orgUrl()}/members`, {
-        // Always the EXTID, never an email address: the colonel adapter runs
-        // `customer` through an identifier sanitizer, and the account picker
-        // already resolved the address to a public id.
-        customer: target.customer,
-        role: target.role,
-      });
+      response = await $api.post(
+        `${orgUrl()}/members`,
+        {
+          // Always the EXTID, never an email address: the colonel adapter runs
+          // `customer` through an identifier sanitizer, and the account picker
+          // already resolved the address to a public id.
+          customer: target.customer,
+          role: target.role,
+        },
+        // Privilege-granting, so gated server-side on the org's name (#4326).
+        { headers: confirmHeaders(orgToken.value) }
+      );
     } catch (err) {
       throw new Error(addMemberFailureMessage(err));
     }

--- a/src/apps/admin/views/AdminOrganizationDetail.vue
+++ b/src/apps/admin/views/AdminOrganizationDetail.vue
@@ -10,6 +10,7 @@
   import EntitlementPicker from '@/apps/admin/components/organizations/EntitlementPicker.vue';
   import type { AddMembershipRequest } from '@/apps/admin/components/organizations/membershipSchemas';
   import { colonelAddMembershipResponseSchema } from '@/apps/admin/components/organizations/membershipSchemas';
+  import { useAdminDestructiveMutation } from '@/apps/admin/composables/useAdminDestructiveMutation';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { confirmHeaders, orgConfirmToken } from '@/apps/admin/utils/confirmHeader';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
@@ -774,7 +775,7 @@
     error: deleteError,
     run: runDeleteMutation,
     reset: resetDelete,
-  } = useAdminMutation(async () => {
+  } = useAdminDestructiveMutation(async () => {
     // The server refuses these on the apply path too (4xx). Checking here means
     // the operator reads the reason instead of a generic request failure.
     if (deleteBlockedReason.value) throw new Error(deleteBlockedReason.value);

--- a/src/apps/admin/views/AdminSecrets.vue
+++ b/src/apps/admin/views/AdminSecrets.vue
@@ -4,7 +4,7 @@
 
   import RevealEmail from '@/apps/admin/components/RevealEmail.vue';
   import { AdminConfirmDialog, JsonViewer } from '@/apps/admin/components/kit';
-  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useAdminDestructiveMutation } from '@/apps/admin/composables/useAdminDestructiveMutation';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
   import { confirmHeaders } from '@/apps/admin/utils/confirmHeader';
   import {
@@ -251,7 +251,7 @@
     error: deleteError,
     run: runDelete,
     reset: resetDelete,
-  } = useAdminMutation(async () => {
+  } = useAdminDestructiveMutation(async () => {
     const secretId = receiptRecord.value?.secret_id;
     if (!secretId) throw new Error('No secret loaded');
     // The shortid the operator retyped is also what the server requires in

--- a/src/apps/admin/views/AdminSecrets.vue
+++ b/src/apps/admin/views/AdminSecrets.vue
@@ -254,8 +254,11 @@
   } = useAdminDestructiveMutation(async () => {
     const secretId = receiptRecord.value?.secret_id;
     if (!secretId) throw new Error('No secret loaded');
-    // The shortid the operator retyped is also what the server requires in
-    // X-OTS-Confirm (#4326) — the URL carries the objid, not the shortid.
+    // X-OTS-Confirm carries the RECEIPT shortid, not the secret shortid (#4326):
+    // the route is keyed by the secret objid and secret.shortid is just its first
+    // 8 chars, so confirming with it would be derivable from the URL and no second
+    // factor at all. DeleteSecret expects the receipt shortid, which the read-out
+    // exposes as details.metadata.shortid — see deleteToken below.
     const response = await $api.delete(
       `/api/colonel/secrets/${encodeURIComponent(secretId)}`,
       { headers: confirmHeaders(deleteToken.value) }
@@ -269,8 +272,15 @@
     );
   });
 
-  /** The exact string the operator must retype to enable the delete. */
-  const deleteToken = computed(() => receiptRecord.value?.shortid ?? '');
+  /**
+   * The exact string the operator must retype to enable the delete: the RECEIPT
+   * shortid (#4326), shown in the receipt-metadata read-out. NOT the secret
+   * shortid (`receiptRecord.shortid`) — that is `secret_id[0,8]`, derivable from
+   * the URL, and the server rejects it. Empty when the secret has no receipt, in
+   * which case DeleteSecret fails closed server-side and the secret must be
+   * removed with the CLI.
+   */
+  const deleteToken = computed(() => receiptDetails.value?.metadata?.shortid ?? '');
 
   function requestDelete(): void {
     resetDelete();

--- a/src/apps/admin/views/AdminSecrets.vue
+++ b/src/apps/admin/views/AdminSecrets.vue
@@ -6,6 +6,7 @@
   import { AdminConfirmDialog, JsonViewer } from '@/apps/admin/components/kit';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import { confirmHeaders } from '@/apps/admin/utils/confirmHeader';
   import {
     colonelSecretDeleteResponseSchema,
     colonelSecretReceiptResponseSchema,
@@ -253,8 +254,11 @@
   } = useAdminMutation(async () => {
     const secretId = receiptRecord.value?.secret_id;
     if (!secretId) throw new Error('No secret loaded');
+    // The shortid the operator retyped is also what the server requires in
+    // X-OTS-Confirm (#4326) — the URL carries the objid, not the shortid.
     const response = await $api.delete(
-      `/api/colonel/secrets/${encodeURIComponent(secretId)}`
+      `/api/colonel/secrets/${encodeURIComponent(secretId)}`,
+      { headers: confirmHeaders(deleteToken.value) }
     );
     // A 2xx means the secret was deleted server-side regardless of ack shape; the
     // parse keeps the contract a live tripwire without failing the action.

--- a/src/apps/admin/views/AdminSessions.vue
+++ b/src/apps/admin/views/AdminSessions.vue
@@ -59,7 +59,20 @@
   const notifications = useNotificationsStore();
 
   const store = useAdminSessions();
-  const { sessions, pagination, scan, loading, error } = storeToRefs(store);
+  const { sessions, pagination, scan, currentSessionHandle, loading, error } =
+    storeToRefs(store);
+
+  /**
+   * The acting colonel's OWN row (#4328). Revoking it signs the operator out
+   * mid-incident, so the server refuses it with a 422; disabling the button
+   * here is defence in depth and spares them the round trip. Matched by
+   * HANDLE — the raw session id never reaches this console.
+   */
+  function isCurrentSession(sessionHandle: string): boolean {
+    return (
+      currentSessionHandle.value !== null && sessionHandle === currentSessionHandle.value
+    );
+  }
 
   // ---- List + search --------------------------------------------------------
 
@@ -329,6 +342,9 @@
   });
 
   function requestRevoke(row: ColonelSession): void {
+    // Fail closed: the disabled button is the UI affordance, this is the guard.
+    // The server refuses a self-revoke regardless (#4328).
+    if (isCurrentSession(row.session_handle)) return;
     revokeTarget.value = row.session_handle;
     revokeOwner.value = row.external_id ?? '';
     revokeToken.value = row.email?.trim() || row.external_id?.trim() || row.session_handle;
@@ -460,7 +476,13 @@
           <button
             type="button"
             :data-testid="`revoke-${row.session_handle}`"
-            class="text-sm font-medium text-red-600 hover:text-red-800 focus:ring-2 focus:ring-red-500 focus:outline-none dark:text-red-400 dark:hover:text-red-300"
+            :disabled="isCurrentSession(row.session_handle)"
+            :title="
+              isCurrentSession(row.session_handle)
+                ? t('web.admin.sessions.revoke.ownSession')
+                : undefined
+            "
+            class="text-sm font-medium text-red-600 hover:text-red-800 focus:ring-2 focus:ring-red-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:text-red-400 dark:hover:text-red-300"
             @click.stop="requestRevoke(row)">
             {{ t('web.admin.sessions.revoke.button') }}
           </button>
@@ -621,7 +643,12 @@
         <button
           type="button"
           data-testid="session-revoke-button"
-          :disabled="!selectedSession"
+          :disabled="!selectedSession || isCurrentSession(selectedSession.session_handle)"
+          :title="
+            selectedSession && isCurrentSession(selectedSession.session_handle)
+              ? t('web.admin.sessions.revoke.ownSession')
+              : undefined
+          "
           class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:ring-2 focus:ring-red-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
           @click="selectedSession && requestRevoke(selectedSession)">
           <OIcon

--- a/src/apps/admin/views/AdminSessions.vue
+++ b/src/apps/admin/views/AdminSessions.vue
@@ -14,6 +14,7 @@
   import type { DataTableColumn } from '@/apps/admin/components/kit';
   import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
+  import { confirmHeaders } from '@/apps/admin/utils/confirmHeader';
   import { useAdminSessions } from '@/apps/admin/stores/useAdminSessions';
   import type { ColonelSession } from '@/schemas/api/internal/responses/colonel-sessions';
   import {
@@ -294,9 +295,10 @@
   /** Owner hint for the server's two-stage handle resolution (see detailUrl). */
   const revokeOwner = ref('');
   /**
-   * What the operator retypes AND what P2 will send in X-OTS-Confirm: the session
-   * owner's email (its extid when it has none). Never blank — a blank token
-   * silently degrades AdminConfirmDialog to a one-click confirm.
+   * What the operator retypes AND what rides in X-OTS-Confirm (#4326): the
+   * session owner's email (its extid when it has none, the handle for an
+   * anonymous session). Never blank — a blank token silently degrades
+   * AdminConfirmDialog to a one-click confirm, and the server would 403.
    */
   const revokeToken = ref('');
 
@@ -309,8 +311,13 @@
     const handle = revokeTarget.value;
     if (!handle) throw new Error('No session selected');
     const owner = encodeURIComponent(revokeOwner.value);
+    // The owner identifier the operator retyped is also what the server requires
+    // in X-OTS-Confirm (#4326). It rides a HEADER, never the query string: the
+    // token is usually an email address, and `?user_id=` is only an owner HINT
+    // for the handle lookup.
     const response = await $api.delete(
-      `/api/colonel/sessions/${encodeURIComponent(handle)}?user_id=${owner}`
+      `/api/colonel/sessions/${encodeURIComponent(handle)}?user_id=${owner}`,
+      { headers: confirmHeaders(revokeToken.value) }
     );
     // A 2xx means the session was revoked server-side regardless of ack shape;
     // the parse keeps the contract a live tripwire without failing the action.

--- a/src/apps/admin/views/AdminSessions.vue
+++ b/src/apps/admin/views/AdminSessions.vue
@@ -39,12 +39,19 @@
    *   a thin adapter over `Onetime::Operations::Sessions::List` (bounded scan,
    *   #2211) and supports a server-side `search` filter (email / external id).
    * - DETAIL DRAWER: a row opens {@link DetailDrawer} loading
-   *   `GET /api/colonel/sessions/:session_id` via {@link useResourceFetch}
+   *   `GET /api/colonel/sessions/:session_handle` via {@link useResourceFetch}
    *   (`Sessions::Inspect`) — typed field read-out + raw JSON inspector.
    * - GUARDED REVOKE (D4): revoking a session logs that user out mid-flight, so it
-   *   is gated by {@link AdminConfirmDialog} typed-confirmation (retype the session
-   *   id) in danger mode and audited SERVER-SIDE by `Sessions::Delete`. It can be
-   *   triggered from the row action or the drawer footer.
+   *   is gated by {@link AdminConfirmDialog} typed-confirmation in danger mode and
+   *   audited SERVER-SIDE by `Sessions::Delete`. It can be triggered from the row
+   *   action or the drawer footer.
+   *
+   * OPAQUE HANDLES (#4330): a row carries `session_handle`, a non-reversible
+   * digest — never the raw session id, which is byte-identical to the user's
+   * `onetime.session` cookie. Routing, the revoke URL and the drawer title all
+   * speak handles, and the value the operator retypes is the session OWNER's
+   * email (P2 sends that same value in `X-OTS-Confirm`), so a screen share or a
+   * log capture of this console yields nothing replayable.
    */
   const { t } = useI18n();
   const $api = useApi();
@@ -63,7 +70,7 @@
   // filters out CSRF-only anonymous ones — so the near-constant `Auth` column is
   // dropped in favour of `Role`, which actually varies and aids triage.
   const columns = computed<DataTableColumn<ColonelSession>[]>(() => [
-    { key: 'session_id', label: t('web.admin.sessions.columns.sessionId') },
+    { key: 'session_handle', label: t('web.admin.sessions.columns.sessionHandle') },
     { key: 'email', label: t('web.admin.sessions.columns.email') },
     { key: 'role', label: t('web.admin.sessions.columns.role') },
     { key: 'external_id', label: t('web.admin.sessions.columns.externalId') },
@@ -158,8 +165,17 @@
   /** The row that opened the drawer — the source of the detail id. */
   const selectedSession = ref<ColonelSession | null>(null);
 
-  const detailUrl = (): string =>
-    `/api/colonel/sessions/${encodeURIComponent(selectedSession.value?.session_id ?? '')}`;
+  /**
+   * The detail endpoint takes the handle, plus the owning account as an OWNER
+   * HINT: it lets the server resolve the handle over that customer's own bounded
+   * active-session set instead of a 10k-key keyspace scan. It is not
+   * authorization — a wrong or absent hint just falls back to the scan.
+   */
+  const detailUrl = (): string => {
+    const handle = encodeURIComponent(selectedSession.value?.session_handle ?? '');
+    const owner = encodeURIComponent(selectedSession.value?.external_id ?? '');
+    return `/api/colonel/sessions/${handle}?user_id=${owner}`;
+  };
 
   const {
     data: detailData,
@@ -175,6 +191,18 @@
   });
 
   const detailRecord = computed(() => detailData.value?.record ?? null);
+
+  /**
+   * Whether this "not found" may really mean "not sampled". The server resolves
+   * a handle over the owner's own sessions when the row names one, and falls
+   * back to a bounded keyspace scan otherwise (`details.scan_capped` reports the
+   * truncation on a successful load; a 404 body carries nothing). So a miss is
+   * only ambiguous when the listing's own scan was capped, or when the row had
+   * no owner to hint with — exactly the two cases surfaced here.
+   */
+  const detailMissMayBeSampling = computed(
+    () => scan.value?.scan_capped === true || !selectedSession.value?.external_id
+  );
 
   /** A non-404 network/HTTP failure, or a Zod contract mismatch. */
   const detailLoadFailed = computed(
@@ -216,8 +244,11 @@
     const r = detailRecord.value;
     if (!r) return [];
     return [
-      { key: 'sessionId', label: t('web.admin.sessions.fields.sessionId'), value: r.session_id },
-      { key: 'key', label: t('web.admin.sessions.fields.key'), value: r.key },
+      {
+        key: 'sessionHandle',
+        label: t('web.admin.sessions.fields.sessionHandle'),
+        value: r.session_handle,
+      },
       { key: 'ttl', label: t('web.admin.sessions.fields.ttl'), value: ttlLabel(r.ttl) },
       {
         key: 'authenticated',
@@ -258,8 +289,16 @@
   // ---- Guarded revoke (D4) --------------------------------------------------
 
   const revokeDialogOpen = ref(false);
-  /** The session id the confirm dialog is gating (retype token + request target). */
+  /** Routes the request. Never rendered in full, never a confirmation token. */
   const revokeTarget = ref('');
+  /** Owner hint for the server's two-stage handle resolution (see detailUrl). */
+  const revokeOwner = ref('');
+  /**
+   * What the operator retypes AND what P2 will send in X-OTS-Confirm: the session
+   * owner's email (its extid when it has none). Never blank — a blank token
+   * silently degrades AdminConfirmDialog to a one-click confirm.
+   */
+  const revokeToken = ref('');
 
   const {
     loading: revokeLoading,
@@ -267,10 +306,11 @@
     run: runRevoke,
     reset: resetRevoke,
   } = useAdminMutation(async () => {
-    const sessionId = revokeTarget.value;
-    if (!sessionId) throw new Error('No session selected');
+    const handle = revokeTarget.value;
+    if (!handle) throw new Error('No session selected');
+    const owner = encodeURIComponent(revokeOwner.value);
     const response = await $api.delete(
-      `/api/colonel/sessions/${encodeURIComponent(sessionId)}`
+      `/api/colonel/sessions/${encodeURIComponent(handle)}?user_id=${owner}`
     );
     // A 2xx means the session was revoked server-side regardless of ack shape;
     // the parse keeps the contract a live tripwire without failing the action.
@@ -281,14 +321,16 @@
     );
   });
 
-  function requestRevoke(sessionId: string): void {
-    revokeTarget.value = sessionId;
+  function requestRevoke(row: ColonelSession): void {
+    revokeTarget.value = row.session_handle;
+    revokeOwner.value = row.external_id ?? '';
+    revokeToken.value = row.email?.trim() || row.external_id?.trim() || row.session_handle;
     resetRevoke();
     revokeDialogOpen.value = true;
   }
 
   async function onRevokeConfirm(): Promise<void> {
-    const revokedId = revokeTarget.value;
+    const revokedHandle = revokeTarget.value;
     const ok = await runRevoke();
     if (!ok) return; // Failure message stays in the dialog for retry/cancel.
 
@@ -296,7 +338,7 @@
     notifications.show(t('web.admin.sessions.revoke.success'), 'success');
 
     // If the revoked session is the one open in the drawer, close it.
-    if (selectedSession.value?.session_id === revokedId) {
+    if (selectedSession.value?.session_handle === revokedHandle) {
       closeDrawer();
     }
     // The revoked row is gone — refresh the current page.
@@ -361,14 +403,21 @@
       <DataTable
         :columns="columns"
         :rows="sessions"
-        row-key="session_id"
+        row-key="session_handle"
         :loading="loading"
         :empty-text="t('web.admin.sessions.list.empty')"
         clickable-rows
         testid="sessions-table"
         @row-click="openDetail">
-        <template #cell-session_id="{ row }">
-          <span class="font-mono text-gray-900 dark:text-white">{{ row.session_id }}</span>
+        <!-- Truncated: the full handle is not a credential, but a short prefix
+             is what an operator can match against a CLI row without a wall of
+             hex; the title attribute carries the whole value. -->
+        <template #cell-session_handle="{ row }">
+          <span
+            class="font-mono text-gray-900 dark:text-white"
+            :title="row.session_handle"
+            >{{ row.session_handle.slice(0, 12) }}…</span
+          >
         </template>
 
         <template #cell-email="{ row }">
@@ -403,9 +452,9 @@
         <template #cell-actions="{ row }">
           <button
             type="button"
-            :data-testid="`revoke-${row.session_id}`"
+            :data-testid="`revoke-${row.session_handle}`"
             class="text-sm font-medium text-red-600 hover:text-red-800 focus:ring-2 focus:ring-red-500 focus:outline-none dark:text-red-400 dark:hover:text-red-300"
-            @click.stop="requestRevoke(row.session_id)">
+            @click.stop="requestRevoke(row)">
             {{ t('web.admin.sessions.revoke.button') }}
           </button>
         </template>
@@ -446,7 +495,11 @@
     <!-- Detail drawer (inspect) -->
     <DetailDrawer
       v-model:open="drawerOpen"
-      :title="selectedSession ? t('web.admin.sessions.drawer.title', { id: selectedSession.session_id }) : ''"
+      :title="
+        selectedSession
+          ? t('web.admin.sessions.drawer.title', { id: selectedSession.session_handle.slice(0, 12) })
+          : ''
+      "
       :subtitle="selectedSession ? emailLabel(selectedSession.email) : undefined"
       width-class="max-w-lg"
       testid="session-drawer"
@@ -479,6 +532,12 @@
         </h3>
         <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
           {{ t('web.admin.sessions.drawer.notFoundDescription') }}
+        </p>
+        <p
+          v-if="detailMissMayBeSampling"
+          class="mt-2 text-sm text-amber-700 dark:text-amber-400"
+          data-testid="session-drawer-scan-capped">
+          {{ t('web.admin.sessions.errors.scanCapped') }}
         </p>
       </div>
 
@@ -541,6 +600,8 @@
           <h3 class="mb-2 text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-400">
             {{ t('web.admin.sessions.sections.raw') }}
           </h3>
+          <!-- Credential keys (csrf) are stripped SERVER-SIDE before this
+               payload is serialized (#4330) — nothing to filter here. -->
           <JsonViewer
             :data="detailData?.details?.data"
             :expand-depth="1"
@@ -555,7 +616,7 @@
           data-testid="session-revoke-button"
           :disabled="!selectedSession"
           class="inline-flex w-full items-center justify-center gap-1 rounded-md border border-red-300 px-3 py-2 text-sm font-semibold text-red-700 hover:bg-red-50 focus:ring-2 focus:ring-red-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
-          @click="selectedSession && requestRevoke(selectedSession.session_id)">
+          @click="selectedSession && requestRevoke(selectedSession)">
           <OIcon
             collection="heroicons"
             name="trash"
@@ -569,8 +630,13 @@
     <AdminConfirmDialog
       v-model:open="revokeDialogOpen"
       :title="t('web.admin.sessions.revoke.confirmTitle')"
-      :description="t('web.admin.sessions.revoke.confirmDescription', { id: revokeTarget })"
-      :confirm-token="revokeTarget"
+      :description="
+        t('web.admin.sessions.revoke.confirmDescription', {
+          id: revokeTarget.slice(0, 12),
+          token: revokeToken,
+        })
+      "
+      :confirm-token="revokeToken"
       variant="danger"
       :confirm-text="t('web.admin.sessions.revoke.button')"
       :loading="revokeLoading"

--- a/src/apps/admin/views/AdminSessions.vue
+++ b/src/apps/admin/views/AdminSessions.vue
@@ -12,7 +12,7 @@
     KitPagination,
   } from '@/apps/admin/components/kit';
   import type { DataTableColumn } from '@/apps/admin/components/kit';
-  import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+  import { useAdminDestructiveMutation } from '@/apps/admin/composables/useAdminDestructiveMutation';
   import { useResourceFetch } from '@/apps/admin/composables/useResourceFetch';
   import { confirmHeaders } from '@/apps/admin/utils/confirmHeader';
   import { useAdminSessions } from '@/apps/admin/stores/useAdminSessions';
@@ -307,7 +307,7 @@
     error: revokeError,
     run: runRevoke,
     reset: resetRevoke,
-  } = useAdminMutation(async () => {
+  } = useAdminDestructiveMutation(async () => {
     const handle = revokeTarget.value;
     if (!handle) throw new Error('No session selected');
     const owner = encodeURIComponent(revokeOwner.value);

--- a/src/schemas/api/internal/responses/colonel-customer-sessions.ts
+++ b/src/schemas/api/internal/responses/colonel-customer-sessions.ts
@@ -22,19 +22,13 @@
 // and are kept numeric. user_id is the customer EXTERNAL id (extid, 'ur...').
 
 import { createApiResponseSchema } from '@/schemas/api/base';
+import { sessionHandleSchema } from './session-handle';
 import { z } from 'zod';
 
-/**
- * The non-reversible session handle (F-01): the first 32 hex chars of an
- * HMAC-SHA256 over the raw sid (SessionMetadata.handle_for). Validating the
- * exact shape — not just z.string() — makes the schema a security tripwire:
- * a backend regression that leaks the raw 64+-char sid (or anything else)
- * under a *_handle key fails parsing here instead of flowing a replayable
- * bearer value into the admin UI.
- */
-export const sessionHandleSchema = z
-  .string()
-  .regex(/^[0-9a-f]{32}$/, 'session_handle must be a 32-char lowercase hex handle');
+// The handle definition moved to ./session-handle when #4330 gave the GLOBAL
+// console handles too — one regex, one tripwire, two contracts. Re-exported so
+// existing importers of this module are untouched.
+export { sessionHandleSchema };
 
 // ============================================================================
 // ListCustomerSessions — one customer's session rows

--- a/src/schemas/api/internal/responses/colonel-elevation.ts
+++ b/src/schemas/api/internal/responses/colonel-elevation.ts
@@ -1,0 +1,87 @@
+// src/schemas/api/internal/responses/colonel-elevation.ts
+//
+// The colonel step-up (sudo) window (#4327).
+//
+//   GET    /api/colonel/elevation → GetElevationStatus
+//   POST   /api/colonel/elevation → ElevateSession
+//   DELETE /api/colonel/elevation → DropElevation
+//
+// A dedicated contract rather than a field on GET /info: GetColonelInfo is
+// pinned to the frozen `colonelInfo` shape in ./colonel.ts, which this epic
+// deliberately does not disturb.
+//
+// Shapes verified against the logic classes in
+// apps/api/colonel/logic/colonel/{get_elevation_status,elevate_session,drop_elevation}.rb.
+// Epochs are bare Unix seconds; the console counts down CLIENT-SIDE from
+// `expires_at` and never polls the endpoint (a poll would advance the session's
+// last_activity_at on every tick and make #4331's idle timeout unreachable).
+
+import { createApiResponseSchema } from '@/schemas/api/base';
+import { z } from 'zod';
+
+/**
+ * The window itself. `expires_at` is null exactly when `elevated` is false —
+ * which includes a window minted by a DIFFERENT identity in the same session,
+ * since the server ignores those (a cookie can outlive an identity change).
+ */
+export const colonelElevationRecordSchema = z.object({
+  elevated: z.boolean(),
+  expires_at: z.number().nullable(),
+  seconds_remaining: z.number(),
+});
+
+/**
+ * Per-ACCOUNT capability, not global config. `factors` is what THIS operator
+ * may use, so the console can render "your account has no password and no grace
+ * is configured" instead of looping on an unsatisfiable prompt.
+ *
+ * `password_available` false + `factors` ['password'] is the SSO-only-no-grace
+ * fork: nothing the operator can do from the browser, so the prompt shows the
+ * remediation and no input.
+ */
+export const colonelElevationDetailsSchema = z.object({
+  enabled: z.boolean(),
+  window: z.number(),
+  reauth_grace: z.number(),
+  grace_available: z.boolean(),
+  password_available: z.boolean(),
+  factors: z.array(z.string()),
+});
+
+/**
+ * POST's details name the factor the live window was minted with, so the banner
+ * can label a `recent_auth` window distinctly while it is live — the weaker path
+ * must be visible, not silent.
+ */
+export const colonelElevationGrantDetailsSchema = z.object({
+  factor: z.string(),
+  window: z.number(),
+});
+
+/** DELETE's details: a message plus whether anything was actually live. */
+export const colonelElevationDropDetailsSchema = z.object({
+  message: z.string(),
+  was_elevated: z.boolean(),
+});
+
+export const colonelElevationStatusResponseSchema = createApiResponseSchema(
+  colonelElevationRecordSchema,
+  colonelElevationDetailsSchema
+);
+
+export const colonelElevationGrantResponseSchema = createApiResponseSchema(
+  colonelElevationRecordSchema,
+  colonelElevationGrantDetailsSchema
+);
+
+export const colonelElevationDropResponseSchema = createApiResponseSchema(
+  colonelElevationRecordSchema,
+  colonelElevationDropDetailsSchema
+);
+
+export type ColonelElevationRecord = z.infer<typeof colonelElevationRecordSchema>;
+export type ColonelElevationDetails = z.infer<typeof colonelElevationDetailsSchema>;
+export type ColonelElevationGrantDetails = z.infer<typeof colonelElevationGrantDetailsSchema>;
+export type ColonelElevationStatusResponse = z.infer<typeof colonelElevationStatusResponseSchema>;
+export type ColonelElevationGrantResponse = z.infer<typeof colonelElevationGrantResponseSchema>;
+export type ColonelElevationDropResponse = z.infer<typeof colonelElevationDropResponseSchema>;

--- a/src/schemas/api/internal/responses/colonel-sessions.ts
+++ b/src/schemas/api/internal/responses/colonel-sessions.ts
@@ -72,11 +72,23 @@ export const colonelSessionScanSchema = z.object({
   scan_capped: z.boolean(),
 });
 
-/** Sessions list response details: rows + pagination + keyspace scan meta. */
+/**
+ * Sessions list response details: rows + pagination + keyspace scan meta, plus
+ * the acting colonel's OWN session handle.
+ *
+ * `current_session_handle` (#4328) lets the console badge and disable the
+ * operator's own row: revoking it would sign them out mid-incident, and the
+ * server refuses it with a 422 regardless — this only spares them the round
+ * trip. It is a HANDLE, never the sid, so the response still carries nothing
+ * replayable. Null when the request session cannot be identified, and
+ * `.optional()` so a response from a backend predating #4328 still parses
+ * instead of dropping the whole session list mid-deploy.
+ */
 export const colonelSessionsDetailsSchema = z.object({
   sessions: z.array(colonelSessionSchema),
   pagination: paginationSchema,
   scan: colonelSessionScanSchema,
+  current_session_handle: sessionHandleSchema.nullable().optional(),
 });
 
 // ============================================================================

--- a/src/schemas/api/internal/responses/colonel-sessions.ts
+++ b/src/schemas/api/internal/responses/colonel-sessions.ts
@@ -7,9 +7,16 @@
 // session endpoints (there was no old colonel session screen — CLI-only until
 // now):
 //
-//   - ListSessions     → GET    /api/colonel/sessions             (list + search)
-//   - GetSessionDetail → GET    /api/colonel/sessions/:session_id (detail drawer)
-//   - DeleteSession    → DELETE /api/colonel/sessions/:session_id (guarded revoke)
+//   - ListSessions     → GET    /api/colonel/sessions                 (list + search)
+//   - GetSessionDetail → GET    /api/colonel/sessions/:session_handle (detail drawer)
+//   - DeleteSession    → DELETE /api/colonel/sessions/:session_handle (guarded revoke)
+//
+// Sessions are identified by session_handle, a non-reversible digest of the raw
+// session id (#4330 / finding F-01) — the same identifier the per-customer panel
+// already used. The raw sid IS the `onetime.session` cookie and the Redis blob
+// key name, so neither it nor `key` may appear on the wire; both were removed
+// from these shapes, which makes any backend regression that re-adds one a
+// parse failure here rather than a credential rendered in the console.
 //
 // Shapes verified against the live logic classes
 // (apps/api/colonel/logic/colonel/{list_sessions,get_session_detail,delete_session}.rb),
@@ -19,6 +26,7 @@
 
 import { createApiResponseSchema } from '@/schemas/api/base';
 import { paginationSchema } from './colonel';
+import { sessionHandleSchema } from './session-handle';
 import { z } from 'zod';
 
 // ============================================================================
@@ -26,8 +34,9 @@ import { z } from 'zod';
 // ============================================================================
 
 /**
- * A single session summary row (ListSessions `details.sessions[]`). `session_id`
- * is the bare id used for routing + revoke; `key` is the resolved Redis key.
+ * A single session summary row (ListSessions `details.sessions[]`).
+ * `session_handle` is the non-reversible identifier used for routing, inspect
+ * and revoke (#4330); the raw session id and its Redis key never cross the API.
  * Identity fields are nullable (anonymous / pre-auth sessions carry no email or
  * external id). `created_at` is `authenticated_at` as a Unix-second number.
  *
@@ -39,8 +48,7 @@ import { z } from 'zod';
  * dropping the whole session list.
  */
 export const colonelSessionSchema = z.object({
-  session_id: z.string(),
-  key: z.string(),
+  session_handle: sessionHandleSchema,
   authenticated: z.boolean(),
   email: z.string().nullable(),
   external_id: z.string().nullable(),
@@ -83,8 +91,7 @@ export const colonelSessionsDetailsSchema = z.object({
  * string or number depending on the auth backend.
  */
 export const colonelSessionDetailRecordSchema = z.object({
-  session_id: z.string(),
-  key: z.string(),
+  session_handle: sessionHandleSchema,
   ttl: z.number().nullable(),
   authenticated: z.boolean(),
   email: z.string().nullable(),
@@ -111,15 +118,20 @@ export const colonelSessionDetailRecordSchema = z.object({
  */
 export const colonelSessionDetailDetailsSchema = z.object({
   data: z.record(z.string(), z.unknown()),
+  // True when the bounded keyspace scan that resolved the handle hit its cap:
+  // a 404 then means "not among the keys sampled", not "does not exist".
+  // Optional so a response from a backend predating #4330's two-stage
+  // resolution still parses.
+  scan_capped: z.boolean().optional(),
 });
 
 // ============================================================================
 // DeleteSession — guarded revoke ack
 // ============================================================================
 
-/** DeleteSession `record`: the revoked session's id + a deleted flag. */
+/** DeleteSession `record`: the revoked session's handle + a deleted flag. */
 export const colonelSessionDeleteRecordSchema = z.object({
-  session_id: z.string(),
+  session_handle: sessionHandleSchema,
   deleted: z.boolean(),
 });
 
@@ -151,13 +163,13 @@ export const colonelSessionsResponseSchema = createApiResponseSchema(
   colonelSessionsDetailsSchema
 );
 
-// GET /api/colonel/sessions/:session_id → GetSessionDetail
+// GET /api/colonel/sessions/:session_handle → GetSessionDetail
 export const colonelSessionDetailResponseSchema = createApiResponseSchema(
   colonelSessionDetailRecordSchema,
   colonelSessionDetailDetailsSchema
 );
 
-// DELETE /api/colonel/sessions/:session_id → DeleteSession
+// DELETE /api/colonel/sessions/:session_handle → DeleteSession
 export const colonelSessionDeleteResponseSchema = createApiResponseSchema(
   colonelSessionDeleteRecordSchema,
   colonelSessionDeleteDetailsSchema

--- a/src/schemas/api/internal/responses/session-handle.ts
+++ b/src/schemas/api/internal/responses/session-handle.ts
@@ -1,0 +1,21 @@
+// src/schemas/api/internal/responses/session-handle.ts
+//
+// The one definition of the colonel-facing session identifier, shared by the
+// GLOBAL sessions console (colonel-sessions.ts) and the PER-CUSTOMER session
+// panel (colonel-customer-sessions.ts). It lived on the per-customer contract
+// until #4330 extended handles to the global console; both now import it here so
+// a single regex guards every session identifier that reaches the admin UI.
+
+import { z } from 'zod';
+
+/**
+ * The non-reversible session handle (F-01): the first 32 hex chars of an
+ * HMAC-SHA256 over the raw sid (SessionMetadata.handle_for). Validating the
+ * exact shape — not just z.string() — makes the schema a security tripwire:
+ * a backend regression that leaks the raw 64+-char sid (or anything else)
+ * under a *_handle key fails parsing here instead of flowing a replayable
+ * bearer value into the admin UI.
+ */
+export const sessionHandleSchema = z
+  .string()
+  .regex(/^[0-9a-f]{32}$/, 'session_handle must be a 32-char lowercase hex handle');

--- a/src/schemas/contracts/config/section/site.ts
+++ b/src/schemas/contracts/config/section/site.ts
@@ -145,13 +145,21 @@ const colonelRateLimitBucketSchema = z.object({
 
 /**
  * Rate limits for the colonel API surface, keyed on the acting colonel's extid
- * (#4327 ships `elevation`; #4329 adds the mutation / destructive /
- * handle-resolve buckets). The parent `enabled` flag short-circuits every
- * bucket.
+ * — never on a session id (#4327 ships `elevation`; #4329 adds the mutation /
+ * destructive / handle-resolve buckets). The parent `enabled` flag
+ * short-circuits every bucket. Every bucket has the same four fields; the
+ * shipped sizing differs per bucket and lives in
+ * `shapes/config/section/site.ts`.
  */
 const siteAdminRateLimitSchema = z.object({
   enabled: z.boolean().optional(),
   elevation: colonelRateLimitBucketSchema.optional(),
+  /** Every mutating colonel verb, charged from the base logic constructor. */
+  mutation: colonelRateLimitBucketSchema.optional(),
+  /** TIER 1 verbs only, charged after step-up, confirmation and interlocks. */
+  destructive: colonelRateLimitBucketSchema.optional(),
+  /** The two session reads that resolve an opaque handle (#4330). */
+  handle_resolve: colonelRateLimitBucketSchema.optional(),
 });
 
 const siteAdminSchema = z.object({

--- a/src/schemas/contracts/config/section/site.ts
+++ b/src/schemas/contracts/config/section/site.ts
@@ -120,7 +120,43 @@ const middlewareSchema = z.object({
  * a distinction the boot check warns on (#4127), so the template must not
  * collapse null to []. Runtime behavior is identical for both shapes.
  */
+/**
+ * Step-up (sudo) window for destructive colonel actions (#4327).
+ *
+ * `window` is the elevation lifetime in seconds. `reauth_grace` is the
+ * post-sign-in grace during which a PASSWORD-LESS colonel may elevate with no
+ * credential — 0 (the shipped default) disables it, so it is the one numeric
+ * here where 0 is a legitimate value rather than a typo'd env var.
+ * Defaults belong in `shapes/config/section/site.ts`.
+ */
+const siteAdminElevationSchema = z.object({
+  enabled: z.boolean().optional(),
+  window: z.number().optional(),
+  reauth_grace: z.number().optional(),
+});
+
+/** One colonel rate-limit bucket: cap, counting window, lockout — all seconds. */
+const colonelRateLimitBucketSchema = z.object({
+  enabled: z.boolean().optional(),
+  max_attempts: z.number().optional(),
+  window: z.number().optional(),
+  lockout: z.number().optional(),
+});
+
+/**
+ * Rate limits for the colonel API surface, keyed on the acting colonel's extid
+ * (#4327 ships `elevation`; #4329 adds the mutation / destructive /
+ * handle-resolve buckets). The parent `enabled` flag short-circuits every
+ * bucket.
+ */
+const siteAdminRateLimitSchema = z.object({
+  enabled: z.boolean().optional(),
+  elevation: colonelRateLimitBucketSchema.optional(),
+});
+
 const siteAdminSchema = z.object({
+  elevation: siteAdminElevationSchema.optional(),
+  rate_limit: siteAdminRateLimitSchema.optional(),
   allowed_hosts: z.array(z.string()).nullable().optional(),
   allowed_cidrs: z.array(z.string()).optional(),
 });

--- a/src/schemas/contracts/config/section/site.ts
+++ b/src/schemas/contracts/config/section/site.ts
@@ -162,9 +162,25 @@ const siteAdminRateLimitSchema = z.object({
   handle_resolve: colonelRateLimitBucketSchema.optional(),
 });
 
+/**
+ * Idle + absolute bounds on the ADMIN API SURFACE (/api/colonel) only (#4331).
+ * They do not shorten the shared onetime.session cookie and do not gate the
+ * /colonel SPA shell. `0` disables a bound and is a legitimate value here rather
+ * than a typo'd env var, so neither number is `.positive()` in the shape file.
+ * Defaults belong in `shapes/config/section/site.ts`.
+ */
+const siteAdminSessionSchema = z.object({
+  enabled: z.boolean().optional(),
+  /** Seconds of inactivity, read from the best-effort SessionMetadata sidecar. */
+  idle_timeout: z.number().optional(),
+  /** Seconds since sign-in, read from session['authenticated_at']. */
+  absolute_timeout: z.number().optional(),
+});
+
 const siteAdminSchema = z.object({
   elevation: siteAdminElevationSchema.optional(),
   rate_limit: siteAdminRateLimitSchema.optional(),
+  session: siteAdminSessionSchema.optional(),
   allowed_hosts: z.array(z.string()).nullable().optional(),
   allowed_cidrs: z.array(z.string()).optional(),
 });

--- a/src/schemas/shapes/config/section/site.ts
+++ b/src/schemas/shapes/config/section/site.ts
@@ -100,16 +100,31 @@ const adminElevationTree: AugmentTree = {
   reauth_grace: (n) => n.int().min(0).default(0),
 };
 
-const colonelRateLimitBucketTree: AugmentTree = {
+// One colonel rate-limit bucket. Every bucket has the same four fields but its
+// OWN shipped sizing, so this is a factory rather than a shared constant — a
+// single tree would have to pick one bucket's numbers and silently misreport
+// the other three in the generated JSON Schema. The values must stay in step
+// with config.defaults.yaml and with the DEFAULT_* constants in
+// lib/onetime/security/colonel_rate_limiter.rb.
+const colonelRateLimitBucketTree = (
+  maxAttempts: number,
+  window: number,
+  lockout: number
+): AugmentTree => ({
   enabled: (b) => b.default(true),
-  max_attempts: (n) => n.int().positive().default(5),
-  window: (n) => n.int().positive().default(900),
-  lockout: (n) => n.int().positive().default(900),
-};
+  max_attempts: (n) => n.int().positive().default(maxAttempts),
+  window: (n) => n.int().positive().default(window),
+  lockout: (n) => n.int().positive().default(lockout),
+});
 
 const adminRateLimitTree: AugmentTree = {
   enabled: (b) => b.default(true),
-  elevation: colonelRateLimitBucketTree,
+  // Step-up attempts (#4327); the mutation / destructive / handle-resolve
+  // buckets (#4329). Sizing rationale is in config.defaults.yaml.
+  elevation: colonelRateLimitBucketTree(5, 900, 900),
+  mutation: colonelRateLimitBucketTree(120, 300, 300),
+  destructive: colonelRateLimitBucketTree(10, 300, 900),
+  handle_resolve: colonelRateLimitBucketTree(60, 300, 300),
 };
 
 const adminTree: AugmentTree = {

--- a/src/schemas/shapes/config/section/site.ts
+++ b/src/schemas/shapes/config/section/site.ts
@@ -127,9 +127,20 @@ const adminRateLimitTree: AugmentTree = {
   handle_resolve: colonelRateLimitBucketTree(60, 300, 300),
 };
 
+// Idle + absolute bounds on the ADMIN API SURFACE only (#4331), mirroring
+// config.defaults.yaml. Both numbers use .min(0) rather than .positive():
+// 0 DISABLES that bound and is a legitimate operator choice, unlike the
+// "typo'd env var collapsed to 0" case the positive() guards elsewhere catch.
+const adminSessionTree: AugmentTree = {
+  enabled: (b) => b.default(true),
+  idle_timeout: (n) => n.int().min(0).default(3600),
+  absolute_timeout: (n) => n.int().min(0).default(43200),
+};
+
 const adminTree: AugmentTree = {
   elevation: adminElevationTree,
   rate_limit: adminRateLimitTree,
+  session: adminSessionTree,
   // Empty defaults mirror config.defaults.yaml, but the two gates read empty
   // differently. Host gate: an empty list is still ACTIVE — it anchors on the
   // canonical hosts (DEFAULT_DOMAIN / site.host plus www. siblings) and

--- a/src/schemas/shapes/config/section/site.ts
+++ b/src/schemas/shapes/config/section/site.ts
@@ -87,7 +87,34 @@ const securityTree: AugmentTree = {
   csp: cspTree,
 };
 
+// Step-up (sudo) window for destructive colonel actions (#4327). ON by
+// default, mirroring config.defaults.yaml: a colonel session alone is not
+// sufficient for a tier-1 verb.
+//
+// reauth_grace defaults to 0, and 0 is a MEANINGFUL value here (the grace is
+// off) rather than the "typo'd env var" case every other numeric guards
+// against — hence .min(0) and not .positive().
+const adminElevationTree: AugmentTree = {
+  enabled: (b) => b.default(true),
+  window: (n) => n.int().positive().default(600),
+  reauth_grace: (n) => n.int().min(0).default(0),
+};
+
+const colonelRateLimitBucketTree: AugmentTree = {
+  enabled: (b) => b.default(true),
+  max_attempts: (n) => n.int().positive().default(5),
+  window: (n) => n.int().positive().default(900),
+  lockout: (n) => n.int().positive().default(900),
+};
+
+const adminRateLimitTree: AugmentTree = {
+  enabled: (b) => b.default(true),
+  elevation: colonelRateLimitBucketTree,
+};
+
 const adminTree: AugmentTree = {
+  elevation: adminElevationTree,
+  rate_limit: adminRateLimitTree,
   // Empty defaults mirror config.defaults.yaml, but the two gates read empty
   // differently. Host gate: an empty list is still ACTIVE — it anchors on the
   // canonical hosts (DEFAULT_DOMAIN / site.host plus www. siblings) and

--- a/src/tests/apps/admin/AdminCustomerDetail.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetail.spec.ts
@@ -273,7 +273,11 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.delete).toHaveBeenCalledWith('/api/colonel/users/ur_alice');
+      // The typed token is also what rides X-OTS-Confirm (#4326), and the URL
+      // stays free of the address.
+      expect(mockApi.delete).toHaveBeenCalledWith('/api/colonel/users/ur_alice', {
+        headers: { 'X-OTS-Confirm': encodeURIComponent(PURGE_TOKEN) },
+      });
       expect(showMock).toHaveBeenCalledWith('web.admin.customers.actions.purge.success', 'success');
       expect(pushMock).toHaveBeenCalledWith({ name: 'AdminCustomers' });
     });
@@ -320,7 +324,12 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/users/ur_alice/verify', {});
+      // Verify is the restorative arm: un-gated, so no confirmation header.
+      expect(mockApi.post).toHaveBeenCalledWith(
+        '/api/colonel/users/ur_alice/verify',
+        {},
+        undefined
+      );
       expect(showMock).toHaveBeenCalledWith(
         'web.admin.customers.actions.verify.success',
         'success'
@@ -330,7 +339,10 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       expect(pushMock).not.toHaveBeenCalled();
     });
 
-    it('shows unverify for a verified customer and calls the unverify endpoint', async () => {
+    // Unverify joined DANGER_ACTIONS with #4326: it STRIPS colonel eligibility
+    // (system roles require a verified email), so it is typed-confirmation
+    // gated here and confirmation-gated on the server.
+    it('gates unverify on the retyped email and sends it in the header', async () => {
       mockApi.get.mockResolvedValue({ data: detailPayload({ verified: true }) });
       mockApi.post.mockResolvedValue({ data: mutationAck() });
       wrapper = mountView();
@@ -338,10 +350,20 @@ describe('AdminCustomerDetail (ticket #22)', () => {
 
       expect(wrapper.find('[data-testid="verify-button"]').exists()).toBe(false);
       await wrapper.find('[data-testid="unverify-button"]').trigger('click');
+      await flushPromises();
+
+      expect(dialogInput(wrapper).exists()).toBe(true);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue(PURGE_TOKEN);
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/users/ur_alice/unverify', {});
+      expect(mockApi.post).toHaveBeenCalledWith(
+        '/api/colonel/users/ur_alice/unverify',
+        {},
+        { headers: { 'X-OTS-Confirm': encodeURIComponent(PURGE_TOKEN) } }
+      );
     });
   });
 
@@ -364,7 +386,7 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       await flushPromises();
     });
 
-    it('requires retyping the public id, then POSTs suspend with the reason', async () => {
+    it('requires retyping the account email, then POSTs suspend with the reason', async () => {
       mockApi.post.mockResolvedValue({ data: mutationAck() });
 
       await wrapper.find('[data-testid="suspend-reason"]').setValue('abuse report');
@@ -375,15 +397,22 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       expect(dialogInput(wrapper).exists()).toBe(true);
       expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
 
+      // #4326 moved every danger token to the account email, so the four gated
+      // verbs ask for (and send) one identifier, not two.
       await dialogInput(wrapper).setValue(PUBLIC_ID);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue(PURGE_TOKEN);
       expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
 
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/users/ur_alice/suspend', {
-        reason: 'abuse report',
-      });
+      expect(mockApi.post).toHaveBeenCalledWith(
+        '/api/colonel/users/ur_alice/suspend',
+        { reason: 'abuse report' },
+        { headers: { 'X-OTS-Confirm': encodeURIComponent(PURGE_TOKEN) } }
+      );
       expect(showMock).toHaveBeenCalledWith(
         'web.admin.customers.actions.suspend.success',
         'success'
@@ -396,11 +425,15 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       mockApi.post.mockResolvedValue({ data: mutationAck() });
 
       await wrapper.find('[data-testid="suspend-button"]').trigger('click');
-      await dialogInput(wrapper).setValue(PUBLIC_ID);
+      await dialogInput(wrapper).setValue(PURGE_TOKEN);
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/users/ur_alice/suspend', {});
+      expect(mockApi.post).toHaveBeenCalledWith(
+        '/api/colonel/users/ur_alice/suspend',
+        {},
+        { headers: { 'X-OTS-Confirm': encodeURIComponent(PURGE_TOKEN) } }
+      );
     });
 
     it('does NOT suspend when submitted without a matching token', async () => {
@@ -436,7 +469,12 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/users/ur_alice/unsuspend', {});
+      // Unsuspend is the restorative arm: un-gated, so no confirmation header.
+      expect(mockApi.post).toHaveBeenCalledWith(
+        '/api/colonel/users/ur_alice/unsuspend',
+        {},
+        undefined
+      );
       expect(showMock).toHaveBeenCalledWith(
         'web.admin.customers.actions.unsuspend.success',
         'success'
@@ -463,7 +501,9 @@ describe('AdminCustomerDetail (ticket #22)', () => {
     });
   });
 
-  describe('change role — simple confirm', () => {
+  // setRole joined DANGER_ACTIONS with #4326: promoting an account to colonel
+  // was a plain one-click confirm.
+  describe('change role — typed-confirmation gate', () => {
     it('is disabled until a different role is chosen, then posts the role change', async () => {
       mockApi.get.mockResolvedValue({ data: detailPayload({ role: 'customer' }) });
       mockApi.post.mockResolvedValue({ data: mutationAck() });
@@ -477,12 +517,20 @@ describe('AdminCustomerDetail (ticket #22)', () => {
       expect(wrapper.find('[data-testid="role-apply"]').attributes('disabled')).toBeUndefined();
 
       await wrapper.find('[data-testid="role-apply"]').trigger('click');
+      await flushPromises();
+
+      expect(dialogInput(wrapper).exists()).toBe(true);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      await dialogInput(wrapper).setValue(PURGE_TOKEN);
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/users/ur_alice/role', {
-        role: 'admin',
-      });
+      expect(mockApi.post).toHaveBeenCalledWith(
+        '/api/colonel/users/ur_alice/role',
+        { role: 'admin' },
+        { headers: { 'X-OTS-Confirm': encodeURIComponent(PURGE_TOKEN) } }
+      );
       expect(showMock).toHaveBeenCalledWith('web.admin.customers.actions.role.success', 'success');
     });
   });

--- a/src/tests/apps/admin/AdminCustomerDetailPurge.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetailPurge.spec.ts
@@ -172,7 +172,11 @@ describe('AdminCustomerDetail — purge gate (typed email) + verification state'
     await wrapper.find('form').trigger('submit');
     await flushPromises();
 
-    expect(mockApi.delete).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}`);
+    // The typed email is also what the server is gated on (#4326) — sent as a
+    // HEADER, so the address never enters the URL, a log, or browser history.
+    expect(mockApi.delete).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}`, {
+      headers: { 'X-OTS-Confirm': encodeURIComponent(EMAIL) },
+    });
     expect(showMock).toHaveBeenCalledWith('web.admin.customers.actions.purge.success', 'success');
     expect(pushMock).toHaveBeenCalledWith({ name: 'AdminCustomers' });
   });
@@ -193,18 +197,30 @@ describe('AdminCustomerDetail — purge gate (typed email) + verification state'
     expect(showMock).not.toHaveBeenCalled();
   });
 
-  it('leaves SUSPEND on the public-id token (only purge moved to the email)', async () => {
+  // #4326 moved SUSPEND onto the same email token: the server gates all four
+  // danger verbs on the account identifier, and a dialog that asked for the
+  // public id while sending the email would be two gates disagreeing.
+  it('puts SUSPEND on the email token too, not the public id', async () => {
     await mountLoaded();
     mockApi.post.mockResolvedValue({ data: mutationAck() });
 
     await wrapper.find('[data-testid="suspend-button"]').trigger('click');
     await flushPromises();
 
-    await dialogInput(wrapper).setValue(EMAIL);
+    await dialogInput(wrapper).setValue(PUBLIC_ID);
     expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
 
-    await dialogInput(wrapper).setValue(PUBLIC_ID);
+    await dialogInput(wrapper).setValue(EMAIL);
     expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith(
+      `/api/colonel/users/${PUBLIC_ID}/suspend`,
+      {},
+      { headers: { 'X-OTS-Confirm': encodeURIComponent(EMAIL) } }
+    );
   });
 
   it('states the verification badge both ways and offers only the matching verb', async () => {
@@ -237,7 +253,12 @@ describe('AdminCustomerDetail — purge gate (typed email) + verification state'
     await wrapper.find('form').trigger('submit');
     await flushPromises();
 
-    expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}/verify`, {});
+    // Verify is the restorative arm: un-gated, so no confirmation header.
+    expect(mockApi.post).toHaveBeenCalledWith(
+      `/api/colonel/users/${PUBLIC_ID}/verify`,
+      {},
+      undefined
+    );
     expect(pushMock).not.toHaveBeenCalled();
     expect(wrapper.find('[data-testid="verified-badge"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="unverify-button"]').exists()).toBe(true);

--- a/src/tests/apps/admin/AdminCustomerDetailPurge.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetailPurge.spec.ts
@@ -72,6 +72,10 @@ vi.mock('@headlessui/vue', () => ({
 }));
 
 import AdminCustomerDetail from '@/apps/admin/views/AdminCustomerDetail.vue';
+import {
+  __resetColonelElevationState,
+  useColonelElevation,
+} from '@/apps/admin/composables/useColonelElevation';
 import { createTestI18n } from '@tests/setup';
 
 const i18n = createTestI18n();
@@ -135,7 +139,12 @@ const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-subm
 describe('AdminCustomerDetail — purge gate (typed email) + verification state', () => {
   let wrapper: VueWrapper;
 
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The step-up window is module-level singleton state (#4327); reset it so
+    // one example's elevation cannot satisfy the next one's gate.
+    __resetColonelElevationState();
+  });
   afterEach(() => wrapper?.unmount());
 
   async function mountLoaded(overrides: { verified?: boolean } = {}): Promise<void> {
@@ -262,5 +271,75 @@ describe('AdminCustomerDetail — purge gate (typed email) + verification state'
     expect(pushMock).not.toHaveBeenCalled();
     expect(wrapper.find('[data-testid="verified-badge"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="unverify-button"]').exists()).toBe(true);
+  });
+
+  // ---- Step-up (sudo) window (#4327) ---------------------------------------
+  //
+  // The loop is: attempt -> 403 elevation_required -> prompt -> the operator
+  // acts -> retry ONCE. The retry must never fire without that gesture; an
+  // automatic elevate-and-retry would put a colonel session alone back in
+  // charge of a destructive verb, which is what this issue exists to stop.
+  describe('a 403 elevation_required opens the sudo prompt', () => {
+    async function submitPurge(): Promise<void> {
+      await wrapper.find('[data-testid="purge-button"]').trigger('click');
+      await dialogInput(wrapper).setValue(EMAIL);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+    }
+
+    it('opens the prompt and does NOT retry until the operator acts', async () => {
+      await mountLoaded();
+      mockApi.delete.mockRejectedValue(
+        axiosError(403, { error: 'Step-up authentication required', error_code: 'elevation_required' })
+      );
+
+      await submitPurge();
+
+      const elevation = useColonelElevation();
+      expect(elevation.promptOpen.value).toBe(true);
+      // One attempt so far. The retry is still waiting on the operator.
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+      expect(pushMock).not.toHaveBeenCalled();
+
+      // The operator elevates; the prompt resolves and the verb is retried once.
+      mockApi.delete.mockResolvedValue({ data: mutationAck() });
+      elevation.resolvePrompt(true);
+      await flushPromises();
+
+      expect(mockApi.delete).toHaveBeenCalledTimes(2);
+      expect(showMock).toHaveBeenCalledWith('web.admin.customers.actions.purge.success', 'success');
+    });
+
+    it('surfaces the original error and retries nothing when the operator cancels', async () => {
+      await mountLoaded();
+      mockApi.delete.mockRejectedValue(
+        axiosError(403, { error: 'Step-up authentication required', error_code: 'elevation_required' })
+      );
+
+      await submitPurge();
+
+      const elevation = useColonelElevation();
+      elevation.resolvePrompt(false);
+      await flushPromises();
+
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+      expect(wrapper.find('[data-testid="admin-confirm-dialog"]').text()).toContain(
+        'Step-up authentication required'
+      );
+      expect(pushMock).not.toHaveBeenCalled();
+      expect(showMock).not.toHaveBeenCalled();
+    });
+
+    it('leaves a confirmation_required failure alone — no sudo prompt for that', async () => {
+      await mountLoaded();
+      mockApi.delete.mockRejectedValue(
+        axiosError(403, { error: 'Confirmation required', error_code: 'confirmation_required' })
+      );
+
+      await submitPurge();
+
+      expect(useColonelElevation().promptOpen.value).toBe(false);
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/tests/apps/admin/AdminCustomerDetailPurge.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetailPurge.spec.ts
@@ -342,4 +342,68 @@ describe('AdminCustomerDetail — purge gate (typed email) + verification state'
       expect(mockApi.delete).toHaveBeenCalledTimes(1);
     });
   });
+
+  // ---- Rate limiting (#4329) ------------------------------------------------
+  //
+  // The 429 reaches the dialog with no frontend change (the classifier renders
+  // any 4xx `error` string verbatim); what the composable adds is the wait and
+  // the recovery path, neither of which the server message can carry on its own.
+  describe('a 429 from the colonel limiter', () => {
+    async function submitPurge(): Promise<void> {
+      await wrapper.find('[data-testid="purge-button"]').trigger('click');
+      await dialogInput(wrapper).setValue(EMAIL);
+      await wrapper.find('form').trigger('submit');
+      await flushPromises();
+    }
+
+    const throttled = (retryAfter?: number) =>
+      axiosError(429, {
+        error: 'Too many destructive admin actions. This is a safety limit; try again shortly.',
+        error_type: 'LimitExceeded',
+        max_attempts: 10,
+        ...(retryAfter === undefined ? {} : { retry_after: retryAfter }),
+      });
+
+    it('keeps the server message and adds the wait plus the recovery hint', async () => {
+      await mountLoaded();
+      mockApi.delete.mockRejectedValue(throttled(900));
+
+      await submitPurge();
+
+      const dialog = wrapper.find('[data-testid="admin-confirm-dialog"]').text();
+      expect(dialog).toContain('Too many destructive admin actions');
+      expect(dialog).toContain('web.admin.errors.rateLimited');
+      expect(dialog).toContain('web.admin.errors.rateLimitedRecovery');
+      // Nothing happened but the refusal: no toast, no navigation, no retry.
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+      expect(pushMock).not.toHaveBeenCalled();
+      expect(showMock).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the server message alone when there is no retry_after', async () => {
+      await mountLoaded();
+      mockApi.delete.mockRejectedValue(throttled());
+
+      await submitPurge();
+
+      const dialog = wrapper.find('[data-testid="admin-confirm-dialog"]').text();
+      expect(dialog).toContain('Too many destructive admin actions');
+      // …rateLimitedRecovery still appears (the operator can always clear it),
+      // so the negative match has to exclude the wait key specifically.
+      expect(dialog).not.toMatch(/rateLimited(?!Recovery)/);
+    });
+
+    // A 429 is not an authorization failure: prompting for a password would
+    // teach operators to re-authenticate at a throttle, and the retry would be
+    // refused anyway.
+    it('never opens the sudo prompt and never retries', async () => {
+      await mountLoaded();
+      mockApi.delete.mockRejectedValue(throttled(60));
+
+      await submitPurge();
+
+      expect(useColonelElevation().promptOpen.value).toBe(false);
+      expect(mockApi.delete).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/tests/apps/admin/AdminCustomerDetailSetRole.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetailSetRole.spec.ts
@@ -1,0 +1,255 @@
+// src/tests/apps/admin/AdminCustomerDetailSetRole.spec.ts
+
+import { AxiosError } from 'axios';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Detail-page ROLE CHANGE gate (#4326).
+ *
+ * `setRole` was a plain one-click confirm: promoting an account to colonel —
+ * the most privilege-granting action the console offers — took two clicks and
+ * no typing. It is now a DANGER action, gated client-side on retyping the
+ * account email and server-side on the same token in X-OTS-Confirm.
+ *
+ * Split out of AdminCustomerDetail.spec.ts per the convention this tree already
+ * follows for AdminCustomerDetailPurge.spec.ts: that file owns the happy path,
+ * this one owns the gate.
+ */
+
+/** Build a real AxiosError so the shared classifier extracts `data.error`. */
+function axiosError(status: number, data: unknown, message = 'Request failed'): AxiosError {
+  const err = new AxiosError(message);
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+const pushMock = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: pushMock }),
+  useRoute: () => ({ params: { id: 'ur_alice' } }),
+}));
+
+const showMock = vi.fn();
+vi.mock('@/shared/stores/notificationsStore', () => ({
+  useNotificationsStore: () => ({ show: showMock }),
+}));
+
+vi.mock('@/utils/format', () => ({
+  formatDisplayDateTime: (d: Date) => `DT:${d.toISOString()}`,
+}));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: {
+    name: 'DialogPanel',
+    template: '<div class="dialog-panel" :data-testid="$attrs[\'data-testid\']"><slot /></div>',
+    props: ['class'],
+  },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import AdminCustomerDetail from '@/apps/admin/views/AdminCustomerDetail.vue';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+const PUBLIC_ID = 'ur_alice';
+const EMAIL = 'alice@example.com';
+
+function detailPayload(overrides: { verified?: boolean } = {}) {
+  return {
+    shrimp: '',
+    record: {
+      extid: PUBLIC_ID,
+      email: EMAIL,
+      role: 'customer',
+      verified: overrides.verified ?? false,
+      suspended: false,
+      suspended_at: null,
+      suspended_by: null,
+      suspended_reason: null,
+      created: 1700000000,
+      updated: 1700000100,
+      last_login: 1700000200,
+      planid: 'basic',
+      locale: 'en',
+    },
+    details: {
+      secrets: { count: 0, items: [] },
+      receipts: { count: 0, items: [] },
+      organizations: [],
+      billing: {
+        enabled: false,
+        plan_id: 'basic',
+        organization: null,
+        stripe: {
+          available: false,
+          reason: 'Billing is not configured',
+          customer_id: null,
+          dashboard_url: null,
+          subscription: null,
+          latest_invoice: null,
+        },
+      },
+      stats: { secrets_created: 0, secrets_shared: 0, emails_sent: 0 },
+    },
+  };
+}
+
+function mutationAck() {
+  return { shrimp: '', record: { user_id: 'objid', extid: PUBLIC_ID }, details: { message: 'ok' } };
+}
+
+const mountView = () =>
+  mount(AdminCustomerDetail, {
+    props: { id: PUBLIC_ID },
+    global: { plugins: [i18n], stubs: { AdminCustomerSessionsSection: true } },
+  });
+
+const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
+const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+
+describe('AdminCustomerDetail — role change gate (#4326)', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => wrapper?.unmount());
+
+  async function mountLoaded(record: Record<string, unknown> = {}): Promise<void> {
+    const payload = detailPayload();
+    Object.assign(payload.record, record);
+    mockApi.get.mockResolvedValue({ data: payload });
+    wrapper = mountView();
+    await flushPromises();
+  }
+
+  /** Pick a new role and open the confirm dialog. */
+  async function requestRole(role: string): Promise<void> {
+    await wrapper.find('[data-testid="role-select"]').setValue(role);
+    await wrapper.find('[data-testid="role-apply"]').trigger('click');
+    await flushPromises();
+  }
+
+  it('renders a typed-confirmation input, not a one-click confirm', async () => {
+    await mountLoaded();
+    await requestRole('colonel');
+
+    expect(dialogInput(wrapper).exists()).toBe(true);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+  });
+
+  it('unlocks only on the EXACT account email — the public id does not', async () => {
+    await mountLoaded();
+    await requestRole('colonel');
+
+    await dialogInput(wrapper).setValue(PUBLIC_ID);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+    await dialogInput(wrapper).setValue(EMAIL.toUpperCase());
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+    await dialogInput(wrapper).setValue(EMAIL);
+    expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+  });
+
+  it('POSTs the role with the token in X-OTS-Confirm, and keeps it out of the URL', async () => {
+    await mountLoaded();
+    mockApi.post.mockResolvedValue({ data: mutationAck() });
+
+    await requestRole('colonel');
+    await dialogInput(wrapper).setValue(EMAIL);
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).toHaveBeenCalledWith(
+      `/api/colonel/users/${PUBLIC_ID}/role`,
+      { role: 'colonel' },
+      { headers: { 'X-OTS-Confirm': encodeURIComponent(EMAIL) } }
+    );
+    const [url] = mockApi.post.mock.calls[0];
+    expect(url).not.toContain(encodeURIComponent(EMAIL));
+    expect(showMock).toHaveBeenCalledWith('web.admin.customers.actions.role.success', 'success');
+  });
+
+  it('does NOT post when the token does not match', async () => {
+    await mountLoaded();
+    mockApi.post.mockResolvedValue({ data: mutationAck() });
+
+    await requestRole('colonel');
+    await dialogInput(wrapper).setValue('not-the-email');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(mockApi.post).not.toHaveBeenCalled();
+  });
+
+  // FAIL CLOSED: AdminConfirmDialog treats a blank token as simple-confirm
+  // mode, so an account with no email must not open the dialog at all rather
+  // than silently degrading a privilege grant to one click.
+  it('refuses to open the dialog for an account with no email or public id', async () => {
+    await mountLoaded({ email: '', extid: '' });
+
+    await requestRole('colonel');
+
+    expect(dialogInput(wrapper).exists()).toBe(false);
+    expect(mockApi.post).not.toHaveBeenCalled();
+  });
+
+  // The dialog stays shut for a no-op, so the operator never confirms nothing.
+  it('ignores an apply that would not change the role', async () => {
+    await mountLoaded({ role: 'customer' });
+
+    await wrapper.find('[data-testid="role-apply"]').trigger('click');
+    await flushPromises();
+
+    expect(dialogInput(wrapper).exists()).toBe(false);
+  });
+
+  it('surfaces a server refusal in the dialog and stays put', async () => {
+    await mountLoaded();
+    mockApi.post.mockRejectedValue(
+      axiosError(403, {
+        error: 'Confirmation required: re-send this request with the X-OTS-Confirm header set to the target account\'s email address.',
+        error_type: 'ConfirmationRequired',
+        error_code: 'confirmation_required',
+      })
+    );
+
+    await requestRole('colonel');
+    await dialogInput(wrapper).setValue(EMAIL);
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="admin-confirm-dialog"]').text()).toContain(
+      'Confirmation required'
+    );
+    expect(showMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/apps/admin/AdminCustomerDetailSetRole.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerDetailSetRole.spec.ts
@@ -76,6 +76,7 @@ vi.mock('@headlessui/vue', () => ({
 }));
 
 import AdminCustomerDetail from '@/apps/admin/views/AdminCustomerDetail.vue';
+import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { createTestI18n } from '@tests/setup';
 
 const i18n = createTestI18n();
@@ -135,6 +136,17 @@ const mountView = () =>
 
 const dialogInput = (w: VueWrapper) => w.find('#admin-confirm-input');
 const dialogSubmit = (w: VueWrapper) => w.find('[data-testid="admin-confirm-submit"]');
+
+type BootstrapCust = ReturnType<typeof useBootstrapStore>['cust'];
+
+/**
+ * Who the console thinks is logged in. Only `extid` is read by the #4328
+ * self-target guards, so the rest of the customer shape is irrelevant here.
+ */
+function actAs(extid: string | null): void {
+  const bootstrap = useBootstrapStore();
+  bootstrap.cust = extid ? ({ extid } as unknown as NonNullable<BootstrapCust>) : null;
+}
 
 describe('AdminCustomerDetail — role change gate (#4326)', () => {
   let wrapper: VueWrapper;
@@ -251,5 +263,76 @@ describe('AdminCustomerDetail — role change gate (#4326)', () => {
       'Confirmation required'
     );
     expect(showMock).not.toHaveBeenCalled();
+  });
+
+  // ---- Self-target interlocks (#4328) ---------------------------------------
+  //
+  // The server refuses these with a 422 whatever the browser does; blocking
+  // here is defence in depth (the `purgeBlocked` pattern), so the operator is
+  // never asked to retype a token for an action that cannot succeed.
+  describe('your own account', () => {
+    afterEach(() => actAs(null));
+
+    it('disables the role apply button for a self-DEMOTION and states why', async () => {
+      actAs(PUBLIC_ID);
+      await mountLoaded({ role: 'colonel' });
+      await wrapper.find('[data-testid="role-select"]').setValue('customer');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="role-apply"]').attributes('disabled')).toBeDefined();
+      expect(wrapper.find('[data-testid="self-demote-reason"]').text()).toBe(
+        'web.admin.customers.actions.role.selfDemote'
+      );
+    });
+
+    it('opens no dialog and POSTs nothing for a self-demotion', async () => {
+      actAs(PUBLIC_ID);
+      await mountLoaded({ role: 'colonel' });
+      await requestRole('customer');
+
+      expect(dialogInput(wrapper).exists()).toBe(false);
+      expect(mockApi.post).not.toHaveBeenCalled();
+    });
+
+    it('still allows RAISING your own role (only demotion is a lockout risk)', async () => {
+      actAs(PUBLIC_ID);
+      await mountLoaded({ role: 'admin' });
+      await wrapper.find('[data-testid="role-select"]').setValue('colonel');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="role-apply"]').attributes('disabled')).toBeUndefined();
+      expect(wrapper.find('[data-testid="self-demote-reason"]').exists()).toBe(false);
+    });
+
+    it('disables unverify on your own account and states why', async () => {
+      actAs(PUBLIC_ID);
+      await mountLoaded({ role: 'colonel', verified: true });
+
+      expect(wrapper.find('[data-testid="unverify-button"]').attributes('disabled')).toBeDefined();
+      expect(wrapper.find('[data-testid="self-unverify-reason"]').text()).toBe(
+        'web.admin.customers.actions.unverify.selfUnverify'
+      );
+      await wrapper.find('[data-testid="unverify-button"]').trigger('click');
+      await flushPromises();
+      expect(dialogInput(wrapper).exists()).toBe(false);
+    });
+
+    it('leaves SOMEONE ELSE\'S account fully actionable, with a last-colonel warning', async () => {
+      actAs('ur_someone_else');
+      await mountLoaded({ role: 'colonel', verified: true });
+      await wrapper.find('[data-testid="role-select"]').setValue('customer');
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="role-apply"]').attributes('disabled')).toBeUndefined();
+      expect(wrapper.find('[data-testid="unverify-button"]').attributes('disabled')).toBeUndefined();
+      // Advisory, not a gate: the console cannot know the roster (exposing it
+      // would be the oracle #4328 closes), so it warns rather than blocks.
+      expect(wrapper.find('[data-testid="last-colonel-warning"]').text()).toBe(
+        'web.admin.customers.actions.role.lastColonel'
+      );
+      expect(wrapper.find('[data-testid="unverify-last-colonel-warning"]').text()).toBe(
+        'web.admin.customers.actions.unverify.lastColonel'
+      );
+    });
   });
 });

--- a/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
@@ -85,9 +85,9 @@ function sessionsPayload(
   };
 }
 
-const mountSection = () =>
+const mountSection = (extraProps: Record<string, unknown> = {}) =>
   mount(AdminCustomerSessionsSection, {
-    props: { userId: USER_ID },
+    props: { userId: USER_ID, ...extraProps },
     global: {
       plugins: [i18n],
       // The confirm dialogs (HeadlessUI) have their own spec; the badge/revoke
@@ -155,6 +155,38 @@ describe('AdminCustomerSessionsSection — current-session badge', () => {
     expect(wrapper.find('[data-testid^="session-current-"]').exists()).toBe(false);
     expect(revoke(wrapper, 'a15e5510000000000000000000000001').exists()).toBe(true);
     expect(revoke(wrapper, 'a15e5510000000000000000000000002').exists()).toBe(true);
+  });
+
+  // #4328: revoke-all against your OWN account is deliberately NOT refused —
+  // it is the first containment step for a leaked colonel cookie — but the
+  // server keeps the session you are working in, so the copy has to say so
+  // rather than promising a full logout.
+  describe('revoke-all confirm copy', () => {
+    /** The revoke-all dialog is the LAST AdminConfirmDialog in the template. */
+    function revokeAllDescription(w: VueWrapper): unknown {
+      const dialogs = w.findAllComponents({ name: 'AdminConfirmDialog' });
+      return dialogs[dialogs.length - 1].props('description');
+    }
+
+    it('promises a full logout for another account', async () => {
+      mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, null) });
+      wrapper = mountSection();
+      await flushPromises();
+
+      expect(revokeAllDescription(wrapper)).toBe(
+        'web.admin.customers.detail.sessions.revokeAll.confirmDescription'
+      );
+    });
+
+    it('says the current session is kept on your own account', async () => {
+      mockApi.get.mockResolvedValue({ data: sessionsPayload(undefined, null) });
+      wrapper = mountSection({ isSelf: true });
+      await flushPromises();
+
+      expect(revokeAllDescription(wrapper)).toBe(
+        'web.admin.customers.detail.sessions.revokeAll.selfDescription'
+      );
+    });
   });
 });
 

--- a/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
+++ b/src/tests/apps/admin/AdminCustomerSessionsSection.spec.ts
@@ -39,6 +39,15 @@ const i18n = createTestI18n();
 
 const USER_ID = 'ur_abc123';
 
+/**
+ * #4326 made `confirmToken` a REQUIRED prop (the account email, extid fallback):
+ * the detail view is the only surface holding the record, so the section is
+ * handed the token rather than deriving one. Every mount here needs it or
+ * `type-check:tests` fails — Vue only warns at runtime, so vitest alone does
+ * not catch a missing required prop.
+ */
+const CONFIRM_TOKEN = 'colonel-target@example.com';
+
 /** Pass-through i18n (ADR-014): keys render verbatim, so assert on the key. */
 const COUNTRY_HEADER = 'web.admin.customers.detail.sessions.columns.country';
 const UNKNOWN = 'web.admin.customers.detail.sessions.unknown';
@@ -87,7 +96,7 @@ function sessionsPayload(
 
 const mountSection = (extraProps: Record<string, unknown> = {}) =>
   mount(AdminCustomerSessionsSection, {
-    props: { userId: USER_ID, ...extraProps },
+    props: { userId: USER_ID, confirmToken: CONFIRM_TOKEN, ...extraProps },
     global: {
       plugins: [i18n],
       // The confirm dialogs (HeadlessUI) have their own spec; the badge/revoke

--- a/src/tests/apps/admin/AdminCustomersActions.spec.ts
+++ b/src/tests/apps/admin/AdminCustomersActions.spec.ts
@@ -194,7 +194,12 @@ describe('AdminCustomers — drawer operator actions', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}/verify`, {});
+      // Verify is the restorative arm: un-gated, so no confirmation header.
+      expect(mockApi.post).toHaveBeenCalledWith(
+        `/api/colonel/users/${PUBLIC_ID}/verify`,
+        {},
+        undefined
+      );
       expect(showMock).toHaveBeenCalledWith(
         'web.admin.customers.actions.verify.success',
         'success'
@@ -220,7 +225,13 @@ describe('AdminCustomers — drawer operator actions', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}/unverify`, {});
+      // Unverify strips colonel eligibility, so the server gates it on the
+      // account identifier (#4326) and the drawer sends it.
+      expect(mockApi.post).toHaveBeenCalledWith(
+        `/api/colonel/users/${PUBLIC_ID}/unverify`,
+        {},
+        { headers: { 'X-OTS-Confirm': encodeURIComponent(EMAIL) } }
+      );
       expect(drawer(wrapper).find('[data-testid="customer-drawer-verification"]').text()).toContain(
         'web.admin.customers.verification.unverified'
       );
@@ -277,7 +288,11 @@ describe('AdminCustomers — drawer operator actions', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.delete).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}`);
+      // The typed email is also what rides X-OTS-Confirm (#4326); the URL is
+      // left free of the address.
+      expect(mockApi.delete).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}`, {
+        headers: { 'X-OTS-Confirm': encodeURIComponent(EMAIL) },
+      });
       expect(showMock).toHaveBeenCalledWith('web.admin.customers.actions.purge.success', 'success');
       expect(drawer(wrapper).exists()).toBe(false);
       // The list is re-read (totals/pagination move server-side).
@@ -338,9 +353,14 @@ describe('useAdminCustomers — operator mutations', () => {
     const store = await seeded({ verified: false });
     mockApi.post.mockResolvedValue({ data: mutationAck() });
 
-    const updated = await store.setVerification(PUBLIC_ID, true);
+    const updated = await store.setVerification(PUBLIC_ID, true, EMAIL);
 
-    expect(mockApi.post).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}/verify`, {});
+    // The verify arm is un-gated, so the token is dropped rather than sent.
+    expect(mockApi.post).toHaveBeenCalledWith(
+      `/api/colonel/users/${PUBLIC_ID}/verify`,
+      {},
+      undefined
+    );
     expect(updated?.verified).toBe(true);
     expect(store.customers[0].verified).toBe(true);
   });
@@ -357,9 +377,11 @@ describe('useAdminCustomers — operator mutations', () => {
     const store = await seeded();
     mockApi.delete.mockResolvedValue({ data: mutationAck() });
 
-    await store.purge(PUBLIC_ID);
+    await store.purge(PUBLIC_ID, EMAIL);
 
-    expect(mockApi.delete).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}`);
+    expect(mockApi.delete).toHaveBeenCalledWith(`/api/colonel/users/${PUBLIC_ID}`, {
+      headers: { 'X-OTS-Confirm': encodeURIComponent(EMAIL) },
+    });
     expect(store.customers).toHaveLength(0);
   });
 
@@ -367,7 +389,7 @@ describe('useAdminCustomers — operator mutations', () => {
     const store = await seeded();
     mockApi.delete.mockRejectedValue(axiosError(422, { error: 'nope' }));
 
-    await expect(store.purge(PUBLIC_ID)).rejects.toBeTruthy();
+    await expect(store.purge(PUBLIC_ID, EMAIL)).rejects.toBeTruthy();
     expect(store.customers).toHaveLength(1);
   });
 
@@ -375,10 +397,11 @@ describe('useAdminCustomers — operator mutations', () => {
     const store = await seeded();
     mockApi.delete.mockResolvedValue({ data: mutationAck() });
 
-    await store.purge('ur alice/../colonel');
+    await store.purge('ur alice/../colonel', EMAIL);
 
     expect(mockApi.delete).toHaveBeenCalledWith(
-      '/api/colonel/users/ur%20alice%2F..%2Fcolonel'
+      '/api/colonel/users/ur%20alice%2F..%2Fcolonel',
+      { headers: { 'X-OTS-Confirm': encodeURIComponent(EMAIL) } }
     );
   });
 });

--- a/src/tests/apps/admin/AdminDomainDetail.spec.ts
+++ b/src/tests/apps/admin/AdminDomainDetail.spec.ts
@@ -71,6 +71,14 @@ import { createTestI18n } from '@tests/setup';
 const i18n = createTestI18n();
 
 const EXTID = 'cd_abc123';
+/**
+ * The hostname the server gates every applying domain verb on (#4326) — an
+ * identifier the URL (an extid) does not carry. The typed-confirm dialog still
+ * asks for the extid; the header is what the server checks.
+ */
+const CONFIRM_HEADERS = {
+  headers: { 'X-OTS-Confirm': encodeURIComponent('secrets.example.com') },
+};
 const DETAIL_URL = `/api/colonel/domains/${EXTID}`;
 
 function detailPayload(overrides: Record<string, unknown> = {}) {
@@ -346,7 +354,8 @@ describe('AdminDomainDetail', () => {
       await wrapper.find('[data-testid="remove-preview"]').trigger('click');
       await flushPromises();
 
-      expect(mockApi.delete).toHaveBeenCalledWith(`${DETAIL_URL}?dry_run=true`);
+      // A preview is EXEMPT server-side, so it sends no confirmation header.
+      expect(mockApi.delete).toHaveBeenCalledWith(`${DETAIL_URL}?dry_run=true`, undefined);
       const plan = wrapper.find('[data-testid="remove-plan"]');
       expect(plan.exists()).toBe(true);
       expect(plan.text()).toContain('Acme');
@@ -400,7 +409,10 @@ describe('AdminDomainDetail', () => {
       await flushPromises();
 
       // The apply MUST say dry_run=false — the endpoint defaults it to true.
-      expect(mockApi.delete).toHaveBeenCalledWith(`${DETAIL_URL}?dry_run=false`);
+      expect(mockApi.delete).toHaveBeenCalledWith(
+        `${DETAIL_URL}?dry_run=false`,
+        CONFIRM_HEADERS
+      );
       expect(showMock).toHaveBeenCalledWith('web.admin.domains.actions.remove.success', 'success');
       expect(pushMock).toHaveBeenCalledWith({ name: 'AdminDomains' });
     });
@@ -418,10 +430,11 @@ describe('AdminDomainDetail', () => {
       await wrapper.find('[data-testid="transfer-preview"]').trigger('click');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/transfer`, {
-        dry_run: true,
-        to_org: 'org_new',
-      });
+      expect(mockApi.post).toHaveBeenCalledWith(
+        `${DETAIL_URL}/transfer`,
+        { dry_run: true, to_org: 'org_new' },
+        undefined
+      );
       expect(wrapper.find('[data-testid="transfer-plan"]').text()).toContain('Globex');
 
       await wrapper.find('[data-testid="transfer-apply"]').trigger('click');
@@ -430,10 +443,11 @@ describe('AdminDomainDetail', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/transfer`, {
-        dry_run: false,
-        to_org: 'org_new',
-      });
+      expect(mockApi.post).toHaveBeenCalledWith(
+        `${DETAIL_URL}/transfer`,
+        { dry_run: false, to_org: 'org_new' },
+        CONFIRM_HEADERS
+      );
       expect(showMock).toHaveBeenCalledWith(
         'web.admin.domains.actions.transfer.success',
         'success'
@@ -454,7 +468,11 @@ describe('AdminDomainDetail', () => {
       await wrapper.find('[data-testid="repair-preview"]').trigger('click');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/repair`, { dry_run: true });
+      expect(mockApi.post).toHaveBeenCalledWith(
+        `${DETAIL_URL}/repair`,
+        { dry_run: true },
+        undefined
+      );
       expect(wrapper.find('[data-testid="repair-status"]').text()).toBe('planned');
 
       await wrapper.find('[data-testid="repair-apply"]').trigger('click');
@@ -463,7 +481,11 @@ describe('AdminDomainDetail', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/repair`, { dry_run: false });
+      expect(mockApi.post).toHaveBeenCalledWith(
+        `${DETAIL_URL}/repair`,
+        { dry_run: false },
+        CONFIRM_HEADERS
+      );
       expect(showMock).toHaveBeenCalledWith('web.admin.domains.actions.repair.success', 'success');
     });
 
@@ -476,10 +498,11 @@ describe('AdminDomainDetail', () => {
       await wrapper.find('[data-testid="repair-preview"]').trigger('click');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenCalledWith(`${DETAIL_URL}/repair`, {
-        dry_run: true,
-        org_id: 'org_rescue',
-      });
+      expect(mockApi.post).toHaveBeenCalledWith(
+        `${DETAIL_URL}/repair`,
+        { dry_run: true, org_id: 'org_rescue' },
+        undefined
+      );
     });
   });
 });

--- a/src/tests/apps/admin/AdminDomainToolbox.spec.ts
+++ b/src/tests/apps/admin/AdminDomainToolbox.spec.ts
@@ -65,6 +65,14 @@ const i18n = createTestI18n();
 
 const ORPHAN_URL = '/api/colonel/domains/orphaned';
 const EXTID = 'cd_ext_1';
+/**
+ * The hostname the server gates the applying toolbox verbs on (#4326). The
+ * toolbox is driven by extid alone, so it carries the hostname off the
+ * PREVIEW's record — which is why the apply is only reachable behind a preview.
+ */
+const CONFIRM_HEADERS = {
+  headers: { 'X-OTS-Confirm': encodeURIComponent('orphan.example.com') },
+};
 
 function orphanedPayload(rows = [orphanRow()]) {
   return {
@@ -238,9 +246,11 @@ describe('AdminDomainToolbox (orphaned + probe + repair + transfer — ticket #4
       await flushPromises();
 
       // Apply POST carries dry_run:false.
-      expect(mockApi.post).toHaveBeenLastCalledWith(`/api/colonel/domains/${EXTID}/repair`, {
-        dry_run: false,
-      });
+      expect(mockApi.post).toHaveBeenLastCalledWith(
+        `/api/colonel/domains/${EXTID}/repair`,
+        { dry_run: false },
+        CONFIRM_HEADERS
+      );
       expect(showMock).toHaveBeenCalledWith('web.admin.domaintoolbox.repair.success', 'success');
     });
 
@@ -303,10 +313,11 @@ describe('AdminDomainToolbox (orphaned + probe + repair + transfer — ticket #4
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.post).toHaveBeenLastCalledWith(`/api/colonel/domains/${EXTID}/transfer`, {
-        dry_run: false,
-        to_org: 'on_dest',
-      });
+      expect(mockApi.post).toHaveBeenLastCalledWith(
+        `/api/colonel/domains/${EXTID}/transfer`,
+        { dry_run: false, to_org: 'on_dest' },
+        CONFIRM_HEADERS
+      );
       expect(showMock).toHaveBeenCalledWith('web.admin.domaintoolbox.transfer.success', 'success');
     });
   });

--- a/src/tests/apps/admin/AdminOrganizationAddMember.spec.ts
+++ b/src/tests/apps/admin/AdminOrganizationAddMember.spec.ts
@@ -77,6 +77,11 @@ const i18n = createTestI18n();
 const ORG_EXTID = 'on_abc123';
 const ORG_URL = `/api/colonel/organizations/${ORG_EXTID}`;
 const MEMBERS_URL = `${ORG_URL}/members`;
+/**
+ * Adding a member is privilege-granting, so the server gates it on the
+ * organization's NAME in X-OTS-Confirm (#4326).
+ */
+const CONFIRM_HEADERS = { headers: { 'X-OTS-Confirm': encodeURIComponent('Acme') } };
 const USERS_URL = '/api/colonel/users';
 
 /** Existing owner already on the roster. */
@@ -370,10 +375,11 @@ describe('AdminOrganizationDetail — add an existing account to the organizatio
     await flushPromises();
 
     // Never an email address: the colonel adapter resolves the public id.
-    expect(mockApi.post).toHaveBeenCalledWith(MEMBERS_URL, {
-      customer: CANDIDATE_EXTID,
-      role: 'admin',
-    });
+    expect(mockApi.post).toHaveBeenCalledWith(
+      MEMBERS_URL,
+      { customer: CANDIDATE_EXTID, role: 'admin' },
+      CONFIRM_HEADERS
+    );
     expect(showMock).toHaveBeenCalledTimes(1);
     expect(showMock.mock.calls[0][0]).toBe('web.admin.organizations.addMember.success');
     expect(showMock.mock.calls[0][1]).toBe('success');
@@ -529,10 +535,11 @@ describe('AdminOrganizationDetail — add an existing account to the organizatio
 
     await wrapper.find('[data-testid="add-member-submit"]').trigger('click');
     await flushPromises();
-    expect(mockApi.post).toHaveBeenCalledWith(MEMBERS_URL, {
-      customer: CANDIDATE_EXTID,
-      role: 'member',
-    });
+    expect(mockApi.post).toHaveBeenCalledWith(
+      MEMBERS_URL,
+      { customer: CANDIDATE_EXTID, role: 'member' },
+      CONFIRM_HEADERS
+    );
   });
 
   it('renders a retryable banner when the account search itself fails', async () => {

--- a/src/tests/apps/admin/AdminOrganizationDetail.spec.ts
+++ b/src/tests/apps/admin/AdminOrganizationDetail.spec.ts
@@ -68,6 +68,11 @@ import { createTestI18n } from '@tests/setup';
 
 const i18n = createTestI18n();
 const PUBLIC_ID = 'on_abc123';
+/**
+ * The organization NAME the server gates every org-scoped destructive verb on
+ * (#4326) — an identifier the URL (an org id) does not carry.
+ */
+const CONFIRM_HEADERS = { headers: { 'X-OTS-Confirm': encodeURIComponent('Acme') } };
 
 function detailPayload(overrides: Record<string, unknown> = {}) {
   return {
@@ -410,7 +415,8 @@ describe('AdminOrganizationDetail (org detail + entitlements + reconcile)', () =
 
     expect(mockApi.post).toHaveBeenCalledWith(
       `/api/colonel/organizations/${PUBLIC_ID}/entitlements/grant`,
-      { entitlement: 'api_access' }
+      { entitlement: 'api_access' },
+      CONFIRM_HEADERS
     );
     expect(showMock).toHaveBeenCalledTimes(1);
     expect(showMock.mock.calls[0][1]).toBe('success');
@@ -574,7 +580,8 @@ describe('AdminOrganizationDetail (org detail + entitlements + reconcile)', () =
 
     expect(mockApi.post).toHaveBeenCalledWith(
       `/api/colonel/organizations/${PUBLIC_ID}/entitlements/grant`,
-      { entitlement: 'ships_next_release' }
+      { entitlement: 'ships_next_release' },
+      CONFIRM_HEADERS
     );
   });
 
@@ -598,7 +605,8 @@ describe('AdminOrganizationDetail (org detail + entitlements + reconcile)', () =
     await flushPromises();
 
     expect(mockApi.delete).toHaveBeenCalledWith(
-      `/api/colonel/organizations/${PUBLIC_ID}/entitlements/overrides`
+      `/api/colonel/organizations/${PUBLIC_ID}/entitlements/overrides`,
+      CONFIRM_HEADERS
     );
     expect(wrapper.find('[data-testid="org-entitlement-select"]').exists()).toBe(true);
   });

--- a/src/tests/apps/admin/AdminSecrets.spec.ts
+++ b/src/tests/apps/admin/AdminSecrets.spec.ts
@@ -237,7 +237,11 @@ describe('AdminSecrets (lookup-first inspect + guarded delete — ticket #30)', 
       await dialogForm(wrapper).trigger('submit');
       await flushPromises();
 
-      expect(mockApi.delete).toHaveBeenCalledWith(RECEIPT_URL);
+      // The same shortid the operator retyped rides X-OTS-Confirm (#4326); the
+      // URL carries the objid, so the token is an identifier it does not have.
+      expect(mockApi.delete).toHaveBeenCalledWith(RECEIPT_URL, {
+        headers: { 'X-OTS-Confirm': encodeURIComponent(SHORT_ID) },
+      });
       expect(showMock).toHaveBeenCalledWith('web.admin.secrets.actions.delete.success', 'success');
       // The read-out clears back to the lookup prompt (the secret is gone).
       expect(wrapper.find('[data-testid="secret-lookup-result"]').exists()).toBe(false);

--- a/src/tests/apps/admin/AdminSecrets.spec.ts
+++ b/src/tests/apps/admin/AdminSecrets.spec.ts
@@ -65,6 +65,10 @@ const i18n = createTestI18n();
 
 const SECRET_ID = 's1';
 const SHORT_ID = 'abc123';
+// The #4326 confirm token is the RECEIPT shortid (details.metadata.shortid), NOT
+// the secret shortid — the latter is secret_id[0,8], derivable from the URL, and
+// the server rejects it. Deliberately distinct from SHORT_ID here.
+const RECEIPT_SHORT_ID = 'rh1';
 const RECEIPT_URL = `/api/colonel/secrets/${SECRET_ID}`;
 
 function receiptPayload() {
@@ -87,7 +91,7 @@ function receiptPayload() {
     details: {
       metadata: {
         receipt_id: 'r1',
-        shortid: 'rh1',
+        shortid: RECEIPT_SHORT_ID,
         state: 'viewed',
         secret_ttl: 3600,
         recipients: ['alice@example.com'],
@@ -205,7 +209,7 @@ describe('AdminSecrets (lookup-first inspect + guarded delete — ticket #30)', 
       await lookup(wrapper);
     });
 
-    it('opens a danger dialog whose confirm stays disabled until the short id is retyped', async () => {
+    it('opens a danger dialog whose confirm stays disabled until the RECEIPT short id is retyped', async () => {
       await wrapper.find('[data-testid="secret-delete-button"]').trigger('click');
       await flushPromises();
 
@@ -215,7 +219,12 @@ describe('AdminSecrets (lookup-first inspect + guarded delete — ticket #30)', 
       await dialogInput(wrapper).setValue('not-the-id');
       expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
 
+      // The SECRET shortid (URL-derivable) must NOT unlock the delete (#4326).
       await dialogInput(wrapper).setValue(SHORT_ID);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
+
+      // Only the RECEIPT shortid does.
+      await dialogInput(wrapper).setValue(RECEIPT_SHORT_ID);
       expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
     });
 
@@ -233,14 +242,15 @@ describe('AdminSecrets (lookup-first inspect + guarded delete — ticket #30)', 
       });
 
       await wrapper.find('[data-testid="secret-delete-button"]').trigger('click');
-      await dialogInput(wrapper).setValue(SHORT_ID);
+      await dialogInput(wrapper).setValue(RECEIPT_SHORT_ID);
       await dialogForm(wrapper).trigger('submit');
       await flushPromises();
 
-      // The same shortid the operator retyped rides X-OTS-Confirm (#4326); the
-      // URL carries the objid, so the token is an identifier it does not have.
+      // The RECEIPT shortid the operator retyped rides X-OTS-Confirm (#4326): the
+      // route is keyed by the secret objid and secret.shortid is just its first 8
+      // chars, so the token must be an identifier the URL does not carry.
       expect(mockApi.delete).toHaveBeenCalledWith(RECEIPT_URL, {
-        headers: { 'X-OTS-Confirm': encodeURIComponent(SHORT_ID) },
+        headers: { 'X-OTS-Confirm': encodeURIComponent(RECEIPT_SHORT_ID) },
       });
       expect(showMock).toHaveBeenCalledWith('web.admin.secrets.actions.delete.success', 'success');
       // The read-out clears back to the lookup prompt (the secret is gone).
@@ -265,7 +275,7 @@ describe('AdminSecrets (lookup-first inspect + guarded delete — ticket #30)', 
       mockApi.delete.mockRejectedValue(axiosError(422, { error: 'Secret not found' }));
 
       await wrapper.find('[data-testid="secret-delete-button"]').trigger('click');
-      await dialogInput(wrapper).setValue(SHORT_ID);
+      await dialogInput(wrapper).setValue(RECEIPT_SHORT_ID);
       await dialogForm(wrapper).trigger('submit');
       await flushPromises();
 

--- a/src/tests/apps/admin/AdminSessions.spec.ts
+++ b/src/tests/apps/admin/AdminSessions.spec.ts
@@ -81,7 +81,10 @@ const DETAIL_URL = `${LIST_URL}/${HANDLE}?user_id=${OWNER}`;
 const COUNTRY_HEADER = 'web.admin.sessions.columns.country';
 const UNKNOWN = 'web.admin.sessions.detail.unknown';
 
-function sessionsPayload(rows: ColonelSession[] = [sessionRow()]) {
+function sessionsPayload(
+  rows: ColonelSession[] = [sessionRow()],
+  currentSessionHandle: string | null = null
+) {
   return {
     shrimp: '',
     record: {},
@@ -89,6 +92,9 @@ function sessionsPayload(rows: ColonelSession[] = [sessionRow()]) {
       sessions: rows,
       pagination: { page: 1, per_page: 50, total_count: rows.length, total_pages: 1 },
       scan: { scanned: rows.length, anonymous_count: 0, scan_capped: false },
+      // The acting colonel's OWN row (#4328) — null when the server cannot
+      // identify the request session.
+      current_session_handle: currentSessionHandle,
     },
   };
 }
@@ -437,6 +443,62 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
       expect(showMock).not.toHaveBeenCalled();
       expect(dialogInput(wrapper).exists()).toBe(true);
       expect(listGetCount()).toBe(before);
+    });
+  });
+
+  // ---- Self-revoke interlock (#4328) ----------------------------------------
+  //
+  // The server refuses a self-revoke with a 422 regardless; disabling here is
+  // defence in depth (mirroring the per-customer panel's badge) so the operator
+  // is not asked to retype a confirmation token for an action that cannot work.
+  describe('own session', () => {
+    const OTHER_HANDLE = 'fedcba9876543210fedcba9876543210';
+
+    async function mountWithCurrent(current: string | null) {
+      mockApi.get.mockResolvedValue({
+        data: sessionsPayload(
+          [sessionRow(), sessionRow({ session_handle: OTHER_HANDLE, email: 'bob@example.com' })],
+          current
+        ),
+      });
+      wrapper = mountView(pinia);
+      await flushPromises();
+    }
+
+    it('disables the revoke button on the row matching current_session_handle', async () => {
+      await mountWithCurrent(HANDLE);
+
+      expect(
+        wrapper.find(`[data-testid="revoke-${HANDLE}"]`).attributes('disabled')
+      ).toBeDefined();
+      expect(wrapper.find(`[data-testid="revoke-${HANDLE}"]`).attributes('title')).toBe(
+        'web.admin.sessions.revoke.ownSession'
+      );
+    });
+
+    it('leaves every other row revocable', async () => {
+      await mountWithCurrent(HANDLE);
+
+      expect(
+        wrapper.find(`[data-testid="revoke-${OTHER_HANDLE}"]`).attributes('disabled')
+      ).toBeUndefined();
+    });
+
+    it('opens no confirm dialog and issues no DELETE for the own row', async () => {
+      await mountWithCurrent(HANDLE);
+      await wrapper.find(`[data-testid="revoke-${HANDLE}"]`).trigger('click');
+      await flushPromises();
+
+      expect(dialogInput(wrapper).exists()).toBe(false);
+      expect(mockApi.delete).not.toHaveBeenCalled();
+    });
+
+    it('disables nothing when the server sends no current handle', async () => {
+      await mountWithCurrent(null);
+
+      expect(
+        wrapper.find(`[data-testid="revoke-${HANDLE}"]`).attributes('disabled')
+      ).toBeUndefined();
     });
   });
 });

--- a/src/tests/apps/admin/AdminSessions.spec.ts
+++ b/src/tests/apps/admin/AdminSessions.spec.ts
@@ -65,7 +65,17 @@ import { createTestI18n } from '@tests/setup';
 const i18n = createTestI18n();
 
 const LIST_URL = '/api/colonel/sessions';
-const SID = 'sid_auth_1';
+/**
+ * A 32-hex opaque handle (#4330). The console never receives the raw session id
+ * — that value is the user's `onetime.session` cookie — so every route, testid
+ * and confirmation below is keyed on this instead. RAW_SID exists only to be
+ * asserted ABSENT from the DOM.
+ */
+const HANDLE = '0123456789abcdef0123456789abcdef';
+const RAW_SID = 'a'.repeat(64);
+const OWNER = 'ext_1';
+const OWNER_EMAIL = 'alice@example.com';
+const DETAIL_URL = `${LIST_URL}/${HANDLE}?user_id=${OWNER}`;
 
 /** Pass-through i18n (ADR-014): keys render verbatim, so assert on the key. */
 const COUNTRY_HEADER = 'web.admin.sessions.columns.country';
@@ -85,11 +95,10 @@ function sessionsPayload(rows: ColonelSession[] = [sessionRow()]) {
 
 function sessionRow(overrides: Partial<ColonelSession> = {}): ColonelSession {
   return {
-    session_id: SID,
-    key: `session:${SID}`,
+    session_handle: HANDLE,
     authenticated: true,
-    email: 'alice@example.com',
-    external_id: 'ext_1',
+    email: OWNER_EMAIL,
+    external_id: OWNER,
     role: 'customer',
     ip_address: '203.0.113.7',
     user_agent: 'Mozilla/5.0',
@@ -116,8 +125,7 @@ function detailPayload() {
   return {
     shrimp: '',
     record: {
-      session_id: SID,
-      key: `session:${SID}`,
+      session_handle: HANDLE,
       ttl: 3600,
       authenticated: true,
       email: 'alice@example.com',
@@ -132,14 +140,17 @@ function detailPayload() {
       authenticated_by: ['password'],
       active_session_id: 'as_1',
     },
-    details: { data: { authenticated: true, email: 'alice@example.com' } },
+    details: {
+      data: { authenticated: true, email: 'alice@example.com' },
+      scan_capped: false,
+    },
   };
 }
 
 function revokeAck() {
   return {
     shrimp: '',
-    record: { session_id: SID, deleted: true },
+    record: { session_handle: HANDLE, deleted: true },
     details: { message: 'Session revoked successfully' },
   };
 }
@@ -192,10 +203,30 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
     });
     const table = wrapper.find('[data-testid="sessions-table"]');
     expect(table.exists()).toBe(true);
-    expect(table.text()).toContain(SID);
+    // Truncated handle in the cell, full value in the title attribute.
+    expect(table.text()).toContain(HANDLE.slice(0, 12));
     // Email is obscured by default (RevealEmail); full address hidden until reveal.
     expect(table.text()).not.toContain('alice@example.com');
     expect(table.text()).toContain('a•••@e•••.com');
+  });
+
+  it('never renders a raw session id, even when the backend leaks one', async () => {
+    // The schema strips unknown keys, so a leaked sid cannot reach the row —
+    // this is the belt-and-braces DOM assertion for #4330: no 64-hex string
+    // (the raw sid shape) anywhere in the console, list or drawer.
+    const leaky = { ...sessionRow(), session_id: RAW_SID, key: `session:${RAW_SID}` };
+    mockApi.get.mockResolvedValueOnce({
+      data: sessionsPayload([leaky as unknown as ColonelSession]),
+    });
+    wrapper = mountView(pinia);
+    await flushPromises();
+
+    mockApi.get.mockResolvedValueOnce({ data: detailPayload() });
+    await wrapper.find('[data-testid="sessions-table"] tbody tr').trigger('click');
+    await flushPromises();
+
+    expect(wrapper.html()).not.toMatch(/[0-9a-f]{64}/i);
+    expect(wrapper.html()).not.toContain(RAW_SID);
   });
 
   it('debounces the search box into a single filtered fetch', async () => {
@@ -273,8 +304,8 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
     it('renders a null and an absent geo_country as Unknown', async () => {
       mockApi.get.mockResolvedValue({
         data: sessionsPayload([
-          sessionRow({ session_id: 'sid_null', geo_country: null }),
-          sessionRowWithoutCountry({ session_id: 'sid_absent' }),
+          sessionRow({ session_handle: 'b'.repeat(32), geo_country: null }),
+          sessionRowWithoutCountry({ session_handle: 'c'.repeat(32) }),
         ]),
       });
       wrapper = mountView(pinia);
@@ -286,9 +317,13 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
 
     it('never leaks an IP into the country cell — only a 2-letter code or Unknown', async () => {
       const rows = [
-        sessionRow({ session_id: 'sid_code', ip_address: '203.0.113.7', geo_country: 'DE' }),
-        sessionRow({ session_id: 'sid_null', ip_address: '192.0.2.44', geo_country: null }),
-        sessionRowWithoutCountry({ session_id: 'sid_absent', ip_address: '2001:db8::1' }),
+        sessionRow({
+          session_handle: 'd'.repeat(32),
+          ip_address: '203.0.113.7',
+          geo_country: 'DE',
+        }),
+        sessionRow({ session_handle: 'e'.repeat(32), ip_address: '192.0.2.44', geo_country: null }),
+        sessionRowWithoutCountry({ session_handle: 'f'.repeat(32), ip_address: '2001:db8::1' }),
       ];
       mockApi.get.mockResolvedValue({ data: sessionsPayload(rows) });
       wrapper = mountView(pinia);
@@ -314,7 +349,8 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
     await wrapper.find('[data-testid="sessions-table"] tbody tr').trigger('click');
     await flushPromises();
 
-    expect(mockApi.get).toHaveBeenCalledWith(`${LIST_URL}/${SID}`, undefined);
+    // The handle routes, and the row's owner rides along as the resolution hint.
+    expect(mockApi.get).toHaveBeenCalledWith(DETAIL_URL, undefined);
     const content = wrapper.find('[data-testid="session-drawer-content"]');
     expect(content.exists()).toBe(true);
     expect(content.text()).toContain('as_1'); // active_session_id field
@@ -329,17 +365,30 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
       await flushPromises();
     });
 
-    it('opens a danger dialog from the row action, gated until the id is retyped', async () => {
-      await wrapper.find(`[data-testid="revoke-${SID}"]`).trigger('click');
+    it('opens a danger dialog gated on the session OWNER, not on the handle', async () => {
+      await wrapper.find(`[data-testid="revoke-${HANDLE}"]`).trigger('click');
       await flushPromises();
 
       expect(dialogInput(wrapper).exists()).toBe(true);
       expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
 
-      await dialogInput(wrapper).setValue('not-the-id');
+      // The handle is what routes the request, so retyping it must NOT unlock
+      // the gate — the token is a second, independent identifier (#4330/#4326).
+      await dialogInput(wrapper).setValue(HANDLE);
       expect(dialogSubmit(wrapper).attributes('disabled')).toBeDefined();
 
-      await dialogInput(wrapper).setValue(SID);
+      await dialogInput(wrapper).setValue(OWNER_EMAIL);
+      expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
+    });
+
+    it('falls back to the external id as the confirmation token when the row has no email', async () => {
+      wrapper.unmount();
+      mockApi.get.mockResolvedValue({ data: sessionsPayload([sessionRow({ email: null })]) });
+      wrapper = mountView(pinia);
+      await flushPromises();
+
+      await wrapper.find(`[data-testid="revoke-${HANDLE}"]`).trigger('click');
+      await dialogInput(wrapper).setValue(OWNER);
       expect(dialogSubmit(wrapper).attributes('disabled')).toBeUndefined();
     });
 
@@ -347,12 +396,12 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
       mockApi.delete.mockResolvedValue({ data: revokeAck() });
       const before = listGetCount();
 
-      await wrapper.find(`[data-testid="revoke-${SID}"]`).trigger('click');
-      await dialogInput(wrapper).setValue(SID);
+      await wrapper.find(`[data-testid="revoke-${HANDLE}"]`).trigger('click');
+      await dialogInput(wrapper).setValue(OWNER_EMAIL);
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.delete).toHaveBeenCalledWith(`${LIST_URL}/${SID}`);
+      expect(mockApi.delete).toHaveBeenCalledWith(DETAIL_URL);
       expect(showMock).toHaveBeenCalledWith('web.admin.sessions.revoke.success', 'success');
       expect(dialogInput(wrapper).exists()).toBe(false);
       expect(listGetCount()).toBe(before + 1);
@@ -360,7 +409,7 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
 
     it('does NOT DELETE when submitted without a matching token', async () => {
       mockApi.delete.mockResolvedValue({ data: revokeAck() });
-      await wrapper.find(`[data-testid="revoke-${SID}"]`).trigger('click');
+      await wrapper.find(`[data-testid="revoke-${HANDLE}"]`).trigger('click');
       await dialogInput(wrapper).setValue('wrong');
       await wrapper.find('form').trigger('submit');
       await flushPromises();
@@ -373,8 +422,8 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
       mockApi.delete.mockRejectedValue(axiosError(404, { error: 'Session not found' }));
       const before = listGetCount();
 
-      await wrapper.find(`[data-testid="revoke-${SID}"]`).trigger('click');
-      await dialogInput(wrapper).setValue(SID);
+      await wrapper.find(`[data-testid="revoke-${HANDLE}"]`).trigger('click');
+      await dialogInput(wrapper).setValue(OWNER_EMAIL);
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 

--- a/src/tests/apps/admin/AdminSessions.spec.ts
+++ b/src/tests/apps/admin/AdminSessions.spec.ts
@@ -401,7 +401,13 @@ describe('AdminSessions (list + search + inspect + guarded revoke — ticket #40
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.delete).toHaveBeenCalledWith(DETAIL_URL);
+      // The session owner's email rides X-OTS-Confirm (#4326) — a HEADER, so it
+      // never lands in an access log or the operator's history. `?user_id=` is
+      // only the owner hint for the handle lookup.
+      expect(mockApi.delete).toHaveBeenCalledWith(DETAIL_URL, {
+        headers: { 'X-OTS-Confirm': encodeURIComponent(OWNER_EMAIL) },
+      });
+      expect(DETAIL_URL).not.toContain(encodeURIComponent(OWNER_EMAIL));
       expect(showMock).toHaveBeenCalledWith('web.admin.sessions.revoke.success', 'success');
       expect(dialogInput(wrapper).exists()).toBe(false);
       expect(listGetCount()).toBe(before + 1);

--- a/src/tests/apps/admin/DomainConfigsSection.spec.ts
+++ b/src/tests/apps/admin/DomainConfigsSection.spec.ts
@@ -68,6 +68,16 @@ const i18n = createTestI18n();
 
 const EXTID = 'cd_abc123';
 const CONFIGS_URL = `/api/colonel/domains/${EXTID}/configs`;
+
+/**
+ * The composed token the server requires for the per-config verbs (#4326):
+ * "<display_domain>:<kind>". The URL carries the extid and the kind, so the
+ * hostname is the half a scraped-URL replay does not have. `ensure` is un-gated.
+ */
+function confirmHeadersFor(kind: string) {
+  return { headers: { 'X-OTS-Confirm': encodeURIComponent(`secrets.example.com:${kind}`) } };
+}
+
 const ALL_KINDS = ['signin', 'signup', 'homepage', 'api', 'incoming', 'sso', 'mailer'] as const;
 
 function envelopeRecord() {
@@ -520,9 +530,11 @@ describe('DomainConfigsSection', () => {
 
       // Audit fidelity: only the diff ships, so the server's `changed:[...]`
       // audit detail lists real changes.
-      expect(mockApi.put).toHaveBeenCalledWith(`${CONFIGS_URL}/signin`, {
-        email_auth_enabled: true,
-      });
+      expect(mockApi.put).toHaveBeenCalledWith(
+        `${CONFIGS_URL}/signin`,
+        { email_auth_enabled: true },
+        confirmHeadersFor('signin')
+      );
       expect(showMock).toHaveBeenCalledWith('web.admin.domains.configs.edit.success', 'success');
       expect(mockApi.get).toHaveBeenCalledTimes(2);
       expect(wrapper.find('[data-testid="config-edit-modal"]').exists()).toBe(false);
@@ -558,13 +570,17 @@ describe('DomainConfigsSection', () => {
       await wrapper.find('[data-testid="config-edit-submit"]').trigger('click');
       await flushPromises();
 
-      expect(mockApi.put).toHaveBeenCalledWith(`${CONFIGS_URL}/signup`, {
-        enabled: false,
-        signup_enabled: false,
-        autoverify: false,
-        validation_strategy: 'passthrough',
-        allowed_signup_domains: [],
-      });
+      expect(mockApi.put).toHaveBeenCalledWith(
+        `${CONFIGS_URL}/signup`,
+        {
+          enabled: false,
+          signup_enabled: false,
+          autoverify: false,
+          validation_strategy: 'passthrough',
+          allowed_signup_domains: [],
+        },
+        confirmHeadersFor('signup')
+      );
     });
 
     it('falls back to passthrough when a legacy record hydrates a null strategy', async () => {
@@ -589,9 +605,11 @@ describe('DomainConfigsSection', () => {
 
       await wrapper.find('[data-testid="config-edit-submit"]').trigger('click');
       await flushPromises();
-      expect(mockApi.put).toHaveBeenCalledWith(`${CONFIGS_URL}/signup`, {
-        validation_strategy: 'passthrough',
-      });
+      expect(mockApi.put).toHaveBeenCalledWith(
+        `${CONFIGS_URL}/signup`,
+        { validation_strategy: 'passthrough' },
+        confirmHeadersFor('signup')
+      );
     });
 
     it('still succeeds on an upsert ack that fails the contract, but warns', async () => {
@@ -656,7 +674,10 @@ describe('DomainConfigsSection', () => {
       await wrapper.find('form').trigger('submit');
       await flushPromises();
 
-      expect(mockApi.delete).toHaveBeenCalledWith(`${CONFIGS_URL}/sso`);
+      expect(mockApi.delete).toHaveBeenCalledWith(
+        `${CONFIGS_URL}/sso`,
+        confirmHeadersFor('sso')
+      );
       expect(showMock).toHaveBeenCalledWith(
         'web.admin.domains.configs.delete.success',
         'success'

--- a/src/tests/apps/admin/ElevationBanner.spec.ts
+++ b/src/tests/apps/admin/ElevationBanner.spec.ts
@@ -152,7 +152,7 @@ describe('ElevationBanner', () => {
         await flushPromises();
 
         expect(fetchMock).toHaveBeenCalledWith(
-          '/auth/logout',
+          '/logout',
           expect.objectContaining({ method: 'GET' })
         );
         expect(assignMock).toHaveBeenCalledWith('/signin?redirect=/colonel');

--- a/src/tests/apps/admin/ElevationBanner.spec.ts
+++ b/src/tests/apps/admin/ElevationBanner.spec.ts
@@ -121,19 +121,49 @@ describe('ElevationBanner', () => {
   });
 
   describe('the expired state (#4331)', () => {
-    it('renders the notice with a sign-in link once a 401 carries the marker', async () => {
-      await mountWith();
-      expect(wrapper.find('[data-testid="admin-session-expired-banner"]').exists()).toBe(false);
+    it('renders the notice with a session-clearing recovery control once a 401 carries the marker', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchMock);
+      const originalLocation = window.location;
+      const assignMock = vi.fn();
+      Object.defineProperty(window, 'location', {
+        value: { assign: assignMock },
+        writable: true,
+        configurable: true,
+      });
 
-      noteAdminSessionExpiry(expiredError('idle'));
-      await flushPromises();
+      try {
+        await mountWith();
+        expect(wrapper.find('[data-testid="admin-session-expired-banner"]').exists()).toBe(false);
 
-      const banner = wrapper.find('[data-testid="admin-session-expired-banner"]');
-      expect(banner.exists()).toBe(true);
-      expect(banner.text()).toContain('web.admin.session.expired');
-      expect(wrapper.find('[data-testid="admin-session-signin"]').attributes('href')).toBe(
-        '/signin?redirect=/colonel'
-      );
+        noteAdminSessionExpiry(expiredError('idle'));
+        await flushPromises();
+
+        const banner = wrapper.find('[data-testid="admin-session-expired-banner"]');
+        expect(banner.exists()).toBe(true);
+        expect(banner.text()).toContain('web.admin.session.expired');
+
+        // The recovery affordance is an ACTION, not a bare link: a /signin link
+        // no-ops in simple mode while the cookie still reads authenticated, so
+        // clicking it clears the session first, then navigates (#4331).
+        const signin = wrapper.find('[data-testid="admin-session-signin"]');
+        expect(signin.exists()).toBe(true);
+        await signin.trigger('click');
+        await flushPromises();
+
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/auth/logout',
+          expect.objectContaining({ method: 'GET' })
+        );
+        expect(assignMock).toHaveBeenCalledWith('/signin?redirect=/colonel');
+      } finally {
+        Object.defineProperty(window, 'location', {
+          value: originalLocation,
+          writable: true,
+          configurable: true,
+        });
+        vi.unstubAllGlobals();
+      }
     });
 
     // Priority, both ways round: an operator with a live sudo window whose admin

--- a/src/tests/apps/admin/ElevationBanner.spec.ts
+++ b/src/tests/apps/admin/ElevationBanner.spec.ts
@@ -1,0 +1,206 @@
+// src/tests/apps/admin/ElevationBanner.spec.ts
+
+import { AxiosError } from 'axios';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The one banner mounted in AdminLayout, in both of its states.
+ *
+ * #4327 — a live step-up window counts down here, and NOTHING renders when no
+ * window is open (a permanent "you are not elevated" bar would train operators
+ * to ignore the bar that matters).
+ *
+ * #4331 — the expired-admin-session notice. The server bounds /api/colonel but
+ * deliberately does NOT gate the /colonel shell, so the SPA loads on a stale
+ * session and this banner is where the operator learns why nothing works. It
+ * WINS over every elevation state: an elevation window is meaningless once the
+ * surface itself refuses the session.
+ *
+ * The other load-bearing property asserted here is the absence of a timer that
+ * makes a request: the countdown is local, so an idle admin tab issues no HTTP.
+ * A poll would refresh the server-side activity clock the #4331 idle bound reads
+ * and silently disable a shipped security control.
+ */
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+import ElevationBanner from '@/apps/admin/components/ElevationBanner.vue';
+import {
+  __resetColonelElevationState,
+  useColonelElevation,
+} from '@/apps/admin/composables/useColonelElevation';
+import {
+  ADMIN_SESSION_EXPIRED_PREFIX,
+  noteAdminSessionExpiry,
+} from '@/apps/admin/utils/adminSessionExpiry';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+function statusPayload(record: Record<string, unknown> = {}) {
+  return {
+    shrimp: '',
+    record: { elevated: false, expires_at: null, seconds_remaining: 0, ...record },
+    details: {
+      enabled: true,
+      window: 600,
+      reauth_grace: 0,
+      grace_available: false,
+      password_available: true,
+      factors: ['password'],
+    },
+  };
+}
+
+/** An Axios 401 carrying the server's admin-session-expired marker. */
+function expiredError(reason = 'absolute'): AxiosError {
+  const error = new AxiosError('Request failed with status code 401');
+  error.response = {
+    status: 401,
+    statusText: 'Unauthorized',
+    headers: {},
+    config: {} as never,
+    data: {
+      error: 'Authentication Required',
+      message: `${ADMIN_SESSION_EXPIRED_PREFIX} Admin session ${reason} timeout exceeded; sign in again`,
+    },
+  };
+  return error;
+}
+
+describe('ElevationBanner', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetColonelElevationState();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    __resetColonelElevationState();
+  });
+
+  async function mountWith(record: Record<string, unknown> = {}): Promise<void> {
+    mockApi.get.mockResolvedValue({ data: statusPayload(record) });
+    wrapper = mount(ElevationBanner, { global: { plugins: [i18n] } });
+    await flushPromises();
+  }
+
+  describe('the elevation states (#4327)', () => {
+    it('renders nothing when no window is open', async () => {
+      await mountWith();
+
+      expect(wrapper.find('[data-testid="elevation-banner"]').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="admin-session-expired-banner"]').exists()).toBe(false);
+    });
+
+    it('renders the countdown while a window is live', async () => {
+      await mountWith({ elevated: true, expires_at: 1_700_000_600, seconds_remaining: 305 });
+
+      // i18n is pass-through in these specs, so the interpolated mm:ss does not
+      // land in the rendered text — assert on the key instead.
+      const banner = wrapper.find('[data-testid="elevation-banner"]');
+      expect(banner.exists()).toBe(true);
+      expect(banner.text()).toContain('web.admin.elevation.banner.active');
+    });
+  });
+
+  describe('the expired state (#4331)', () => {
+    it('renders the notice with a sign-in link once a 401 carries the marker', async () => {
+      await mountWith();
+      expect(wrapper.find('[data-testid="admin-session-expired-banner"]').exists()).toBe(false);
+
+      noteAdminSessionExpiry(expiredError('idle'));
+      await flushPromises();
+
+      const banner = wrapper.find('[data-testid="admin-session-expired-banner"]');
+      expect(banner.exists()).toBe(true);
+      expect(banner.text()).toContain('web.admin.session.expired');
+      expect(wrapper.find('[data-testid="admin-session-signin"]').attributes('href')).toBe(
+        '/signin?redirect=/colonel'
+      );
+    });
+
+    // Priority, both ways round: an operator with a live sudo window whose admin
+    // surface has expired must see the reason nothing works, not a countdown
+    // that no longer buys them anything.
+    it('WINS over a live elevation window', async () => {
+      await mountWith({ elevated: true, expires_at: 1_700_000_600, seconds_remaining: 305 });
+      expect(wrapper.find('[data-testid="elevation-banner"]').exists()).toBe(true);
+
+      noteAdminSessionExpiry(expiredError());
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="admin-session-expired-banner"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="elevation-banner"]').exists()).toBe(false);
+    });
+
+    it('WINS over a recent_auth window too', async () => {
+      await mountWith({ elevated: true, expires_at: 1_700_000_600, seconds_remaining: 305 });
+      useColonelElevation().activeFactor.value = 'recent_auth';
+      await flushPromises();
+      expect(wrapper.find('[data-testid="elevation-banner"]').exists()).toBe(true);
+
+      noteAdminSessionExpiry(expiredError());
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="admin-session-expired-banner"]').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="elevation-banner"]').exists()).toBe(false);
+    });
+
+    // The composable's own catch is what discovers the expiry on a stale tab:
+    // refresh() is the first request the console makes on entry.
+    it('is raised by the status fetch the banner itself makes on mount', async () => {
+      mockApi.get.mockRejectedValue(expiredError());
+      wrapper = mount(ElevationBanner, { global: { plugins: [i18n] } });
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="admin-session-expired-banner"]').exists()).toBe(true);
+    });
+
+    it('ignores a 401 that is not an expired admin window', async () => {
+      await mountWith();
+
+      const other = new AxiosError('Request failed with status code 401');
+      other.response = {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: {},
+        config: {} as never,
+        data: { error: 'Authentication Required', message: '[SESSION_NOT_AUTHENTICATED]' },
+      };
+      expect(noteAdminSessionExpiry(other)).toBe(false);
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="admin-session-expired-banner"]').exists()).toBe(false);
+    });
+  });
+
+  // #4331's idle bound only bites because nothing here polls.
+  it('makes exactly ONE request for the life of the banner', async () => {
+    await mountWith({ elevated: true, expires_at: 1_700_000_600, seconds_remaining: 305 });
+    const calls = mockApi.get.mock.calls.length;
+
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(60_000);
+    vi.useRealTimers();
+    await flushPromises();
+
+    expect(mockApi.get.mock.calls.length).toBe(calls);
+  });
+});

--- a/src/tests/apps/admin/ElevationPrompt.spec.ts
+++ b/src/tests/apps/admin/ElevationPrompt.spec.ts
@@ -1,0 +1,241 @@
+// src/tests/apps/admin/ElevationPrompt.spec.ts
+
+import { AxiosError } from 'axios';
+import { flushPromises, mount, VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The step-up (sudo) prompt (#4327).
+ *
+ * The property under test is the one the security review's B-3 finding turns
+ * on: the prompt NEVER elevates without an explicit operator gesture. The
+ * rejected first draft called `elevate('recent_auth')` silently on open, which
+ * made step-up a no-op for the first N seconds after every colonel sign-in.
+ *
+ * Three forks, decided by what the SERVER says this account can do:
+ *   1. password holder      → the shared password modal;
+ *   2. SSO-only + a grace   → one deliberate "confirm it's me" click;
+ *   3. SSO-only, no grace   → the remediation, and no input at all.
+ */
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+vi.mock('@/shared/components/icons/OIcon.vue', () => ({
+  default: {
+    name: 'OIcon',
+    template: '<span class="o-icon" :data-name="name" />',
+    props: ['collection', 'name', 'class', 'size', 'aria-label'],
+  },
+}));
+
+vi.mock('@headlessui/vue', () => ({
+  Dialog: {
+    name: 'Dialog',
+    template: '<div role="dialog" @close="$emit(\'close\')"><slot /></div>',
+    props: ['class'],
+    emits: ['close'],
+  },
+  DialogPanel: { name: 'DialogPanel', template: '<div class="dialog-panel"><slot /></div>', props: ['class'] },
+  DialogTitle: { name: 'DialogTitle', template: '<h3><slot /></h3>', props: ['as', 'class'] },
+  TransitionRoot: {
+    name: 'TransitionRoot',
+    template: '<div v-if="show"><slot /></div>',
+    props: ['as', 'show'],
+  },
+  TransitionChild: { name: 'TransitionChild', template: '<div><slot /></div>', props: ['as'] },
+}));
+
+import ElevationPrompt from '@/apps/admin/components/ElevationPrompt.vue';
+import {
+  __resetColonelElevationState,
+  useColonelElevation,
+} from '@/apps/admin/composables/useColonelElevation';
+import { createTestI18n } from '@tests/setup';
+
+const i18n = createTestI18n();
+
+function statusPayload(details: Record<string, unknown> = {}) {
+  return {
+    shrimp: '',
+    record: { elevated: false, expires_at: null, seconds_remaining: 0 },
+    details: {
+      enabled: true,
+      window: 600,
+      reauth_grace: 0,
+      grace_available: false,
+      password_available: true,
+      factors: ['password'],
+      ...details,
+    },
+  };
+}
+
+function grantPayload(factor = 'password') {
+  return {
+    shrimp: '',
+    record: { elevated: true, expires_at: 1_700_000_600, seconds_remaining: 600 },
+    details: { factor, window: 600 },
+  };
+}
+
+describe('ElevationPrompt', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetColonelElevationState();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    __resetColonelElevationState();
+  });
+
+  async function mountWith(details: Record<string, unknown> = {}): Promise<void> {
+    mockApi.get.mockResolvedValue({ data: statusPayload(details) });
+    wrapper = mount(ElevationPrompt, { global: { plugins: [i18n] } });
+    // Seed the per-account capability before anything opens the prompt.
+    await useColonelElevation().refresh();
+    await flushPromises();
+  }
+
+  it('renders nothing while closed', async () => {
+    await mountWith();
+
+    expect(wrapper.find('[data-testid="elevation-prompt-alt"]').exists()).toBe(false);
+    expect(wrapper.html()).not.toContain('elevation-confirm-its-you');
+  });
+
+  describe('password fork (the normal case)', () => {
+    it('elevates with the typed password and resolves the pending request', async () => {
+      await mountWith();
+      mockApi.post.mockResolvedValue({ data: grantPayload() });
+
+      const elevation = useColonelElevation();
+      const pending = elevation.requestElevation();
+      await flushPromises();
+
+      // The shared modal owns the input; drive its emit directly.
+      const modal = wrapper.findComponent({ name: 'PasswordConfirmModal' });
+      expect(modal.exists()).toBe(true);
+      modal.vm.$emit('confirm', 'hunter2');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/elevation', {
+        factor: 'password',
+        password: 'hunter2',
+      });
+      await expect(pending).resolves.toBe(true);
+    });
+
+    it('keeps the prompt open and resolves nothing when the password is wrong', async () => {
+      await mountWith();
+      // A real AxiosError, so the shared classifier extracts `data.error` —
+      // the server's remediation message is the whole point of showing it.
+      const rejection = new AxiosError('Request failed');
+      rejection.response = {
+        status: 403,
+        data: { error: 'Password verification failed.', error_code: 'elevation_failed' },
+        statusText: '',
+        headers: {},
+        config: {} as never,
+      };
+      mockApi.post.mockRejectedValue(rejection);
+
+      const elevation = useColonelElevation();
+      void elevation.requestElevation();
+      await flushPromises();
+
+      wrapper.findComponent({ name: 'PasswordConfirmModal' }).vm.$emit('confirm', 'wrong');
+      await flushPromises();
+
+      expect(elevation.promptOpen.value).toBe(true);
+      expect(elevation.error.value).toBe('Password verification failed.');
+    });
+
+    it('resolves false on cancel and elevates nothing', async () => {
+      await mountWith();
+
+      const elevation = useColonelElevation();
+      const pending = elevation.requestElevation();
+      await flushPromises();
+
+      wrapper.findComponent({ name: 'PasswordConfirmModal' }).vm.$emit('cancel');
+      await flushPromises();
+
+      await expect(pending).resolves.toBe(false);
+      expect(mockApi.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recent_auth fork (SSO-only account, grace configured)', () => {
+    const details = {
+      password_available: false,
+      reauth_grace: 300,
+      grace_available: true,
+      factors: ['password', 'recent_auth'],
+    };
+
+    // The B-3 regression guard, on the client side.
+    it('does NOT elevate on open — it waits for a click', async () => {
+      await mountWith(details);
+
+      void useColonelElevation().requestElevation();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="elevation-confirm-its-you"]').exists()).toBe(true);
+      expect(mockApi.post).not.toHaveBeenCalled();
+    });
+
+    it('elevates on the deliberate click', async () => {
+      await mountWith(details);
+      mockApi.post.mockResolvedValue({ data: grantPayload('recent_auth') });
+
+      const pending = useColonelElevation().requestElevation();
+      await flushPromises();
+
+      await wrapper.find('[data-testid="elevation-confirm-its-you"]').trigger('click');
+      await flushPromises();
+
+      expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/elevation', {
+        factor: 'recent_auth',
+        password: '',
+      });
+      await expect(pending).resolves.toBe(true);
+    });
+  });
+
+  describe('unsatisfiable fork (SSO-only account, no grace)', () => {
+    const details = { password_available: false, factors: ['password'] };
+
+    it('renders the remediation and NO input', async () => {
+      await mountWith(details);
+
+      void useColonelElevation().requestElevation();
+      await flushPromises();
+
+      expect(wrapper.find('[data-testid="elevation-prompt-unsatisfiable"]').exists()).toBe(true);
+      expect(wrapper.find('input').exists()).toBe(false);
+      expect(wrapper.find('[data-testid="elevation-confirm-its-you"]').exists()).toBe(false);
+      expect(wrapper.findComponent({ name: 'PasswordConfirmModal' }).exists()).toBe(false);
+    });
+
+    it('closes without elevating', async () => {
+      await mountWith(details);
+
+      const pending = useColonelElevation().requestElevation();
+      await flushPromises();
+
+      await wrapper.find('button').trigger('click');
+      await flushPromises();
+
+      await expect(pending).resolves.toBe(false);
+      expect(mockApi.post).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/tests/apps/admin/adminSessionExpiry.spec.ts
+++ b/src/tests/apps/admin/adminSessionExpiry.spec.ts
@@ -1,0 +1,107 @@
+// src/tests/apps/admin/adminSessionExpiry.spec.ts
+
+import { AxiosError } from 'axios';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+/**
+ * The single recogniser for the #4331 expired-admin-session 401, and its wiring
+ * into the mutation path.
+ *
+ * The marker is a string contract shared with
+ * `lib/onetime/application/auth_strategies/base_session_auth_strategy.rb`, and
+ * matching too loosely is the failure mode that matters: an ordinary 401
+ * (signed out, session missing) must NOT raise a banner telling the operator
+ * their admin window expired, and a 403 from the step-up gate must not either.
+ */
+
+import { useAdminMutation } from '@/apps/admin/composables/useAdminMutation';
+import {
+  ADMIN_SESSION_EXPIRED_PREFIX,
+  adminSessionExpired,
+  clearAdminSessionExpired,
+  noteAdminSessionExpiry,
+} from '@/apps/admin/utils/adminSessionExpiry';
+
+function axiosError(status: number, data: Record<string, unknown>): AxiosError {
+  const error = new AxiosError(`Request failed with status code ${status}`);
+  error.response = {
+    status,
+    statusText: '',
+    headers: {},
+    config: {} as never,
+    data,
+  };
+  return error;
+}
+
+const expiredBody = {
+  error: 'Authentication Required',
+  message: `${ADMIN_SESSION_EXPIRED_PREFIX} Admin session idle timeout exceeded; sign in again`,
+};
+
+describe('noteAdminSessionExpiry', () => {
+  beforeEach(() => {
+    clearAdminSessionExpired();
+  });
+
+  // Otto renders an auth failure as {error: 'Authentication Required',
+  // message: '<reason>'}, so the marker arrives in `message`.
+  it('recognises the marker in the Otto auth-failure message', () => {
+    expect(noteAdminSessionExpiry(axiosError(401, expiredBody))).toBe(true);
+    expect(adminSessionExpired.value).toBe(true);
+  });
+
+  it('also recognises it in a top-level error field', () => {
+    const error = axiosError(401, { error: `${ADMIN_SESSION_EXPIRED_PREFIX} whatever` });
+
+    expect(noteAdminSessionExpiry(error)).toBe(true);
+    expect(adminSessionExpired.value).toBe(true);
+  });
+
+  it('ignores an ordinary 401', () => {
+    const error = axiosError(401, {
+      error: 'Authentication Required',
+      message: '[SESSION_NOT_AUTHENTICATED] Not authenticated',
+    });
+
+    expect(noteAdminSessionExpiry(error)).toBe(false);
+    expect(adminSessionExpired.value).toBe(false);
+  });
+
+  // The marker only ever rides a 401. A 403 carrying the same text would be a
+  // different control (#4326/#4327) and must not end the console session.
+  it('ignores the marker on any other status', () => {
+    expect(noteAdminSessionExpiry(axiosError(403, expiredBody))).toBe(false);
+    expect(adminSessionExpired.value).toBe(false);
+  });
+
+  it('ignores a network error with no response', () => {
+    expect(noteAdminSessionExpiry(new Error('Network Error'))).toBe(false);
+    expect(noteAdminSessionExpiry(null)).toBe(false);
+    expect(adminSessionExpired.value).toBe(false);
+  });
+});
+
+describe('useAdminMutation', () => {
+  beforeEach(() => {
+    clearAdminSessionExpired();
+  });
+
+  it('raises the shared flag when a mutation is refused for an expired window', async () => {
+    const mutation = useAdminMutation(() => Promise.reject(axiosError(401, expiredBody)));
+
+    expect(await mutation.run()).toBe(false);
+    expect(adminSessionExpired.value).toBe(true);
+    // The per-action error is still populated: the dialog shows the reason too.
+    expect(mutation.error.value).toBeTruthy();
+  });
+
+  it('leaves the flag alone for an ordinary failure', async () => {
+    const mutation = useAdminMutation(() =>
+      Promise.reject(axiosError(422, { error: 'Cannot purge your own account' }))
+    );
+
+    expect(await mutation.run()).toBe(false);
+    expect(adminSessionExpired.value).toBe(false);
+  });
+});

--- a/src/tests/apps/admin/adminSessionExpiry.spec.ts
+++ b/src/tests/apps/admin/adminSessionExpiry.spec.ts
@@ -1,7 +1,7 @@
 // src/tests/apps/admin/adminSessionExpiry.spec.ts
 
 import { AxiosError } from 'axios';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * The single recogniser for the #4331 expired-admin-session 401, and its wiring
@@ -20,6 +20,7 @@ import {
   adminSessionExpired,
   clearAdminSessionExpired,
   noteAdminSessionExpiry,
+  recoverAdminSession,
 } from '@/apps/admin/utils/adminSessionExpiry';
 
 function axiosError(status: number, data: Record<string, unknown>): AxiosError {
@@ -103,5 +104,60 @@ describe('useAdminMutation', () => {
 
     expect(await mutation.run()).toBe(false);
     expect(adminSessionExpired.value).toBe(false);
+  });
+});
+
+// The recovery a bare /signin link cannot do in simple mode (#4331): while the
+// shared cookie still reads authenticated, GET /signin short-circuits to
+// "already logged in" without re-stamping, so the session must be CLEARED first.
+describe('recoverAdminSession', () => {
+  let originalLocation: Location;
+  let assignMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalLocation = window.location;
+    assignMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      value: { assign: assignMock },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('logs out to clear the session, THEN navigates to sign-in', async () => {
+    const order: string[] = [];
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      order.push('logout');
+      return { ok: true };
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    assignMock.mockImplementation(() => order.push('navigate'));
+
+    await recoverAdminSession();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/auth/logout',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(assignMock).toHaveBeenCalledWith('/signin?redirect=/colonel');
+    // Order is the whole point: clearing the session must precede the sign-in.
+    expect(order).toEqual(['logout', 'navigate']);
+  });
+
+  it('still navigates when logout fails (never worse than the dead-end)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+
+    await recoverAdminSession();
+
+    expect(assignMock).toHaveBeenCalledWith('/signin?redirect=/colonel');
   });
 });

--- a/src/tests/apps/admin/adminSessionExpiry.spec.ts
+++ b/src/tests/apps/admin/adminSessionExpiry.spec.ts
@@ -145,7 +145,7 @@ describe('recoverAdminSession', () => {
     await recoverAdminSession();
 
     expect(fetchMock).toHaveBeenCalledWith(
-      '/auth/logout',
+      '/logout',
       expect.objectContaining({ method: 'GET' })
     );
     expect(assignMock).toHaveBeenCalledWith('/signin?redirect=/colonel');

--- a/src/tests/apps/admin/sessionSchemas.spec.ts
+++ b/src/tests/apps/admin/sessionSchemas.spec.ts
@@ -126,6 +126,42 @@ describe('colonelSessionsResponseSchema (ListSessions)', () => {
     delete payload.details.sessions[0].authenticated;
     expect(colonelSessionsResponseSchema.safeParse(payload).success).toBe(false);
   });
+
+  // #4328: the acting colonel's own row, so the console can disable its revoke.
+  it('parses current_session_handle as a handle or a null', () => {
+    const payload = listPayload() as unknown as {
+      details: { current_session_handle?: string | null };
+    };
+    payload.details.current_session_handle = HANDLE_B;
+    let result = colonelSessionsResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.details?.current_session_handle).toBe(HANDLE_B);
+    }
+
+    payload.details.current_session_handle = null;
+    result = colonelSessionsResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.details?.current_session_handle).toBeNull();
+    }
+  });
+
+  it('parses a listing that OMITS current_session_handle (deploy skew)', () => {
+    const payload = listPayload();
+    expect('current_session_handle' in payload.details).toBe(false);
+    expect(colonelSessionsResponseSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('rejects a raw session id under current_session_handle', () => {
+    // The acting colonel's OWN sid is still a bearer credential: the same
+    // tripwire has to cover it.
+    const payload = listPayload() as unknown as {
+      details: { current_session_handle?: string | null };
+    };
+    payload.details.current_session_handle = RAW_SID;
+    expect(colonelSessionsResponseSchema.safeParse(payload).success).toBe(false);
+  });
 });
 
 describe('colonelSessionDetailResponseSchema (GetSessionDetail)', () => {

--- a/src/tests/apps/admin/sessionSchemas.spec.ts
+++ b/src/tests/apps/admin/sessionSchemas.spec.ts
@@ -8,6 +8,11 @@ import {
   colonelSessionDeleteResponseSchema,
 } from '@/schemas/api/internal/responses/colonel-sessions';
 
+const HANDLE = '0123456789abcdef0123456789abcdef';
+const HANDLE_B = 'fedcba9876543210fedcba9876543210';
+/** The raw sid shape the console must never see again (#4330). */
+const RAW_SID = 'a'.repeat(64);
+
 /**
  * Zod tripwire (CONTRACT 3) for the three NEW Sessions-console contracts. These
  * payloads are shaped exactly as the live logic classes emit them — verified
@@ -24,8 +29,7 @@ function listPayload() {
     details: {
       sessions: [
         {
-          session_id: 'sid_auth',
-          key: 'session:sid_auth',
+          session_handle: HANDLE,
           authenticated: true,
           email: 'alice@example.com',
           external_id: 'ext_1',
@@ -35,8 +39,7 @@ function listPayload() {
           created_at: 1700000000,
         },
         {
-          session_id: 'sid_anon',
-          key: 'session:sid_anon',
+          session_handle: HANDLE_B,
           authenticated: false,
           email: null,
           external_id: null,
@@ -94,6 +97,28 @@ describe('colonelSessionsResponseSchema (ListSessions)', () => {
     expect(result.data.details?.sessions[0].geo_country).toBeUndefined();
   });
 
+  it('rejects a raw session id under session_handle — the security tripwire', () => {
+    // A backend regression that put the bearer sid back on the wire must fail
+    // parsing here (the handle regex is 32 lowercase hex), not render in the UI.
+    const payload = listPayload();
+    (payload.details.sessions[0] as unknown as Record<string, unknown>).session_handle = RAW_SID;
+    expect(colonelSessionsResponseSchema.safeParse(payload).success).toBe(false);
+  });
+
+  it('strips session_id / key if a backend still emits them', () => {
+    const payload = listPayload();
+    const row = payload.details.sessions[0] as unknown as Record<string, unknown>;
+    row.session_id = RAW_SID;
+    row.key = `session:${RAW_SID}`;
+
+    const result = colonelSessionsResponseSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const parsed = result.data.details?.sessions[0] as unknown as Record<string, unknown>;
+    expect(parsed.session_id).toBeUndefined();
+    expect(parsed.key).toBeUndefined();
+  });
+
   it('rejects a row missing the required authenticated flag (contract drift)', () => {
     const payload = listPayload() as unknown as {
       details: { sessions: Array<{ authenticated?: boolean }> };
@@ -108,8 +133,7 @@ describe('colonelSessionDetailResponseSchema (GetSessionDetail)', () => {
     return {
       shrimp: '',
       record: {
-        session_id: 'sid_auth',
-        key: 'session:sid_auth',
+        session_handle: HANDLE,
         ttl: 3600,
         authenticated: true,
         email: 'alice@example.com',
@@ -125,7 +149,10 @@ describe('colonelSessionDetailResponseSchema (GetSessionDetail)', () => {
         active_session_id: 'as_1',
       },
       details: {
-        data: { authenticated: true, email: 'alice@example.com', csrf: 'abc' },
+        // csrf is stripped SERVER-SIDE now (#4330); the open record still
+        // tolerates whatever session keys remain.
+        data: { authenticated: true, email: 'alice@example.com' },
+        scan_capped: false,
       },
     };
   }
@@ -137,6 +164,18 @@ describe('colonelSessionDetailResponseSchema (GetSessionDetail)', () => {
     expect(result.data.record.ttl).toBe(3600);
     expect(result.data.record.account_id).toBe(42);
     expect(result.data.details?.data.email).toBe('alice@example.com');
+  });
+
+  it('accepts a detail payload that omits scan_capped (older backend)', () => {
+    const payload = detailPayload();
+    delete (payload.details as { scan_capped?: boolean }).scan_capped;
+    expect(colonelSessionDetailResponseSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('rejects a raw session id under record.session_handle', () => {
+    const payload = detailPayload();
+    payload.record.session_handle = RAW_SID;
+    expect(colonelSessionDetailResponseSchema.safeParse(payload).success).toBe(false);
   });
 
   it('accepts an anonymous session: -1 ttl and null identity fields', () => {
@@ -161,7 +200,7 @@ describe('colonelSessionDeleteResponseSchema (DeleteSession)', () => {
   it('validates the revoke ack', () => {
     const payload = {
       shrimp: '',
-      record: { session_id: 'sid_auth', deleted: true },
+      record: { session_handle: HANDLE, deleted: true },
       details: { message: 'Session revoked successfully' },
     };
     const result = colonelSessionDeleteResponseSchema.safeParse(payload);
@@ -172,7 +211,7 @@ describe('colonelSessionDeleteResponseSchema (DeleteSession)', () => {
 
   it('rejects an ack missing details.message', () => {
     const payload = {
-      record: { session_id: 'sid_auth', deleted: true },
+      record: { session_handle: HANDLE, deleted: true },
       details: {},
     };
     expect(colonelSessionDeleteResponseSchema.safeParse(payload).success).toBe(false);

--- a/src/tests/apps/admin/useAdminCustomerSessions.spec.ts
+++ b/src/tests/apps/admin/useAdminCustomerSessions.spec.ts
@@ -16,6 +16,8 @@ vi.mock('@/shared/composables/useApi', () => ({
 import { useAdminCustomerSessions } from '@/apps/admin/stores/useAdminCustomerSessions';
 
 const USER_ID = 'ur_abc123';
+/** The account identifier both revoke verbs are gated on server-side (#4326). */
+const CONFIRM = 'owner@example.com';
 
 function sessionRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -174,10 +176,13 @@ describe('useAdminCustomerSessions', () => {
     await store.fetchForCustomer(USER_ID);
     expect(store.sessions).toHaveLength(2);
 
-    await store.revoke(USER_ID, 'a15e5510000000000000000000000001');
+    await store.revoke(USER_ID, 'a15e5510000000000000000000000001', CONFIRM);
 
+    // The account identifier rides X-OTS-Confirm (#4326), never the URL — the
+    // token is normally an email address.
     expect(mockApi.delete).toHaveBeenCalledWith(
-      '/api/colonel/users/ur_abc123/sessions/a15e5510000000000000000000000001'
+      '/api/colonel/users/ur_abc123/sessions/a15e5510000000000000000000000001',
+      { headers: { 'X-OTS-Confirm': encodeURIComponent(CONFIRM) } }
     );
     expect(store.sessions).toHaveLength(1);
     expect(store.sessions.map((s) => s.session_handle)).toEqual(['a15e5510000000000000000000000002']);
@@ -189,7 +194,9 @@ describe('useAdminCustomerSessions', () => {
     const store = useAdminCustomerSessions();
     await store.fetchForCustomer(USER_ID);
 
-    await expect(store.revoke(USER_ID, 'a15e5510000000000000000000000001')).rejects.toThrow('403');
+    await expect(
+      store.revoke(USER_ID, 'a15e5510000000000000000000000001', CONFIRM)
+    ).rejects.toThrow('403');
     expect(store.sessions).toHaveLength(2);
   });
 
@@ -200,11 +207,13 @@ describe('useAdminCustomerSessions', () => {
     await store.fetchForCustomer(USER_ID);
     expect(store.sessions).toHaveLength(2);
 
-    const record = await store.revokeAll(USER_ID);
+    const record = await store.revokeAll(USER_ID, CONFIRM);
 
     // Wrong path 404s in prod but passes a naive mock — assert it. POST, not DELETE.
     expect(mockApi.post).toHaveBeenCalledWith(
-      '/api/colonel/users/ur_abc123/sessions/revoke-all'
+      '/api/colonel/users/ur_abc123/sessions/revoke-all',
+      undefined,
+      { headers: { 'X-OTS-Confirm': encodeURIComponent(CONFIRM) } }
     );
     expect(store.sessions).toEqual([]);
     expect(record.blobs_deleted).toBe(3);
@@ -217,7 +226,7 @@ describe('useAdminCustomerSessions', () => {
     const store = useAdminCustomerSessions();
     await store.fetchForCustomer(USER_ID);
 
-    const record = await store.revokeAll(USER_ID);
+    const record = await store.revokeAll(USER_ID, CONFIRM);
 
     expect(store.sessions).toEqual([]);
     // Drift degrades to the zero-count fallback rather than throwing.
@@ -236,7 +245,7 @@ describe('useAdminCustomerSessions', () => {
     const store = useAdminCustomerSessions();
     await store.fetchForCustomer(USER_ID);
 
-    await expect(store.revokeAll(USER_ID)).rejects.toThrow('403');
+    await expect(store.revokeAll(USER_ID, CONFIRM)).rejects.toThrow('403');
     expect(store.sessions).toHaveLength(2);
   });
 

--- a/src/tests/apps/admin/useAdminDestructiveMutation.spec.ts
+++ b/src/tests/apps/admin/useAdminDestructiveMutation.spec.ts
@@ -1,0 +1,87 @@
+// src/tests/apps/admin/useAdminDestructiveMutation.spec.ts
+
+import { AxiosError } from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveGuardCode,
+  retryAfterMinutes,
+} from '@/apps/admin/composables/useAdminDestructiveMutation';
+
+/**
+ * The two pure resolvers behind the destructive-mutation loop.
+ *
+ * The composable itself is exercised end-to-end through a mounted view in
+ * AdminCustomerDetailPurge.spec.ts (it calls useI18n and needs an app context);
+ * these examples pin the rules that view cannot show as clearly — the precedence
+ * between backend code and status family (#4327/#4329), and the rounding of the
+ * operator-facing wait.
+ */
+function axiosError(status: number, data: unknown): AxiosError {
+  const err = new AxiosError('Request failed');
+  err.response = { status, data, statusText: '', headers: {}, config: {} as never };
+  return err;
+}
+
+describe('resolveGuardCode', () => {
+  it('reads the backend error_code first', () => {
+    expect(resolveGuardCode(axiosError(403, { error_code: 'elevation_required' }))).toBe(
+      'needs_elevation'
+    );
+    expect(resolveGuardCode(axiosError(403, { error_code: 'confirmation_required' }))).toBe(
+      'needs_confirmation'
+    );
+    expect(resolveGuardCode(axiosError(403, { error_code: 'elevation_failed' }))).toBe(
+      'elevation_failed'
+    );
+  });
+
+  it('recognises a 429 by status — LimitExceeded carries no error_code', () => {
+    expect(resolveGuardCode(axiosError(429, { error_type: 'LimitExceeded' }))).toBe('rate_limited');
+  });
+
+  // 403 is shared by "not a colonel", "no elevation", "wrong confirmation" and
+  // "elevation attempt failed", so a status-first resolver would shadow all of
+  // them. The backend code always wins where both are present.
+  it('prefers the backend code over the status family', () => {
+    expect(
+      resolveGuardCode(
+        axiosError(429, { error_code: 'elevation_required', error_type: 'LimitExceeded' })
+      )
+    ).toBe('needs_elevation');
+  });
+
+  it('returns null for everything else', () => {
+    expect(
+      resolveGuardCode(axiosError(422, { error: 'Cannot purge your own account' }))
+    ).toBeNull();
+    expect(resolveGuardCode(axiosError(403, { error: 'Forbidden' }))).toBeNull();
+    expect(resolveGuardCode(axiosError(500, {}))).toBeNull();
+    expect(resolveGuardCode(new Error('network down'))).toBeNull();
+    expect(resolveGuardCode(null)).toBeNull();
+  });
+});
+
+describe('retryAfterMinutes', () => {
+  // Rounded UP: telling an operator to retry a second before the lockout
+  // expires just spends another request on a 429.
+  it('rounds partial minutes up', () => {
+    expect(retryAfterMinutes(axiosError(429, { retry_after: 900 }))).toBe(15);
+    expect(retryAfterMinutes(axiosError(429, { retry_after: 901 }))).toBe(16);
+    expect(retryAfterMinutes(axiosError(429, { retry_after: 61 }))).toBe(2);
+  });
+
+  it('never reports less than a minute of waiting', () => {
+    expect(retryAfterMinutes(axiosError(429, { retry_after: 1 }))).toBe(1);
+  });
+
+  // Null means "say nothing about the wait" — the server's own message stands
+  // alone rather than the console inventing a number.
+  it('is null when retry_after is absent, zero, negative or unparseable', () => {
+    expect(retryAfterMinutes(axiosError(429, {}))).toBeNull();
+    expect(retryAfterMinutes(axiosError(429, { retry_after: 0 }))).toBeNull();
+    expect(retryAfterMinutes(axiosError(429, { retry_after: -5 }))).toBeNull();
+    expect(retryAfterMinutes(axiosError(429, { retry_after: 'soon' }))).toBeNull();
+    expect(retryAfterMinutes(new Error('network down'))).toBeNull();
+  });
+});

--- a/src/tests/apps/admin/useAdminDomains.spec.ts
+++ b/src/tests/apps/admin/useAdminDomains.spec.ts
@@ -166,15 +166,20 @@ describe('useAdminDomains', () => {
       });
       const store = useAdminDomains();
 
-      const details = await store.upsertConfig(EXTID, 'signin', {
-        enabled: true,
-        restrict_to: null,
-      });
+      const details = await store.upsertConfig(
+        EXTID,
+        'signin',
+        { enabled: true, restrict_to: null },
+        'example.com:signin'
+      );
 
-      expect(mockApi.put).toHaveBeenCalledWith(`${CONFIGS_URL}/signin`, {
-        enabled: true,
-        restrict_to: null,
-      });
+      // The composed confirmation token rides X-OTS-Confirm (#4326), never the
+      // URL: the hostname half is what a scraped-URL replay does not have.
+      expect(mockApi.put).toHaveBeenCalledWith(
+        `${CONFIGS_URL}/signin`,
+        { enabled: true, restrict_to: null },
+        { headers: { 'X-OTS-Confirm': encodeURIComponent('example.com:signin') } }
+      );
       expect(details?.outcome).toBe('updated');
       expect(details?.kind).toBe('signin');
     });
@@ -189,9 +194,11 @@ describe('useAdminDomains', () => {
       });
       const store = useAdminDomains();
 
-      const details = await store.deleteConfig(EXTID, 'mailer');
+      const details = await store.deleteConfig(EXTID, 'mailer', 'example.com:mailer');
 
-      expect(mockApi.delete).toHaveBeenCalledWith(`${CONFIGS_URL}/mailer`);
+      expect(mockApi.delete).toHaveBeenCalledWith(`${CONFIGS_URL}/mailer`, {
+        headers: { 'X-OTS-Confirm': encodeURIComponent('example.com:mailer') },
+      });
       expect(details?.deleted).toBe(true);
     });
 

--- a/src/tests/apps/admin/useAdminSessions.spec.ts
+++ b/src/tests/apps/admin/useAdminSessions.spec.ts
@@ -15,6 +15,9 @@ vi.mock('@/shared/composables/useApi', () => ({
 
 import { useAdminSessions } from '@/apps/admin/stores/useAdminSessions';
 
+/** Opaque 32-hex session handle — the only session identifier on the wire (#4330). */
+const HANDLE = '0123456789abcdef0123456789abcdef';
+
 function sessionsPayload() {
   return {
     shrimp: '',
@@ -22,8 +25,7 @@ function sessionsPayload() {
     details: {
       sessions: [
         {
-          session_id: 'sid_1',
-          key: 'session:sid_1',
+          session_handle: HANDLE,
           authenticated: true,
           email: 'alice@example.com',
           external_id: 'ext_1',
@@ -63,7 +65,7 @@ describe('useAdminSessions', () => {
       params: { page: 1, per_page: 50 },
     });
     expect(store.sessions).toHaveLength(1);
-    expect(store.sessions[0].session_id).toBe('sid_1');
+    expect(store.sessions[0].session_handle).toBe(HANDLE);
     expect(store.pagination?.total_count).toBe(1);
   });
 

--- a/src/tests/apps/admin/useAdminSessions.spec.ts
+++ b/src/tests/apps/admin/useAdminSessions.spec.ts
@@ -38,6 +38,8 @@ function sessionsPayload() {
       pagination: { page: 1, per_page: 50, total_count: 1, total_pages: 1 },
       // Keyspace scan meta (list_sessions.rb success_data.details.scan).
       scan: { scanned: 64, anonymous_count: 63, scan_capped: false },
+      // The acting colonel's own row (#4328).
+      current_session_handle: HANDLE,
     },
   };
 }
@@ -67,6 +69,20 @@ describe('useAdminSessions', () => {
     expect(store.sessions).toHaveLength(1);
     expect(store.sessions[0].session_handle).toBe(HANDLE);
     expect(store.pagination?.total_count).toBe(1);
+    expect(store.currentSessionHandle).toBe(HANDLE);
+  });
+
+  it('clears currentSessionHandle when the listing omits it (deploy skew)', async () => {
+    const payload = sessionsPayload() as unknown as {
+      details: { current_session_handle?: string };
+    };
+    delete payload.details.current_session_handle;
+    mockApi.get.mockResolvedValue({ data: payload });
+    const store = useAdminSessions();
+
+    await store.fetchPage(1);
+
+    expect(store.currentSessionHandle).toBeNull();
   });
 
   it('passes the search term through as a server query param', async () => {
@@ -87,6 +103,7 @@ describe('useAdminSessions', () => {
     await expect(store.fetchPage(1)).rejects.toThrow('Network Error');
     expect(store.sessions).toEqual([]);
     expect(store.pagination).toBeNull();
+    expect(store.currentSessionHandle).toBeNull();
   });
 
   it('$reset restores initial state', async () => {
@@ -99,6 +116,7 @@ describe('useAdminSessions', () => {
 
     expect(store.sessions).toEqual([]);
     expect(store.pagination).toBeNull();
+    expect(store.currentSessionHandle).toBeNull();
     expect(store.page).toBe(1);
   });
 });

--- a/src/tests/apps/admin/useColonelElevation.spec.ts
+++ b/src/tests/apps/admin/useColonelElevation.spec.ts
@@ -1,0 +1,274 @@
+// src/tests/apps/admin/useColonelElevation.spec.ts
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The step-up (sudo) composable (#4327).
+ *
+ * The load-bearing assertion in this file is the one about CALL COUNTS: the
+ * countdown must advance with ZERO additional HTTP. `TrackMetadata` advances a
+ * session's `last_activity_at` on every authenticated request, so a banner that
+ * polled GET /api/colonel/elevation would re-stamp it forever and make the admin
+ * idle timeout (#4331) unreachable while a tab is open. A timer here is not a
+ * performance question, it disables a shipped security control.
+ *
+ * The rest pins the fetch triggers the design allows: mount, after elevate,
+ * after drop, and (exercised in AdminCustomerDetailPurge.spec.ts) on a 403.
+ */
+
+const mockApi = {
+  get: vi.fn(),
+  post: vi.fn(),
+  delete: vi.fn(),
+};
+vi.mock('@/shared/composables/useApi', () => ({ useApi: () => mockApi }));
+
+import {
+  __resetColonelElevationState,
+  useColonelElevation,
+} from '@/apps/admin/composables/useColonelElevation';
+
+const NOW = 1_700_000_000;
+
+function statusPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    shrimp: '',
+    record: { elevated: false, expires_at: null, seconds_remaining: 0, ...(overrides.record ?? {}) },
+    details: {
+      enabled: true,
+      window: 600,
+      reauth_grace: 0,
+      grace_available: false,
+      password_available: true,
+      factors: ['password'],
+      ...(overrides.details ?? {}),
+    },
+  };
+}
+
+function grantPayload(factor = 'password') {
+  return {
+    shrimp: '',
+    record: { elevated: true, expires_at: NOW + 600, seconds_remaining: 600 },
+    details: { factor, window: 600 },
+  };
+}
+
+describe('useColonelElevation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW * 1000);
+    __resetColonelElevationState();
+  });
+
+  afterEach(() => {
+    __resetColonelElevationState();
+    vi.useRealTimers();
+  });
+
+  it('reads status on refresh and reports the un-elevated default', async () => {
+    mockApi.get.mockResolvedValue({ data: statusPayload() });
+
+    const elevation = useColonelElevation();
+    await elevation.refresh();
+
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+    expect(mockApi.get).toHaveBeenCalledWith('/api/colonel/elevation');
+    expect(elevation.elevated.value).toBe(false);
+    expect(elevation.enabled.value).toBe(true);
+    expect(elevation.window.value).toBe(600);
+    expect(elevation.factors.value).toEqual(['password']);
+  });
+
+  it('surfaces a live window with a countdown seed', async () => {
+    mockApi.get.mockResolvedValue({
+      data: statusPayload({
+        record: { elevated: true, expires_at: NOW + 420, seconds_remaining: 420 },
+      }),
+    });
+
+    const elevation = useColonelElevation();
+    await elevation.refresh();
+
+    expect(elevation.elevated.value).toBe(true);
+    expect(elevation.secondsRemaining.value).toBe(420);
+  });
+
+  // THE regression guard for the "do not poll" property.
+  it('counts down with ZERO additional HTTP calls', async () => {
+    mockApi.get.mockResolvedValue({
+      data: statusPayload({
+        record: { elevated: true, expires_at: NOW + 30, seconds_remaining: 30 },
+      }),
+    });
+
+    const elevation = useColonelElevation();
+    await elevation.refresh();
+    const callsAfterRefresh = mockApi.get.mock.calls.length;
+
+    // advanceTimersByTime moves the faked clock too, so Date.now() and the
+    // interval stay in step — exactly what the countdown reads.
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(elevation.secondsRemaining.value).toBe(20);
+    expect(mockApi.get.mock.calls.length).toBe(callsAfterRefresh);
+    expect(mockApi.post).not.toHaveBeenCalled();
+    expect(mockApi.delete).not.toHaveBeenCalled();
+  });
+
+  it('flips to un-elevated locally when the window runs out, still with no HTTP', async () => {
+    mockApi.get.mockResolvedValue({
+      data: statusPayload({
+        record: { elevated: true, expires_at: NOW + 3, seconds_remaining: 3 },
+      }),
+    });
+
+    const elevation = useColonelElevation();
+    await elevation.refresh();
+    const callsAfterRefresh = mockApi.get.mock.calls.length;
+
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(elevation.elevated.value).toBe(false);
+    expect(elevation.secondsRemaining.value).toBe(0);
+    expect(mockApi.get.mock.calls.length).toBe(callsAfterRefresh);
+  });
+
+  it('POSTs the factor and password, then refreshes once', async () => {
+    mockApi.post.mockResolvedValue({ data: grantPayload() });
+    mockApi.get.mockResolvedValue({
+      data: statusPayload({
+        record: { elevated: true, expires_at: NOW + 600, seconds_remaining: 600 },
+      }),
+    });
+
+    const elevation = useColonelElevation();
+    const ok = await elevation.elevate('password', 'hunter2');
+
+    expect(ok).toBe(true);
+    expect(mockApi.post).toHaveBeenCalledWith('/api/colonel/elevation', {
+      factor: 'password',
+      password: 'hunter2',
+    });
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+    expect(elevation.elevated.value).toBe(true);
+    expect(elevation.activeFactor.value).toBe('password');
+  });
+
+  // The weaker path must stay visible while it is live (review B-3.4).
+  it('carries the recent_auth factor back so the banner can label it', async () => {
+    mockApi.post.mockResolvedValue({ data: grantPayload('recent_auth') });
+    mockApi.get.mockResolvedValue({
+      data: statusPayload({
+        record: { elevated: true, expires_at: NOW + 600, seconds_remaining: 600 },
+      }),
+    });
+
+    const elevation = useColonelElevation();
+    await elevation.elevate('recent_auth');
+
+    expect(elevation.activeFactor.value).toBe('recent_auth');
+  });
+
+  it('reports a failed elevation without granting anything', async () => {
+    const err = Object.assign(new Error('nope'), {
+      response: { status: 403, data: { error: 'Password verification failed.' } },
+    });
+    mockApi.post.mockRejectedValue(err);
+
+    const elevation = useColonelElevation();
+    const ok = await elevation.elevate('password', 'wrong');
+
+    expect(ok).toBe(false);
+    expect(elevation.elevated.value).toBe(false);
+    // No refresh on the failure path — nothing changed server-side.
+    expect(mockApi.get).not.toHaveBeenCalled();
+  });
+
+  it('DELETEs on drop and lands un-elevated', async () => {
+    mockApi.delete.mockResolvedValue({ data: {} });
+    mockApi.get.mockResolvedValue({ data: statusPayload() });
+
+    const elevation = useColonelElevation();
+    const ok = await elevation.drop();
+
+    expect(ok).toBe(true);
+    expect(mockApi.delete).toHaveBeenCalledWith('/api/colonel/elevation');
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+    expect(elevation.elevated.value).toBe(false);
+  });
+
+  describe('requestElevation', () => {
+    it('resolves immediately when a window is already live, without prompting', async () => {
+      mockApi.get.mockResolvedValue({
+        data: statusPayload({
+          record: { elevated: true, expires_at: NOW + 600, seconds_remaining: 600 },
+        }),
+      });
+      const elevation = useColonelElevation();
+      await elevation.refresh();
+
+      await expect(elevation.requestElevation()).resolves.toBe(true);
+      expect(elevation.promptOpen.value).toBe(false);
+    });
+
+    it('opens the prompt and waits for the operator', async () => {
+      const elevation = useColonelElevation();
+      const pending = elevation.requestElevation();
+
+      expect(elevation.promptOpen.value).toBe(true);
+
+      elevation.resolvePrompt(true);
+      await expect(pending).resolves.toBe(true);
+      expect(elevation.promptOpen.value).toBe(false);
+    });
+
+    it('resolves false when the operator cancels', async () => {
+      const elevation = useColonelElevation();
+      const pending = elevation.requestElevation();
+
+      elevation.resolvePrompt(false);
+      await expect(pending).resolves.toBe(false);
+    });
+  });
+
+  describe('unsatisfiable', () => {
+    it('is false for an ordinary password-holding account', async () => {
+      mockApi.get.mockResolvedValue({ data: statusPayload() });
+      const elevation = useColonelElevation();
+      await elevation.refresh();
+
+      expect(elevation.unsatisfiable.value).toBe(false);
+    });
+
+    it('is true for an SSO-only account with no grace configured', async () => {
+      mockApi.get.mockResolvedValue({
+        data: statusPayload({
+          details: { password_available: false, factors: ['password'] },
+        }),
+      });
+      const elevation = useColonelElevation();
+      await elevation.refresh();
+
+      expect(elevation.unsatisfiable.value).toBe(true);
+    });
+
+    it('is false once a grace makes recent_auth available', async () => {
+      mockApi.get.mockResolvedValue({
+        data: statusPayload({
+          details: {
+            password_available: false,
+            reauth_grace: 300,
+            grace_available: true,
+            factors: ['password', 'recent_auth'],
+          },
+        }),
+      });
+      const elevation = useColonelElevation();
+      await elevation.refresh();
+
+      expect(elevation.unsatisfiable.value).toBe(false);
+    });
+  });
+});

--- a/src/tests/apps/admin/utils/confirmHeader.spec.ts
+++ b/src/tests/apps/admin/utils/confirmHeader.spec.ts
@@ -1,0 +1,79 @@
+// src/tests/apps/admin/utils/confirmHeader.spec.ts
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  accountConfirmToken,
+  CONFIRM_HEADER,
+  confirmHeaders,
+  orgConfirmToken,
+} from '@/apps/admin/utils/confirmHeader';
+
+/**
+ * The client half of the #4326 confirmation transport.
+ *
+ * Two properties matter and neither is obvious from reading the four-line
+ * module: the value is percent-encoded (HTTP header values are ISO-8859-1 by
+ * RFC 7230, and org display names are not), and the two token helpers must
+ * agree byte-for-byte with the server's `account_confirm_token` /
+ * `org_confirm_token`. A disagreement is a 403 on every gated call.
+ */
+describe('confirmHeaders', () => {
+  it('names the header the server reads', () => {
+    expect(CONFIRM_HEADER).toBe('X-OTS-Confirm');
+    expect(confirmHeaders('x')).toEqual({ 'X-OTS-Confirm': 'x' });
+  });
+
+  it('percent-encodes so a non-ASCII token survives the header charset', () => {
+    const token = 'Acme GmbH Überwachung';
+    const encoded = confirmHeaders(token)[CONFIRM_HEADER];
+
+    expect(encoded).toBe('Acme%20GmbH%20%C3%9Cberwachung');
+    // Round-trips through what Rack::Utils.unescape does server-side.
+    expect(decodeURIComponent(encoded)).toBe(token);
+  });
+
+  it('encodes an email address, so it never rides a URL unescaped by accident', () => {
+    expect(confirmHeaders('victim@example.com')[CONFIRM_HEADER]).toBe('victim%40example.com');
+  });
+
+  it('leaves a plain ASCII token intact, so curl works as typed', () => {
+    expect(confirmHeaders('sec12345')[CONFIRM_HEADER]).toBe('sec12345');
+  });
+
+  it('encodes the colon in a composed token rather than splitting it', () => {
+    expect(confirmHeaders('example.com:signin')[CONFIRM_HEADER]).toBe('example.com%3Asignin');
+    expect(decodeURIComponent('example.com%3Asignin')).toBe('example.com:signin');
+  });
+});
+
+describe('accountConfirmToken', () => {
+  it('prefers the email', () => {
+    expect(accountConfirmToken({ email: 'a@b.example', extid: 'ur_x' })).toBe('a@b.example');
+  });
+
+  it('falls back to the public id when the account has no email', () => {
+    expect(accountConfirmToken({ email: '   ', extid: 'ur_x' })).toBe('ur_x');
+    expect(accountConfirmToken({ email: null, extid: 'ur_x' })).toBe('ur_x');
+  });
+
+  it('trims, so a stray space cannot desync the two halves of the gate', () => {
+    expect(accountConfirmToken({ email: '  a@b.example  ' })).toBe('a@b.example');
+  });
+
+  // Undefined is the fail-closed signal: callers refuse to open the dialog
+  // rather than sending a blank token (which the server answers with a 500).
+  it('is undefined when there is nothing to name', () => {
+    expect(accountConfirmToken(null)).toBeUndefined();
+    expect(accountConfirmToken(undefined)).toBeUndefined();
+    expect(accountConfirmToken({ email: '', extid: '' })).toBeUndefined();
+  });
+});
+
+describe('orgConfirmToken', () => {
+  it('prefers the display name and falls back to the public id', () => {
+    expect(orgConfirmToken({ display_name: 'Acme', extid: 'on_x' })).toBe('Acme');
+    expect(orgConfirmToken({ display_name: null, extid: 'on_x' })).toBe('on_x');
+    expect(orgConfirmToken(null)).toBeUndefined();
+  });
+});

--- a/src/tests/schemas/shapes/config/site.spec.ts
+++ b/src/tests/schemas/shapes/config/site.spec.ts
@@ -291,6 +291,28 @@ describe('siteAdminShape — step-up (sudo) window and colonel rate limits (#432
   });
 });
 
+describe('siteAdminShape — admin-surface session bounds (#4331)', () => {
+  it('ships the bounds ON at 1h idle / 12h absolute', () => {
+    const result = siteAdminShape.parse({ session: {} });
+    expect(result.session?.enabled).toBe(true);
+    expect(result.session?.idle_timeout).toBe(3600);
+    expect(result.session?.absolute_timeout).toBe(43200);
+  });
+
+  // 0 DISABLES a bound and must survive as 0. Unlike the rate-limit caps, this
+  // is not the "typo'd env var collapsed to 0" case — it is how an operator
+  // turns off one bound while keeping the other.
+  it('keeps an explicit 0 on either bound rather than falling back', () => {
+    const result = siteAdminShape.parse({ session: { idle_timeout: 0, absolute_timeout: 0 } });
+    expect(result.session?.idle_timeout).toBe(0);
+    expect(result.session?.absolute_timeout).toBe(0);
+  });
+
+  it('preserves an explicit opt-out of the whole subtree', () => {
+    expect(siteAdminShape.parse({ session: { enabled: false } }).session?.enabled).toBe(false);
+  });
+});
+
 describe('siteShape — composed sub-trees', () => {
   it('applies authentication / session / middleware defaults end-to-end', () => {
     const result = siteShape.parse({

--- a/src/tests/schemas/shapes/config/site.spec.ts
+++ b/src/tests/schemas/shapes/config/site.spec.ts
@@ -223,6 +223,46 @@ describe('siteAdminShape — allowed_hosts null/empty distinction', () => {
   });
 });
 
+describe('siteAdminShape — step-up (sudo) window and colonel rate limits (#4327)', () => {
+  it('ships elevation ON with a 600s window and NO reauth grace', () => {
+    const result = siteAdminShape.parse({ elevation: {} });
+    expect(result.elevation?.enabled).toBe(true);
+    expect(result.elevation?.window).toBe(600);
+    // 0 = the password-less grace is OFF. This is the shipped posture and the
+    // whole point of B-3: a non-zero default would make step-up a no-op for
+    // the first N seconds after every colonel sign-in.
+    expect(result.elevation?.reauth_grace).toBe(0);
+  });
+
+  it('keeps an explicit reauth_grace of 0 rather than falling back', () => {
+    expect(siteAdminShape.parse({ elevation: { reauth_grace: 0 } }).elevation?.reauth_grace).toBe(0);
+  });
+
+  it('accepts an operator-configured grace', () => {
+    expect(siteAdminShape.parse({ elevation: { reauth_grace: 300 } }).elevation?.reauth_grace).toBe(
+      300
+    );
+  });
+
+  it('ships the colonel rate limits ON with the elevation bucket defaulted', () => {
+    const result = siteAdminShape.parse({ rate_limit: { elevation: {} } });
+    expect(result.rate_limit?.enabled).toBe(true);
+    expect(result.rate_limit?.elevation?.enabled).toBe(true);
+    expect(result.rate_limit?.elevation?.max_attempts).toBe(5);
+    expect(result.rate_limit?.elevation?.window).toBe(900);
+    expect(result.rate_limit?.elevation?.lockout).toBe(900);
+  });
+
+  it('preserves an explicit opt-out of either subtree', () => {
+    const result = siteAdminShape.parse({
+      elevation: { enabled: false },
+      rate_limit: { enabled: false },
+    });
+    expect(result.elevation?.enabled).toBe(false);
+    expect(result.rate_limit?.enabled).toBe(false);
+  });
+});
+
 describe('siteShape — composed sub-trees', () => {
   it('applies authentication / session / middleware defaults end-to-end', () => {
     const result = siteShape.parse({

--- a/src/tests/schemas/shapes/config/site.spec.ts
+++ b/src/tests/schemas/shapes/config/site.spec.ts
@@ -253,6 +253,34 @@ describe('siteAdminShape — step-up (sudo) window and colonel rate limits (#432
     expect(result.rate_limit?.elevation?.lockout).toBe(900);
   });
 
+  // #4329. Each bucket carries its OWN sizing — a shared tree would report one
+  // bucket's numbers for all four. These must match config.defaults.yaml and
+  // the DEFAULT_* constants in lib/onetime/security/colonel_rate_limiter.rb.
+  it('ships the broad mutation bucket at 120 per 5 minutes', () => {
+    const bucket = siteAdminShape.parse({ rate_limit: { mutation: {} } }).rate_limit?.mutation;
+    expect(bucket?.enabled).toBe(true);
+    expect(bucket?.max_attempts).toBe(120);
+    expect(bucket?.window).toBe(300);
+    expect(bucket?.lockout).toBe(300);
+  });
+
+  it('ships the tight destructive bucket at 10 per 5 minutes with a 15-minute lockout', () => {
+    const bucket = siteAdminShape.parse({ rate_limit: { destructive: {} } }).rate_limit?.destructive;
+    expect(bucket?.enabled).toBe(true);
+    expect(bucket?.max_attempts).toBe(10);
+    expect(bucket?.window).toBe(300);
+    expect(bucket?.lockout).toBe(900);
+  });
+
+  it('ships the handle-resolve bucket at 60 per 5 minutes', () => {
+    const bucket = siteAdminShape.parse({ rate_limit: { handle_resolve: {} } }).rate_limit
+      ?.handle_resolve;
+    expect(bucket?.enabled).toBe(true);
+    expect(bucket?.max_attempts).toBe(60);
+    expect(bucket?.window).toBe(300);
+    expect(bucket?.lockout).toBe(300);
+  });
+
   it('preserves an explicit opt-out of either subtree', () => {
     const result = siteAdminShape.parse({
       elevation: { enabled: false },

--- a/try/integration/api/colonel/admin_ops_expansion_try.rb
+++ b/try/integration/api/colonel/admin_ops_expansion_try.rb
@@ -107,12 +107,11 @@ end
 # (privilege-granting — it hands an account access to the org's data), so it
 # requires the organization's NAME, percent-encoded, in X-OTS-Confirm.
 #
-# Encode the way the console does (encodeURIComponent === URI.encode_uri_component),
-# NOT Rack::Utils.escape: the server decodes with URI.decode_uri_component, which
-# keeps '+' literal, so a form-escaped space ('+') would never match a display_name
-# that contains spaces (auth_strategies.rb #4326).
+# Rack::Utils.escape (form encoding, space -> '+') is one of the encodings the
+# server's form decoder accepts (auth_strategies.rb #4326); '%20' and a raw space
+# work too.
 def confirming_org_headers(org)
-  colonel_headers.merge('HTTP_X_OTS_CONFIRM' => URI.encode_uri_component(org.display_name))
+  colonel_headers.merge('HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(org.display_name))
 end
 
 # ----------------------------------------------------------------

--- a/try/integration/api/colonel/admin_ops_expansion_try.rb
+++ b/try/integration/api/colonel/admin_ops_expansion_try.rb
@@ -103,6 +103,13 @@ def colonel_get_headers
   { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
 end
 
+# Server-side destructive-action confirmation (#4326): AddMembership is TIER 2
+# (privilege-granting — it hands an account access to the org's data), so it
+# requires the organization's NAME, percent-encoded, in X-OTS-Confirm.
+def confirming_org_headers(org)
+  colonel_headers.merge('HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(org.display_name))
+end
+
 # ----------------------------------------------------------------
 # AddMembership by EMAIL (the sanitize_identifier bug)
 # ----------------------------------------------------------------
@@ -110,7 +117,7 @@ end
 ## An email survives sanitization and resolves to the account (200, not 404)
 @before_audit = Onetime::ColonelAuditEvent.count
 post "/api/colonel/organizations/#{@org.extid}/members",
-  { 'customer' => @joiner_email, 'role' => 'admin' }, colonel_headers
+  { 'customer' => @joiner_email, 'role' => 'admin' }, confirming_org_headers(@org)
 @add_resp = JSON.parse(last_response.body)
 [last_response.status, @add_resp['record']['status'], @add_resp['record']['role']]
 #=> [200, "success", "admin"]
@@ -132,7 +139,7 @@ Onetime::Organization.find_by_extid(@org.extid).member?(Onetime::Customer.find_b
 ## Add is strictly additive: a repeat by email is :no_change and audits nothing
 @before_audit2 = Onetime::ColonelAuditEvent.count
 post "/api/colonel/organizations/#{@org.extid}/members",
-  { 'customer' => @joiner_email, 'role' => 'member' }, colonel_headers
+  { 'customer' => @joiner_email, 'role' => 'member' }, confirming_org_headers(@org)
 @again = JSON.parse(last_response.body)
 [last_response.status, @again['record']['status'], @again['record']['role'],
  Onetime::ColonelAuditEvent.count - @before_audit2]

--- a/try/integration/api/colonel/admin_ops_expansion_try.rb
+++ b/try/integration/api/colonel/admin_ops_expansion_try.rb
@@ -106,8 +106,13 @@ end
 # Server-side destructive-action confirmation (#4326): AddMembership is TIER 2
 # (privilege-granting — it hands an account access to the org's data), so it
 # requires the organization's NAME, percent-encoded, in X-OTS-Confirm.
+#
+# Encode the way the console does (encodeURIComponent === URI.encode_uri_component),
+# NOT Rack::Utils.escape: the server decodes with URI.decode_uri_component, which
+# keeps '+' literal, so a form-escaped space ('+') would never match a display_name
+# that contains spaces (auth_strategies.rb #4326).
 def confirming_org_headers(org)
-  colonel_headers.merge('HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(org.display_name))
+  colonel_headers.merge('HTTP_X_OTS_CONFIRM' => URI.encode_uri_component(org.display_name))
 end
 
 # ----------------------------------------------------------------

--- a/try/integration/api/colonel/customer_admin_extid_try.rb
+++ b/try/integration/api/colonel/customer_admin_extid_try.rb
@@ -104,6 +104,13 @@ Auth::Operations::Customers::Purge.prepend(@purge_status_stub)
 @colonel_headers = { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
 @colonel_get_headers = { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
 
+# Server-side destructive-action confirmation (#4326): role change, unverify and
+# purge require the target's email — percent-encoded — in X-OTS-Confirm. The URL
+# carries the extid, so the token is deliberately a different identifier.
+def confirming(email, headers)
+  headers.merge('HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(email))
+end
+
 # ---- Sanity: the extid is NOT the objid --------------------------------
 
 ## An extid and an objid are distinct identifiers (guards against a future
@@ -126,7 +133,7 @@ get "/api/colonel/users/#{@detail_extid}", {}, @colonel_get_headers
 # ---- Role change by extid -----------------------------------------------
 
 ## POST /users/:extid/role resolves by extid and applies the change (200)
-post "/api/colonel/users/#{@role_extid}/role", { role: 'admin' }.to_json, @colonel_headers
+post "/api/colonel/users/#{@role_extid}/role", { role: 'admin' }.to_json, confirming(@role_target.email, @colonel_headers)
 @role_resp = JSON.parse(last_response.body)
 [last_response.status, @role_resp['record']['new_role'], @role_resp['record']['old_role']]
 #=> [200, "admin", "customer"]
@@ -143,14 +150,14 @@ post "/api/colonel/users/#{@verify_extid}/verify", {}.to_json, @colonel_headers
 #=> [200, true]
 
 ## POST /users/:extid/unverify resolves by extid and clears verified (200)
-post "/api/colonel/users/#{@verify_extid}/unverify", {}.to_json, @colonel_headers
+post "/api/colonel/users/#{@verify_extid}/unverify", {}.to_json, confirming(@verify_target.email, @colonel_headers)
 [last_response.status, Onetime::Customer.load(@verify_objid).verified?]
 #=> [200, false]
 
 # ---- Purge by extid -----------------------------------------------------
 
 ## DELETE /users/:extid resolves by extid, destroys the record (200)
-delete "/api/colonel/users/#{@purge_extid}", {}, @colonel_get_headers
+delete "/api/colonel/users/#{@purge_extid}", {}, confirming(@purge_target.email, @colonel_get_headers)
 @purge_resp = JSON.parse(last_response.body)
 [last_response.status, @purge_resp['record']['deleted'], Onetime::Customer.load(@purge_objid).nil?]
 #=> [200, true, true]
@@ -174,7 +181,7 @@ delete "/api/colonel/users/#{@purge_extid}", {}, @colonel_get_headers
 ## DELETE surfaces the operation's :not_found status instead of a phantom success
 begin
   Thread.current[:tryouts_forced_purge_status] = :not_found
-  delete "/api/colonel/users/#{@status_extid}", {}, @colonel_get_headers
+  delete "/api/colonel/users/#{@status_extid}", {}, confirming(@status_target.email, @colonel_get_headers)
 ensure
   Thread.current[:tryouts_forced_purge_status] = nil
 end
@@ -187,7 +194,7 @@ end
 ## DELETE fails loudly (422) on an unrecognised purge status
 begin
   Thread.current[:tryouts_forced_purge_status] = :quarantined
-  delete "/api/colonel/users/#{@status_extid}", {}, @colonel_get_headers
+  delete "/api/colonel/users/#{@status_extid}", {}, confirming(@status_target.email, @colonel_get_headers)
 ensure
   Thread.current[:tryouts_forced_purge_status] = nil
 end
@@ -201,7 +208,7 @@ Thread.current[:tryouts_forced_purge_status]
 # ---- Self-purge guard ---------------------------------------------------
 
 ## DELETE of the acting colonel's own extid is refused (422), account survives
-delete "/api/colonel/users/#{@colonel.extid}", {}, @colonel_get_headers
+delete "/api/colonel/users/#{@colonel.extid}", {}, confirming(@colonel.email, @colonel_get_headers)
 [last_response.status, Onetime::Customer.load(@colonel.objid).nil?]
 #=> [422, false]
 

--- a/try/integration/api/colonel/customer_admin_try.rb
+++ b/try/integration/api/colonel/customer_admin_try.rb
@@ -65,6 +65,13 @@ AE = Onetime::ColonelAuditEvent
 @colonel_headers = { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json', 'HTTP_X_CSRF_TOKEN' => tryouts_csrf_token(@colonel_session) }
 @regular_headers = { 'rack.session' => @regular_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json', 'HTTP_X_CSRF_TOKEN' => tryouts_csrf_token(@regular_session) }
 
+# Server-side destructive-action confirmation (#4326): the gated verbs below
+# (role change, unverify, purge) require the target's email — percent-encoded —
+# in X-OTS-Confirm. Verify is the restorative arm and needs nothing.
+def confirming(customer, headers = @colonel_headers)
+  headers.merge('HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(customer.email))
+end
+
 # ---- Authorization (both-auth-layers) ---------------------------------
 
 ## Non-colonel gets 403 on role change
@@ -99,7 +106,7 @@ last_response.status
 
 ## Role change returns 200 with the expected record shape
 AE.events.clear
-post "/api/colonel/users/#{@role_target.objid}/role", { role: 'admin' }.to_json, @colonel_headers
+post "/api/colonel/users/#{@role_target.objid}/role", { role: 'admin' }.to_json, confirming(@role_target)
 @role_resp = JSON.parse(last_response.body)
 [last_response.status, @role_resp['record']['new_role'], @role_resp['record']['old_role'], @role_resp['details']['changed']]
 #=> [200, "admin", "customer", true]
@@ -121,7 +128,7 @@ post "/api/colonel/users/#{@verify_target.objid}/verify", {}.to_json, @colonel_h
 #=> [200, true, "customer.set_verification"]
 
 ## Unverify returns 200 and marks the user unverified
-post "/api/colonel/users/#{@verify_target.objid}/unverify", {}.to_json, @colonel_headers
+post "/api/colonel/users/#{@verify_target.objid}/unverify", {}.to_json, confirming(@verify_target)
 [last_response.status, Onetime::Customer.load(@verify_target.objid).verified?]
 #=> [200, false]
 
@@ -129,7 +136,7 @@ post "/api/colonel/users/#{@verify_target.objid}/unverify", {}.to_json, @colonel
 
 ## Purge (DELETE) returns 200, destroys the user, audits once
 AE.events.clear
-delete "/api/colonel/users/#{@purge_target.objid}", {}, { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json', 'HTTP_X_CSRF_TOKEN' => tryouts_csrf_token(@colonel_session) }
+delete "/api/colonel/users/#{@purge_target.objid}", {}, confirming(@purge_target, { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json', 'HTTP_X_CSRF_TOKEN' => tryouts_csrf_token(@colonel_session) })
 @purge_resp = JSON.parse(last_response.body)
 [last_response.status, @purge_resp['record']['deleted'], Onetime::Customer.load(@purge_target_objid).nil?, AE.count, AE.recent(1).first['verb']]
 #=> [200, true, true, 1, "customer.purge"]

--- a/try/integration/api/colonel/destructive_confirmation_try.rb
+++ b/try/integration/api/colonel/destructive_confirmation_try.rb
@@ -1,0 +1,142 @@
+# try/integration/api/colonel/destructive_confirmation_try.rb
+#
+# frozen_string_literal: true
+
+# Server-side destructive-action confirmation (#4326) over a REAL Rack stack.
+#
+# The unit specs prove the guard; this proves the TRANSPORT — that the
+# X-OTS-Confirm request header actually reaches the logic layer through the
+# colonel session auth strategy's metadata, and that nothing else does.
+#
+# Covers, against DELETE /api/colonel/users/:user_id (PurgeUser, TIER 1):
+# - no header                    -> 403 error_code=confirmation_required
+# - wrong header                 -> 403, same body (no oracle)
+# - ?confirm=<email>, no header  -> STILL 403. The query parameter is not a
+#                                   fallback: putting a target's email in a URL
+#                                   writes it into every access log, proxy log
+#                                   and browser history, which is the whole
+#                                   reason this is a header.
+# - percent-encoded header       -> accepted (a non-ASCII token has to survive
+#                                   the ISO-8859-1 header charset)
+# - correct header               -> 200, the account is really gone
+# - a POST verb (unverify, TIER 2) reads the SAME header, so there is one rule
+# - the rejections write NO ColonelAuditEvent (Forbidden family — otherwise a
+#   hammered gate is a log-eviction primitive against the count-capped trail)
+#
+# Run: try --agent try/integration/api/colonel/destructive_confirmation_try.rb
+
+require 'rack/test'
+require_relative '../../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/application/registry'
+Onetime::Application::Registry.prepare_application_registry
+
+@test = Object.new
+@test.extend Rack::Test::Methods
+
+def @test.app
+  Onetime::Application::Registry.generate_rack_url_map
+end
+
+def post(*args);   @test.post(*with_csrf(args));   end
+def delete(*args); @test.delete(*with_csrf(args)); end
+def last_response; @test.last_response; end
+def body; JSON.parse(last_response.body); end
+
+AE = Onetime::ColonelAuditEvent
+
+@timestamp = Familia.now.to_i
+
+@colonel = Onetime::Customer.create!(email: "colonel_dconf_#{@timestamp}@example.com")
+@colonel.role     = 'colonel'
+@colonel.verified = 'true'
+@colonel.save
+
+@target = Onetime::Customer.create!(email: "target_dconf_#{@timestamp}@example.com")
+@target.verified = 'true'
+@target.save
+
+@unverify_target = Onetime::Customer.create!(email: "unver_dconf_#{@timestamp}@example.com")
+@unverify_target.verified = 'true'
+@unverify_target.save
+
+@colonel_session = {
+  'authenticated' => true,
+  'external_id'   => @colonel.extid,
+  'email'         => @colonel.email,
+}
+
+# `confirm` is the percent-encoded token, exactly as the console sends it.
+def colonel_headers(confirm = nil)
+  headers = { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
+  headers['HTTP_X_OTS_CONFIRM'] = confirm if confirm
+  headers
+end
+
+@purge_url = "/api/colonel/users/#{@target.extid}"
+
+## Without the confirmation header the purge is refused
+delete @purge_url, {}, colonel_headers
+[last_response.status, body['error_type'], body['error_code'], body['field']]
+#=> [403, "ConfirmationRequired", "confirmation_required", "user_id"]
+
+## The refusal names the header and what to put in it, never the value itself
+[body['error'].include?('X-OTS-Confirm'), body['error'].include?(@target.email)]
+#=> [true, false]
+
+## A wrong token gets the identical body — no oracle on which half was wrong
+@refusal = body
+delete @purge_url, {}, colonel_headers('someone%40else.example')
+[last_response.status, body['error'] == @refusal['error']]
+#=> [403, true]
+
+## The account is still there after both refusals
+Onetime::Customer.load(@target.objid)&.exists?
+#=> true
+
+## A `confirm` QUERY PARAMETER is NOT a fallback — the header is the transport
+delete "#{@purge_url}?confirm=#{Rack::Utils.escape(@target.email)}", {}, colonel_headers
+[last_response.status, body['error_code']]
+#=> [403, "confirmation_required"]
+
+## A `confirm` BODY parameter is not a fallback either
+delete @purge_url, { 'confirm' => @target.email }, colonel_headers
+[last_response.status, body['error_code']]
+#=> [403, "confirmation_required"]
+
+## None of those refusals wrote an audit event
+AE.events.revrange(0, -1).map { |id| AE.load(id) }.compact.count do |event|
+  event.target.to_s == @target.extid && event.verb.to_s == 'account.purge'
+end
+#=> 0
+
+## The SAME header gates a POST verb (unverify, TIER 2) — one rule, not two
+post "/api/colonel/users/#{@unverify_target.extid}/unverify", {}, colonel_headers
+[last_response.status, body['error_code']]
+#=> [403, "confirmation_required"]
+
+## ...and the correct token lets that POST through
+post "/api/colonel/users/#{@unverify_target.extid}/unverify", {},
+  colonel_headers(Rack::Utils.escape(@unverify_target.email))
+last_response.status
+#=> 200
+
+## The restorative twin (verify) needs no header at all
+post "/api/colonel/users/#{@unverify_target.extid}/verify", {}, colonel_headers
+last_response.status
+#=> 200
+
+## A percent-encoded token decodes server-side and is accepted
+delete @purge_url, {}, colonel_headers(Rack::Utils.escape(@target.email))
+[last_response.status, body['record']['deleted']]
+#=> [200, true]
+
+## ...and the account really is gone
+!Onetime::Customer.load(@target.objid)&.exists?
+#=> true
+
+# Teardown.
+@unverify_target.destroy! if @unverify_target.exists?
+@colonel.destroy! if @colonel.exists?

--- a/try/integration/api/colonel/domain_configs_try.rb
+++ b/try/integration/api/colonel/domain_configs_try.rb
@@ -97,6 +97,16 @@ def colonel_headers
   { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
 end
 
+# Server-side destructive-action confirmation (#4326): the config upsert (TIER 2)
+# and delete (TIER 1) verbs require "<display_domain>:<kind>", percent-encoded,
+# in X-OTS-Confirm — the URL carries only the extid. `ensure` is TIER 3
+# (idempotent backfill of missing rows) and needs nothing.
+def confirming_config(domain, kind)
+  colonel_headers.merge(
+    'HTTP_X_OTS_CONFIRM' => Rack::Utils.escape("#{domain.display_domain}:#{kind}"),
+  )
+end
+
 # ----------------------------------------------------------------
 # Authorization — GET /domains/:extid/configs
 # ----------------------------------------------------------------
@@ -204,7 +214,7 @@ post "/api/colonel/domains/#{@extid}/configs/ensure", { 'dry_run' => 'false' }, 
 ## PUT signin: partial update returns real JSON booleans and outcome=updated
 @before_audit = Onetime::ColonelAuditEvent.count
 put "/api/colonel/domains/#{@extid}/configs/signin",
-  { 'enabled' => 'true', 'signin_enabled' => 'true' }, colonel_headers
+  { 'enabled' => 'true', 'signin_enabled' => 'true' }, confirming_config(@domain, 'signin')
 @resp = JSON.parse(last_response.body)
 d = @resp['details']
 [last_response.status, d['kind'], d['outcome'],
@@ -226,7 +236,7 @@ cfg = Onetime::CustomDomain::SigninConfig.find_by_domain_id(@domain.identifier)
 
 ## PUT signin on the SECOND domain (no ensure ran there): outcome=created
 @before_audit = Onetime::ColonelAuditEvent.count
-put "/api/colonel/domains/#{@extid2}/configs/signin", { 'enabled' => 'true' }, colonel_headers
+put "/api/colonel/domains/#{@extid2}/configs/signin", { 'enabled' => 'true' }, confirming_config(@domain2, 'signin')
 @resp = JSON.parse(last_response.body)
 [last_response.status, @resp['details']['outcome'], @resp['details']['config']['enabled'],
  Onetime::ColonelAuditEvent.count - @before_audit]
@@ -246,14 +256,14 @@ put "/api/colonel/domains/#{@extid2}/configs/signin", { 'enabled' => 'true' }, c
 
 ## PUT signin with an invalid restrict_to enum -> 422 at the adapter, no audit
 @before_audit = Onetime::ColonelAuditEvent.count
-put "/api/colonel/domains/#{@extid}/configs/signin", { 'restrict_to' => 'bogus' }, colonel_headers
+put "/api/colonel/domains/#{@extid}/configs/signin", { 'restrict_to' => 'bogus' }, confirming_config(@domain, 'signin')
 [last_response.status, Onetime::ColonelAuditEvent.count - @before_audit]
 #=> [422, 0]
 
 ## PUT signup with an invalid allowed_signup_domains entry -> 422 from the model setter
 @before_audit = Onetime::ColonelAuditEvent.count
 put "/api/colonel/domains/#{@extid}/configs/signup",
-  { 'allowed_signup_domains' => ['not_a_domain'] }, colonel_headers
+  { 'allowed_signup_domains' => ['not_a_domain'] }, confirming_config(@domain, 'signup')
 [last_response.status, Onetime::ColonelAuditEvent.count - @before_audit]
 #=> [422, 1]
 
@@ -265,7 +275,7 @@ put "/api/colonel/domains/#{@extid}/configs/signup",
 
 ## PUT signup with a VALID allowlist round-trips the array
 put "/api/colonel/domains/#{@extid}/configs/signup",
-  { 'validation_strategy' => 'domain_allowlist', 'allowed_signup_domains' => ['corp.example.com'] }, colonel_headers
+  { 'validation_strategy' => 'domain_allowlist', 'allowed_signup_domains' => ['corp.example.com'] }, confirming_config(@domain, 'signup')
 @resp = JSON.parse(last_response.body)
 [last_response.status, @resp['details']['config']['validation_strategy'], @resp['details']['config']['allowed_signup_domains']]
 #=> [200, 'domain_allowlist', ['corp.example.com']]
@@ -339,7 +349,7 @@ mailer = @resp['details']['configs']['mailer']
 
 ## DELETE signin: 200 with deleted:true and ONE domain.config_delete audit event
 @before_audit = Onetime::ColonelAuditEvent.count
-delete "/api/colonel/domains/#{@extid}/configs/signin", {}, colonel_headers
+delete "/api/colonel/domains/#{@extid}/configs/signin", {}, confirming_config(@domain, 'signin')
 @resp = JSON.parse(last_response.body)
 @latest = Onetime::ColonelAuditEvent.recent(1, 0).first
 [last_response.status, @resp['details']['kind'], @resp['details']['deleted'],
@@ -348,7 +358,7 @@ delete "/api/colonel/domains/#{@extid}/configs/signin", {}, colonel_headers
 
 ## DELETE signin again: the record is gone -> 404 and ONE result: :failure event
 @before_audit = Onetime::ColonelAuditEvent.count
-delete "/api/colonel/domains/#{@extid}/configs/signin", {}, colonel_headers
+delete "/api/colonel/domains/#{@extid}/configs/signin", {}, confirming_config(@domain, 'signin')
 [last_response.status, Onetime::ColonelAuditEvent.count - @before_audit,
  Onetime::CustomDomain::SigninConfig.exists_for_domain?(@domain.identifier)]
 #=> [404, 1, false]
@@ -360,7 +370,7 @@ delete "/api/colonel/domains/#{@extid}/configs/signin", {}, colonel_headers
 #=> ["domain.config_delete", @extid, "failure", 'not_found', 'signin']
 
 ## DELETE sso: the credential kinds are deletable (recovery posture)
-delete "/api/colonel/domains/#{@extid}/configs/sso", {}, colonel_headers
+delete "/api/colonel/domains/#{@extid}/configs/sso", {}, confirming_config(@domain, 'sso')
 @resp = JSON.parse(last_response.body)
 [last_response.status, @resp['details']['deleted'],
  Onetime::CustomDomain::SsoConfig.exists_for_domain?(@domain.identifier)]

--- a/try/integration/api/colonel/elevation_try.rb
+++ b/try/integration/api/colonel/elevation_try.rb
@@ -1,0 +1,254 @@
+# try/integration/api/colonel/elevation_try.rb
+#
+# frozen_string_literal: true
+
+# Integration tests for the colonel step-up (sudo) window (#4327):
+#
+#   GET    /api/colonel/elevation
+#   POST   /api/colonel/elevation
+#   DELETE /api/colonel/elevation
+#
+# The whole loop over real Rack, in AUTHENTICATION_MODE=simple: attempt a TIER 1
+# verb with nothing but a colonel session, get 403 elevation_required, elevate
+# with the account password, retry the verb WITH the #4326 confirmation header,
+# succeed, drop the window, and be refused again. That sequence is the epic's
+# definition of done for this issue — "a colonel session alone is no longer
+# sufficient for destruction" — and it is only provable end to end.
+#
+# It also pins the two orderings the unit specs cannot see from inside one class:
+#
+#   - elevation is checked BEFORE confirmation, so an unelevated caller sending a
+#     wrong token still gets elevation_required and no confirmation oracle;
+#   - a failed step-up writes a SECURITY audit event and the successful one
+#     writes an operator event carrying the factor, while the ElevationRequired
+#     refusal writes NOTHING (a cookie holder could otherwise mint events on
+#     demand into a count-capped, TTL-less trail).
+#
+# Elevation ships ENABLED but spec/config.test.yaml disables it for suite
+# hygiene, so this file turns it on in-process and restores OT.conf in teardown
+# (tryout files share one process and one global config).
+#
+# Run: try --agent try/integration/api/colonel/elevation_try.rb
+
+require 'rack/test'
+require_relative '../../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/application/registry'
+Onetime::Application::Registry.prepare_application_registry
+
+@test = Object.new
+@test.extend Rack::Test::Methods
+
+def @test.app
+  Onetime::Application::Registry.generate_rack_url_map
+end
+
+def post(*args);   @test.post(*with_csrf(args));   end
+def delete(*args); @test.delete(*with_csrf(args)); end
+def get(*args);    @test.get(*args);               end
+def last_response; @test.last_response;            end
+def body;          JSON.parse(@test.last_response.body); end
+
+AE = Onetime::ColonelAuditEvent
+
+@saved_conf = YAML.load(YAML.dump(OT.conf))
+
+def set_elevation(cfg)
+  new_conf = YAML.load(YAML.dump(OT.conf))
+  new_conf['site'] ||= {}
+  new_conf['site']['admin'] ||= {}
+  new_conf['site']['admin']['elevation'] = cfg
+  OT.send(:conf=, new_conf)
+end
+
+set_elevation('enabled' => true, 'window' => 600, 'reauth_grace' => 0)
+
+@timestamp = Familia.now.to_i
+@password  = "elevate-me-#{@timestamp}"
+
+@colonel = Onetime::Customer.create!(email: "colonel_elev_#{@timestamp}@example.com")
+@colonel.role = 'colonel'
+@colonel.verified = 'true'
+@colonel.save
+@colonel.update_passphrase!(@password)
+
+@target = Onetime::Customer.create!(email: "target_elev_#{@timestamp}@example.com")
+@target.verified = 'true'
+@target.save
+
+@regular = Onetime::Customer.create!(email: "regular_elev_#{@timestamp}@example.com")
+@regular.verified = 'true'
+@regular.save
+
+# Seeds the authenticated colonel identity into each request. The session
+# MIDDLEWARE owns the hash the logic classes actually read and write (and
+# persists it across requests through the cookie jar), so assertions about what
+# elevation stored read @test.last_request.env['rack.session'], not this seed.
+@sess = {
+  'authenticated' => true,
+  'external_id' => @colonel.extid,
+  'email' => @colonel.email,
+  'authenticated_at' => Familia.now.to_i,
+}
+
+def colonel_headers
+  { 'rack.session' => @sess, 'HTTP_ACCEPT' => 'application/json' }
+end
+
+# TIER 1 verb under test: revoking all of a customer's sessions. Its #4326
+# confirmation token is the target's EMAIL, an identifier the URL never carries.
+def confirming_headers
+  colonel_headers.merge('HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(@target.email))
+end
+
+ELEVATION_URL = '/api/colonel/elevation'
+
+def revoke_all_url
+  "/api/colonel/users/#{@target.extid}/sessions/revoke-all"
+end
+
+# --- Authorization on the elevation endpoints themselves ------------------
+
+## A non-colonel cannot read elevation status
+@test.clear_cookies
+get ELEVATION_URL, {}, { 'rack.session' => { 'authenticated' => true,
+                                             'external_id' => @regular.extid,
+                                             'email' => @regular.email },
+                         'HTTP_ACCEPT' => 'application/json' }
+last_response.status
+#=> 403
+
+## An anonymous caller gets 401
+@test.clear_cookies
+get ELEVATION_URL, {}, { 'HTTP_ACCEPT' => 'application/json' }
+last_response.status
+#=> 401
+
+# --- The unelevated colonel ----------------------------------------------
+
+## Status starts at "not elevated", and reports the configured window
+@test.clear_cookies
+get ELEVATION_URL, {}, colonel_headers
+[last_response.status, body['record']['elevated'], body['details']['enabled'], body['details']['window']]
+#=> [200, false, true, 600]
+
+## The account has a password, so `password` is the only offered factor
+[body['details']['password_available'], body['details']['factors']]
+#=> [true, ["password"]]
+
+## A TIER 1 verb refuses with 403 elevation_required — a colonel session and the
+## correct confirmation token are together NOT sufficient
+AE.events.clear
+post revoke_all_url, {}, confirming_headers
+[last_response.status, body['error_type'], body['error_code'], body['window']]
+#=> [403, "ElevationRequired", "elevation_required", 600]
+
+## That refusal writes NO audit event: it is drivable on demand by whoever holds
+## the cookie, and the operator trail is count-capped with no TTL
+AE.count
+#=> 0
+
+## Elevation is checked BEFORE confirmation, so a WRONG token still answers
+## elevation_required — no confirmation oracle for an unelevated caller
+post revoke_all_url, {}, colonel_headers.merge('HTTP_X_OTS_CONFIRM' => 'not-the-token')
+[last_response.status, body['error_code']]
+#=> [403, "elevation_required"]
+
+# --- Elevating -----------------------------------------------------------
+
+## A wrong password is 403 elevation_failed, and grants nothing
+AE.security_events.clear
+post ELEVATION_URL, { 'factor' => 'password', 'password' => 'wrong-password' }, colonel_headers
+[last_response.status, body['error_type'], body['error_code'],
+ @test.last_request.env['rack.session'].key?('elevated_until')]
+#=> [403, "ElevationFailed", "elevation_failed", false]
+
+## The failure is recorded as a SECURITY event, not on the operator trail
+[AE.security_count, AE.count]
+#=> [1, 0]
+
+## `recent_auth` is refused for an account that HAS a password, even one second
+## after sign-in — the B-3 lock, live over HTTP
+post ELEVATION_URL, { 'factor' => 'recent_auth' }, colonel_headers
+[last_response.status, body['error_code']]
+#=> [403, "elevation_failed"]
+
+## An unknown factor is a 422, not a 403
+post ELEVATION_URL, { 'factor' => 'telepathy' }, colonel_headers
+last_response.status
+#=> 422
+
+## The right password mints a window
+AE.events.clear
+post ELEVATION_URL, { 'factor' => 'password', 'password' => @password }, colonel_headers
+[last_response.status, body['record']['elevated'], body['details']['factor'], body['details']['window']]
+#=> [200, true, "password", 600]
+
+## What landed IN THE SESSION is an identity-bound object, never a bare epoch.
+## Read through the request Rack actually served: the session middleware owns
+## the hash the logic class wrote to, not the seed hash passed in the env.
+@stored = @test.last_request.env['rack.session']['elevated_until']
+[@stored.is_a?(Hash), @stored['extid'], @stored['exp'] > Familia.now.to_i]
+#=> [true, @colonel.extid, true]
+
+## Exactly one colonel.elevate event, carrying the FACTOR so the weaker path
+## would be visible in the trail
+@ev = AE.recent(1).first
+[AE.count, @ev['verb'], @ev['actor'], @ev['target']]
+#=> [1, "colonel.elevate", "#{@colonel.extid}", "#{@colonel.extid}"]
+
+## Status now reports the live window with a countdown seed
+get ELEVATION_URL, {}, colonel_headers
+[last_response.status, body['record']['elevated'], body['record']['seconds_remaining'].positive?]
+#=> [200, true, true]
+
+# --- The elevated colonel ------------------------------------------------
+
+## The TIER 1 verb now succeeds — with the confirmation header still required
+AE.events.clear
+post revoke_all_url, {}, confirming_headers
+[last_response.status, body['record']['revoked']]
+#=> [200, true]
+
+## Elevation does NOT replace confirmation: the same elevated session without
+## the header is still 403, now on the confirmation gate
+post revoke_all_url, {}, colonel_headers
+[last_response.status, body['error_code']]
+#=> [403, "confirmation_required"]
+
+# --- Dropping ------------------------------------------------------------
+
+## DELETE ends the window
+AE.events.clear
+delete ELEVATION_URL, {}, colonel_headers
+[last_response.status, body['record']['elevated'],
+ @test.last_request.env['rack.session'].key?('elevated_until')]
+#=> [200, false, false]
+
+## ...and it is audited as the closing half of the bracket
+[AE.count, AE.recent(1).first['verb']]
+#=> [1, "colonel.elevate_drop"]
+
+## The TIER 1 verb is refused again
+post revoke_all_url, {}, confirming_headers
+[last_response.status, body['error_code']]
+#=> [403, "elevation_required"]
+
+# --- Disabled by config --------------------------------------------------
+
+## With elevation disabled the tier-1 verb runs on confirmation alone — the
+## pre-#4327 posture, which is what enabled:false is for
+set_elevation('enabled' => false)
+post revoke_all_url, {}, confirming_headers
+last_response.status
+#=> 200
+
+## ...and the elevation endpoint refuses to mint a window at all
+post ELEVATION_URL, { 'factor' => 'password', 'password' => @password }, colonel_headers
+last_response.status
+#=> 422
+
+# Restore the shared config for later tryout files.
+OT.send(:conf=, @saved_conf)

--- a/try/integration/api/colonel/last_colonel_interlock_try.rb
+++ b/try/integration/api/colonel/last_colonel_interlock_try.rb
@@ -1,0 +1,183 @@
+# try/integration/api/colonel/last_colonel_interlock_try.rb
+#
+# frozen_string_literal: true
+
+# Self-target and last-colonel interlocks (#4328) over a REAL Rack stack and a
+# REAL role index. The unit specs prove each guard in isolation; this proves the
+# guards are actually WIRED — including the ordering that keeps them from being
+# an information oracle.
+#
+# ## What is reachable over HTTP, and what is not
+#
+# `verify_one_of_roles!` routes through `has_system_role?`, which requires
+# `verified? && role == 'colonel'`. So the ACTING colonel is, by construction,
+# always a member of `RoleSupport.active_colonels`. That makes the LAST-COLONEL
+# refusals unreachable over HTTP for a target that is not the caller — there are
+# always at least two active colonels in that scenario — and it is the
+# SELF-target arm that fires when an install's only colonel tries to strip their
+# own powers. The last-colonel arm is the CLI's (`bin/ots customers role demote`,
+# covered in spec/cli/customers_command_role_spec.rb) and the op-level backstop.
+# That asymmetry is the whole reason both arms exist; asserting it here keeps a
+# future refactor from "simplifying" one of them away.
+#
+# Covers:
+# - demoting your own colonel account          -> 422, field user_id, role unchanged
+# - promoting yourself is still allowed        -> 200 (only demotion is a lockout)
+# - unverifying your own account               -> 422, field user_id, still verified
+# - both 422s are reachable ONLY after the confirmation gate (M-2 oracle guard):
+#   with no X-OTS-Confirm header the answer is 403 confirmation_required
+# - a SECOND colonel can be promoted and verified, and colonel A can then demote
+#   and unverify colonel B normally
+# - revoking your OWN session through the global console -> 422 (sign out instead)
+# - revoke-all against your OWN account -> 200, and the session you are working
+#   in survives (the containment path, deliberately NOT refused)
+#
+# Run: try --agent try/integration/api/colonel/last_colonel_interlock_try.rb
+
+require 'rack/test'
+require_relative '../../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/application/registry'
+Onetime::Application::Registry.prepare_application_registry
+
+@test = Object.new
+@test.extend Rack::Test::Methods
+
+def @test.app
+  Onetime::Application::Registry.generate_rack_url_map
+end
+
+def get(*args);    @test.get(*args);              end
+def post(*args);   @test.post(*with_csrf(args));  end
+def delete(*args); @test.delete(*with_csrf(args)); end
+def last_response; @test.last_response; end
+def body; JSON.parse(last_response.body); end
+
+@timestamp = Familia.now.to_i
+
+@colonel = Onetime::Customer.create!(email: "colonel_lci_#{@timestamp}@example.com")
+@colonel.role     = 'colonel'
+@colonel.verified = 'true'
+@colonel.save
+
+@second = Onetime::Customer.create!(email: "second_lci_#{@timestamp}@example.com")
+@second.verified = 'true'
+@second.save
+
+@colonel_session = {
+  'authenticated' => true,
+  'external_id'   => @colonel.extid,
+  'email'         => @colonel.email,
+}
+
+# `confirm` is the percent-encoded token, exactly as the console sends it.
+def colonel_headers(confirm = nil)
+  headers = { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
+  headers['HTTP_X_OTS_CONFIRM'] = confirm if confirm
+  headers
+end
+
+def confirming(customer)
+  colonel_headers(Rack::Utils.escape(customer.email))
+end
+
+@self_role_url     = "/api/colonel/users/#{@colonel.extid}/role"
+@self_unverify_url = "/api/colonel/users/#{@colonel.extid}/unverify"
+
+## Demoting your own colonel account is refused, naming the field to highlight
+post @self_role_url, { 'role' => 'customer' }, confirming(@colonel)
+[last_response.status, body['field']]
+#=> [422, "user_id"]
+
+## ...and the refusal names the CLI remediation, because nobody else can do it
+body['error'].include?('bin/ots customers role demote')
+#=> true
+
+## ...and the role really is unchanged
+Onetime::Customer.load(@colonel.objid).role.to_s
+#=> "colonel"
+
+## M-2: with NO confirmation header the answer is the 403, never the 422 —
+## the interlock must not tell a cookie holder whether an account is their own
+post @self_role_url, { 'role' => 'customer' }, colonel_headers
+[last_response.status, body['error_code']]
+#=> [403, "confirmation_required"]
+
+## Unverifying your own account is refused too (it strips colonel eligibility)
+post @self_unverify_url, {}, confirming(@colonel)
+[last_response.status, body['field']]
+#=> [422, "user_id"]
+
+## ...and the account is still verified
+Onetime::Customer.load(@colonel.objid).verified?
+#=> true
+
+## M-2 again on the unverify arm
+post @self_unverify_url, {}, colonel_headers
+[last_response.status, body['error_code']]
+#=> [403, "confirmation_required"]
+
+## Promoting YOURSELF is not a lockout, so it is still allowed
+post @self_role_url, { 'role' => 'colonel' }, confirming(@colonel)
+[last_response.status, body['details']['changed']]
+#=> [200, false]
+
+## An EMAIL identifier now resolves (sanitize_identifier used to strip @ and .)
+post "/api/colonel/users/#{Rack::Utils.escape(@second.email)}/role",
+  { 'role' => 'colonel' }, confirming(@second)
+[last_response.status, Onetime::Customer.load(@second.objid).role.to_s]
+#=> [200, "colonel"]
+
+## With a second verified colonel in place, colonel A can unverify colonel B
+post "/api/colonel/users/#{@second.extid}/unverify", {}, confirming(@second)
+[last_response.status, Onetime::Customer.load(@second.objid).verified?]
+#=> [200, false]
+
+## ...and re-verify, then demote them, both normally
+post "/api/colonel/users/#{@second.extid}/verify", {}, colonel_headers
+last_response.status
+#=> 200
+
+## Demoting the OTHER colonel succeeds — only the caller's own account is barred
+post "/api/colonel/users/#{@second.extid}/role", { 'role' => 'customer' }, confirming(@second)
+[last_response.status, Onetime::Customer.load(@second.objid).role.to_s]
+#=> [200, "customer"]
+
+## The global sessions console names the caller's OWN row by handle
+get '/api/colonel/sessions', {}, colonel_headers
+@own_handle = body['details']['current_session_handle']
+@own_handle.is_a?(String) && !@own_handle.empty?
+#=> true
+
+## Revoking that row is refused — sign out instead of self-revoking
+delete "/api/colonel/sessions/#{@own_handle}", {}, confirming(@colonel)
+[last_response.status, body['field']]
+#=> [422, "session_handle"]
+
+## ...and the caller is still authenticated afterwards
+get '/api/colonel/sessions', {}, colonel_headers
+last_response.status
+#=> 200
+
+## Revoke-all against your OWN account is SUPPORTED, not refused: it is the
+## first containment step for a leaked colonel cookie
+post "/api/colonel/users/#{@colonel.extid}/sessions/revoke-all", {}, confirming(@colonel)
+[last_response.status, body['details']['message']]
+#=> [200, "Revoked all of your other sessions; this one was kept."]
+
+## ...and the session it was issued from still works
+get '/api/colonel/sessions', {}, colonel_headers
+last_response.status
+#=> 200
+
+## Revoke-all against an unknown identifier is now a 404, not a silent zero
+post '/api/colonel/users/ur_does_not_exist_lci/sessions/revoke-all', {},
+  colonel_headers(Rack::Utils.escape('nobody@example.com'))
+last_response.status
+#=> 404
+
+# Teardown.
+@second.destroy! if @second.exists?
+@colonel.destroy! if @colonel.exists?

--- a/try/integration/api/colonel/manage_entitlement_override_try.rb
+++ b/try/integration/api/colonel/manage_entitlement_override_try.rb
@@ -91,11 +91,10 @@ def last_response;  @test.last_response;  end
 # The 404-for-unknown-org case below deliberately sends NO header: shape and
 # existence are checked before the gate, so it must still answer 404.
 #
-# Encode the way the console does (encodeURIComponent === URI.encode_uri_component),
-# NOT Rack::Utils.escape: the server decodes with URI.decode_uri_component, which
-# treats '+' as a literal plus, so a form-escaped space ('+') would arrive as '+'
-# and never match a display_name that contains spaces (auth_strategies.rb #4326).
-@confirm_header = { 'HTTP_X_OTS_CONFIRM' => URI.encode_uri_component(@org.display_name) }
+# Rack::Utils.escape (form encoding, space -> '+') is one of the encodings the
+# server's form decoder accepts (auth_strategies.rb #4326); '%20' and a raw space
+# work too.
+@confirm_header = { 'HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(@org.display_name) }
 @colonel_json_headers = {
   'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json',
   'HTTP_ACCEPT' => 'application/json',

--- a/try/integration/api/colonel/manage_entitlement_override_try.rb
+++ b/try/integration/api/colonel/manage_entitlement_override_try.rb
@@ -90,7 +90,12 @@ def last_response;  @test.last_response;  end
 # them requires the organization's NAME — percent-encoded — in X-OTS-Confirm.
 # The 404-for-unknown-org case below deliberately sends NO header: shape and
 # existence are checked before the gate, so it must still answer 404.
-@confirm_header = { 'HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(@org.display_name) }
+#
+# Encode the way the console does (encodeURIComponent === URI.encode_uri_component),
+# NOT Rack::Utils.escape: the server decodes with URI.decode_uri_component, which
+# treats '+' as a literal plus, so a form-escaped space ('+') would arrive as '+'
+# and never match a display_name that contains spaces (auth_strategies.rb #4326).
+@confirm_header = { 'HTTP_X_OTS_CONFIRM' => URI.encode_uri_component(@org.display_name) }
 @colonel_json_headers = {
   'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json',
   'HTTP_ACCEPT' => 'application/json',

--- a/try/integration/api/colonel/manage_entitlement_override_try.rb
+++ b/try/integration/api/colonel/manage_entitlement_override_try.rb
@@ -85,6 +85,20 @@ def last_response;  @test.last_response;  end
   'email'         => @regular.email,
 }
 
+# Server-side destructive-action confirmation (#4326): this endpoint is TIER 2 on
+# ALL arms (grant is privilege-granting, clear is irreversible), so every one of
+# them requires the organization's NAME — percent-encoded — in X-OTS-Confirm.
+# The 404-for-unknown-org case below deliberately sends NO header: shape and
+# existence are checked before the gate, so it must still answer 404.
+@confirm_header = { 'HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(@org.display_name) }
+@colonel_json_headers = {
+  'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json',
+  'HTTP_ACCEPT' => 'application/json',
+}.merge(@confirm_header)
+@colonel_plain_headers = {
+  'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json',
+}.merge(@confirm_header)
+
 # ----------------------------------------------------------------
 # Authorization
 # ----------------------------------------------------------------
@@ -111,7 +125,7 @@ last_response.status
 ## Colonel gets 404 when org does not exist
 post "/api/colonel/organizations/nonexistent_org_#{@timestamp}/entitlements/grant",
   { entitlement: 'custom_domains' }.to_json,
-  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_json_headers.reject { |k, _| k == 'HTTP_X_OTS_CONFIRM' }
 [last_response.status, JSON.parse(last_response.body).key?('error')]
 #=> [404, true]
 
@@ -122,7 +136,7 @@ post "/api/colonel/organizations/nonexistent_org_#{@timestamp}/entitlements/gran
 ## Grant: returns 200 with expected structure
 post "/api/colonel/organizations/#{@org.objid}/entitlements/grant",
   { entitlement: 'custom_domains' }.to_json,
-  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_json_headers
 resp = JSON.parse(last_response.body)
 [
   last_response.status,
@@ -152,7 +166,7 @@ resp['record']['effective_entitlements'].include?('custom_domains')
 ## Grant: unknown entitlement succeeds (intentional, for future entitlements)
 post "/api/colonel/organizations/#{@org.objid}/entitlements/grant",
   { entitlement: 'future_feature_xyz' }.to_json,
-  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_json_headers
 resp = JSON.parse(last_response.body)
 [last_response.status, resp['record']['action']]
 #=> [200, 'granted']
@@ -164,7 +178,7 @@ resp = JSON.parse(last_response.body)
 ## Revoke: returns 200 with action='revoked'
 post "/api/colonel/organizations/#{@org.objid}/entitlements/revoke",
   { entitlement: 'api_access' }.to_json,
-  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_json_headers
 resp = JSON.parse(last_response.body)
 [last_response.status, resp['record']['action']]
 #=> [200, 'revoked']
@@ -187,7 +201,7 @@ resp['record']['effective_entitlements'].include?('api_access')
 ## Grant after revoke: removes from revokes and adds to grants (reciprocal)
 post "/api/colonel/organizations/#{@org.objid}/entitlements/grant",
   { entitlement: 'api_access' }.to_json,
-  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_json_headers
 resp = JSON.parse(last_response.body)
 [resp['record']['revokes'].include?('api_access'), resp['record']['grants'].include?('api_access')]
 #=> [false, true]
@@ -199,14 +213,14 @@ resp = JSON.parse(last_response.body)
 ## Grant without entitlement param returns 422 (FormError)
 post "/api/colonel/organizations/#{@org.objid}/entitlements/grant",
   {}.to_json,
-  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_json_headers
 last_response.status
 #=> 422
 
 ## Revoke without entitlement param returns 422 (FormError)
 post "/api/colonel/organizations/#{@org.objid}/entitlements/revoke",
   {}.to_json,
-  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_json_headers
 last_response.status
 #=> 422
 
@@ -217,7 +231,7 @@ last_response.status
 ## Clear: returns 200 with action='cleared'
 delete "/api/colonel/organizations/#{@org.objid}/entitlements/overrides",
   {},
-  { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_plain_headers
 resp = JSON.parse(last_response.body)
 [last_response.status, resp['record']['action']]
 #=> [200, 'cleared']
@@ -263,7 +277,7 @@ last_response.status
 ## Grant via the org's PUBLIC extid resolves the org and returns 200 (extid-first)
 post "/api/colonel/organizations/#{@org.extid}/entitlements/grant",
   { entitlement: 'audit_probe_one' }.to_json,
-  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_json_headers
 [last_response.status, JSON.parse(last_response.body)['record']['action']]
 #=> [200, 'granted']
 
@@ -271,7 +285,7 @@ post "/api/colonel/organizations/#{@org.extid}/entitlements/grant",
 @before_count = Onetime::ColonelAuditEvent.count
 post "/api/colonel/organizations/#{@org.extid}/entitlements/grant",
   { entitlement: 'audit_probe_two' }.to_json,
-  { 'rack.session' => @colonel_session, 'CONTENT_TYPE' => 'application/json', 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_json_headers
 @evt = Onetime::ColonelAuditEvent.recent(1).first
 [
   Onetime::ColonelAuditEvent.count - @before_count,
@@ -286,7 +300,7 @@ post "/api/colonel/organizations/#{@org.extid}/entitlements/grant",
 ## Clear records an audit event with the clear verb and an empty detail
 delete "/api/colonel/organizations/#{@org.extid}/entitlements/overrides",
   {},
-  { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
+  @colonel_plain_headers
 @evt = Onetime::ColonelAuditEvent.recent(1).first
 [last_response.status, @evt['verb'], @evt['target'] == @org.extid, @evt['detail']]
 #=> [200, 'organization.entitlement.clear', true, {}]

--- a/try/integration/api/colonel/revoke_all_customer_sessions_try.rb
+++ b/try/integration/api/colonel/revoke_all_customer_sessions_try.rb
@@ -83,6 +83,14 @@ def colonel_headers
   { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
 end
 
+# Server-side destructive-action confirmation (#4326): revoking sessions is
+# TIER 1, so it requires the account's email — percent-encoded — in
+# X-OTS-Confirm. The URL carries the extid (and, for the single revoke, an
+# opaque handle); the token is deliberately a different identifier.
+def confirming_headers
+  colonel_headers.merge('HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(@target.email))
+end
+
 # Two tracked blobs + one untracked (pre-sidecar) blob for the target.
 @tracked = ["intracs_a_#{@nonce}", "intracs_b_#{@nonce}"]
 @tracked.each do |sid|
@@ -120,7 +128,7 @@ post URL, {}, { 'HTTP_ACCEPT' => 'application/json' }
 
 ## POST by the colonel returns 200 with revoked=true and a kill count of 3
 AE.events.clear
-post URL, {}, colonel_headers
+post URL, {}, confirming_headers
 @resp = JSON.parse(last_response.body)
 [last_response.status, @resp['record']['revoked'], @resp['record']['blobs_deleted'], @resp['record']['untracked_deleted']]
 #=> [200, true, 3, 1]

--- a/try/integration/api/colonel/revoke_customer_session_try.rb
+++ b/try/integration/api/colonel/revoke_customer_session_try.rb
@@ -84,6 +84,14 @@ def colonel_headers
   { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json' }
 end
 
+# Server-side destructive-action confirmation (#4326): revoking sessions is
+# TIER 1, so it requires the account's email — percent-encoded — in
+# X-OTS-Confirm. The URL carries the extid (and, for the single revoke, an
+# opaque handle); the token is deliberately a different identifier.
+def confirming_headers
+  colonel_headers.merge('HTTP_X_OTS_CONFIRM' => Rack::Utils.escape(@target.email))
+end
+
 @sid = "intrcs_#{@nonce}"
 @key = "session:#{@sid}"
 
@@ -130,7 +138,7 @@ delete URL, {}, { 'HTTP_ACCEPT' => 'application/json' }
 
 ## DELETE by the colonel returns 200 with record.revoked=true and the HANDLE echoed
 AE.events.clear
-delete URL, {}, colonel_headers
+delete URL, {}, confirming_headers
 @resp = JSON.parse(last_response.body)
 [last_response.status, @resp['record']['revoked'], @resp['record']['session_handle'], @resp['details']['message']]
 #=> [200, true, "#{@handle}", 'Session revoked successfully']
@@ -160,7 +168,7 @@ AE.recent(1).first['detail']['session_id']
 ## a second DELETE with the now-stale handle 404s — the first revoke ZREM'd the
 ## sid from the active set, so the handle resolves to no session to revoke
 AE.events.clear
-delete URL, {}, colonel_headers
+delete URL, {}, confirming_headers
 last_response.status
 #=> 404
 

--- a/try/unit/colonel/destructive_action_try.rb
+++ b/try/unit/colonel/destructive_action_try.rb
@@ -1,0 +1,181 @@
+# try/unit/colonel/destructive_action_try.rb
+#
+# frozen_string_literal: true
+
+# ColonelAPI::Logic::DestructiveAction — the shared guard concern introduced by
+# #4326 and extended by the rest of epic #4323.
+#
+# What this file covers, at the level of the concern itself rather than any one
+# verb (the per-class specs do that):
+#
+# 1. `truthy?` — the hoisted table. Ten colonel classes each had their own and
+#    two of them disagreed (purge_dlq / replay_dlq accepted only %w[1 true yes]
+#    and did not strip). This pins the widened, single form.
+# 2. `supplied_confirmation` reads STRATEGY METADATA, never params — a `confirm`
+#    query parameter must not be a back door, because the whole point of the
+#    header transport is keeping target emails out of access logs and history.
+# 3. The 255-char post-decode cap, and that whitespace is stripped.
+# 4. `require_confirmation!` with a blank expected token raises
+#    Onetime::GuardMisconfigured (500) rather than admitting the request.
+# 5. `guard_destructive_action!` rejects an unknown tier — a typo'd tier would
+#    otherwise silently drop elevation (#4327) and the tight bucket (#4329).
+# 6. The rejection stays inside the Onetime::Forbidden family, which is what
+#    keeps a hammered gate from minting audit events and flushing the
+#    count-capped operator trail.
+#
+# Run: try --agent try/unit/colonel/destructive_action_try.rb
+
+require_relative '../../support/test_models'
+require 'colonel/logic'
+
+OT.boot! :test
+
+# A minimal host for the concern: a real colonel logic class needs a target to
+# resolve, and none of that is what this file is about.
+class TryDestructiveHost < ColonelAPI::Logic::Base
+  def process_params; end
+  def raise_concerns; end
+end
+
+def host_with(confirm_token)
+  metadata = confirm_token.nil? ? {} : { confirm_token: confirm_token }
+  TryDestructiveHost.new(
+    MockStrategyResult.new(session: {}, user: nil, auth_method: 'sessionauth', metadata: metadata),
+    {},
+  )
+end
+
+@host = host_with('victim@example.com')
+
+## truthy? accepts the whole widened table, case- and whitespace-insensitively
+%W[true 1 yes on TRUE On \ yes\  #{"\ttrue\n"}].map { |v| @host.truthy?(v) }
+#=> [true, true, true, true, true, true, true, true]
+
+## truthy? rejects everything else, including nil and the falsy strings
+[nil, '', 'false', '0', 'no', 'off', 'maybe', 'ontario'].map { |v| @host.truthy?(v) }
+#=> [false, false, false, false, false, false, false, false]
+
+## supplied_confirmation reads the strategy metadata
+host_with('abc').supplied_confirmation
+#=> "abc"
+
+## supplied_confirmation is '' when no header was sent
+host_with(nil).supplied_confirmation
+#=> ""
+
+## supplied_confirmation strips surrounding whitespace (headers pick it up)
+host_with("  spaced@example.com \n").supplied_confirmation
+#=> "spaced@example.com"
+
+## supplied_confirmation caps at MAX_CONFIRM_LENGTH
+host_with('z' * 1000).supplied_confirmation.length
+#=> 255
+
+## a `confirm` PARAM is NOT a fallback — the header is the only transport
+TryDestructiveHost.new(
+  MockStrategyResult.new(session: {}, user: nil, auth_method: 'sessionauth', metadata: {}),
+  { 'confirm' => 'victim@example.com' },
+).supplied_confirmation
+#=> ""
+
+## a non-ASCII token that survived percent-decoding compares equal
+host_with('Acme Gmbh Überwachung').require_confirmation!(
+  'Acme Gmbh Überwachung', subject: "the organization's name"
+)
+#=> true
+
+## the exact token passes
+@host.require_confirmation!('victim@example.com', subject: 'the account email address')
+#=> true
+
+## a wrong token is refused
+begin
+  @host.require_confirmation!('someone@else.example', subject: 'the account email address')
+rescue Onetime::ConfirmationRequired => ex
+  [ex.class.name, ex.to_h[:error_code], ex.is_a?(Onetime::Forbidden)]
+end
+#=> ["Onetime::ConfirmationRequired", "confirmation_required", true]
+
+## a missing token is refused with the SAME message (no oracle)
+missing = begin
+  host_with(nil).require_confirmation!('victim@example.com', subject: 'the account email address')
+rescue Onetime::ConfirmationRequired => ex
+  ex.message
+end
+wrong = begin
+  @host.require_confirmation!('someone@else.example', subject: 'the account email address')
+rescue Onetime::ConfirmationRequired => ex
+  ex.message
+end
+missing == wrong
+#=> true
+
+## the refusal message names the header and the subject, never the expected value
+begin
+  host_with(nil).require_confirmation!('victim@example.com', subject: 'the account email address')
+  'no raise'
+rescue Onetime::ConfirmationRequired => ex
+  ex.message
+end
+#=> "Confirmation required: re-send this request with the X-OTS-Confirm header set to the account email address."
+
+## the refusal carries the field the console should highlight
+begin
+  host_with(nil).require_confirmation!('x', subject: 's', field: :user_id)
+rescue Onetime::ConfirmationRequired => ex
+  ex.to_h[:field]
+end
+#=> :user_id
+
+## a BLANK expected token is a 500, never a silent admit
+begin
+  @host.require_confirmation!('', subject: 'anything')
+rescue Onetime::GuardMisconfigured => ex
+  [ex.to_h[:error_type], ex.to_h[:error_code]]
+end
+#=> ["GuardMisconfigured", "guard_misconfigured"]
+
+## a whitespace-only expected token is blank too
+begin
+  @host.require_confirmation!("  \n", subject: 'anything')
+rescue Onetime::GuardMisconfigured
+  :guarded
+end
+#=> :guarded
+
+## guard_destructive_action! passes the confirmation through on a valid tier
+@host.guard_destructive_action!(
+  tier: :destructive, confirm_with: 'victim@example.com', confirm_subject: 'the email'
+)
+#=> true
+
+## guard_destructive_action! refuses an unknown tier rather than downgrading
+begin
+  @host.guard_destructive_action!(
+    tier: :mild, confirm_with: 'victim@example.com', confirm_subject: 'the email'
+  )
+rescue Onetime::GuardMisconfigured => ex
+  ex.to_h[:error_code]
+end
+#=> "guard_misconfigured"
+
+## account_confirm_token prefers the email
+@host.account_confirm_token(Struct.new(:email, :extid).new('a@b.example', 'ur_x'))
+#=> "a@b.example"
+
+## account_confirm_token falls back to the extid when there is no email
+@host.account_confirm_token(Struct.new(:email, :extid).new('  ', 'ur_x'))
+#=> "ur_x"
+
+## org_confirm_token prefers the display name, falls back to the extid
+org = Struct.new(:display_name, :extid)
+[@host.org_confirm_token(org.new('Acme', 'or_x')), @host.org_confirm_token(org.new('', 'or_x'))]
+#=> ["Acme", "or_x"]
+
+## every colonel logic class HAS the guards (they are on the shared Base)
+ColonelAPI::Logic::Colonel::PurgeUser.method_defined?(:guard_destructive_action!)
+#=> true
+
+## charge_destructive_budget! is a declared no-op until #4329 fills it in
+@host.charge_destructive_budget!
+#=> nil

--- a/try/unit/colonel/dry_run_side_effects_try.rb
+++ b/try/unit/colonel/dry_run_side_effects_try.rb
@@ -1,0 +1,167 @@
+# try/unit/colonel/dry_run_side_effects_try.rb
+#
+# frozen_string_literal: true
+
+# "A preview writes nothing" — proven, not assumed.
+#
+# The #4326 PREVIEW EXEMPTION lets every dry_run-capable colonel verb skip the
+# confirmation gate (and, once #4327/#4329 land, step-up and the tight rate-limit
+# bucket) on its preview path. The entire justification is that a preview has no
+# side effects. That was prose in the design doc; this file makes it a test.
+#
+# For each dry_run class it drives the REAL logic against REAL Redis with NO
+# confirmation header and asserts three things:
+#
+#   1. raise_concerns does not refuse (the exemption works);
+#   2. no Redis key is CREATED and the target's own hash is byte-identical
+#      (pre-existing keys expiring on their own TTL are ignored — that is the
+#      datastore, not us);
+#   3. no ColonelAuditEvent is recorded.
+#
+# NOT covered here: PurgeDlq and ReplayDlq. Their preview path needs a live
+# RabbitMQ connection ($rmq_conn) that this container does not have, and their
+# adapters refuse with "Message queue is not connected" before reaching the
+# guard. Their preview exemption is covered at the unit level in
+# apps/api/colonel/spec/logic/colonel/purge_dlq_spec.rb instead.
+#
+# Run: try --agent try/unit/colonel/dry_run_side_effects_try.rb
+
+require_relative '../../support/test_models'
+require 'colonel/logic'
+
+OT.boot! :test
+
+@timestamp = Familia.now.to_i
+@db = Familia.dbclient
+
+@colonel = Onetime::Customer.create!(email: "colonel_dryrun_#{@timestamp}@example.com")
+@colonel.role     = 'colonel'
+@colonel.verified = 'true'
+@colonel.save
+
+@target = Onetime::Customer.create!(email: "target_dryrun_#{@timestamp}@example.com")
+@target.verified = 'true'
+@target.save
+
+@org = Onetime::Organization.create!("DryRun Org #{@timestamp}", @colonel,
+  "billing_dryrun_#{@timestamp}@example.com")
+@other_org = Onetime::Organization.create!("DryRun Dest #{@timestamp}", @colonel)
+@domain = Onetime::CustomDomain.create!("dryrun-#{@timestamp}.example.com", @org.objid)
+
+# No confirmation token anywhere: that is the point. A preview that needed one
+# would fail these with Onetime::ConfirmationRequired.
+def colonel_strategy
+  MockStrategyResult.new(
+    session: {}, user: @colonel, auth_method: 'sessionauth', metadata: {},
+  )
+end
+
+# Everything a preview could touch, in one comparable value.
+def snapshot(target_key)
+  {
+    keys: @db.keys('*').sort,
+    target: @db.hgetall(target_key),
+    audit: Onetime::ColonelAuditEvent.events.size,
+  }
+end
+
+# Returns [keys_created, target_changed?, audit_events_written].
+# Deletions are ignored: an unrelated key reaching its TTL mid-run is the
+# datastore expiring, not this preview writing.
+def diff(before, after)
+  [
+    (after[:keys] - before[:keys]),
+    after[:target] != before[:target],
+    after[:audit] - before[:audit],
+  ]
+end
+
+def preview(klass, params, target_key)
+  before = snapshot(target_key)
+  logic  = klass.new(colonel_strategy, params)
+  logic.raise_concerns
+  logic.process
+  diff(before, snapshot(target_key))
+end
+
+## RemoveCustomDomain previews with no confirmation, and writes nothing
+preview(
+  ColonelAPI::Logic::Colonel::RemoveCustomDomain,
+  { 'extid' => @domain.extid },
+  @domain.dbkey,
+)
+#=> [[], false, 0]
+
+## RepairDomain previews with no confirmation, and writes nothing
+preview(
+  ColonelAPI::Logic::Colonel::RepairDomain,
+  { 'extid' => @domain.extid },
+  @domain.dbkey,
+)
+#=> [[], false, 0]
+
+## TransferDomain previews with no confirmation, and writes nothing
+preview(
+  ColonelAPI::Logic::Colonel::TransferDomain,
+  { 'extid' => @domain.extid, 'to_org' => @other_org.extid },
+  @domain.dbkey,
+)
+#=> [[], false, 0]
+
+## ChangeUserEmail previews with no confirmation, and writes nothing
+preview(
+  ColonelAPI::Logic::Colonel::ChangeUserEmail,
+  { 'user_id' => @target.extid, 'new_email' => "moved_#{@timestamp}@example.com" },
+  @target.dbkey,
+)
+#=> [[], false, 0]
+
+## DeleteOrganization previews with no confirmation, and writes nothing
+preview(
+  ColonelAPI::Logic::Colonel::DeleteOrganization,
+  { 'org_id' => @org.extid },
+  @org.dbkey,
+)
+#=> [[], false, 0]
+
+## An APPLY, by contrast, IS gated — the exemption is the preview, not the verb
+begin
+  logic = ColonelAPI::Logic::Colonel::RemoveCustomDomain.new(
+    colonel_strategy, { 'extid' => @domain.extid, 'dry_run' => 'false' },
+  )
+  logic.raise_concerns
+  :not_gated
+rescue Onetime::ConfirmationRequired => ex
+  ex.to_h[:error_code]
+end
+#=> "confirmation_required"
+
+## ...and the refused apply still wrote nothing
+before = snapshot(@domain.dbkey)
+begin
+  ColonelAPI::Logic::Colonel::RemoveCustomDomain.new(
+    colonel_strategy, { 'extid' => @domain.extid, 'dry_run' => 'false' },
+  ).raise_concerns
+rescue Onetime::ConfirmationRequired
+  nil
+end
+diff(before, snapshot(@domain.dbkey))
+#=> [[], false, 0]
+
+## The confirmed apply DOES go through (the gate is a gate, not a wall)
+logic = ColonelAPI::Logic::Colonel::RemoveCustomDomain.new(
+  MockStrategyResult.new(
+    session: {}, user: @colonel, auth_method: 'sessionauth',
+    metadata: { confirm_token: @domain.display_domain },
+  ),
+  { 'extid' => @domain.extid, 'dry_run' => 'false' },
+)
+logic.raise_concerns
+logic.process[:record][:deleted]
+#=> true
+
+# Teardown: the domain is already gone (the apply above removed it).
+@org.destroy! if @org.exists?
+@other_org.destroy! if @other_org.exists?
+@target.destroy! if @target.exists?
+@colonel.destroy! if @colonel.exists?

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -65,6 +65,9 @@
 #  14. Boot logging is once per process, not once per mounted app
 #  15. Full-precision CIDR matching via env['otto.ip_match']: a /32 admits its
 #      own client and denies neighbors that share its masked form
+#  16. Route-requirement ANNOTATION (#4332): the verdict + mode env keys, the
+#      allocation-free maybe_admin_surface? prefilter that puts them on the
+#      both-gates-inactive path, and the advisory boot line
 
 require_relative '../../support/test_helpers'
 
@@ -88,7 +91,7 @@ require_relative '../../../lib/onetime/middleware/admin_network_isolation'
 class TestAdminNetworkIsolation < Onetime::Middleware::AdminNetworkIsolation
   public :admin_surface?, :colonel_shell?, :colonel_api?, :request_path, :allowed?,
     :host_gate_active?, :network_gate_active?, :route_requirement_met?, :host_allowed?,
-    :normalize_host, :detected_host
+    :normalize_host, :detected_host, :route_requirement_mode, :maybe_admin_surface?
 
   def allowed_hosts
     @allowed_hosts
@@ -1286,12 +1289,14 @@ status_for(@both, 'tenant.example.com', client_ip: '203.0.113.9')
 status_for(@both, 'tenant.example.com', path_info: '/dashboard', client_ip: '203.0.113.9')
 #=> 200
 
-## both gates inactive - strict no-op on /colonel
+## both gates inactive - no denial on /colonel
+## (#4332 added the verdict-key annotation to this path; it still denies
+## nothing, which is what these three cases have always been about)
 @none = build_mw(hosts: [], cidrs: [], site_host: '127.0.0.1:3000')
 [@none.host_gate_active?, @none.network_gate_active?, status_for(@none, 'anything.example.test')]
 #=> [false, false, 200]
 
-## both gates inactive - strict no-op on /api/colonel with no detected host
+## both gates inactive - no denial on /api/colonel with no detected host
 status_for(@none, nil, script_name: '/api/colonel', path_info: '/info')
 #=> 200
 
@@ -1603,13 +1608,124 @@ build_mw(cidrs: ['', '   ']).network_gate_active?
 #=> false
 
 # =================================================================
+# ROUTE-REQUIREMENT ANNOTATION (#4332)
+# =================================================================
+# `network=admin_if_configured` on the 15 destructive colonel routes reads TWO
+# env keys this middleware writes: the boolean verdict (pre-existing) and the
+# tri-state MODE. Absence of the mode key means the middleware never ran, and
+# Application::NetworkRequirements treats that as a denial — so the keys have to
+# be written even on the both-gates-inactive path, which used to return before
+# touching env at all.
+#
+# The env key the annotation reads.
+@mode_key = Onetime::Middleware::AdminNetworkIsolation::ROUTE_REQUIREMENT_MODE_ENV_KEY
+@met_key  = Onetime::Middleware::AdminNetworkIsolation::ROUTE_REQUIREMENT_ENV_KEY
+
+# Run one request and hand back the two verdict keys it left behind.
+def verdict_keys(mw, script_name: '', path_info: '/colonel', detected_host: nil, client_ip: '203.0.113.9')
+  env = admin_env(script_name: script_name, path_info: path_info,
+                  client_ip: client_ip, detected_host: detected_host)
+  mw.call(env)
+  [env[Onetime::Middleware::AdminNetworkIsolation::ROUTE_REQUIREMENT_ENV_KEY],
+   env[Onetime::Middleware::AdminNetworkIsolation::ROUTE_REQUIREMENT_MODE_ENV_KEY]]
+end
+
+## posture E (explicit hosts + a parseable CIDR) is the ONLY enforced one
+build_mw(hosts: ['admin.example.com'], cidrs: ['10.0.0.0/8']).route_requirement_mode
+#=> :enforced
+
+## posture A - neither knob set: advisory
+build_mw(hosts: [], cidrs: [], site_host: '127.0.0.1:3000').route_requirement_mode
+#=> :advisory
+
+## posture B - canonical anchor only: advisory (the fallback is not explicit)
+build_mw(hosts: [], cidrs: ['10.0.0.0/8'], site_host: 'admin.example.com').route_requirement_mode
+#=> :advisory
+
+## posture C - hosts only: advisory
+build_mw(hosts: ['admin.example.com'], cidrs: []).route_requirement_mode
+#=> :advisory
+
+## posture D - explicit wildcard plus CIDRs: advisory (the wildcard is inactive)
+build_mw(hosts: ['*'], cidrs: ['10.0.0.0/8']).route_requirement_mode
+#=> :advisory
+
+## the mode always agrees with route_requirement_met?
+@modes = [build_mw(hosts: ['admin.example.com'], cidrs: ['10.0.0.0/8']),
+          build_mw(hosts: ['admin.example.com'], cidrs: [])]
+@modes.map { |mw| [mw.route_requirement_met?, mw.route_requirement_mode] }
+#=> [[true, :enforced], [false, :advisory]]
+
+## both gates inactive - an admin request now carries BOTH keys
+@stock = build_mw(hosts: [], cidrs: [], site_host: '127.0.0.1:3000')
+verdict_keys(@stock)
+#=> [false, :advisory]
+
+## both gates inactive - the mounted API surface carries them too
+verdict_keys(@stock, script_name: '/api/colonel', path_info: '/info')
+#=> [false, :advisory]
+
+## both gates inactive - a NON-admin path is still untouched (no keys at all)
+@non_admin_env = admin_env(script_name: '', path_info: '/dashboard', client_ip: '203.0.113.9')
+@stock.call(@non_admin_env)
+[@non_admin_env.key?(@met_key), @non_admin_env.key?(@mode_key)]
+#=> [false, false]
+
+## an admitted request in posture E carries the enforced mode
+@enforced = build_mw(hosts: ['admin.example.com'], cidrs: ['10.0.0.0/8'])
+verdict_keys(@enforced, script_name: '/api/colonel', path_info: '/info',
+                        detected_host: 'admin.example.com', client_ip: '10.0.0.5')
+#=> [true, :enforced]
+
+## a DENIED request writes nothing - the 404 short-circuits before the annotation
+@denied_env = admin_env(script_name: '/api/colonel', path_info: '/info',
+                        client_ip: '203.0.113.9', detected_host: 'admin.example.com')
+[@enforced.call(@denied_env).first, @denied_env.key?(@met_key), @denied_env.key?(@mode_key)]
+#=> [404, false, false]
+
+# The prefilter that keeps the no-op fast path allocation-free. It is
+# deliberately over-broad (#annotate_route_requirement re-checks exactly), so
+# these cases pin what it must never MISS, not what it may wave through.
+
+## a mounted colonel API app is recognized by SCRIPT_NAME alone
+@stock.maybe_admin_surface?('SCRIPT_NAME' => '/api/colonel', 'PATH_INFO' => '/info')
+#=> true
+
+## a mounted colonel SHELL app likewise
+@stock.maybe_admin_surface?('SCRIPT_NAME' => '/colonel', 'PATH_INFO' => '/settings')
+#=> true
+
+## an unmounted /colonel path is recognized by PATH_INFO
+@stock.maybe_admin_surface?('SCRIPT_NAME' => '', 'PATH_INFO' => '/colonel')
+#=> true
+
+## a DIFFERENT mounted app is not, whatever its PATH_INFO says
+@stock.maybe_admin_surface?('SCRIPT_NAME' => '/api/secret', 'PATH_INFO' => '/colonel')
+#=> false
+
+## nor is an ordinary tenant path
+@stock.maybe_admin_surface?('SCRIPT_NAME' => '', 'PATH_INFO' => '/dashboard')
+#=> false
+
+## a nil PATH_INFO does not raise
+@stock.maybe_admin_surface?('SCRIPT_NAME' => nil, 'PATH_INFO' => nil)
+#=> false
+
+# =================================================================
 # BOOT LOGGING — once per process, not once per mounted app
 # =================================================================
 # MiddlewareStack.configure runs for each of the 13 registered applications, all
 # from one config. Without a ledger every boot prints 13 identical posture lines
 # and 13 copies of each WARN, which reads like 13 separate misconfigurations.
+#
+# COUNTS INCLUDE THE #4332 ADVISORY LINE. Every posture below except a fully
+# configured one emits it alongside the posture line, so each expectation here
+# is one higher than it was before that change. It is deduped by the same
+# ledger, on a payload that carries the two gate states — which is why a
+# different HOST list collapses onto the same advisory line while a different
+# GATE POSTURE would not.
 
-## an identical posture built twice announces once
+## an identical posture built twice announces once (posture + advisory)
 @log_counts = begin
   Onetime::Middleware::AdminNetworkIsolation.reset_boot_announcements!
   build_mw(hosts: ['admin.example.com'])
@@ -1617,12 +1733,13 @@ build_mw(cidrs: ['', '   ']).network_gate_active?
   12.times { build_mw(hosts: ['admin.example.com']) }
   [first, Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count]
 end
-#=> [1, 1]
+#=> [2, 2]
 
 ## a DIFFERENT posture still announces - dedupe is per posture, not a mute
+## (only the posture line is new: the advisory payload is gate state, not hosts)
 build_mw(hosts: ['other.example.com'])
 Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count
-#=> 2
+#=> 3
 
 ## the wildcard WARN and the posture line are separate announcements
 @wild_counts = begin
@@ -1630,7 +1747,7 @@ Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count
   build_mw(hosts: ['*'])
   Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count
 end
-#=> 2
+#=> 3
 
 ## the `*`-with-siblings case adds the ignored-siblings WARN
 @sibling_counts = begin
@@ -1638,7 +1755,62 @@ end
   build_mw(hosts: ['*', 'admin.example.com'])
   Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count
 end
-#=> 3
+#=> 4
+
+# The advisory line itself. It is the ONLY thing that tells an operator whether
+# the annotation on the 15 destructive routes is doing anything, so its level
+# carries meaning: a stock install configured nothing and is not misconfigured
+# (INFO), while a half-configured one believes a restriction is in force that
+# is not (WARN).
+
+# Build one instance against a recording logger and return its boot lines.
+def boot_lines(**opts)
+  Onetime::Middleware::AdminNetworkIsolation.reset_boot_announcements!
+  recorder = TestAdminNetworkIsolation::LogRecorder.new
+  real     = Onetime.method(:get_logger)
+  Onetime.define_singleton_method(:get_logger) do |name|
+    name == 'AdminNetworkIsolation' ? recorder : real.call(name)
+  end
+  build_mw(**opts)
+  recorder.entries
+ensure
+  Onetime.define_singleton_method(:get_logger, real)
+end
+
+## a stock install is told, at INFO - not nagged
+@stock_lines = boot_lines(hosts: [], cidrs: [], site_host: '127.0.0.1:3000')
+  .select { |entry| entry.message.include?('advisory') }
+[@stock_lines.size, @stock_lines.first.level]
+#=> [1, :info]
+
+## hosts without CIDRs is half-configured, and WARNs
+@half_lines = boot_lines(hosts: ['admin.example.com'], cidrs: [])
+  .select { |entry| entry.message.include?('ADVISORY') }
+[@half_lines.size, @half_lines.first.level]
+#=> [1, :warn]
+
+## CIDRs without an explicit host list is the other half, and WARNs too
+@half_cidr_lines = boot_lines(hosts: [], cidrs: ['10.0.0.0/8'], site_host: 'admin.example.com')
+  .select { |entry| entry.message.include?('ADVISORY') }
+[@half_cidr_lines.size, @half_cidr_lines.first.level]
+#=> [1, :warn]
+
+## the advisory line names the remedy
+@half_lines.first.payload[:consequence].include?('set BOTH ADMIN_ALLOWED_HOSTS')
+#=> true
+
+## a fully configured install gets NO advisory line
+boot_lines(hosts: ['admin.example.com'], cidrs: ['10.0.0.0/8'])
+  .count { |entry| entry.message.downcase.include?('advisory') }
+#=> 0
+
+## the advisory line goes through log_once - 13 mounts, one line
+@advisory_once = begin
+  Onetime::Middleware::AdminNetworkIsolation.reset_boot_announcements!
+  13.times { build_mw(hosts: ['admin.example.com'], cidrs: []) }
+  Onetime::Middleware::AdminNetworkIsolation.boot_announcement_count
+end
+#=> 2
 
 # Restore every global this file mutated: both admin lists, site.host, the
 # features.domains block, and the DetectHost result field. `rake try:unit` runs

--- a/try/unit/operations/customers/role_support_try.rb
+++ b/try/unit/operations/customers/role_support_try.rb
@@ -1,0 +1,123 @@
+# try/unit/operations/customers/role_support_try.rb
+#
+# frozen_string_literal: true
+
+#
+# Unit tryouts for Onetime::Operations::Customers::RoleSupport (#4328) — the
+# shared "who is still a colonel" predicate behind the last-colonel interlocks
+# on the role endpoint, the unverify endpoint and `bin/ots customers role`.
+#
+# The point of these cases is the FAIL-OPEN failure mode. Customer.colonel_count
+# / role_index_for read a DERIVED index that drifts UPWARD through two
+# documented familia-2.12 mechanisms (reconcile_role_index.rb):
+#
+#   * ADD-ONLY partial writes retain the previous role's bucket member, so an
+#     account demoted through a targeted writer stays in `role_index:colonel`
+#   * a TTL-expired customer hash leaves its index member behind forever
+#
+# and `has_system_role?` additionally refuses every elevated role to an
+# UNVERIFIED account. So a guard that counted the index would answer "another
+# colonel exists" when none does, and cheerfully demote the last one.
+#
+# These run against REAL Redis with a deliberately drifted index, which is the
+# only way to prove the re-validation actually happens.
+#
+# Run: try --agent try/unit/operations/customers/role_support_try.rb
+
+require_relative '../../../support/test_helpers'
+
+OT.boot! :test
+
+require 'onetime/operations/customers/role_support'
+
+RS = Onetime::Operations::Customers::RoleSupport
+
+@nonce  = Familia.generate_id[0, 12]
+@bucket = Onetime::Customer.role_index_for('colonel')
+
+# Every colonel this file did not create is noise for the "sole colonel" cases,
+# so the roster is measured RELATIVE to a snapshot taken before seeding.
+@preexisting = RS.active_colonels.map(&:objid)
+
+def make_customer(label, role:, verified:)
+  cust = Onetime::Customer.create!(email: "rolesupport_#{label}_#{@nonce}@example.com")
+  cust.role     = role
+  cust.verified = verified ? 'true' : 'false'
+  cust.save
+  cust
+end
+
+# Ours, relative to the snapshot.
+def ours(colonels)
+  colonels.reject { |c| @preexisting.include?(c.objid) }
+end
+
+@colonel   = make_customer('primary', role: 'colonel', verified: true)
+@unverified = make_customer('unverified', role: 'colonel', verified: false)
+@demoted   = make_customer('demoted', role: 'customer', verified: true)
+
+# DRIFT 1 — add-only partial write: the demoted account still sits in the
+# colonel bucket, exactly as a targeted writer would leave it.
+@bucket.add(@demoted.objid)
+
+# DRIFT 2 — an index member whose customer hash no longer exists (the
+# TTL-expiry shape). Nothing else in Redis names this objid.
+@ghost_objid = "cust_ghost_#{@nonce}"
+@bucket.add(@ghost_objid)
+
+## The drifted index over-reports: colonel_count sees every seeded member
+[@bucket.member?(@demoted.objid), @bucket.member?(@ghost_objid)]
+#=> [true, true]
+
+## active_colonels EXCLUDES an index member whose customer hash is gone
+ours(RS.active_colonels).map(&:objid).include?(@ghost_objid)
+#=> false
+
+## ...EXCLUDES one whose authoritative role field disagrees with the bucket
+ours(RS.active_colonels).map(&:objid).include?(@demoted.objid)
+#=> false
+
+## ...and EXCLUDES an unverified colonel (has_system_role? would refuse it too)
+ours(RS.active_colonels).map(&:objid).include?(@unverified.objid)
+#=> false
+
+## ...leaving exactly the one account that is authoritatively a colonel
+ours(RS.active_colonels).map(&:objid)
+#=> [@colonel.objid]
+
+## last_colonel_by_verification? is TRUE for the sole verified colonel
+RS.last_colonel_by_verification?(@colonel)
+#=> @preexisting.empty?
+
+## last_colonel? is TRUE for demoting that same account
+RS.last_colonel?(@colonel, 'customer')
+#=> @preexisting.empty?
+
+## ...but a PROMOTION (to colonel) is never a last-colonel refusal
+RS.last_colonel?(@colonel, 'colonel')
+#=> false
+
+## ...and a non-colonel target is never one either
+RS.last_colonel?(@demoted, 'customer')
+#=> false
+
+## An UNVERIFIED colonel is not "the last colonel" by verification — it is not
+## eligible for the role in the first place, so unverifying it changes nothing
+RS.last_colonel_by_verification?(@unverified)
+#=> false
+
+## Once a SECOND verified colonel exists, neither predicate refuses
+@second = make_customer('second', role: 'colonel', verified: true)
+[RS.last_colonel?(@colonel, 'customer'), RS.last_colonel_by_verification?(@colonel)]
+#=> [false, false]
+
+## ...and the roster now names both
+ours(RS.active_colonels).map(&:objid).sort == [@colonel.objid, @second.objid].sort
+#=> true
+
+# Teardown: destroy the customers, then drop the two synthetic index members
+# (destroy! only clears the CURRENT role's bucket, so the drift we seeded by
+# hand has to be removed by hand).
+[@colonel, @unverified, @demoted, @second].each { |c| c.destroy! if c.exists? }
+@bucket.remove(@demoted.objid)
+@bucket.remove(@ghost_objid)

--- a/try/unit/operations/email_ratelimit_tools_try.rb
+++ b/try/unit/operations/email_ratelimit_tools_try.rb
@@ -137,7 +137,7 @@ AE.count
 
 ## the registry knows the canonical limiter kinds, in registry order
 Onetime::Operations::RateLimit::Registry.kinds
-#=> ["feedback", "passphrase", "invite", "login", "reset_request_ip", "reset_request_email", "create_account_ip", "colonel_elevation", "dns", "create_secret"]
+#=> ["feedback", "passphrase", "invite", "login", "reset_request_ip", "reset_request_email", "create_account_ip", "colonel_elevation", "colonel_mutation", "colonel_destructive", "colonel_handle_resolve", "dns", "create_secret"]
 
 ## keys_for expands the templates byte-identically to the CLI's emitted keys
 Onetime::Operations::RateLimit::Registry.keys_for('feedback', '1.2.3.4')
@@ -163,6 +163,39 @@ Onetime::Operations::RateLimit::Registry.keys_for('create_secret', '203.0.113.0'
 ## operator. Byte-identical with ColonelRateLimiter's own key builder.
 Onetime::Operations::RateLimit::Registry.keys_for('colonel_elevation', 'ur_colonel')
 #=> ["colonel:elevation:attempts:ur_colonel", "colonel:elevation:locked:ur_colonel"]
+
+## the three #4329 colonel buckets derive their keys from the same templates
+## ColonelRateLimiter builds. colonel_destructive in particular MUST resolve:
+## POST /ratelimit/reset with that kind is the documented recovery for an
+## operator who has locked themselves out of destructive actions, and it is a
+## TIER 2 verb precisely so it stays reachable while that bucket is exhausted.
+%w[colonel_mutation colonel_destructive colonel_handle_resolve].map do |kind|
+  Onetime::Operations::RateLimit::Registry.keys_for(kind, 'ur_colonel')
+end
+#=> [["colonel:mutation:attempts:ur_colonel", "colonel:mutation:locked:ur_colonel"], ["colonel:destructive:attempts:ur_colonel", "colonel:destructive:locked:ur_colonel"], ["colonel:handle_resolve:attempts:ur_colonel", "colonel:handle_resolve:locked:ur_colonel"]]
+
+## every colonel bucket lives on the Customer shard, matching
+## ColonelRateLimiter#colonel_rate_limit_redis — a row pointing at another shard
+## would inspect and clear keys that do not exist
+%w[colonel_elevation colonel_mutation colonel_destructive colonel_handle_resolve].map do |kind|
+  Onetime::Operations::RateLimit::Registry.dbclient_for(kind).equal?(Onetime::Customer.dbclient)
+end
+#=> [true, true, true, true]
+
+## a real destructive lockout is inspectable and clearable through the operator
+## tooling — the end-to-end shape of the documented recovery
+@dbc = Onetime::Customer.dbclient
+@dbc.setex('colonel:destructive:locked:ur_lockedout', 900, '1')
+@insp_colonel = Onetime::Operations::RateLimit::Inspect.new(
+  kind: 'colonel_destructive', subject: 'ur_lockedout',
+).call
+@reset_colonel = Onetime::Operations::RateLimit::Reset.new(
+  kind: 'colonel_destructive', subject: 'ur_lockedout', actor: @actor,
+).call
+[@insp_colonel.entries.any? { |e| e.key == 'colonel:destructive:locked:ur_lockedout' && e.exists },
+ @reset_colonel.status,
+ @dbc.exists?('colonel:destructive:locked:ur_lockedout'),]
+#=> [true, :success, false]
 
 ## an unknown kind yields nil (the CLI prints its "Unknown" branch)
 Onetime::Operations::RateLimit::Registry.keys_for('nope', 'x')

--- a/try/unit/operations/email_ratelimit_tools_try.rb
+++ b/try/unit/operations/email_ratelimit_tools_try.rb
@@ -137,7 +137,7 @@ AE.count
 
 ## the registry knows the canonical limiter kinds, in registry order
 Onetime::Operations::RateLimit::Registry.kinds
-#=> ["feedback", "passphrase", "invite", "login", "reset_request_ip", "reset_request_email", "create_account_ip", "dns", "create_secret"]
+#=> ["feedback", "passphrase", "invite", "login", "reset_request_ip", "reset_request_email", "create_account_ip", "colonel_elevation", "dns", "create_secret"]
 
 ## keys_for expands the templates byte-identically to the CLI's emitted keys
 Onetime::Operations::RateLimit::Registry.keys_for('feedback', '1.2.3.4')
@@ -156,6 +156,13 @@ Onetime::Operations::RateLimit::Registry.keys_for('reset_request_email', 'user@e
 ## — the stored form the limiter writes, so operator clears actually hit
 Onetime::Operations::RateLimit::Registry.keys_for('create_secret', '203.0.113.0')
 #=> ["create_secret:attempts:ip:203.0.113.0", "create_secret:locked:ip:203.0.113.0"]
+
+## the colonel step-up limiter (#4327) keys on the acting colonel's PUBLIC
+## extid — never an objid and never a session id — so `bin/ots ratelimit keys`,
+## GET /ratelimit/inspect and POST /ratelimit/reset can all clear a locked-out
+## operator. Byte-identical with ColonelRateLimiter's own key builder.
+Onetime::Operations::RateLimit::Registry.keys_for('colonel_elevation', 'ur_colonel')
+#=> ["colonel:elevation:attempts:ur_colonel", "colonel:elevation:locked:ur_colonel"]
 
 ## an unknown kind yields nil (the CLI prints its "Unknown" branch)
 Onetime::Operations::RateLimit::Registry.keys_for('nope', 'x')

--- a/try/unit/operations/sessions/delete_session_audit_try.rb
+++ b/try/unit/operations/sessions/delete_session_audit_try.rb
@@ -1,0 +1,83 @@
+# try/unit/operations/sessions/delete_session_audit_try.rb
+#
+# frozen_string_literal: true
+
+# Unit tryouts for the AUDIT TARGET of the global session revoke (#4330):
+#   Onetime::Operations::Sessions::Delete
+#
+# The trail used to record the raw session id. That value is the user's live
+# `onetime.session` cookie, and ColonelAuditEvent.record writes into a
+# count-capped set with NO TTL — so every revoke persisted a replayable bearer
+# credential, indefinitely, in the one place operators are encouraged to read.
+#
+# RSpec stubs ColonelAuditEvent.record; these cases do a REAL write and read the
+# event back, which is the only way to prove what actually lands in the trail.
+# Covers the success path and the failure path (audit_failures), plus the
+# no-op/not-found path that must record nothing at all.
+#
+# Run: try --agent try/unit/operations/sessions/delete_session_audit_try.rb
+
+require_relative '../../../support/test_helpers'
+
+OT.boot! :test
+
+require 'securerandom'
+require 'onetime/operations/sessions/store'
+require 'onetime/operations/sessions/delete_session'
+
+Delete = Onetime::Operations::Sessions::Delete
+SM     = Onetime::SessionMetadata
+AE     = Onetime::ColonelAuditEvent
+DB     = Familia.dbclient
+
+@nonce = Familia.generate_id[0, 12]
+@actor = 'ur1colonelpub' # a PUBLIC id (extid-shaped), never an objid
+
+@sid    = SecureRandom.hex(32)
+@key    = "session:#{@sid}"
+@handle = SM.handle_for(@sid)
+DB.set(@key, JSON.generate({ 'authenticated' => true, 'email' => "del+#{@nonce}@example.com" }))
+AE.events.clear
+
+## the revoke succeeds and records exactly one event
+@res = Delete.new(session_id: @sid, actor: @actor).call
+[@res.status, AE.count]
+#=> [:deleted, 1]
+
+## the recorded target is the 32-hex HANDLE — never the bearer sid
+@ev = AE.recent(1).first
+[@ev['verb'], @ev['target'] == @handle, @ev['target'].match?(/\A[0-9a-f]{32}\z/)]
+#=> ["session.delete", true, true]
+
+## the raw sid appears NOWHERE in the serialized event
+@ev.to_s.include?(@sid)
+#=> false
+
+## a not-found revoke records nothing (nothing mutated)
+AE.events.clear
+[Delete.new(session_id: SecureRandom.hex(32), actor: @actor).call.status, AE.count]
+#=> [:not_found, 0]
+
+## the FAILURE path (audit_failures) also records the handle, not the sid: the
+## delete is made to raise mid-flight, and the event written on the way out
+## carries the same non-bearer target
+AE.events.clear
+@fail_sid    = SecureRandom.hex(32)
+@fail_handle = SM.handle_for(@fail_sid)
+DB.set("session:#{@fail_sid}", JSON.generate({ 'authenticated' => true }))
+@exploding = Object.new
+def @exploding.exists(*_args) = 1
+def @exploding.del(*_args) = raise(IOError, 'datastore went away')
+begin
+  Delete.new(session_id: @fail_sid, actor: @actor, dbclient: @exploding).call
+rescue IOError
+  nil
+end
+@fail_ev = AE.recent(1).first
+[AE.count, @fail_ev['target'] == @fail_handle, @fail_ev['target'] == @fail_sid]
+#=> [1, true, false]
+
+# Cleanup
+DB.del(@key)
+DB.del("session:#{@fail_sid}")
+AE.events.clear

--- a/try/unit/operations/sessions/list_sessions_handles_try.rb
+++ b/try/unit/operations/sessions/list_sessions_handles_try.rb
@@ -1,0 +1,112 @@
+# try/unit/operations/sessions/list_sessions_handles_try.rb
+#
+# frozen_string_literal: true
+
+# Unit tryouts for the OPAQUE-HANDLE contract of the global session listing
+# (#4330): Onetime::Operations::Sessions::List.
+#
+# The raw session id is byte-identical to the user's `onetime.session` cookie
+# and to the `session:<sid>` blob key name, so it must never leave this op
+# unless the caller explicitly asks. Covers:
+# - default rows carry `:session_handle` and NEITHER `:session_id` NOR `:key`
+# - `reveal_session_id: true` (the `bin/ots session` opt-in) restores both
+# - the emitted handle is exactly SessionMetadata.handle_for(sid), so it
+#   round-trips through Store.resolve_handle
+# - the geo_country join still populates after the strip (it keys on the sid
+#   internally, so order matters)
+# - searching by a handle PREFIX returns the right row, and identity search
+#   still works
+#
+# Run: try --agent try/unit/operations/sessions/list_sessions_handles_try.rb
+
+require_relative '../../../support/test_helpers'
+
+OT.boot! :test
+
+require 'securerandom'
+require 'onetime/operations/sessions/store'
+require 'onetime/operations/sessions/list_sessions'
+require 'onetime/operations/sessions/track_metadata'
+
+List  = Onetime::Operations::Sessions::List
+Store = Onetime::Operations::Sessions::Store
+SM    = Onetime::SessionMetadata
+AE    = Onetime::ColonelAuditEvent
+DB    = Familia.dbclient
+
+@nonce = Familia.generate_id[0, 12]
+
+# Two real 64-hex sids with identity blobs — the shape the app stores.
+@sid_x = SecureRandom.hex(32)
+@sid_y = SecureRandom.hex(32)
+@key_x = "session:#{@sid_x}"
+@key_y = "session:#{@sid_y}"
+@handle_x = SM.handle_for(@sid_x)
+@handle_y = SM.handle_for(@sid_y)
+
+DB.set(@key_x, JSON.generate({
+  'authenticated' => true,
+  'email' => "xena+#{@nonce}@example.com",
+  'external_id' => "ext_x_#{@nonce}",
+  'authenticated_at' => 2_000_000_400,
+}))
+DB.set(@key_y, JSON.generate({
+  'authenticated' => true,
+  'email' => "yuri+#{@nonce}@example.com",
+  'external_id' => "ext_y_#{@nonce}",
+  'authenticated_at' => 2_000_000_500,
+}))
+AE.events.clear
+
+## the DEFAULT listing identifies a session by handle only — the bearer sid and
+## its Redis key are stripped before the rows leave the op
+@row = List.new(page: 1, per_page: 100).call.sessions.find { |s| s[:session_handle] == @handle_x }
+[@row.nil?, @row&.key?(:session_id), @row&.key?(:key)]
+#=> [false, false, false]
+
+## the emitted handle is exactly SessionMetadata.handle_for — the same value the
+## per-customer panel already speaks — so it resolves back to the sid
+[@row[:session_handle] == @handle_x, Store.resolve_handle(DB, @row[:session_handle]).first == @sid_x]
+#=> [true, true]
+
+## the row still carries its identity fields (the strip is surgical)
+[@row[:email], @row[:external_id]]
+#=> ["xena+#{@nonce}@example.com", "ext_x_#{@nonce}"]
+
+## reveal_session_id: true (the `bin/ots session` opt-in) restores BOTH internal
+## identifiers alongside the handle
+@revealed = List.new(page: 1, per_page: 100, reveal_session_id: true)
+  .call.sessions.find { |s| s[:session_handle] == @handle_x }
+[@revealed[:session_id], @revealed[:key], @revealed[:session_handle]]
+#=> [@sid_x, @key_x, @handle_x]
+
+## the geo_country join survives the strip: it keys on the sid internally, so it
+## must run BEFORE the identifiers are removed
+SM.new(session_id: @sid_y, geo_country: 'FR').save
+@geo_row = List.new(page: 1, per_page: 100).call.sessions.find { |s| s[:session_handle] == @handle_y }
+[@geo_row[:geo_country], @geo_row.key?(:session_id)]
+#=> ["FR", false]
+
+## searching by a handle PREFIX finds exactly that session — the console renders
+## a truncated handle, so a prefix is all an operator can copy
+@by_prefix = List.new(search: @handle_x[0, 10], per_page: 100).call.sessions
+[@by_prefix.size, @by_prefix.first[:session_handle]]
+#=> [1, @handle_x]
+
+## the FULL handle works too
+List.new(search: @handle_x, per_page: 100).call.sessions.map { |s| s[:session_handle] }
+#=> [@handle_x]
+
+## identity search is unaffected
+List.new(search: "yuri+#{@nonce}", per_page: 100).call.sessions.map { |s| s[:session_handle] }
+#=> [@handle_y]
+
+## listing is read-only: no audit event, handles or not
+AE.count
+#=> 0
+
+# Cleanup
+DB.del(@key_x)
+DB.del(@key_y)
+DB.del(SM.dbkey(@sid_y))
+AE.events.clear

--- a/try/unit/operations/sessions/track_metadata_try.rb
+++ b/try/unit/operations/sessions/track_metadata_try.rb
@@ -76,6 +76,37 @@ TM.new(session_id: @sid, session_data: @auth_session).call
 [@r2.created_at.to_i >= @ts, @r2.last_activity_at.to_i >= @ts]
 #=> [true, true]
 
+# ---- last_activity_at: the value the #4331 idle bound reads -----------
+
+## a subsequent authenticated write ADVANCES last_activity_at (back-dated first,
+## because the field is epoch SECONDS and a same-second re-track cannot show a
+## change). This is the refresh the admin idle bound depends on: it is what makes
+## an in-use admin session stay usable, and it is why nothing under
+## src/apps/admin may poll — a timer would refresh this forever.
+@stale = SM.load(@sid)
+@stale.last_activity_at = @ts - 7_200
+@stale.save
+TM.new(session_id: @sid, session_data: @auth_session).call
+SM.load(@sid).last_activity_at.to_i >= @ts
+#=> true
+
+## a request REFUSED by the admin-surface session bounds (#4331) does NOT stamp
+## activity: the auth strategy flags the env, and the whole upsert is skipped.
+## Without this the very request the idle bound just refused would slide the
+## window forward on its way out and the next one would be allowed through.
+@expired_key = Onetime::Application::AuthStrategies::AdminSessionLifetime::EXPIRED_ENV_KEY
+@refused = SM.load(@sid)
+@refused.last_activity_at = @ts - 7_200
+@refused.save
+TM.new(session_id: @sid, session_data: @auth_session, env: { @expired_key => 'idle' }).call
+SM.load(@sid).last_activity_at.to_i
+#=> @ts - 7_200
+
+## the flag is per-request, not sticky: the next unflagged write stamps normally
+TM.new(session_id: @sid, session_data: @auth_session).call
+SM.load(@sid).last_activity_at.to_i >= @ts
+#=> true
+
 # ---- anonymous / unresolvable -> no-op --------------------------------
 
 ## an anonymous session (no 'authenticated'/'external_id') is a no-op -> nil

--- a/try/unit/operations/sessions_try.rb
+++ b/try/unit/operations/sessions_try.rb
@@ -14,6 +14,14 @@
 # - Delete: removes the key, returns :deleted, records EXACTLY ONE audit event
 #   (verb session.delete, actor = PUBLIC id, target = session id)
 # - Delete not-found: revoking a non-existent session is a no-op (:not_found, NO audit)
+# - Store: opaque session handles (#4330) — summarize emits one, resolve_handle
+#   round-trips it back to a sid (owner-hinted first, bounded scan second), and
+#   matches_search? matches a handle prefix
+#
+# The List cases below pass `reveal_session_id: true` wherever they assert on
+# `:session_id` / `:key`: those identifiers are the bearer cookie value and are
+# stripped by default (#4330). The default, HTTP-facing shape is covered in
+# try/unit/operations/sessions/list_sessions_handles_try.rb.
 #
 # Run: try --agent try/unit/operations/sessions_try.rb
 
@@ -83,7 +91,7 @@ DB.set(@sidecar_key, 'sidecar-envelope-bytes')
 
 ## List returns a Result whose sessions include the seeded pair
 ## (with the non-string session:* key planted — see the regression note above)
-@list = Onetime::Operations::Sessions::List.new(page: 1, per_page: 50).call
+@list = Onetime::Operations::Sessions::List.new(page: 1, per_page: 50, reveal_session_id: true).call
 ids   = @list.sessions.map { |s| s[:session_id] }
 [ids.include?(@sid_a), ids.include?(@sid_b)]
 #=> [true, true]
@@ -154,7 +162,7 @@ DB.hset(Onetime::SessionMetadata.dbkey(@sid_b), 'geo_country', '"**"')
 DB.set("session:#{@sid_c}", JSON.generate(
   @data_a.merge('external_id' => "ext_c2_#{@nonce}", 'email' => "cyn+#{@nonce}@example.com"),
 ))
-@geo_map = Onetime::Operations::Sessions::List.new(page: 1, per_page: 50).call
+@geo_map = Onetime::Operations::Sessions::List.new(page: 1, per_page: 50, reveal_session_id: true).call
   .sessions.to_h { |s| [s[:session_id], s[:geo_country]] }
 [@geo_map[@sid_a], @geo_map[@sid_b], @geo_map.key?(@sid_c), @geo_map[@sid_c]]
 #=> ["US", nil, true, nil]
@@ -166,7 +174,7 @@ Onetime::SessionMetadata.define_singleton_method(:load_multi) do |*_args|
   raise IOError, 'pipeline blew up'
 end
 begin
-  @fb_map = Onetime::Operations::Sessions::List.new(page: 1, per_page: 50).call
+  @fb_map = Onetime::Operations::Sessions::List.new(page: 1, per_page: 50, reveal_session_id: true).call
     .sessions.to_h { |s| [s[:session_id], s[:geo_country]] }
 ensure
   Onetime::SessionMetadata.singleton_class.remove_method(:load_multi)
@@ -180,7 +188,7 @@ DB.del("session:#{@sid_c}")
 # ---- List: search filter ----------------------------------------------
 
 ## a search term matches only the session whose identity contains it
-@found = Onetime::Operations::Sessions::List.new(search: "alice+#{@nonce}").call
+@found = Onetime::Operations::Sessions::List.new(search: "alice+#{@nonce}", reveal_session_id: true).call
 @found.sessions.map { |s| s[:session_id] }
 #=> ["#{@sid_a}"]
 
@@ -223,7 +231,7 @@ Onetime::Operations::Sessions::Store.identified?({ 'csrf' => 'abc123' })
 @anon_sid = "trysess_anon_#{@nonce}"
 @anon_key = "session:#{@anon_sid}"
 DB.set(@anon_key, @codec.encode({ 'csrf' => "tok_#{@nonce}" }))
-@flt = Onetime::Operations::Sessions::List.new(page: 1, per_page: 50).call
+@flt = Onetime::Operations::Sessions::List.new(page: 1, per_page: 50, reveal_session_id: true).call
 # hidden from the rows, present in the anonymous tally
 [@flt.sessions.map { |s| s[:session_id] }.include?(@anon_sid), @flt.anonymous_count >= 1]
 #=> [false, true]
@@ -272,10 +280,16 @@ DB.exists(@key_a)
 AE.count
 #=> 1
 
-## the audit event is the delete verb, targeting the session id, actored by the PUBLIC id
+## the audit event is the delete verb, targeting the session HANDLE (never the
+## bearer sid — the trail is count-capped with no TTL, #4330), actored by the
+## PUBLIC id
 @ev = AE.recent(1).first
 [@ev['verb'], @ev['target'], @ev['actor']]
-#=> ["session.delete", "#{@sid_a}", "ur1colonelpub"]
+#=> ["session.delete", Onetime::SessionMetadata.handle_for(@sid_a), "ur1colonelpub"]
+
+## the recorded target is a 32-hex handle and is NOT the raw session id
+[@ev['target'].match?(/\A[0-9a-f]{32}\z/), @ev['target'] == @sid_a]
+#=> [true, false]
 
 ## the audit actor is never an internal objid
 @ev['actor'].include?('objid')
@@ -307,6 +321,89 @@ DB.set("sidecar:#{@hex_sid}:domain_context", 'y')
 [@delres.status, DB.exists(@hex_key),
  DB.exists("sidecar:#{@hex_sid}:awaiting_mfa", "sidecar:#{@hex_sid}:domain_context")]
 #=> [:deleted, 0, 0]
+
+# ---- Store: opaque session handles (#4330) ----------------------------
+
+## summarize emits a 32-hex handle for the session it summarizes — the ONLY
+## identifier that is safe to serialize (the sid is the bearer cookie)
+@h_sid    = SecureRandom.hex(32)
+@h_key    = "session:#{@h_sid}"
+@h_data   = { 'authenticated' => true, 'email' => "hank+#{@nonce}@example.com",
+              'external_id' => "ext_h_#{@nonce}" }
+@h_summary = Onetime::Operations::Sessions::Store.summarize(@h_sid, @h_key, @h_data)
+[@h_summary[:session_handle] == Onetime::SessionMetadata.handle_for(@h_sid),
+ @h_summary[:session_handle].match?(/\A[0-9a-f]{32}\z/)]
+#=> [true, true]
+
+## resolve_handle round-trips a handle back to its sid through the bounded scan
+## (no owner hint), reporting an uncapped scan
+DB.set(@h_key, JSON.generate(@h_data))
+Onetime::Operations::Sessions::Store.resolve_handle(DB, @h_summary[:session_handle])
+#=> [@h_sid, false]
+
+## the handle is case-insensitive on the way in (operators paste)
+Onetime::Operations::Sessions::Store.resolve_handle(DB, @h_summary[:session_handle].upcase).first
+#=> @h_sid
+
+## a malformed handle never touches the datastore: it fails the shape guard and
+## answers [nil, false] — which is why the API can 404 it exactly like an
+## unknown handle, with no oracle for a scanner
+Onetime::Operations::Sessions::Store.resolve_handle(DB, 'not-a-handle')
+#=> [nil, false]
+
+## a well-formed but unknown handle answers [nil, capped] — the truncation flag
+## rides along so a caller can say "not sampled" instead of "does not exist"
+Onetime::Operations::Sessions::Store.resolve_handle(DB, 'f' * 32)
+#=> [nil, false]
+
+## the OWNER-HINTED stage never scans the keyspace: with the customer's own
+## active_sessions holding the sid, resolution succeeds even while scan_keys is
+## stubbed to explode (proving stage 2 was not reached)
+@hint_cust = Onetime::Customer.create!(email: "handle_#{@nonce}@example.com")
+@hint_cust.verified = 'true'
+@hint_cust.save
+@hint_sid = SecureRandom.hex(32)
+@hint_cust.active_sessions.add(@hint_sid, Familia.now.to_i)
+@hint_handle = Onetime::SessionMetadata.handle_for(@hint_sid)
+Store = Onetime::Operations::Sessions::Store unless defined?(Store)
+Store.singleton_class.alias_method(:__real_scan_keys, :scan_keys)
+Store.define_singleton_method(:scan_keys) { |*_args, **_kw| raise 'scan must not run' }
+begin
+  @hinted = Store.resolve_handle(DB, @hint_handle, owner_hint: @hint_cust.extid)
+ensure
+  Store.singleton_class.remove_method(:scan_keys)
+  Store.singleton_class.alias_method(:scan_keys, :__real_scan_keys)
+  Store.singleton_class.remove_method(:__real_scan_keys)
+end
+@hinted
+#=> [@hint_sid, false]
+
+## a WRONG owner hint is not authorization — it only picks a cheaper search
+## space, so resolution falls through to the bounded scan and still finds it
+Onetime::Operations::Sessions::Store.resolve_handle(
+  DB, @h_summary[:session_handle], owner_hint: @hint_cust.extid,
+).first
+#=> @h_sid
+
+## matches_search? matches a handle PREFIX when the sid is supplied (the console
+## renders a truncated handle, so a prefix is what an operator can copy)
+[Onetime::Operations::Sessions::Store.matches_search?(
+   @h_data, @h_summary[:session_handle][0, 8], session_id: @h_sid),
+ Onetime::Operations::Sessions::Store.matches_search?(
+   @h_data, @h_summary[:session_handle], session_id: @h_sid)]
+#=> [true, true]
+
+## a handle-shaped needle that is not THIS session's handle does not match
+Onetime::Operations::Sessions::Store.matches_search?(
+  @h_data, 'deadbeef', session_id: @h_sid,
+)
+#=> false
+
+## identity search is unchanged, with or without the sid keyword (the CLI
+## caller still passes none)
+[Onetime::Operations::Sessions::Store.matches_search?(@h_data, "hank+#{@nonce}"),
+ Onetime::Operations::Sessions::Store.matches_search?(@h_data, "ext_h_#{@nonce}", session_id: @h_sid)]
+#=> [true, true]
 
 # ---- Store.extract_id: recover the bare sid from every key shape (#3858) ----
 
@@ -340,4 +437,7 @@ DB.del(@hex_key)
 # as the revoke_* tryouts' teardowns).
 DB.del("sidecar:#{@hex_sid}:awaiting_mfa")
 DB.del("sidecar:#{@hex_sid}:domain_context")
+DB.del(@h_key)
+@hint_cust.active_sessions.clear
+@hint_cust.destroy!
 AE.events.clear

--- a/try/unit/security/colonel_rate_limiter_try.rb
+++ b/try/unit/security/colonel_rate_limiter_try.rb
@@ -15,7 +15,13 @@
 # does not increment Rodauth's own lockout counter. This module is the only
 # backstop against guessing there.
 #
-# We test:
+# #4329 adds three more buckets over the same body — colonel:mutation (every
+# mutating verb, charged from the logic base constructor), colonel:destructive
+# (TIER 1 only, charged last so a rejected attempt costs nothing) and
+# colonel:handle_resolve (the two session reads that may fall back to a bounded
+# 10 000-key SCAN). All four are asserted here.
+#
+# We test, for every bucket:
 # 1. Under-limit attempts are allowed
 # 2. The EXACT key shape (it must stay byte-identical with the registry row, or
 #    `bin/ots ratelimit`, GET /ratelimit/inspect and POST /ratelimit/reset cannot
@@ -25,6 +31,7 @@
 # 4. A different colonel is unaffected (the bucket is per-identity)
 # 5. A blank subject writes NO blank-suffixed key and never raises
 # 6. enabled:false — at the bucket AND at the parent flag — is a total no-op
+# 7. The buckets are INDEPENDENT: locking one leaves the others spending
 #
 # Run: try --agent try/unit/security/colonel_rate_limiter_try.rb
 
@@ -166,9 +173,182 @@ results = (1..6).map { @raises.call(@off_b) }
 [results.none?, @redis.exists?("colonel:elevation:attempts:#{@off_b}")]
 #=> [true, false]
 
+# -- #4329: the mutation / destructive / handle-resolve buckets --------------
+#
+# Same body, same guarantees, three more prefixes. The lifecycle helper below
+# runs the full nine-assertion sequence against one bucket and reports what the
+# datastore actually saw, so each bucket is asserted as one readable expectation
+# instead of nine near-identical copies.
+
+set_colonel_rate_limit(
+  'enabled' => true,
+  'elevation' => { 'enabled' => true, 'max_attempts' => 3, 'window' => 900, 'lockout' => 900 },
+  'mutation' => { 'enabled' => true, 'max_attempts' => 3, 'window' => 300, 'lockout' => 300 },
+  'destructive' => { 'enabled' => true, 'max_attempts' => 3, 'window' => 300, 'lockout' => 900 },
+  'handle_resolve' => { 'enabled' => true, 'max_attempts' => 3, 'window' => 300, 'lockout' => 300 },
+)
+
+# Drive one bucket from empty to locked out and report every observable.
+# `enforce` is the module's public entry point for that bucket; `window` is the
+# configured counting window, so the TTL assertion is bucket-specific.
+def bucket_lifecycle(redis, prefix, cap, window, enforce)
+  subject = "ur_#{prefix.tr(':', '_')}_#{Familia.now.to_i}_#{rand(100_000)}"
+  other   = "#{subject}_other"
+  attempts_key = "#{prefix}:attempts:#{subject}"
+  lockout_key  = "#{prefix}:locked:#{subject}"
+  raises = lambda do |subj|
+    enforce.call(subj)
+    false
+  rescue Onetime::LimitExceeded
+    true
+  end
+
+  redis.del(attempts_key, lockout_key)
+
+  # cap - 1 calls stay under the limit, then the cap-reaching call is itself
+  # ALLOWED and sets the lockout for the next one.
+  under      = (1...cap).map { raises.call(subject) }
+  ttl        = redis.ttl(attempts_key)
+  at_cap     = raises.call(subject)
+  over       = raises.call(subject)
+  reported   = begin
+    enforce.call(subject)
+    nil
+  rescue Onetime::LimitExceeded => e
+    [e.max_attempts, e.retry_after.positive?]
+  end
+
+  result = {
+    under_limit_allowed: under.none?,
+    counter_ttl_within_window: ttl.positive? && ttl <= window,
+    cap_reaching_call_allowed: at_cap == false,
+    locked_after_cap: redis.exists?(lockout_key),
+    counter_cleared_after_cap: redis.exists?(attempts_key) == false,
+    next_call_raises: over,
+    reported_cap_and_retry_after: reported,
+    other_subject_unaffected: raises.call(other) == false,
+    blank_subject_skipped: [raises.call(nil), raises.call('')].none?,
+    blank_suffixed_keys_absent: [redis.exists?("#{prefix}:attempts:"),
+                                 redis.exists?("#{prefix}:locked:"),].none?,
+  }
+
+  redis.del(attempts_key, lockout_key, "#{prefix}:attempts:#{other}", "#{prefix}:locked:#{other}")
+  result
+end
+
+@expected_lifecycle = {
+  under_limit_allowed: true,
+  counter_ttl_within_window: true,
+  cap_reaching_call_allowed: true,
+  locked_after_cap: true,
+  counter_cleared_after_cap: true,
+  next_call_raises: true,
+  reported_cap_and_retry_after: [3, true],
+  other_subject_unaffected: true,
+  blank_subject_skipped: true,
+  blank_suffixed_keys_absent: true,
+}
+
+## The broad mutation bucket runs the whole lifecycle correctly
+bucket_lifecycle(@redis, 'colonel:mutation', 3, 300,
+                 ->(s) { @tester.enforce_colonel_mutation_limit!(s) })
+#=> @expected_lifecycle
+
+## The tight destructive bucket runs the whole lifecycle correctly
+bucket_lifecycle(@redis, 'colonel:destructive', 3, 300,
+                 ->(s) { @tester.enforce_colonel_destructive_limit!(s) })
+#=> @expected_lifecycle
+
+## The handle-resolve bucket runs the whole lifecycle correctly
+bucket_lifecycle(@redis, 'colonel:handle_resolve', 3, 300,
+                 ->(s) { @tester.enforce_colonel_handle_resolve_limit!(s) })
+#=> @expected_lifecycle
+
+## Every bucket's keys are exactly the registry templates filled with the
+## subject — `bin/ots ratelimit`, GET /ratelimit/inspect and POST
+## /ratelimit/reset all derive their keys from those templates, so a drift here
+## is a limiter no operator can inspect or clear
+%w[colonel_mutation colonel_destructive colonel_handle_resolve].map do |kind|
+  Onetime::Operations::RateLimit::Registry::LIMITERS[kind][:keys].map { |t| format(t, 'ur_x') }
+end
+#=> [["colonel:mutation:attempts:ur_x", "colonel:mutation:locked:ur_x"], ["colonel:destructive:attempts:ur_x", "colonel:destructive:locked:ur_x"], ["colonel:handle_resolve:attempts:ur_x", "colonel:handle_resolve:locked:ur_x"]]
+
+## The buckets are INDEPENDENT: exhausting the destructive budget must leave the
+## operator able to reach POST /ratelimit/reset (a mutation) to clear it, which
+## is the documented lockout recovery
+@iso = "ur_iso_#{Familia.now.to_i}_#{rand(10_000)}"
+4.times do
+  @tester.enforce_colonel_destructive_limit!(@iso)
+rescue Onetime::LimitExceeded
+  nil
+end
+[begin
+  @tester.enforce_colonel_destructive_limit!(@iso)
+  false
+rescue Onetime::LimitExceeded
+  true
+end,
+ begin
+   @tester.enforce_colonel_mutation_limit!(@iso)
+   false
+ rescue Onetime::LimitExceeded
+   true
+ end,]
+#=> [true, false]
+
+## A per-bucket enabled:false is a no-op for THAT bucket only
+set_colonel_rate_limit(
+  'enabled' => true,
+  'destructive' => { 'enabled' => false, 'max_attempts' => 2 },
+  'mutation' => { 'enabled' => true, 'max_attempts' => 2 },
+)
+@mixed = "ur_mixed_#{Familia.now.to_i}_#{rand(10_000)}"
+@destructive_off = (1..5).map do
+  @tester.enforce_colonel_destructive_limit!(@mixed)
+  false
+rescue Onetime::LimitExceeded
+  true
+end
+@mutation_on = (1..5).map do
+  @tester.enforce_colonel_mutation_limit!(@mixed)
+  false
+rescue Onetime::LimitExceeded
+  true
+end
+[@destructive_off.none?, @mutation_on.any?,
+ @redis.exists?("colonel:destructive:attempts:#{@mixed}")]
+#=> [true, true, false]
+
+## The PARENT flag short-circuits all four buckets — this is what
+## spec/config.test.yaml relies on
+set_colonel_rate_limit(
+  'enabled' => false,
+  'mutation' => { 'enabled' => true, 'max_attempts' => 2 },
+  'destructive' => { 'enabled' => true, 'max_attempts' => 2 },
+  'handle_resolve' => { 'enabled' => true, 'max_attempts' => 2 },
+)
+@parent_off = "ur_parent_off_#{Familia.now.to_i}_#{rand(10_000)}"
+[[->(s) { @tester.enforce_colonel_mutation_limit!(s) },
+  ->(s) { @tester.enforce_colonel_destructive_limit!(s) },
+  ->(s) { @tester.enforce_colonel_handle_resolve_limit!(s) },].map do |enforce|
+   (1..5).map do
+     enforce.call(@parent_off)
+     false
+   rescue Onetime::LimitExceeded
+     true
+   end.none?
+ end,
+ @redis.keys("colonel:*:*:#{@parent_off}").empty?,]
+#=> [[true, true, true], true]
+
 # Clean up test keys and restore the shared config for later tryout files.
 cleanup(@redis, @extid_a)
 cleanup(@redis, @extid_b)
 cleanup(@redis, @off_a)
 cleanup(@redis, @off_b)
+%w[colonel:mutation colonel:destructive colonel:handle_resolve].each do |prefix|
+  [@iso, @mixed, @parent_off].each do |subject|
+    @redis.del("#{prefix}:attempts:#{subject}", "#{prefix}:locked:#{subject}")
+  end
+end
 OT.send(:conf=, @saved_conf)

--- a/try/unit/security/colonel_rate_limiter_try.rb
+++ b/try/unit/security/colonel_rate_limiter_try.rb
@@ -1,0 +1,174 @@
+# try/unit/security/colonel_rate_limiter_try.rb
+#
+# frozen_string_literal: true
+
+# #4327: ColonelRateLimiter throttles colonel step-up (sudo) attempts.
+#
+# The first limiter in the repo keyed on an AUTHENTICATED identity rather than a
+# perimeter IP: the subject is `cust.extid`, the acting colonel's PUBLIC id and
+# the same value every colonel op passes as its audit `actor`. Per-ACCOUNT, not
+# per-session — a per-session bucket bounds one cookie, and an attacker with any
+# second way in gets a fresh budget.
+#
+# It matters that this is enforced at all: the Rodauth password check behind
+# POST /api/colonel/elevation is an INTERNAL REQUEST, so it is not a login and
+# does not increment Rodauth's own lockout counter. This module is the only
+# backstop against guessing there.
+#
+# We test:
+# 1. Under-limit attempts are allowed
+# 2. The EXACT key shape (it must stay byte-identical with the registry row, or
+#    `bin/ots ratelimit`, GET /ratelimit/inspect and POST /ratelimit/reset cannot
+#    see the keys) and the counter's TTL
+# 3. At the cap: lockout key set, counter cleared, next call raises with the
+#    configured max_attempts and a positive retry_after
+# 4. A different colonel is unaffected (the bucket is per-identity)
+# 5. A blank subject writes NO blank-suffixed key and never raises
+# 6. enabled:false — at the bucket AND at the parent flag — is a total no-op
+#
+# Run: try --agent try/unit/security/colonel_rate_limiter_try.rb
+
+require_relative '../../support/test_models'
+require 'onetime/security/colonel_rate_limiter'
+
+OT.boot! :test, true
+
+# Tryout files share one process and OT.conf is global; snapshot the booted
+# config so the teardown can restore it for later files.
+@saved_conf = YAML.load(YAML.dump(OT.conf))
+
+# The test config ships site.admin.rate_limit disabled; enable it here with
+# small, known caps.
+def set_colonel_rate_limit(cfg)
+  new_conf = YAML.load(YAML.dump(OT.conf))
+  new_conf['site'] ||= {}
+  new_conf['site']['admin'] ||= {}
+  new_conf['site']['admin']['rate_limit'] = cfg
+  OT.send(:conf=, new_conf)
+end
+
+set_colonel_rate_limit(
+  'enabled' => true,
+  'elevation' => { 'enabled' => true, 'max_attempts' => 3, 'window' => 900, 'lockout' => 900 },
+)
+
+class ColonelRateLimiterTester
+  include Onetime::Security::ColonelRateLimiter
+end
+
+@tester = ColonelRateLimiterTester.new
+@redis  = Onetime::Customer.dbclient
+
+@extid_a = "ur_a_#{Familia.now.to_i}_#{rand(10_000)}"
+@extid_b = "ur_b_#{Familia.now.to_i}_#{rand(10_000)}"
+
+# true if a single enforce call raises LimitExceeded, false otherwise.
+@raises = lambda do |subject|
+  @tester.enforce_colonel_elevation_limit!(subject)
+  false
+rescue Onetime::LimitExceeded
+  true
+end
+
+def cleanup(redis, subject)
+  redis.del("colonel:elevation:attempts:#{subject}", "colonel:elevation:locked:#{subject}")
+end
+
+cleanup(@redis, @extid_a)
+cleanup(@redis, @extid_b)
+
+## -- Under-limit ----------------------------------------------------------
+
+## A single step-up attempt under the cap is allowed
+@raises.call(@extid_a)
+#=> false
+
+## The attempts counter uses the key shape the registry row publishes
+@redis.exists?("colonel:elevation:attempts:#{@extid_a}")
+#=> true
+
+## The counter carries a TTL inside the configured window
+ttl = @redis.ttl("colonel:elevation:attempts:#{@extid_a}")
+ttl.positive? && ttl <= 900
+#=> true
+
+## The key names are exactly the registry's templates filled with the subject
+require 'onetime/operations/ratelimit/registry'
+Onetime::Operations::RateLimit::Registry::LIMITERS['colonel_elevation'][:keys].map { |t| format(t, @extid_a) }
+#=> ["colonel:elevation:attempts:#{@extid_a}", "colonel:elevation:locked:#{@extid_a}"]
+
+## -- Over-limit (max_attempts = 3) ----------------------------------------
+
+## Two more attempts reach the cap and lock the account
+[@raises.call(@extid_a), @raises.call(@extid_a)]
+#=> [false, false]
+
+## The lockout key is now set
+@redis.exists?("colonel:elevation:locked:#{@extid_a}")
+#=> true
+
+## The attempts counter is cleared once the bucket locks
+@redis.exists?("colonel:elevation:attempts:#{@extid_a}")
+#=> false
+
+## The next attempt raises LimitExceeded
+@raises.call(@extid_a)
+#=> true
+
+## The raised error reports the configured cap and a positive retry_after
+begin
+  @tester.enforce_colonel_elevation_limit!(@extid_a)
+  nil
+rescue Onetime::LimitExceeded => e
+  [e.max_attempts, e.retry_after.positive?]
+end
+#=> [3, true]
+
+## A DIFFERENT colonel is unaffected: the bucket is per-identity, not global
+@raises.call(@extid_b)
+#=> false
+
+## -- Blank subject --------------------------------------------------------
+
+## A blank subject is skipped entirely rather than sharing one bucket — a
+## blank-suffixed key would let the first few subject-less callers lock out
+## every later one (a colonel-wide outage)
+[@raises.call(nil), @raises.call(''),
+ @redis.exists?('colonel:elevation:attempts:'), @redis.exists?('colonel:elevation:locked:')]
+#=> [false, false, false, false]
+
+## -- Configured off -------------------------------------------------------
+
+## With the BUCKET disabled the limiter is a total no-op past the cap
+set_colonel_rate_limit(
+  'enabled' => true,
+  'elevation' => { 'enabled' => false, 'max_attempts' => 3 },
+)
+@off_a = "ur_off_a_#{Familia.now.to_i}_#{rand(10_000)}"
+cleanup(@redis, @off_a)
+(1..6).map { @raises.call(@off_a) }.none?
+#=> true
+
+## ...and it writes no keys at all
+[@redis.exists?("colonel:elevation:attempts:#{@off_a}"), @redis.exists?("colonel:elevation:locked:#{@off_a}")]
+#=> [false, false]
+
+## The PARENT flag short-circuits the bucket too — this is what
+## spec/config.test.yaml relies on, so the colonel suites do not throttle
+## themselves through one actor
+set_colonel_rate_limit(
+  'enabled' => false,
+  'elevation' => { 'enabled' => true, 'max_attempts' => 3 },
+)
+@off_b = "ur_off_b_#{Familia.now.to_i}_#{rand(10_000)}"
+cleanup(@redis, @off_b)
+results = (1..6).map { @raises.call(@off_b) }
+[results.none?, @redis.exists?("colonel:elevation:attempts:#{@off_b}")]
+#=> [true, false]
+
+# Clean up test keys and restore the shared config for later tryout files.
+cleanup(@redis, @extid_a)
+cleanup(@redis, @extid_b)
+cleanup(@redis, @off_a)
+cleanup(@redis, @off_b)
+OT.send(:conf=, @saved_conf)

--- a/try/unit/session/sidecar_try.rb
+++ b/try/unit/session/sidecar_try.rb
@@ -403,6 +403,64 @@ SC.write(@sid, 'awaiting_mfa', true, codec: @codec)
 DB.ttl(@key_mfa).positive? && DB.ttl(@key_mfa) <= 30
 #=> true
 
+# ---- elevated_until: the colonel step-up window (#4327) ------------------
+
+## the field is registered, so purge/cleanup can enumerate it and the write
+## gate admits it
+SC::FIELDS.key?('elevated_until')
+#=> true
+
+## it satisfies the admission rule's externalize policy: encrypted (it is a
+## capability bound to a sid), merged on read, and converged to ABSENT rather
+## than parked when it goes falsy
+SC::FIELDS['elevated_until'].values_at(:encrypted, :merge_on_read, :externalize, :absent_when_falsy)
+#=> [true, true, true, true]
+
+## its TTL is a backstop above the default 600s window, so the sidecar itself
+## can never drop a live elevation mid-window (the stored exp is the authority)
+SC::FIELDS['elevated_until'][:ttl] > 600
+#=> true
+
+## the value is an OBJECT, not a bare epoch, and it round-trips through the
+## encrypted envelope with its keys and types intact
+DB.set(@blob_key, 'x', ex: 86_400)
+@elev = { 'extid' => 'ur_colonel', 'exp' => Familia.now.to_i + 600 }
+SC.write(@sid, 'elevated_until', @elev, codec: @codec)
+SC.read(@sid, 'elevated_until', codec: @codec)
+#=> @elev
+
+## the key lives outside the session: namespace, so the *session* scans
+## (colonel listings, revoke-all sweeps) never see it as a phantom blob
+SC.key_for(@sid, 'elevated_until').include?('session')
+#=> false
+
+## its TTL is clamped under the blob's, like every other sidecar field
+[DB.ttl("sidecar:#{@sid}:elevated_until").positive?,
+ DB.ttl("sidecar:#{@sid}:elevated_until") <= SC::FIELDS['elevated_until'][:ttl]]
+#=> [true, true]
+
+## commit externalizes it out of the blob hash
+SC.commit(@sid, { 'account_id' => 7, 'elevated_until' => @elev }, codec: @codec)
+#=> { 'account_id' => 7 }
+
+## ...and merge overlays it back on the next read
+SC.merge(@sid, { 'account_id' => 7 }, codec: @codec)[:data]['elevated_until']
+#=> @elev
+
+## dropping elevation (sess.delete) converges the field to ABSENT — the
+## sidecar key is DELETED, not refreshed with an empty object forever
+SC.commit(@sid, { 'account_id' => 7 }, merged: ['elevated_until'], codec: @codec)
+DB.exists("sidecar:#{@sid}:elevated_until")
+#=> 0
+
+## an elevation record forged under a DIFFERENT sid reads as absent: the
+## codec's sid/field binding is the other half of the identity binding the
+## logic layer applies (extid vs the current customer)
+SC.write(@sid, 'elevated_until', @elev, codec: @codec)
+DB.set("sidecar:#{@sid2}:elevated_until", DB.get("sidecar:#{@sid}:elevated_until"))
+SC.read(@sid2, 'elevated_until', codec: @codec)
+#=> nil
+
 # Cleanup
 DB.del(@blob_key)
 SC.purge(@sid)


### PR DESCRIPTION
## Summary

[#4323](https://github.com/onetimesecret/onetimesecret/issues/4323) — Epic: Colonel Hardening

Every safety interlock on destructive colonel actions previously lived in the browser: typed-confirmation dialogs, danger flags, and warnings were all Vue-side, while the API executed purge/delete/revoke/role-change on a bare authenticated request. There was no step-up re-authentication, no rate limiting on `/api/colonel/*`, and no guard against a colonel demoting the last colonel. A single leaked colonel session cookie was unbounded, un-throttled destructive capability.

This stack moves enforcement server-side into the **logic classes** (so it composes and covers the CLI, not just the router) and adds the missing interlocks. A colonel session alone is no longer sufficient for destruction.

The work is a stack of one commit per sub-issue, ordered so shared primitives land first:

| # | Commit | Sub-issue |
|---|--------|-----------|
| 1 | `fix(colonel): replace raw session ids with opaque handles in the console` | #4330 |
| 2 | `feat(colonel): enforce destructive-action confirmation server-side` | #4326 |
| 3 | `feat(colonel): add a step-up (sudo) window for destructive colonel actions` | #4327 |
| 4 | `feat(colonel): interlock self-demotion, last-colonel lockout and self-revoke` | #4328 |
| 5 | `perf(colonel): rate-limit the colonel API surface` | #4329 |
| 6 | `feat(colonel): bound admin-surface session lifetime` | #4331 |
| 7 | `feat(colonel): gate destructive colonel routes on network=admin_if_configured` | #4332 |

Plus three follow-up `fix(colonel): … (#4323)` commits from whole-stack validation (order-independent test stub, a layout realignment, and a missing test prop).

### What changed

**Shared primitives (land in #4330/#4326/#4327):**
- `ColonelAPI::Logic::DestructiveAction` — a concern included into the colonel logic base carrying a hard five-step **guard order**: role check → target resolution → `require_elevation!` (tier 1) then `require_confirmation!` → per-verb interlocks → `charge_destructive_budget!` (tier 1). Elevation precedes confirmation so there is no token oracle; interlocks follow both so their 422s can't be used to probe "who is the last colonel"; the tight destructive budget is charged last so only executable attempts consume it.
- `ColonelAPI::DestructiveActions` — a machine-readable tier registry (TIER1 = 15 classes, TIER2 = 10, plus an explicit `TIER3_REVIEWED` map) that a spec cross-checks against `routes.txt` so no mutating route can ship un-triaged.
- New error classes (`ConfirmationRequired`, `ElevationRequired`, `ElevationFailed` < `Forbidden`; `GuardMisconfigured` < `Problem`) with exact-class Otto handlers, excluded from failure auditing so a cookie holder cannot flush the count-capped audit trail.

**Server-side confirmation (#4326):** destructive logic classes require a confirmation token, carried in the `X-OTS-Confirm` request header (percent-encoded, POST and DELETE alike) rather than a query parameter — 18 of 25 confirmation tokens are PII (target email, org name, domain) that a URL would write into every access log and browser history. `dry_run` classes gate only the apply path.

**Step-up / sudo window (#4327):** a 10-minute elevation window stored as an identity-bound sidecar (`{extid, exp}`, never a bare epoch, so login/rotation cannot let identity B inherit A's elevation). Two factors — password re-entry (branching on auth mode) and `recent_auth` for accounts that cannot use a password (SSO-only). New `GET/POST/DELETE /api/colonel/elevation`. Both login paths drop the field.

**Interlocks (#4328):** `Customers::RoleSupport` re-validates `active_colonels` against the authoritative role field (`exists? && role == 'colonel' && verified?`) rather than the upward-drifting role index, which would fail open. Refusals for self-demotion, last-colonel demotion, and unverifying the last colonel land in the **Operations** layer (so `bin/ots` is covered too) via a single `build()` exit so the `:failure` audit can't be skipped. Fixes `SetUserRole`'s `sanitize_identifier` → `sanitize_account_identifier`, and routes self-targeted revoke-all to "revoke all except current" (a containment step for a leaked cookie).

**Rate limits (#4329):** `Onetime::Security::ColonelRateLimiter` with four buckets, all keyed on `cust.extid` (never the bearer session id): a broad mutation bucket charged from the logic base constructor (covers all 46 mutating verbs), a tight destructive bucket charged last with a lockout window, a handle-resolve bucket, and the elevation bucket. Registry rows kept byte-identical to the key builders so `bin/ots ratelimit` and reset can see them.

**Admin session lifetime (#4331):** a 1h idle / 12h absolute bound enforced in the session-auth strategy, scoped to `/api/colonel` so it never expires the shared cookie for tenant-app use. `0` disables a bound; a missing session sidecar skips the idle bound rather than logging anyone out.

**Network gating (#4332):** a new `network=admin_if_configured` route strategy applied to the 15 tier-1 routes — enforces isolation where fully configured, falls through when unconfigured (so default self-hosted installs are not bricked), but fails closed if the isolation middleware is ever removed. `/system/proxy-headers` keeps the strict `network=admin` token. Operator docs updated with the five-posture table and the empty-allowlist residual-risk note.

**Frontend:** the admin console is kept working end-to-end — opaque handles throughout `AdminSessions.vue`, `confirmHeaders` threading, `setRole`/`unverify` added to `DANGER_ACTIONS`, a no-polling elevation composable + prompt/banner, and `[ADMIN_SESSION_EXPIRED]` handling. Zod/TS schemas and `.env.reference` mirror the new server contracts.

## Related Issues

Closes #4326
Closes #4327
Closes #4328
Closes #4329
Closes #4330
Closes #4331
Closes #4332

Part of the #4323 epic.

## Test Plan

Whole-stack validation on Ruby 3.4.10 (all green):

- `bundle exec rake spec:fast` — 5,438 + 5,587 + 56 examples, 0 failures
- `bundle exec rspec apps/api/colonel/spec` — 533 examples, 0 failures (up from 139 pre-epic)
- `bundle exec rspec spec/integration/all` (simple mode) — 952 examples, 0 failures
- `bundle exec rake spec:apps:web_auth` — 1,417 examples, 0 failures (the `set_role` / `set_verification` / `change_email` op interlocks)
- `bundle exec rake try:unit` — 8,244 tryout cases, 0 failed
- `bundle exec try try/integration/api/colonel` (simple mode) — 372 cases, 0 failed (real audit-trail writes)
- `pnpm exec vitest run src/tests/apps/admin` — 888 passed / 1 skipped
- `pnpm run type-check` + `type-check:tests` + `eslint` on the 53 changed frontend files — clean
- `bundle exec rubocop` on the 66 changed Ruby files — clean (4 pre-existing convention offenses on untouched lines remain)
- Boot smoke — `bin/ots --version` and a full Rack::URLMap load confirm tier registry (TIER1=15, TIER2=10, TIER3=22) and guard composition wire up with no require-order breakage

New coverage includes the guard-order contract, the tier-registry-vs-routes cross-check, dry-run side-effect-freedom, the identity-bound elevation regression, the role-index-drift fail-open regression, the last-colonel/unverify lockout paths, the rate-limiter bucket ordering, opaque-handle round-trips, and the network-posture matrix.

New server-side gates ship enabled with documented config knobs (`site.admin.*`) and fail safe for default self-hosted installs; `spec/config.test.yaml` disables the rate limits so unrelated tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8yncPbzHMNh74gsMLnUXf)_