### PR TITLE
fix(auth): validate simple-mode login against the attempted identity only

### DIFF
--- a/apps/web/core/logic/authentication/authenticate_session.rb
+++ b/apps/web/core/logic/authentication/authenticate_session.rb
@@ -51,10 +51,23 @@ module Core::Logic
         # MEANINGFUL value: "looked, no such account", which records nothing.
         @potential_customer = potential
 
-        return unless potential
-
-        passwd_matches = potential.passphrase?(@passwd)
-        @cust          = potential if passwd_matches
+        # AUTHENTICATION IS AGAINST THE ATTEMPTED IDENTITY ONLY. Base#initialize
+        # seeds @cust with strategy_result.user — whoever the request's session
+        # already resolved to, which need not be the account the `login` param
+        # names. Left standing on a mismatch, that seed handed the submitted
+        # password a SECOND identity to try: a request carrying customer C's
+        # session that submitted `login=X` with C's password sailed through
+        # success? re-authenticated as C, the login param silently ignored —
+        # and skipped the failure funnel, so the attempt against X was never
+        # counted or audited. Full mode has no such fallback: Rodauth resolves
+        # the account from the submitted `login` and verifies the password
+        # against that account alone (its default already_logged_in is a no-op
+        # and this app never configures it). So @cust is unconditionally
+        # overwritten here — the attempted account when its passphrase matches,
+        # nil otherwise — which makes raise_concerns the single failure funnel
+        # for EVERY rejected credential, carried session or not.
+        passwd_matches = potential ? potential.passphrase?(@passwd) : false
+        @cust          = passwd_matches ? potential : nil
         @objid         = @cust.objid if @cust
 
         migrate_password_hash_if_needed(potential, @passwd) if passwd_matches
@@ -94,10 +107,11 @@ module Core::Logic
 
         return unless @cust.nil?
 
-        # @cust is nil for BOTH unknown-email and wrong-password (only set when
-        # the passphrase matches), so this is the single failure funnel. Count
-        # the failed attempt before raising the (deliberately non-enumerating)
-        # error.
+        # @cust is nil for unknown-email, wrong-password, AND a carried-session
+        # request whose password matched nobody — process_params overwrites the
+        # strategy_result.user seed unconditionally — so this is the single
+        # failure funnel. Count the failed attempt before raising the
+        # (deliberately non-enumerating) error.
         record_failed_login_attempt!(login_rate_limit_email, login_rate_limit_ip)
 
         # #4339: and audit it, when the address that was tried is a real
@@ -111,33 +125,31 @@ module Core::Logic
 
       def process
         unless success?
+          # Defense-in-depth recheck, not the production failure funnel:
+          # process_params pins @cust to the attempted account or nil, and
+          # raise_concerns raises on nil, so reaching here with success? false
+          # means the state process_params verified went stale between
+          # construction and now (e.g. a concurrent password change). The two
+          # rejection sites stay mutually exclusive per attempt (raise_concerns
+          # runs first and raises), which keeps the at-most-one-event property.
+          #
+          # Attribution — log line and audit event alike — is the ATTEMPTED
+          # identity from the `login` param, never strategy_result.user:
+          # exactly what full mode's after_login_failure logs (the submitted
+          # `login`) and what the funnel above records. The event answers
+          # "which admin account is being tried"; a carried-session identity
+          # here would be a false brute-force signal about an account nobody
+          # was working on. nil (unknown address) records nothing, per the
+          # helper's contract.
           auth_logger.warn 'Login failed',
             {
-              email: cust.obscure_email,
-              role: cust.role,
+              email: @potential_customer&.obscure_email,
+              role: @potential_customer&.role,
               session_id: safe_session_id,
               ip: @strategy_result.metadata[:ip],
               reason: :invalid_credentials,
             }
 
