### PR TITLE
Remove CI failure log PR comments

### DIFF
--- a/.github/actions/run-test-lane/action.yml
+++ b/.github/actions/run-test-lane/action.yml
@@ -6,9 +6,9 @@
 # Version: 1.0.0
 # Repository: onetimesecret/onetimesecret
 #
-# Runs one test lane (tests/lanes/<lane>) and layers the CI-only concerns on
-# top: failure-tail PR comments and job summaries. The lane owns environment
-# and task list (what runs in which environment); this action owns reporting.
+# Runs one test lane (tests/lanes/<lane>) and layers CI-only result artifacts
+# and job summaries on top. The lane owns environment and task list (what runs
+# in which environment); this action owns reporting.
 # That split is rule 4 in tests/lanes/README.md.
 #
 # The workflow owns service lifecycle (docker compose -f compose.test.yml),
@@ -27,8 +27,8 @@
 
 name: Run Test Lane
 description: |
-  Runs a test lane via tests/lanes/run with CI reporting layered on top:
-  failure tails posted to the PR and a job summary.
+  Runs a test lane via tests/lanes/run with CI result artifacts and a job
+  summary.
 
 inputs:
   lane:
@@ -59,7 +59,6 @@ runs:
         detached: true
 
     - name: Run lane
-      id: lane
       shell: bash
       env:
         LANE: ${{ inputs.lane }}
@@ -67,9 +66,6 @@ runs:
         RESULTS_FILE: ${{ inputs.results-file }}
         # CI owns service lifecycle; never let the runner start compose.
         LANES_NO_AUTOSTART: '1'
-      # Pipe through tee so the runner's live log still streams while we keep
-      # a copy on disk for the failure-comment step. PIPESTATUS[0] preserves
-      # the lane's exit code.
       run: |
         mkdir -p tmp
         if [ -n "$RESULTS_FILE" ]; then
@@ -79,8 +75,7 @@ runs:
         if [ -n "$OVERLAY" ]; then
           args+=(--overlay "$OVERLAY")
         fi
-        "${args[@]}" 2>&1 | tee tmp/lane.log
-        exit ${PIPESTATUS[0]}
+        "${args[@]}"
 
     # The lane writes RSpec's JSON to tmp/ but nothing collected it, so the
     # T5 aggregate job had nothing to aggregate (its unified report read
@@ -116,54 +111,6 @@ runs:
         # A lane that dies before RSpec runs has no JSON to upload, and that
         # is already reported as the lane step's failure.
         if-no-files-found: ignore
-
-    - name: Post failure tail to PR
-      # Only on PR events that actually failed. Skips push/manual runs to keep
-      # comment churn off main. Caller workflow must grant pull-requests: write.
-      if: failure() && steps.lane.outcome == 'failure' && github.event_name == 'pull_request'
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-        PR_NUMBER: ${{ github.event.pull_request.number }}
-        REPO: ${{ github.repository }}
-        JOB_NAME: ${{ github.job }}
-        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
-        LANE: ${{ inputs.lane }}
-        OVERLAY: ${{ inputs.overlay }}
-      run: |
-        if [ ! -f tmp/lane.log ]; then
-          echo "No captured log to post; skipping PR comment."
-          exit 0
-        fi
-
-        # 300 lines is enough for one tryouts/rspec failure with stack trace
-        # but stays well under GitHub's 65k-char comment limit.
-        tail -n 300 tmp/lane.log > /tmp/tail.log
-
-        lane_label="$LANE"
-        if [ -n "$OVERLAY" ]; then
-          lane_label="${LANE} --overlay ${OVERLAY}"
-        fi
-
-        body_file=$(mktemp)
-        {
-          echo "### CI failure: ${JOB_NAME} (lane: \`${lane_label}\`)"
-          echo ""
-          echo "[Run log](${RUN_URL})"
-          echo ""
-          echo "<details><summary>Last 300 lines of output</summary>"
-          echo ""
-          echo '```'
-          cat /tmp/tail.log
-          echo '```'
-          echo "</details>"
-          echo ""
-          echo "<sub>Posted by run-test-lane action so unauthenticated reviewers (humans + agents) can read the failure without log-viewer access.</sub>"
-        } > "$body_file"
-
-        gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
-          -f body="$(cat "$body_file")" >/dev/null
-        echo "Posted failure tail to PR #${PR_NUMBER}"
 
     - name: Generate job summary
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ name: CI
 # Composite Actions:
 # - setup-ruby-test-env: Ruby environment, artifacts, config, secrets
 # - setup-node-env: Node.js, pnpm, caching
