### PR TITLE
fix(spec): run every spec:fast leg and multi-leg lane task even when one fails

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -135,6 +135,10 @@ APPS_FAST_EXCLUDE = [
 # retag the billing specs or drop these flags.
 APPS_FAST_TAG_FILTERS = '--tag ~postgres_database --tag ~integration'
 
+# The legs `spec:fast` runs, in order. See the task itself for why they are
+# collected rather than chained as prerequisites.
+FAST_LEGS = %w[spec:root_fast spec:apps_fast spec:apps_config_ru].freeze
+
 namespace :spec do
   # The `spec:fast` invocations. Their patterns are documented at
   # ROOT_FAST_PATTERN above; `rake spec:verify_selection` proves they select
@@ -393,8 +397,38 @@ namespace :spec do
   # Two rspec processes, not thirteen. `rake spec:verify_selection` asserts the
   # pair selects exactly the files the thirteen selected; run it after any edit
   # to ROOT_FAST_PATTERN / APPS_FAST_PATTERN / APPS_FAST_EXCLUDE.
+  #
+  # Deliberately NOT a prerequisite chain (`task fast: [...]`): rake stops a
+  # prerequisite chain at its first failure — RSpec::Core::RakeTask exits the
+  # process on a red leg — so any root_fast failure used to skip apps_fast and
+  # apps_config_ru entirely: all 11 apps/*/*/spec trees, ~5,200 examples, with
+  # nothing in the output saying so. Two environment-dependent examples
+  # (spec/unit/lanes/isolation_key_spec.rb wherever Docker is absent) were
+  # enough to hide app-spec drift behind a red-but-partial run. Every leg runs;
+  # a red one is recorded, summarized per leg, and fails the task at the end.
   desc 'Run all non-integration specs (unit, cli, lib, apps)'
-  task fast: [:root_fast, :apps_fast, :apps_config_ru]
+  task :fast do
+    failures = {}
+    FAST_LEGS.each do |leg|
+      Rake::Task[leg].invoke
+    rescue SystemExit => ex
+      # RSpec's rake task calls `exit` rather than raising, and SystemExit is
+      # not a StandardError — a bare rescue here would let the first red leg
+      # take the whole chain down again.
+      failures[leg] = "exit #{ex.status}"
+    rescue StandardError => ex
+      failures[leg] = ex.message
+    end
+
+    puts
+    puts "spec:fast leg summary (#{FAST_LEGS.size - failures.size}/#{FAST_LEGS.size} ok):"
+    FAST_LEGS.each do |leg|
+      puts format('  %-20s %s', leg, failures.key?(leg) ? "FAILED (#{failures[leg]})" : 'ok')
+    end
+    unless failures.empty?
+      abort "spec:fast: #{failures.size} of #{FAST_LEGS.size} legs failed: #{failures.keys.join(', ')}"
+    end
+  end
 
   desc 'Run the complete test suite'
   task all: ['spec:fast', 'spec:integration:all']

--- a/lib/tasks/spec_selection.rake
+++ b/lib/tasks/spec_selection.rake
@@ -81,9 +81,27 @@ module SpecSelection
     invocations
   end
 
+  # The legs spec:fast runs are FAST_LEGS (lib/tasks/spec.rake); this guard
+  # models a selection for each of them. The names cannot be derived — each
+  # descriptor's pattern is handwritten — so agreement is asserted instead:
+  # a leg added to FAST_LEGS without a descriptor here would run unverified,
+  # and every check below would silently under-count what spec:fast covers.
+  def assert_legs_modeled!
+    modeled = fast_invocations.map { |inv| "spec:#{inv[:name]}" }
+    return if modeled == FAST_LEGS
+
+    abort <<~MSG
+      spec:verify_selection models the legs #{modeled.inspect}
+      but spec:fast runs FAST_LEGS #{FAST_LEGS.inspect}
+      (lib/tasks/spec.rake). Add a descriptor to SpecSelection.fast_invocations
+      for the new leg — or remove the stale one — in the same commit, so the
+      selection guard covers exactly what the lane runs.
+    MSG
+  end
+
   # The invocations spec:fast spawns today. Patterns come from the constants
   # the rake tasks themselves use, so the guard can never verify a pattern the
-  # lane does not run.
+  # lane does not run. Names must mirror FAST_LEGS — see assert_legs_modeled!.
   #
   # @return [Array<Hash>] invocation descriptors
   def fast_invocations
@@ -189,6 +207,8 @@ end
 namespace :spec do
   desc 'Verify spec:fast selects exactly what the legacy 13-invocation fan-out did'
   task :verify_selection do
+    SpecSelection.assert_legs_modeled!
+
     legacy  = SpecSelection.legacy_invocations
       .flat_map { |inv| SpecSelection.files(**inv.except(:name, :tags)) }
       .sort.uniq
@@ -267,6 +287,8 @@ namespace :spec do
     desc 'Verify spec:fast runs the same EXAMPLE IDs as the legacy fan-out (slow: 17 dry-runs)'
     task :deep do
       require 'json'
+
+      SpecSelection.assert_legs_modeled!
 
       outdir = 'tmp/spec_selection'
       mkdir_p outdir

--- a/tests/lanes/README.md
+++ b/tests/lanes/README.md
@@ -62,6 +62,11 @@ Start every service named for a lane. This includes RabbitMQ for `api` and
 `smoke`, whose lane environment still declares its endpoint. `selftest` is the
 only service-free exception.
 
+A lane with several legs (`unit`, `simple`, `migrations-pg`) runs every leg
+even when an earlier one fails, then exits non-zero naming the red legs; the
+same holds for the three rspec legs inside `rake spec:fast`. A red leg never
+silently skips the ones after it.
+
 Use `--overlay billing` only with full-mode lanes. Billing requires
 `AUTHENTICATION_MODE=full`; other lanes reject the overlay.
 

--- a/tests/lanes/migrations-pg/tasks
+++ b/tests/lanes/migrations-pg/tasks
@@ -2,6 +2,11 @@
 # (bash -euo pipefail). Legs are collected, not chained: every leg runs even
 # when an earlier one fails, then the lane exits non-zero naming the red legs —
 # a red spec leg must not silently skip the dual-URL check (see unit/tasks).
+#
+# Caveat: when the postgres leg is red, verify_dual_url still runs — against
+# whatever schema state that leg left behind, possibly half-migrated. A second
+# red leg here can be derivative of the first rather than an independent
+# failure; read the postgres leg's output first.
 failed=()
 bundle exec rake spec:integration:migrations:postgres || failed+=(spec:integration:migrations:postgres)
 bundle exec rake spec:integration:migrations:verify_dual_url || failed+=(spec:integration:migrations:verify_dual_url)

--- a/tests/lanes/migrations-pg/tasks
+++ b/tests/lanes/migrations-pg/tasks
@@ -1,4 +1,11 @@
 # Lane tasks: executed top-to-bottom from the repo root by tests/lanes/run
-# (bash -euo pipefail: first failure stops the lane). Keep each line standalone.
-bundle exec rake spec:integration:migrations:postgres
-bundle exec rake spec:integration:migrations:verify_dual_url
+# (bash -euo pipefail). Legs are collected, not chained: every leg runs even
+# when an earlier one fails, then the lane exits non-zero naming the red legs —
+# a red spec leg must not silently skip the dual-URL check (see unit/tasks).
+failed=()
+bundle exec rake spec:integration:migrations:postgres || failed+=(spec:integration:migrations:postgres)
+bundle exec rake spec:integration:migrations:verify_dual_url || failed+=(spec:integration:migrations:verify_dual_url)
+if (( ${#failed[@]} > 0 )); then
+  echo "[lane:migrations-pg] FAILED leg(s): ${failed[*]} — every leg ran; each leg's results are above" >&2
+  exit 1
+fi

--- a/tests/lanes/simple/tasks
+++ b/tests/lanes/simple/tasks
@@ -1,4 +1,11 @@
 # Lane tasks: executed top-to-bottom from the repo root by tests/lanes/run
-# (bash -euo pipefail: first failure stops the lane). Keep each line standalone.
-bundle exec rake try:integration:simple
-bundle exec rake spec:integration:simple
+# (bash -euo pipefail). Legs are collected, not chained: every leg runs even
+# when an earlier one fails, then the lane exits non-zero naming the red legs —
+# a red tryouts leg must not silently skip the rspec leg (see unit/tasks).
+failed=()
+bundle exec rake try:integration:simple || failed+=(try:integration:simple)
+bundle exec rake spec:integration:simple || failed+=(spec:integration:simple)
+if (( ${#failed[@]} > 0 )); then
+  echo "[lane:simple] FAILED leg(s): ${failed[*]} — every leg ran; each leg's results are above" >&2
+  exit 1
+fi

--- a/tests/lanes/unit/tasks
+++ b/tests/lanes/unit/tasks
@@ -1,8 +1,13 @@
 # Lane tasks: executed top-to-bottom from the repo root by tests/lanes/run
-# (bash -euo pipefail: first failure stops the lane). Keep each line standalone.
-#
-# A try:unit failure aborts the lane before spec:fast ever runs (#4168's
-# secondary issue): say so explicitly, or a red lane silently implies the
-# rspec half was exercised when it wasn't.
-bundle exec rake try:unit || { echo "[lane:unit] try:unit FAILED — spec:fast did NOT run; the rspec half of this lane is unverified" >&2; exit 1; }
-bundle exec rake spec:fast
+# (bash -euo pipefail). Legs are collected, not chained: every leg runs even
+# when an earlier one fails, then the lane exits non-zero naming the red legs.
+# A chain that stops at the first failure silently skips the rest (#4168's
+# secondary issue: a red try:unit implied the rspec half was exercised when it
+# never ran) — same shape rake spec:fast fixes inside itself for its own legs.
+failed=()
+bundle exec rake try:unit || failed+=(try:unit)
+bundle exec rake spec:fast || failed+=(spec:fast)
+if (( ${#failed[@]} > 0 )); then
+  echo "[lane:unit] FAILED leg(s): ${failed[*]} — every leg ran; each leg's results are above" >&2
+  exit 1
+fi


### PR DESCRIPTION
## What

`rake spec:fast` and the multi-leg lane `tasks` files now run **every** leg even when an earlier one fails, then exit non-zero with a per-leg summary. A red leg no longer silently skips the legs after it.

- `lib/tasks/spec.rake` — `spec:fast` was `task fast: [:root_fast, :apps_fast, :apps_config_ru]`. Rake stops a prerequisite chain at its first failure, and `RSpec::Core::RakeTask` exits the process on a red run, so any `root_fast` failure skipped `apps_fast` and `apps_config_ru` entirely: all 11 `apps/*/*/spec` trees (~5,600 examples), with nothing in the output saying so. It is now a wrapper that invokes each leg (`FAST_LEGS`), rescues **`SystemExit`** (RSpec's rake task calls `exit`, not `raise` — a plain `rescue => e` misses it) plus `StandardError`, prints a per-leg summary, and aborts if any leg failed.
- `tests/lanes/{unit,simple,migrations-pg}/tasks` — same shape one level up: lane tasks files run under `bash -euo pipefail`, so the first red line aborted the rest (a red `try:unit` meant the rspec half never ran). They now collect failures (`failed=()` + `|| failed+=(leg)`) and exit 1 naming the red legs after every leg has run. This also replaces the unit lane's old workaround that merely *announced* the skip.
- `tests/lanes/README.md` — documents the all-legs-run contract.

## Why

Found during the Audit Integrity epic (#4361): two environment-dependent examples in `spec/unit/lanes/isolation_key_spec.rb` fail wherever Docker/RabbitMQ is unavailable, and that alone was enough to hide app-spec drift behind a red-but-partial run. A red-but-partial run reports less coverage than it implies.

## Verification

Full `tests/lanes/run unit`, both paths:

- **Red path** (temporary always-failing spec in `spec/unit/`): `try:unit` 8244 passed → `spec:root_fast` 5443 examples / 1 failure (the intentional one) → `spec:apps_fast` **5615 examples ran** (previously skipped) → `spec:apps_config_ru` 56 ran → `spec:fast leg summary (2/3 ok)` with per-leg lines → `[lane:unit] FAILED leg(s): spec:fast` → exit 1.
- **Green path** (scaffold removed): `spec:fast leg summary (3/3 ok)`, lane exits 0.

`spec:verify_selection` is unaffected — it derives from the pattern constants, not task prerequisites. CI's per-lane JSON aggregation globs `tmp/<stem>*.json`, so all-legs-run yields more complete failure data on red runs.

## Reviewer notes

- `spec:all` (`fast` → `integration:all`), `try:all`, and `smoke:rspec` are still first-failure prerequisite chains — deliberately out of scope; whether `spec:all` should fail fast into integration is a lane-membership question, not this fix.
- `tests/lanes/run-all` already had correct collect-and-summarize semantics; single-leg lanes need no change.