-          # The OTHER credential-rejection branch (#4339). raise_concerns is the
-          # production funnel — @cust is nil there for both unknown-email and
-          # wrong-password — so this one is only reached when the request
-          # already carried a customer (strategy_result.user) and its passphrase
-          # did not match. The two are mutually exclusive per attempt
-          # (raise_concerns runs first and raises), which is what keeps the
-          # at-most-one-event-per-attempt property.
-          #
-          # THE ATTEMPTED IDENTITY, NOT THE CARRIED ONE — the same
-          # @potential_customer the funnel above uses. `cust` here is
-          # strategy_result.user, i.e. whoever the REQUEST'S SESSION already
-          # belonged to, which need not be the account named in the `login`
-          # param: a request carrying colonel C's session that submits
-          # `login=X` with a bad password would have recorded a failed attempt
-          # against C, a false brute-force signal about an account nobody was
-          # working on. What the event exists to answer is "which admin account
-          # is being tried", so it attributes to the identity that was tried.
-          # nil (unknown address) records nothing, per the helper's contract.
           record_colonel_signin_failure(@potential_customer)
 
           raise_form_error 'Invalid email or password', field: 'email', error_type: 'invalid'
@@ -240,7 +252,17 @@ module Core::Logic
 
       def success?
         # Least-capability auth: a session authenticates only when the supplied
-        # passphrase matches the target customer's own passphrase.
+        # passphrase matches the ATTEMPTED customer's own passphrase. @cust is
+        # the account process_params resolved from the `login` param, or nil —
+        # never strategy_result.user (process_params overwrites the seed), so
+        # the identity this recheck verifies is the identity the session will
+        # be established as. The equal? guard makes that invariant local: if
+        # bookkeeping ever drifts and @cust is not the very object the login
+        # param resolved to, this fails closed rather than vouch for a
+        # different account — the shape of the original defect (#4361 fixed
+        # its audit-attribution half; this fixed the authentication half),
+        # where the carried session identity got a second chance at the
+        # password.
         #
         # A colonel-passphrase-as-any-customer branch is deliberately absent: any
         # such implicit impersonation would mint an authenticated-as-arbitrary
@@ -248,7 +270,10 @@ module Core::Logic
         # impersonation need ever arises it must be an explicit operation gated by
         # both authz layers (Otto role=colonel + verify_one_of_roles!(colonel:true))
         # that writes an audit event on every use — never a clause here.
-        !cust&.anonymous? && cust.passphrase?(@passwd)
+        return false if cust.nil? || cust.anonymous?
+        return false unless cust.equal?(@potential_customer)
+
+        cust.passphrase?(@passwd)
       end
 
       private
@@ -311,11 +336,12 @@ module Core::Logic
       # process_params resolved from the submitted `login` param, nil when the
       # address matched nothing. BOTH rejection branches pass it, so simple
       # mode attributes to the attempted identity exactly as full mode does
-      # (the Rodauth hook hands the helper the submitted `login:`). Passing
-      # `cust` from #process instead would target whoever the request's session
-      # already belonged to. No `login:` is passed and no second lookup
-      # happens. The helper never raises and never writes for a non-colonel,
-      # which is why there is no rescue and no role check here.
+      # (the Rodauth hook hands the helper the submitted `login:`). @cust would
+      # name the same object today — process_params pins it to the attempted
+      # account or nil — but attribution must not ride on that bookkeeping, so
+      # the parameter stays explicit. No `login:` is passed and no second
+      # lookup happens. The helper never raises and never writes for a
+      # non-colonel, which is why there is no rescue and no role check here.
       #
       # No throttle: the event lands in `security_events`, whose budget is
       # trimmed independently of the operator trail. Budget separation IS the

--- a/apps/web/core/spec/logic/authentication/authenticate_session_spec.rb
+++ b/apps/web/core/spec/logic/authentication/authenticate_session_spec.rb
@@ -195,10 +195,12 @@ RSpec.describe Core::Logic::Authentication::AuthenticateSession do
         cust
       end
 
-      # Production-accurate failure path: an anonymous login POST carries
+      # Production-typical failure path: an anonymous login POST carries
       # user=nil (PR #2733), so @cust starts nil (Logic::Base#initialize) and
