### PR TITLE
Pin rodauth-oauth fork at 1.6.6.ots1 and reject PKCE plain explicitly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,13 +35,25 @@ gem 'rodauth', '~> 2.0'
 # mismatch (discovery URLs, issuer, and per-endpoint CSRF exemptions losing the
 # `/auth` mount point) at the gem level — see onetimesecret/onetimesecret#3465
 # and apps/web/auth/docs/rodauth-prefix-mismatch.md. Pinned to an immutable SHA
-# (not the mutable `claude/gifted-volta-4tpzai` branch) so `bundle update` can't
-# silently drift this security-critical gem. Bump the ref when the fork advances;
-# drop the fork once the change is upstreamed to os85/rodauth-oauth.
+# (not a mutable branch) so `bundle update` can't silently drift this
+# security-critical gem. Bump the ref when the fork advances; drop the fork once
+# the change is upstreamed to os85/rodauth-oauth.
+#
+# The fork is at 1.6.6.ots1: upstream 1.6.6 merged on top of the mount-prefix
+# change (onetimesecret/rodauth-oauth#16). Two upstream decisions the app has
+# to account for, see doc/release_notes/1_6_6_ots1.md in the fork:
+#   - `oauth_pkce_allow_plain_method` defaults to true upstream (the fork used
+#     to default it to false); features/oauth.rb sets it to false explicitly.
+#   - the plain OAuth `POST /register` no longer returns
+#     `registration_client_uri`; only the OIDC variant does. Neither dynamic
+#     client registration feature is enabled here.
+# The version constraint stays `~> 1.6`: Gem::Version treats the `.ots1`
+# suffix as a prerelease of 1.6.6, which `~> 1.6` admits but `~> 1.6.6` would
+# not.
 gem 'rodauth-oauth',
   '~> 1.6',
   git: 'https://github.com/onetimesecret/rodauth-oauth.git',
-  ref: '6e91089d5ee598a5ee6e78a5992d9e778ba7ccad'
+  ref: 'b0e7ceb0c26eb43226faa089bfd0a05bdddb8b1d'
 gem 'rodauth-omniauth', '~> 0.4'
 gem 'rodauth-tools', '~> 0.4.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/onetimesecret/rodauth-oauth.git
-  revision: 6e91089d5ee598a5ee6e78a5992d9e778ba7ccad
-  ref: 6e91089d5ee598a5ee6e78a5992d9e778ba7ccad
+  revision: b0e7ceb0c26eb43226faa089bfd0a05bdddb8b1d
+  ref: b0e7ceb0c26eb43226faa089bfd0a05bdddb8b1d
   specs:
-    rodauth-oauth (1.6.5)
+    rodauth-oauth (1.6.6.ots1)
       base64
       rodauth (~> 2.28)
 

--- a/apps/web/auth/config/features/oauth.rb
+++ b/apps/web/auth/config/features/oauth.rb
@@ -120,6 +120,16 @@ module Auth::Config::Features
       # (omniauth.rb sets `pkce: true`), so this rejects no working client.
       auth.oauth_require_pkce true
 
+      # rodauth-oauth 1.6.6 added `oauth_pkce_allow_plain_method` and defaults
+      # it to true for backwards compatibility (our fork used to default it to
+      # false). Left at the gem default, /authorize accepts
+      # code_challenge_method=plain and the grant insert then trips migration
+      # 011's CHECK constraint, turning a bad client request into a 500 instead
+      # of an `invalid_request` redirect. Setting it explicitly keeps the
+      # S256-only posture at the request layer and drops "plain" from
+      # code_challenge_methods_supported in discovery metadata.
+      auth.oauth_pkce_allow_plain_method false
+
       # ─── URI schemes ───────────────────────────────────────────────────
       # Production defaults to https-only: an http:// redirect is interceptable,
       # letting an attacker steal the authorization code before PKCE verification,