-# - run-test-lane: Lane execution + failure-tail PR comments + job summary
+# - run-test-lane: Lane execution + result artifacts + job summary
 #
 # Path Filtering:
 # - Ruby-only changes skip TypeScript jobs
@@ -371,11 +371,8 @@ jobs:
       needs.changes.outputs.ruby == 'true' &&
       (needs.ruby-lint.result == 'success' || needs.ruby-lint.result == 'skipped') &&
       (needs.build-assets.result == 'success' || needs.build-assets.result == 'skipped')
-    # pull-requests: write lets run-test-lane post failure tails as PR
-    # comments. contents: read inherited from workflow-level permissions.
     permissions:
       contents: read
-      pull-requests: write
       # Required to upload coverage data to GitHub Code Quality.
       code-quality: write
 
@@ -533,9 +530,6 @@ jobs:
       (needs.ruby-lint.result == 'success' || needs.ruby-lint.result == 'skipped') &&
       (needs.build-assets.result == 'success' || needs.build-assets.result == 'skipped') &&
       !contains(needs.*.result, 'cancelled')
-    permissions: &perms-pr-comment
-      contents: read
-      pull-requests: write
 
     steps:
       - *checkout-step
@@ -570,7 +564,6 @@ jobs:
     runs-on: *runs-on
     needs: [changes, ruby-lint, build-assets]
     if: *if-ruby-integration
-    permissions: *perms-pr-comment
 
     steps:
       - *checkout-step
@@ -609,7 +602,6 @@ jobs:
     runs-on: *runs-on
     needs: [changes, ruby-lint, build-assets]
     if: *if-ruby-integration
-    permissions: *perms-pr-comment
 
     # Auth-mode, database engine, and endpoints live in the lane env files
     # (tests/lanes/<lane>/env); billing rows are the same lanes with the
@@ -689,7 +681,6 @@ jobs:
     runs-on: *runs-on
     needs: [changes, ruby-lint, build-assets]
     if: *if-ruby-integration
-    permissions: *perms-pr-comment
 
     steps:
       - *checkout-step

--- a/.github/workflows/ruby-4-preview.yml
+++ b/.github/workflows/ruby-4-preview.yml
@@ -17,9 +17,9 @@ name: Ruby 4 Preview
 #   ci.yml and local development — with services from compose.test.yml,
 #   so the only intended variable is the Ruby version. The lanes are
 #   invoked directly (not via the run-test-lane composite): this
-#   workflow is advisory, so the composite's failure-tail PR comments
-#   and results plumbing would be noise (gating and reporting policy is
-#   CI's per-workflow decision; tests/lanes/README.md rule 4).
+#   workflow is advisory, so the composite's result-artifact and summary
+#   reporting would be noise (gating and reporting policy is CI's
+#   per-workflow decision; tests/lanes/README.md rule 4).
 # - Artifacts are scoped per workflow run, so there is no collision with
 #   the main CI workflow's `frontend-build` artifact.
 # - `continue-on-error` is at the step level (not job level) on every

--- a/docs/specs/testing-lanes/testing-lanes.md
+++ b/docs/specs/testing-lanes/testing-lanes.md
@@ -297,9 +297,9 @@ one runner type.
 Ruby test suites enter through lanes and `compose.test.yml`:
 
 - `.github/workflows/ci.yml` uses the `run-test-lane` composite action for Ruby
-  jobs. The composite adds CI-only failure-tail comments and job summaries;
-  `ci.yml` supplies `COVERAGE` through `GITHUB_ENV`. Full-mode matrix rows are
-  lane and overlay combinations.
+  jobs. The composite uploads CI-only RSpec result artifacts and writes job
+  summaries; `ci.yml` supplies `COVERAGE` through `GITHUB_ENV`. Full-mode matrix
+  rows are lane and overlay combinations.
 - `.github/workflows/migration-tests.yml` runs the `migrations-*` lanes through
   the same composite. Its concurrent-boot job is intentionally CI
   orchestration, not a lane, although it uses `compose.test.yml` services.


### PR DESCRIPTION
## Summary
- Stop posting one raw 300-line log tail per failed Ruby test lane to pull requests.
- Retain the lane job summaries and RSpec result artifacts while removing the now-unneeded PR write permissions from those CI jobs.

## Review guide
- Review the simplified lane execution and removed comment step in `.github/actions/run-test-lane/action.yml`.
- Confirm Ruby test jobs inherit read-only repository permissions after the comment path is gone.

## Validation
- `scripts/check-shell-lint.sh`
- `scripts/tests/run.sh`
- Commit and push hooks