-      # stays nil on a mismatch. That nil is what makes raise_concerns the
-      # single failure funnel; a non-nil .user would let it return early.
+      # stays nil on a mismatch. Since the attempted-identity fix, a non-nil
+      # .user changes nothing — process_params overwrites the seed — so
+      # raise_concerns is the single failure funnel either way (pinned in the
+      # 'attempted-identity authentication' describe below).
       let(:strategy_result) do
         result = double('StrategyResult')
         allow(result).to receive_messages(
@@ -515,10 +517,14 @@ RSpec.describe Core::Logic::Authentication::AuthenticateSession do
       expect(OT).to have_received(:le).with('[colonel.signin_failed] audit record failed', hash_including(:exception))
     end
 
-    # The second credential-rejection branch: reachable only when the request
-    # already carried a customer, so raise_concerns returned and #process
-    # rejected on success?. Mutually exclusive with the funnel above, which is
-    # what bounds this to one event per attempt.
+    # The second credential-rejection branch. Since the attempted-identity fix
+    # a carried customer no longer routes here — process_params clears the
+    # strategy_result.user seed on a mismatch, so raise_concerns raises first
+    # in production. The branch survives as a defense-in-depth recheck (state
+    # gone stale between construction and #process, e.g. a concurrent password
+    # change), exercised here by driving #process directly. Still mutually
+    # exclusive with the funnel above, which is what bounds this to one event
+    # per attempt.
     context 'when the rejection happens in #process instead' do
       let(:strategy_result) do
         result = double('StrategyResult')
@@ -540,13 +546,16 @@ RSpec.describe Core::Logic::Authentication::AuthenticateSession do
         )
       end
 
-      # ATTRIBUTION. `cust` in #process is strategy_result.user — whoever the
-      # REQUEST'S SESSION already belonged to — which need not be the account
-      # named in the `login` param. Attributing there would let anyone holding
-      # (or forging) a session mint failed-attempt events against an admin
-      # account nobody was trying, i.e. a false brute-force signal, while the
-      # identity actually being worked on went unrecorded. Both branches
-      # attribute to the ATTEMPTED identity, as full mode's hook does.
+      # ATTRIBUTION. strategy_result.user is whoever the REQUEST'S SESSION
+      # already belonged to, which need not be the account named in the
+      # `login` param. Attributing to it would let anyone holding (or forging)
+      # a session mint failed-attempt events against an admin account nobody
+      # was trying — a false brute-force signal — while the identity actually
+      # being worked on went unrecorded. Both branches attribute to the
+      # ATTEMPTED identity, as full mode's hook does; since the
+      # attempted-identity fix, @cust cannot even carry the session identity
+      # into #process (the success?/log-line halves are pinned in their own
+      # describe below).
       context 'and the session belongs to a different account than the login param' do
         # The colonel whose session the request carries. Not the account being
         # tried: the login param below names someone else entirely.
@@ -611,6 +620,143 @@ RSpec.describe Core::Logic::Authentication::AuthenticateSession do
             expect(Onetime::ColonelAuditEvent).not_to have_received(:record_security)
           end
         end