--- a/apps/web/auth/docs/rodauth-oauth-upstream-mr-runbook.md
+++ b/apps/web/auth/docs/rodauth-oauth-upstream-mr-runbook.md
@@ -3,7 +3,7 @@
 Runbook for upstreaming the `Rack::URLMap` mount-prefix fix (issue #3465) from our
 fork to the gem maintainer once we're ready to drop the fork.
 
-- **Fork:** `onetimesecret/rodauth-oauth` (GitHub) · branch `claude/rodauth-oauth-urlmap-prefix-gczunl` · PR onetimesecret/rodauth-oauth#13
+- **Fork:** `onetimesecret/rodauth-oauth` (GitHub) · branch `claude/rodauth-oauth-urlmap-prefix-gczunl` · PR onetimesecret/rodauth-oauth#13. The fork has since merged upstream 1.6.6 and is versioned `1.6.6.ots1` (onetimesecret/rodauth-oauth#16); upstream 1.6.6 does **not** include the mount-prefix change, so this runbook still applies.
 - **Upstream:** `os85/rodauth-oauth` (GitLab, maintainer: Tiago Cardoso / honeyryderchuck), default branch `master`
 - **Status:** not yet submitted upstream. This is a third-party project; submit only with explicit sign-off from the OTS maintainer who owns the `onetimesecret/rodauth-oauth` fork (currently @delano).
 
@@ -27,10 +27,10 @@ Include the gem change only:
 
 - `lib/rodauth/oauth.rb` — the `auth_server_route` `*_path`/`*_url` regeneration
 - `lib/rodauth/features/oauth_base.rb` — `oauth_mount_prefix`, `authorization_server_url`, docs
-- `lib/rodauth/features/oauth_dynamic_client_registration.rb`, `oidc_dynamic_client_registration.rb` — `registration_client_uri` prepends the prefix
+- `lib/rodauth/features/oidc_dynamic_client_registration.rb` — `registration_client_uri` prepends the prefix (upstream 1.6.6 dropped `registration_client_uri` from the plain OAuth `/register` response, so `oauth_dynamic_client_registration.rb` no longer carries this)
 - `lib/rodauth/features/oauth_application_management.rb`, `oauth_grant_management.rb` — helpers prepend the prefix
-- `test/oauth/mount_prefix_test.rb`, plus the `*_with_mount_prefix` cases in `test/oauth/metadata_test.rb` and `test/oidc/metadata_test.rb`
-- `doc/release_notes/1_6_5.md` (renumber to upstream's next version), `doc/oauth_base.rdoc`
+- `test/oauth/mount_prefix_test.rb`, the `*_with_mount_prefix` cases in `test/oauth/metadata_test.rb` and `test/oidc/metadata_test.rb`, and `test_oidc_client_registration_client_uri_honors_mount_prefix` in `test/oidc/dynamic_client_registration_test.rb`
+- the `oauth_mount_prefix` sections of `doc/release_notes/1_6_6_ots1.md` (renumber to upstream's next version), `doc/oauth_base.rdoc`
 - `doc/mount_prefix_fix.svg` — optional: the prose description above is self-contained, so include it only if the maintainer finds the diagram useful for review
 
 Exclude / adjust:

--- a/apps/web/auth/spec/integration/oauth/oauth_idp_endpoints_spec.rb
+++ b/apps/web/auth/spec/integration/oauth/oauth_idp_endpoints_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe 'OAuth/OIDC IdP endpoints', :sqlite_database, type: :integration 
       expect(body['grant_types_supported']).to match_array(%w[authorization_code refresh_token])
     end
 
-    it 'advertises S256 via the oauth-authorization-server metadata endpoint' do
+    it 'advertises only S256 via the oauth-authorization-server metadata endpoint' do
       # oidc.rb#openid_configuration_body filters response keys through
       # VALID_METADATA_KEYS, which excludes code_challenge_methods_supported.
       # The OAuth 2.0 metadata endpoint (RFC 8414) keeps it.
@@ -176,9 +176,10 @@ RSpec.describe 'OAuth/OIDC IdP endpoints', :sqlite_database, type: :integration 
       get '/auth/.well-known/oauth-authorization-server'
       oauth_meta = JSON.parse(last_response.body)
 
-      # The gem assigns a single value, not an array — assert via String#include?
-      # which works whether the value is a String or an Array.
-      expect(oauth_meta['code_challenge_methods_supported']).to include('S256')
+      # rodauth-oauth 1.6.6 advertises "plain" alongside S256 unless
+      # oauth_pkce_allow_plain_method is false (features/oauth.rb). Pin the
+      # exact list so a gem bump that flips that default is caught here.
+      expect(oauth_meta['code_challenge_methods_supported']).to match_array(%w[S256])
     end
 
     it 'advertises RS256 in id_token_signing_alg_values_supported' do


### PR DESCRIPTION
## Summary

[#3104](https://github.com/onetimesecret/onetimesecret/issues/3104)

Follow-up to the fork's upstream merge in onetimesecret/rodauth-oauth#16. The fork now derives from rodauth-oauth 1.6.6 and is versioned `1.6.6.ots1`. Two upstream decisions affect the IdP:

* **`oauth_pkce_allow_plain_method` defaults to `true` upstream** (the fork used to default it to `false`). Left alone, `/authorize` would accept `code_challenge_method=plain` and the grant insert would then trip migration 011's S256-only CHECK constraint, turning a bad client request into a 500. `features/oauth.rb` now sets it to `false` explicitly, so the request layer keeps rejecting `plain` with `invalid_request` and discovery advertises `S256` only.
* **Plain OAuth `POST /register` no longer returns `registration_client_uri`** (only the OIDC variant does). Neither dynamic client registration feature is enabled here, so this only updates the upstream MR runbook, which listed `oauth_dynamic_client_registration.rb` as part of the mount-prefix change.

Changes:
* `Gemfile` ref moves to the fork commit carrying the version bump; the comment explains both divergences and why the constraint stays `~> 1.6` (`1.6.6.ots1` is a prerelease of 1.6.6 to Gem::Version, so `~> 1.6.6` would not admit it).
* `Gemfile.lock` updated by hand: revision, ref, and version. The gem's dependencies are unchanged between the two pins.
* `oauth_idp_endpoints_spec.rb` pins `code_challenge_methods_supported` to exactly `["S256"]` so a future gem bump that flips the default is caught.

## Related Issues

Companion to onetimesecret/rodauth-oauth#16. That PR should merge first; this pin points at its head commit, which stays fetchable either way.

## Test Plan

* `ruby -c` on the changed Ruby files.
* The container only has Ruby 3.3 and the Gemfile requires 3.4.10, so the rspec suite was not run here. CI should run `spec:integration:oauth`; the metadata spec is the one assertion that changed.
* Verified in the fork's own suite that `oauth_pkce_allow_plain_method false` makes `/authorize` reject `plain` with `invalid_request` and metadata return `["S256"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dmm4SrwgNTJa6FsBGKCiz1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dmm4SrwgNTJa6FsBGKCiz1)_