+      end
+    end
+  end
+
+  # The success? comparison and the 'Login failed' log line, brought into line
+  # with the audit attribution fixed in #4361: authentication is against the
+  # ATTEMPTED identity — the account the `login` param names — never against
+  # strategy_result.user. Full mode has no carried-session fallback (Rodauth
+  # resolves the account from the submitted `login` and verifies the password
+  # against that account alone; its default already_logged_in is a no-op and
+  # this app never configures it), so simple mode must not either. These
+  # scenarios mirror the carried-session-vs-login-param contexts in the
+  # colonel.signin_failed describe above.
+  describe 'attempted-identity authentication (parity with full mode)' do
+    # The customer whose session the request carries. Its passphrase MATCHES
+    # the submitted password — the pre-fix hazard: on a mismatch with the
+    # attempted account, process_params left this object in @cust, so success?
+    # re-authenticated the carried identity while the `login` param named
+    # someone else entirely.
+    let(:session_customer) do
+      cust = double('SessionCustomer')
+      allow(cust).to receive(:passphrase?).and_return(true)
+      allow(cust).to receive_messages(
+        objid: 'cust_carried',
+        email: 'carried@example.com',
+        extid: 'ur_carried',
+        obscure_email: 'ca***@e***.com',
+        role: :customer,
+        anonymous?: false
+      )
+      cust
+    end
+
+    let(:strategy_result) do
+      result = double('StrategyResult')
+      allow(result).to receive_messages(
+        session: rack_session,
+        user: session_customer,
+        auth_method: :session,
+        metadata: { ip: '127.0.0.1' },
+        authenticated?: false
+      )
+      result
+    end
+
+    let(:params) { { 'login' => 'someone-else@example.com', 'password' => test_password } }
+
+    context 'when the submitted password does not match the attempted account' do
+      # The account the `login` param names. Rejects every passphrase — the
+      # submitted password belongs to the CARRIED customer, not this one.
+      let(:customer) do
+        cust = double('AttemptedCustomer')
+        allow(cust).to receive(:passphrase?).and_return(false)
+        allow(cust).to receive_messages(
+          objid: 'cust_attempted',
+          email: 'someone-else@example.com',
+          obscure_email: 'so***@e***.com',
+          role: :customer,
+          anonymous?: false,
+          argon2_hash?: true,
+          passphrase: '$argon2id$...'
+        )
+        cust
+      end
+
+      it 'does not fall back to the carried identity: success? is false' do
+        logic.process_params
+
+        expect(logic.success?).to be false
+      end
+
+      it 'never asks the carried identity to vouch for the submitted password' do
+        logic.process_params
+        logic.success?
+
+        expect(session_customer).not_to have_received(:passphrase?)
+      end
+
+      it 'rejects through the single failure funnel, counting the attempt' do
+        # Pre-fix, a carried session skipped raise_concerns entirely (@cust was
+        # non-nil), so the failed attempt against the attempted account was
+        # never recorded against the rate limiter.
+        expect(logic).to receive(:record_failed_login_attempt!)
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError, 'Invalid email or password')
+      end
+
+      # The log-line half of the #4361 attribution fix, mirroring the audit
+      # event's 'targets the account that was tried' example: the failure is
+      # about the identity that was TRIED, not whoever the session carried.
+      it 'attributes the failure log to the attempted identity, not the carried session' do
+        logic.process_params
+
+        expect(mock_logger).to receive(:warn).with(
+          'Login failed',
+          hash_including(email: 'so***@e***.com', role: :customer),
+        )
+        expect { logic.process }.to raise_error(Onetime::FormError)
+      end
+    end
+
+    context 'when the attempted address matches no account at all' do
+      before { allow(Onetime::Customer).to receive(:find_by_email).and_return(nil) }
+
+      it 'is false — not a second chance for the carried identity' do
+        logic.process_params
+
+        expect(logic.success?).to be false
+      end
+
+      it 'rejects through the failure funnel like any unknown address' do
+        expect { logic.raise_concerns }.to raise_error(Onetime::FormError, 'Invalid email or password')
+      end
+    end
+
+    context 'when the submitted password matches the ATTEMPTED account' do
+      # find_by_email resolves the login param to the default `customer`
+      # double, whose passphrase accepts test_password. This is the identity
+      # SWITCH full mode performs (Rodauth's login → update_session replaces
+      # the session with the account the login named), already working before
+      # the fix and pinned here so the fix cannot regress it.
+      it 'authenticates as the attempted account, replacing the carried identity' do
+        logic.process_params
+        logic.process
+
+        expect(logic.greenlighted).to be true
+        expect(session_data['external_id']).to eq('ur_test123')
+        expect(session_data['external_id']).not_to eq('ur_carried')
+      end
+
+      it 'logs the success as the attempted identity' do
+        logic.process_params
+
+        expect(mock_logger).to receive(:info).with(
+          'Login successful',
+          hash_including(email: 'te***@example.com'),
+        )
+        logic.process
       end
     end
   end

--- a/changelog.d/20260901_180000_claude_simple_auth_attempted_identity.rst
+++ b/changelog.d/20260901_180000_claude_simple_auth_attempted_identity.rst
@@ -1,0 +1,26 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Simple-mode sign-in now validates the submitted password against the
+  **account named in the login field only** — never against a customer the
+  request's session already carried. Previously, a login submission arriving
+  on a session-bearing request could re-authenticate as the session's own
+  customer when the password matched *that* customer, silently ignoring the
+  account the form named; the attempt was also never counted by the login
+  rate limiter or the failed-sign-in audit. No privilege was escalatable (a
+  password was always required for whoever got authenticated), and the path
+  was unreachable through the stock controller, which turns already-signed-in
+  submissions away — this hardens the authentication class itself. Full mode
+  (Rodauth) always behaved this way; the two modes now agree, including the
+  case where a signed-in user submits another account's correct credentials
+  and the session switches to that account.
+
+Fixed
+-----
+
+- The simple-mode ``Login failed`` log line now reports the account that was
+  *attempted* (from the login field), not whichever customer the request's
+  session carried — matching the attribution of the ``colonel.signin_failed``
+  audit event fixed in #4361 and of full mode's login-failure log.


### PR DESCRIPTION
Follow-up to #4361, which fixed the `colonel.signin_failed` audit attribution (6ab5303c) but deliberately left the `success?` comparison and the `Login failed` log line for a change that touches authentication behavior, not just telemetry. **Stacked on `claude/audit-integrity-subissues-i2x8jg` (#4361)** — merge that first.

## The defect

`Logic::Base#initialize` seeds `@cust` with `strategy_result.user` (the session-carried customer). Simple mode's `AuthenticateSession#process_params` only overwrote it on a passphrase match, so on a mismatch the seed survived into `success?`, which compares the submitted password against `cust`:

1. A request carrying account C's session that submitted `login=X` with **C's** password re-authenticated as C — the `login` param silently ignored. Not privilege escalation (whoever got authenticated presented their own password), but the submitted and established identities could differ silently, and the attempt against X was never rate-limit-counted or audited (the carried seed made `raise_concerns` return early).
2. The `Login failed` log line reported the carried customer's email/role instead of the attempted identity.

**Reachability**: none through the stock controller — `StrategyResult#authenticated?` is `!user.nil?`, so `Core::Controllers::Authentication#authenticate` turns session-bearing submissions away (`handle_already_authenticated`) before the logic runs. This hardens the authentication class itself, which is the boundary and must not depend on a controller gate.

## Parity check (full/Rodauth mode)

Rodauth's default `already_logged_in` is a no-op and this app never configures it, so full mode processes a login POST on an existing session normally: the account is resolved from the submitted `login`, the password verified against **that account alone**, and on success the session is replaced with the attempted identity. `after_login_failure` logs the submitted `login`. Simple mode now matches on all three points — validate-against-attempted is the intended product behavior, not reject-on-mismatch.

## The fix

- `process_params` overwrites `@cust` unconditionally: the attempted account on a passphrase match, nil otherwise. `raise_concerns` becomes the single failure funnel for every rejected credential, carried session or not (rate-limit counting and audit included).
- `success?` is nil-safe and fails closed unless `@cust` is the very object the `login` param resolved to.
- The failure log attributes to `@potential_customer` — same identity the audit event uses since #4361.
- Bonus: `@objid` no longer picks up the carried customer's objid on the failure path.

## Tests

- 9 new examples in `authenticate_session_spec.rb` mirroring the #4361 attempted-identity audit scenarios for `success?`, the failure funnel, and the log line; 6 fail against the pre-fix code (verified by reverse-applying the diff), 3 pin the already-correct identity-switch success path so the fix can't regress it.
- Stale spec comments describing the old carried-session reachability updated.
- Unit lane green end to end: tryouts 8187/0; spec:fast 5374+5222+56 examples, 0 failures.
