### PR TITLE
fix(sessions): pass the resolved customer to RevokeAllForCustomer (review fixes)

### DIFF
--- a/apps/api/colonel/logic/colonel/revoke_all_customer_sessions.rb
+++ b/apps/api/colonel/logic/colonel/revoke_all_customer_sessions.rb
@@ -132,9 +132,14 @@ module ColonelAPI
 
         # The offboarding primitive: kills EVERY session and writes the
         # ColonelAuditEvent (CONTRACT 4 — the op owns the trail).
+        #
+        # `customer: user`, not `custid: user_id`: raise_concerns already
+        # resolved (and the operator already confirmed) THIS record, so the op
+        # must act on it rather than re-resolve the route param through the
+        # extid index (drift, #4205/#4217, would silently zero-count the revoke).
         def revoke_all
           Onetime::Operations::Sessions::RevokeAllForCustomer.new(
-            custid: user_id,
+            customer: user,
             actor: cust.extid, # acting colonel's PUBLIC id, never an objid
             reason: reason,    # optional operator-supplied why (#4338)
           ).call

--- a/apps/api/colonel/logic/colonel/revoke_all_customer_sessions.rb
+++ b/apps/api/colonel/logic/colonel/revoke_all_customer_sessions.rb
@@ -151,9 +151,12 @@ module ColonelAPI
         # op's doc block). Naming an `actor` is what makes it write the one
         # ColonelAuditEvent this admin action owes the trail; the self-service
         # callers pass none and stay out of it.
+        #
+        # `customer: user`, not `custid: user_id` — same reason as #revoke_all:
+        # act on the record raise_concerns resolved and the operator confirmed.
         def revoke_all_except_current
           Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent.new(
-            custid: user_id,
+            customer: user,
             except_session_id: current_session_id,
             actor: cust.extid, # acting colonel's PUBLIC id, never an objid
             reason: reason,    # optional operator-supplied why (#4338)

--- a/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
@@ -167,9 +167,29 @@ RSpec.describe ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions do
 
       expect(Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent)
         .to have_received(:new).with(hash_including(
-          custid: 'ur_colonel', except_session_id: 'a' * 64, actor: 'ur_colonel',
+          customer: self_target, except_session_id: 'a' * 64, actor: 'ur_colonel',
         ))
       expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
+    end
+
+    # Same construction rule as the offboarding path below: raise_concerns
+    # resolved (and the operator confirmed) THIS record, so the op gets the
+    # record — never a `custid:` it would re-resolve through the extid index,
+    # where a miss (#4205/#4217 drift) degrades to a silent zero-count revoke
+    # that leaves the leaked colonel's other sessions live. Live-datastore
+    # proof of that gap:
+    # try/unit/operations/sessions/revoke_all_for_customer_except_current_try.rb
+    it 'hands the except-current op the resolved record, never a re-resolvable extid' do
+      logic = self_logic
+      logic.raise_concerns
+      logic.process
+
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent)
+        .to have_received(:new).once
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent)
+        .to have_received(:new).with(hash_including(customer: self_target))
+      expect(Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent)
+        .not_to have_received(:new).with(hash_including(:custid))
     end
 
     it 'tells the operator their current session was kept' do

--- a/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
+++ b/apps/api/colonel/spec/logic/colonel/revoke_all_customer_sessions_spec.rb
@@ -209,13 +209,13 @@ RSpec.describe ColonelAPI::Logic::Colonel::RevokeAllCustomerSessions do
   end
 
   describe 'the happy path still works' do
-    it 'hands the op the custid and the acting colonel extid' do
+    it 'hands the op the resolved customer record and the acting colonel extid' do
       logic = logic_for
       logic.raise_concerns
       data = logic.process
 
       expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new)
-        .with(hash_including(custid: 'ur_target', actor: 'ur_colonel'))
+        .with(hash_including(customer: target, actor: 'ur_colonel'))
       expect(data[:record][:blobs_deleted]).to eq(2)
     end
 

--- a/apps/web/auth/config/hooks/account.rb
+++ b/apps/web/auth/config/hooks/account.rb
@@ -729,6 +729,8 @@ module Auth::Config::Hooks
             # scan_untracked: false keeps the bounded keyspace SCAN out of Rodauth's
             # open reset transaction; the guaranteed tracked kill still revokes every
             # post-sidecar session (see RevokeAllForCustomerExceptCurrent docs).
+            # `custid:` is a genuine id-only entry point: this hook holds a Rodauth
+            # account row (external_id/email), never a Customer record.
             result = Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent.new(
               custid: custid,
               scan_untracked: false,
@@ -935,6 +937,8 @@ module Auth::Config::Hooks
             # scan_untracked: false keeps the bounded keyspace SCAN out of Rodauth's
             # open change transaction; the guaranteed tracked kill still revokes every
             # OTHER post-sidecar session (see RevokeAllForCustomerExceptCurrent docs).
+            # `custid:` is a genuine id-only entry point: this hook holds a Rodauth
+            # account row (external_id/email), never a Customer record.
             result = Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent.new(
               custid: custid,
               except_session_id: current_sid,

--- a/apps/web/auth/operations/customers/change_email.rb
+++ b/apps/web/auth/operations/customers/change_email.rb
@@ -648,8 +648,12 @@ module Auth
         def revoke_sessions
           return false unless @revoke_sessions
 
+          # `customer:` not `custid: @customer.extid` — we hold the record, so
+          # the op must act on it rather than on whatever the extid index
+          # resolves to (index drift, #4205/#4217, would otherwise degrade this
+          # to a silent zero-count revoke).
           Onetime::Operations::Sessions::RevokeAllForCustomer.new(
-            custid: @customer.extid,
+            customer: @customer,
             actor: @actor,
           ).call
           true

--- a/apps/web/auth/operations/customers/purge.rb
+++ b/apps/web/auth/operations/customers/purge.rb
@@ -20,6 +20,13 @@ module Auth
       # for containment, then customer.purge after destruction. This is the colonel
       # single-customer delete verb (DELETE /api/colonel/users/:user_id).
       #
+      # The revoke is handed the SAME resolved record this op holds, never its
+      # extid: callers (PurgeUser logic, `customers purge-one`) may have resolved
+      # by email or objid, and the extid index is not guaranteed to agree with
+      # the record in hand (#4205, #4217 drift). A re-resolution miss would
+      # degrade to a silent zero-count revoke followed by a destroy that leaves
+      # live blobs/sidecars behind a deleted customer.
+      #
       # Scope note: this destroys the customer unconditionally — a colonel deleting
       # a specific account is an explicit, audited decision. The bulk
       # `bin/ots customers purge` inactivity sweep keeps its own billing-protection
@@ -43,7 +50,8 @@ module Auth
         Result = Data.define(:status, :extid, :custid)
 
         # @param customer [Onetime::Customer] target (caller ensures non-nil,
-        #   non-anonymous)
+        #   non-anonymous). Passed through as-is to the session revoke — see the
+        #   class docs for why it is never re-resolved by extid.
         # @param actor [String, #extid, #email] acting admin's PUBLIC identity.
         #   Never an internal objid.
         # @param reason [String, nil] OPTIONAL operator-supplied why (#4338),
@@ -63,8 +71,10 @@ module Auth
           extid  = @customer.extid
           custid = @customer.custid
 
+          # `customer:` not `custid: extid` — the op must act on the record we
+          # hold, not on whatever the extid index resolves to (class docs).
           Onetime::Operations::Sessions::RevokeAllForCustomer.new(
-            custid: extid,
+            customer: @customer,
             actor: @actor,
             reason: @reason,
           ).call
@@ -96,8 +106,11 @@ module Auth
 
         private
 
-        # obscure_email raises for anonymous; the caller guards non-anonymous, but
-        # stay defensive so a purge never fails on audit-detail formatting.
+        # Customer#obscure_email does not raise on its own inputs: anonymous
+        # returns a literal placeholder and OT::Utils.obscure_email yields nil for
+        # a nil email. The rescue is kept as a belt-and-braces guard against
+        # unexpected data (a malformed record mid-purge, a stub without the
+        # method) — audit-detail formatting must never be why a purge fails.
         def obscure(customer)
           customer.obscure_email
         rescue StandardError

--- a/apps/web/auth/operations/update_password_metadata.rb
+++ b/apps/web/auth/operations/update_password_metadata.rb
@@ -29,8 +29,9 @@ module Auth
       private
 
       # Resolve the customer the same way the password hooks and
-      # RevokeAllForCustomerExceptCurrent do: external_id first, falling back to
-      # the account email (Customer.load_by_extid_or_email handles both).
+      # RevokeAllForCustomerExceptCurrent's `custid:` path do: external_id first,
+      # falling back to the account email (Customer.load_by_extid_or_email
+      # handles both).
       # external_id is nullable in the accounts schema, so a bare extid-only
       # lookup would silently skip the watermark stamp for those accounts — and
       # the async sweep (#3810) would then run unguarded and kill the

--- a/apps/web/auth/spec/operations/customers/change_email_spec.rb
+++ b/apps/web/auth/spec/operations/customers/change_email_spec.rb
@@ -514,7 +514,7 @@ RSpec.describe Auth::Operations::Customers::ChangeEmail do
         result = op.call
 
         expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new).with(
-          custid: 'ur_c', actor: 'cli'
+          customer: customer, actor: 'cli'
         )
         expect(revoker).to have_received(:call)
         expect(result.sessions_revoked).to be true
@@ -761,7 +761,7 @@ RSpec.describe Auth::Operations::Customers::ChangeEmail do
       op.call
 
       expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new).with(
-        custid: 'ur_c', actor: 'cli'
+        customer: customer, actor: 'cli'
       )
     end
 

--- a/apps/web/auth/spec/operations/customers/purge_spec.rb
+++ b/apps/web/auth/spec/operations/customers/purge_spec.rb
@@ -9,7 +9,10 @@
 # without auditing when nothing was deleted, and — since #4333 — writes that
 # audit event FAIL-CLOSED: an unwritable event surfaces as a raised
 # Onetime::AuditWriteFailure instead of a clean :success for a purge with no
-# trail.
+# trail. Also pins the kwarg shape handed to RevokeAllForCustomer: the resolved
+# `customer:` record, never a `custid:` the op would re-resolve through the
+# extid index (#4205/#4217 drift) — the live-datastore proof of that gap is in
+# try/unit/auth/operations/customers_ops_try.rb.
 #
 # Run: pnpm run test:rspec apps/web/auth/spec/operations/customers/purge_spec.rb
 
@@ -38,7 +41,7 @@ RSpec.describe Auth::Operations::Customers::Purge do
     expect(result.status).to eq(:success)
     expect(result.extid).to eq('ur_p')
     expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new).with(
-      custid: 'ur_p', actor: 'ur_col', reason: nil,
+      customer: customer, actor: 'ur_col', reason: nil,
     )
     expect(Auth::Operations::DeleteCustomer).to have_received(:new).with(customer: customer)
     expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
@@ -60,8 +63,29 @@ RSpec.describe Auth::Operations::Customers::Purge do
     described_class.new(customer: customer, actor: 'ur_col', reason: 'takeover').call
 
     expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new).with(
-      custid: 'ur_p', actor: 'ur_col', reason: 'takeover',
+      customer: customer, actor: 'ur_col', reason: 'takeover',
     )
+  end
+
+  # The reason the op takes `customer:` at all: a revoke keyed by extid
+  # re-resolves through the extid index, and a miss there degrades to a silent
+  # zero-count revoke followed by a destroy that leaves live blobs behind a
+  # deleted customer. Purge holds the record, so it hands over the record —
+  # and does not itself go back to the index for it.
+  it 'hands the resolved record to the revoke op, never a re-resolvable extid' do
+    allow(deleter).to receive(:call).and_return(true)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email)
+    allow(Onetime::Customer).to receive(:find_by_extid)
+
+    described_class.new(customer: customer, actor: 'ur_col').call
+
+    expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new).once
+    expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new)
+      .with(hash_including(customer: customer))
+    expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
+      .with(hash_including(:custid))
+    expect(Onetime::Customer).not_to have_received(:load_by_extid_or_email)
+    expect(Onetime::Customer).not_to have_received(:find_by_extid)
   end
 
   it 'returns :not_found and does not audit when nothing was deleted' do

--- a/lib/onetime/cli/session_command.rb
+++ b/lib/onetime/cli/session_command.rb
@@ -10,7 +10,10 @@
 #   ots session list [--limit N]
 #   ots session search <email-or-custid>
 #   ots session delete <session-id> [--force]
-#   ots sessions revoke-all <customer> [--force]
+#   ots session revoke-all <customer> [--force]
+#
+# `sessions` is an alias of `session`, so every subcommand also resolves under
+# the plural spelling the break-glass runbook uses (`ots sessions revoke-all`).
 #
 
 require 'json'
@@ -153,14 +156,14 @@ module Onetime
         puts 'Session Inspector'
         puts '=' * 80
         puts
-        puts 'Usage: ots session <subcommand> [options]'
+        puts 'Usage: ots session <subcommand> [options]   (alias: ots sessions ...)'
         puts
         puts 'Available subcommands:'
         puts '  inspect <session-id>              Show detailed session information'
         puts '  list [--limit N]                  List active sessions'
         puts '  search <email-or-custid>          Find sessions for a user'
         puts '  delete <session-id> [--force]     Delete a session'
-        puts '  revoke-all <customer> [--force]    Revoke every session for a customer'
+        puts '  revoke-all <customer> [--force]   Revoke every session for a customer'
         puts
       end
     end
@@ -416,19 +419,18 @@ module Onetime
         desc: 'Skip confirmation prompt'
 
       def call(customer: nil, reason: nil, force: false, **)
+        # Both error paths exit non-zero: a scripted `--force` run with a typo'd
+        # identifier must not read as a successful revoke. Only the interactive
+        # "Cancelled" below returns 0, matching SessionDeleteCommand.
         if customer.to_s.strip.empty?
-          puts 'Error: Customer required'
-          puts 'Usage: ots sessions revoke-all <customer> [--reason TEXT] [--force]'
-          return
+          puts 'Usage: ots session revoke-all <customer> [--reason TEXT] [--force]'
+          error_exit('Customer required')
         end
 
         boot_application!
 
         target = Onetime::Customer.load_by_extid_or_email(customer) || Onetime::Customer.load(customer)
-        unless target&.exists?
-          puts "Error: Customer not found: #{customer}"
-          return
-        end
+        error_exit("Customer not found: #{customer}") unless target&.exists?
 
         unless force
           print "Revoke every session for #{target.obscure_email} (#{target.extid})? (y/N): "
@@ -439,8 +441,10 @@ module Onetime
           end
         end
 
+        # The record just resolved (and confirmed above) is what gets revoked —
+        # never a re-resolution of its extid (see the op's class docs).
         result = Onetime::Operations::Sessions::RevokeAllForCustomer.new(
-          custid: target.extid,
+          customer: target,
           actor: CLI_ACTOR,
           reason: reason,
         ).call
@@ -448,17 +452,28 @@ module Onetime
         puts "Revoked #{result.blobs_deleted} session(s) for #{target.extid}"
         puts 'Warning: untracked-session scan reached its safety cap' if result.scan_capped
       end
+
+      private
+
+      # Same per-command shape as lib/onetime/cli/customers/*_command.rb (minus
+      # their --json branch, which this verb does not offer).
+      def error_exit(message)
+        puts "Error: #{message}"
+        exit 1
+      end
     end
 
-    # Register session commands. The revoke-all command also uses the plural path
-    # named by the break-glass runbook; the established singular path remains valid.
-    register 'session', SessionCommand
-    register 'sessions', SessionCommand
+    # Register session commands. `sessions` (the plural the break-glass runbook
+    # names) is an ALIAS of the `session` node, same pattern as customers_command.rb:
+    # dry-cli attaches aliases to the node itself, so every subcommand resolves
+    # under both spellings. A second `register 'sessions', ...` would instead
+    # create a separate node holding only what is registered beneath it, so
+    # `ots sessions list` fell through to the banner.
+    register 'session', SessionCommand, aliases: ['sessions']
     register 'session inspect', SessionInspectCommand
     register 'session list', SessionListCommand
     register 'session search', SessionSearchCommand
     register 'session delete', SessionDeleteCommand
     register 'session revoke-all', SessionRevokeAllCommand
-    register 'sessions revoke-all', SessionRevokeAllCommand
   end
 end

--- a/lib/onetime/jobs/publisher.rb
+++ b/lib/onetime/jobs/publisher.rb
@@ -444,6 +444,10 @@ module Onetime
 
           require 'onetime/operations/sessions/revoke_all_for_customer_except_current'
 
+          # `custid:` is a genuine id-only entry point here: this method is the
+          # publish API and receives the same identifier string the message
+          # payload carries, so the inline fallback resolves exactly as the
+          # worker it stands in for would.
           result = Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent.new(
             custid: custid,
             except_session_id: except_session_id,

--- a/lib/onetime/jobs/workers/session_revocation_sweep_worker.rb
+++ b/lib/onetime/jobs/workers/session_revocation_sweep_worker.rb
@@ -83,6 +83,8 @@ module Onetime
 
             log_debug "Sweeping sessions: #{custid} (metadata: #{message_metadata})"
 
+            # `custid:` is a genuine id-only entry point: the payload carries an
+            # identifier, never a record, so resolution happens in the op.
             result = Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent.new(
               custid: custid,
               except_session_id: data[:except_session_id],

--- a/lib/onetime/logic/credential_change_session_revocation.rb
+++ b/lib/onetime/logic/credential_change_session_revocation.rb
@@ -97,9 +97,13 @@ module Onetime
       # the encrypted Redis blobs are the app's real auth gate
       # (BaseSessionAuthStrategy), so they must die now, not only when the
       # async sweep lands.
+      #
+      # `customer:` not `custid: customer.extid` — the op must act on the record
+      # we hold, not on whatever the extid index resolves to (drift, #4205/#4217,
+      # would silently zero-count the revoke and leave pre-change blobs live).
       def revoke_session_blobs_inline(customer, except_session_id)
         result = Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent.new(
-          custid: customer.extid,
+          customer: customer,
           except_session_id: except_session_id,
           scan_untracked: false,
         ).call

--- a/lib/onetime/operations/sessions/revoke_all_for_customer.rb
+++ b/lib/onetime/operations/sessions/revoke_all_for_customer.rb
@@ -66,6 +66,9 @@ module Onetime
       # that leaves the account half-revoked.
       #
       # Stateless, single `#call`, returns an immutable {Result}.
+      #
+      # Construction rule: pass `customer:` whenever you hold the record;
+      # `custid:` is for id-only entry points (see #initialize for why).
       class RevokeAllForCustomer
         include Onetime::AuditedFailure
         include Onetime::AuditReason
@@ -82,6 +85,8 @@ module Onetime
         # record prefers: this lambda runs mid-raise, where re-resolving the
         # customer could itself fail (the raise may BE the datastore), and the
         # unresolved param is still an honest record of what the operator acted on.
+        # (For a pre-resolved `customer:` it is that record's extid, captured at
+        # construction — see #initialize — so no lookup happens here either.)
         audit_failures :call, verb: AUDIT_VERB, target: -> { @custid }
 
         # Session-data identity fields matched against the target's extid.
@@ -99,7 +104,21 @@ module Onetime
         #   unaffected; they never touch the scan)
         Result = Data.define(:revoked, :blobs_deleted, :untracked_deleted, :rodauth_rows_deleted, :scan_capped)
 
-        # @param custid [String] the target customer (route param; extid/email/objid).
+        # Exactly one of `custid:` / `customer:` must be given.
+        #
+        # @param custid [String, nil] the target customer AS ADDRESSED (route
+        #   param / CLI arg; extid, email, or objid). Resolved in #load_customer
+        #   via extid → email → objid; an unresolvable value degrades to a
+        #   zero-count revoke (see class docs, section 3).
+        # @param customer [Onetime::Customer, nil] the target ALREADY RESOLVED.
+        #   Callers that hold the record (Auth::Operations::Customers::Purge)
+        #   must pass it rather than its extid: a re-resolution by extid is not
+        #   guaranteed to agree with the record in hand — the extid index has
+        #   drifted before (#4205, #4217) — and a miss would silently take the
+        #   nil-customer branches, write a `blobs_deleted: 0` success, and let a
+        #   following destroy leave live blobs/sidecars/`active_sessions` behind
+        #   a deleted customer. The record is used as given; only `exists?` is
+        #   still checked.
         # @param actor [String, #extid] acting colonel's PUBLIC identity (extid).
         # @param reason [String, nil] OPTIONAL operator-supplied why (#4338),
         #   recorded in the audit detail. Offboarding and account-takeover
@@ -108,8 +127,21 @@ module Onetime
         #   {Onetime::AuditReason} for the bound and the optional-now /
         #   required-later rollout.
         # @param dbclient [Object, nil] Redis-like client; defaults to Familia.dbclient.
-        def initialize(custid:, actor:, reason: nil, dbclient: nil)
-          @custid   = custid
+        def initialize(actor:, custid: nil, customer: nil, reason: nil, dbclient: nil)
+          # Same shape as Operations::VerifyDomain's domain:/domains: guard.
+          if custid.nil? && customer.nil?
+            raise ArgumentError, 'Must provide either custid: or customer:'
+          end
+          if custid && customer
+            raise ArgumentError, 'Cannot provide both custid: and customer:'
+          end
+
+          @customer = customer
+          # @custid is read by the audit_failures target lambda and by the
+          # success-event target fallback in #call; for a pre-resolved customer
+          # its extid IS the addressed identity, so capture it now rather than
+          # touching the record again mid-raise.
+          @custid   = custid || customer.extid
           @actor    = actor
           @reason   = normalize_reason(reason)
           @dbclient = dbclient
@@ -283,10 +315,14 @@ module Onetime
           Auth::Database.connection
         end
 
-        # Same resolution as ListForCustomer / RevokeForCustomer: extid → email →
-        # objid. nil is tolerated — a missing customer yields a zero-count revoke.
+        # A pre-resolved `customer:` is used as given — NEVER re-resolved (see
+        # #initialize for why an extid-index miss here would be silent and
+        # destructive). Otherwise the same resolution as ListForCustomer /
+        # RevokeForCustomer: extid → email → objid. nil is tolerated either way
+        # — a missing customer yields a zero-count revoke.
         def load_customer
-          customer = Onetime::Customer.load_by_extid_or_email(@custid) ||
+          customer = @customer ||
+                     Onetime::Customer.load_by_extid_or_email(@custid) ||
                      Onetime::Customer.load(@custid)
           return nil unless customer&.exists?
 

--- a/lib/onetime/operations/sessions/revoke_all_for_customer_except_current.rb
+++ b/lib/onetime/operations/sessions/revoke_all_for_customer_except_current.rb
@@ -86,6 +86,9 @@ module Onetime
       # Stateless, single `#call`, returns an immutable {Result}. Best-effort by
       # contract: a missing customer degrades to a zero-count revoke rather than
       # raising (callers wrap it in ErrorHandler.safe_execute regardless).
+      #
+      # Construction rule: pass `customer:` whenever you hold the record;
+      # `custid:` is for id-only entry points (see #initialize for why).
       class RevokeAllForCustomerExceptCurrent
         include Onetime::AuditReason
 
@@ -111,7 +114,20 @@ module Onetime
         #   unaffected; they never touch the scan)
         Result = Data.define(:revoked, :blobs_deleted, :untracked_deleted, :scan_capped)
 
-        # @param custid [String] the target customer (extid/email/objid).
+        # Exactly one of `custid:` / `customer:` must be given.
+        #
+        # @param custid [String, nil] the target customer AS ADDRESSED (Rodauth
+        #   account external_id/email, job payload id; extid, email, or objid).
+        #   Resolved in #load_customer via extid → email → objid; an
+        #   unresolvable value degrades to a zero-count revoke (class docs).
+        # @param customer [Onetime::Customer, nil] the target ALREADY RESOLVED.
+        #   Callers that hold the record (the credential-change logic, the
+        #   colonel self-target path) must pass it rather than its extid: a
+        #   re-resolution by extid is not guaranteed to agree with the record in
+        #   hand — the extid index has drifted before (#4205, #4217) — and a
+        #   miss would silently take the nil-customer branch and return a
+        #   `blobs_deleted: 0` success with every pre-change session still
+        #   live. The record is used as given; only `exists?` is still checked.
         # @param except_session_id [String, nil] the bare session id to PRESERVE
         #   (the caller's current session). nil/'' preserves nothing → revoke ALL.
         # @param scan_untracked [Boolean] run the best-effort untracked keyspace
@@ -135,12 +151,24 @@ module Onetime
         #   `actor:` — self-service callers pass neither and no event is
         #   written. Blank is treated as absent; see {Onetime::AuditReason}.
         # @param dbclient [Object, nil] Redis-like client; defaults to Familia.dbclient.
-        def initialize(custid:, except_session_id: nil, scan_untracked: true,
-                       honor_credential_watermark: false, actor: nil, reason: nil,
-                       dbclient: nil)
+        def initialize(custid: nil, customer: nil, except_session_id: nil,
+                       scan_untracked: true, honor_credential_watermark: false,
+                       actor: nil, reason: nil, dbclient: nil)
+          # Same shape as Operations::VerifyDomain's domain:/domains: guard.
+          if custid.nil? && customer.nil?
+            raise ArgumentError, 'Must provide either custid: or customer:'
+          end
+          if custid && customer
+            raise ArgumentError, 'Cannot provide both custid: and customer:'
+          end
+
           @actor                      = actor
           @reason                     = normalize_reason(reason)
-          @custid                     = custid
+          @customer                   = customer
+          # @custid is the admin audit event's target (#record_admin_audit); for
+          # a pre-resolved customer its extid IS the addressed identity, so
+          # capture it now rather than touching the record again later.
+          @custid                     = custid || customer.extid
           # Normalize to a string so the `sid == @except_session_id` guards are
           # type-stable; nil becomes '' which no real sid ever equals → revoke ALL.
           @except_session_id          = except_session_id.to_s
@@ -325,10 +353,14 @@ module Onetime
           data.is_a?(Hash) && data['authenticated_at'].to_i > watermark
         end
 
-        # Same resolution as the sibling ops: extid → email → objid. nil is tolerated
-        # — a missing customer yields a zero-count revoke.
+        # A pre-resolved `customer:` is used as given — NEVER re-resolved (see
+        # #initialize for why an extid-index miss here would be silent and leave
+        # pre-change sessions live). Otherwise the same resolution as the
+        # sibling ops: extid → email → objid. nil is tolerated either way — a
+        # missing customer yields a zero-count revoke.
         def load_customer
-          customer = Onetime::Customer.load_by_extid_or_email(@custid) ||
+          customer = @customer ||
+                     Onetime::Customer.load_by_extid_or_email(@custid) ||
                      Onetime::Customer.load(@custid)
           return nil unless customer&.exists?
 

--- a/spec/cli/session_command_spec.rb
+++ b/spec/cli/session_command_spec.rb
@@ -166,19 +166,26 @@ RSpec.describe 'Session Command', type: :cli do
       allow(Onetime::Operations::Sessions::RevokeAllForCustomer).to receive(:new).and_return(operation)
     end
 
-    it 'requires a customer identifier' do
+    # Both error paths must exit NON-ZERO: a scripted `--force` run with a
+    # typo'd identifier that exits 0 reads as a successful revoke to whatever
+    # runbook step follows it. Exit status is the contract here; the message
+    # is checked on stdout because that is where the customers-CLI
+    # `error_exit` convention prints it.
+    it 'requires a customer identifier and exits non-zero' do
       output = run_cli_command_quietly('sessions', 'revoke-all')
 
       expect(output[:stdout]).to include('Error: Customer required')
+      expect(last_exit_code).not_to eq(0)
       expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
     end
 
-    it 'refuses an unknown customer instead of reporting a zero-count success' do
+    it 'refuses an unknown customer with a non-zero exit instead of a zero-count success' do
       allow(Onetime::Customer).to receive(:load_by_extid_or_email).and_return(nil)
 
       output = run_cli_command_quietly('sessions', 'revoke-all', 'missing', '--force')
 
       expect(output[:stdout]).to include('Error: Customer not found: missing')
+      expect(last_exit_code).not_to eq(0)
       expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
     end
 
@@ -187,10 +194,14 @@ RSpec.describe 'Session Command', type: :cli do
         'sessions', 'revoke-all', 'target@example.com', '--reason', 'takeover', '--force'
       )
 
+      # The CLI resolved the record itself, so it hands the record over —
+      # never an extid the op would re-resolve through the (driftable) index.
       expect(Onetime::Operations::Sessions::RevokeAllForCustomer).to have_received(:new).with(
-        custid: 'ur_target', actor: 'cli', reason: 'takeover',
+        customer: customer, actor: 'cli', reason: 'takeover',
       )
       expect(output[:stdout]).to include('Revoked 3 session(s) for ur_target')
+      # Positive control for the non-zero assertions above: success is 0.
+      expect(last_exit_code).to eq(0)
     end
 
     it 'keeps the established singular namespace available' do
@@ -206,7 +217,39 @@ RSpec.describe 'Session Command', type: :cli do
 
       expect(output[:stdout]).to include('Revoke every session')
       expect(output[:stdout]).to include('Cancelled')
+      # Declining the prompt is not an error (matches SessionDeleteCommand).
+      expect(last_exit_code).to eq(0)
       expect(Onetime::Operations::Sessions::RevokeAllForCustomer).not_to have_received(:new)
+    end
+  end
+
+  # `sessions` is a dry-cli ALIAS of the `session` node, not a second node with
+  # its own (thinner) subcommand set: every subcommand must resolve under the
+  # plural spelling the break-glass runbook uses, while the bare plural still
+  # shows the banner. A separate `register 'sessions', SessionCommand` made
+  # `ots sessions list` fall through to the banner with `list` as an argument.
+  describe 'sessions alias' do
+    it 'routes `sessions list` to the list subcommand, not the banner' do
+      allow(redis).to receive(:scan_each).and_return([].each)
+
+      output = run_cli_command_quietly('sessions', 'list')
+
+      expect(output[:stdout]).to include('Active Sessions')
+      expect(output[:stdout]).not_to include('Session Inspector')
+    end
+
+    it 'routes `sessions inspect` to the inspect subcommand' do
+      output = run_cli_command_quietly('sessions', 'inspect')
+
+      expect(output[:stdout]).to include('Error: Session ID required')
+      expect(output[:stdout]).not_to include('Session Inspector')
+    end
+
+    it 'still prints the banner for the bare plural' do
+      output = run_cli_command_quietly('sessions')
+
+      expect(output[:stdout]).to include('Session Inspector')
+      expect(output[:stdout]).to include('revoke-all')
     end
   end
 end

--- a/spec/lib/onetime/jobs/workers/session_revocation_sweep_worker_spec.rb
+++ b/spec/lib/onetime/jobs/workers/session_revocation_sweep_worker_spec.rb
@@ -140,6 +140,12 @@ RSpec.describe Onetime::Jobs::Workers::SessionRevocationSweepWorker, type: :inte
 
   describe '#work_with_params' do
     context 'happy path' do
+      # `custid:` — NOT `customer:` — is correct here and this is the one
+      # caller where it stays: the worker holds nothing but the queue
+      # payload's id (the record was resolved in another process, seconds
+      # earlier), so it is an id-only entry point by construction. Callers
+      # that hold the record must pass `customer:` instead; see the
+      # construction rule on RevokeAllForCustomerExceptCurrent#initialize.
       it 'delegates to the operation with the full sweep and watermark enabled, then acks' do
         worker.work_with_params(message, delivery_info, metadata)
 
@@ -150,6 +156,8 @@ RSpec.describe Onetime::Jobs::Workers::SessionRevocationSweepWorker, type: :inte
             scan_untracked: true,
             honor_credential_watermark: true,
           )
+        expect(Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent)
+          .not_to have_received(:new).with(hash_including(:customer))
         expect(operation).to have_received(:call)
         expect(worker.acked?).to be true
       end

--- a/spec/unit/onetime/jobs/publisher_spec.rb
+++ b/spec/unit/onetime/jobs/publisher_spec.rb
@@ -1040,6 +1040,13 @@ RSpec.describe Onetime::Jobs::Publisher do
         allow(publisher).to receive(:logger).and_return(logger_double)
       end
 
+      # `custid:` — NOT `customer:` — is correct here: this method is the
+      # publish API and receives the same identifier string the queue payload
+      # carries, so the inline fallback must resolve exactly as the worker it
+      # stands in for would. Callers that hold the record hand it to the op
+      # directly as `customer:` (CredentialChangeSessionRevocation does, for
+      # its inline revoke); see the construction rule on
+      # RevokeAllForCustomerExceptCurrent#initialize.
       it 'runs the op inline with the full sweep and watermark enabled' do
         result = publisher.enqueue_session_revocation_sweep(custid, except_session_id: session_id)
 
@@ -1051,6 +1058,8 @@ RSpec.describe Onetime::Jobs::Publisher do
             scan_untracked: true,
             honor_credential_watermark: true,
           )
+        expect(Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent)
+          .not_to have_received(:new).with(hash_including(:customer))
         expect(mock_operation).to have_received(:call)
       end
 

--- a/spec/unit/onetime/logic/credential_change_session_revocation_spec.rb
+++ b/spec/unit/onetime/logic/credential_change_session_revocation_spec.rb
@@ -1,0 +1,123 @@
+# spec/unit/onetime/logic/credential_change_session_revocation_spec.rb
+#
+# frozen_string_literal: true
+
+# Pins the kwarg shape the simple-mode credential-change mixin hands to
+# RevokeAllForCustomerExceptCurrent: the resolved `customer:` record, never a
+# `custid:` the op would re-resolve through the extid index. A miss there
+# (#4205/#4217 drift) takes the op's nil-customer branch — a silent
+# `blobs_deleted: 0` success with every pre-change session blob still live,
+# the exact M-2 outcome this mixin exists to prevent. The live-datastore proof
+# of that gap is in
+# try/unit/operations/sessions/revoke_all_for_customer_except_current_try.rb;
+# the end-to-end simple-mode paths that include this mixin are covered by
+# try/unit/logic/account/update_password_try.rb and
+# try/unit/logic/authentication/reset_password_try.rb.
+#
+# The async sweep is deliberately still enqueued BY EXTID: the publisher is the
+# queue API and only ever carries an identifier, so that call is not a
+# re-resolution the mixin can avoid — the inline revoke is.
+#
+# Run: pnpm run test:rspec spec/unit/onetime/logic/credential_change_session_revocation_spec.rb
+
+require 'spec_helper'
+require 'onetime/logic/credential_change_session_revocation'
+
+RSpec.describe Onetime::Logic::CredentialChangeSessionRevocation do
+  # Minimal host: the mixin's contract is `#auth_logger` plus a class name
+  # for its failure-path tags. The entry point is private in production
+  # (mixed into UpdatePassword / ResetPassword), so expose it here.
+  let(:host_class) do
+    Class.new do
+      include Onetime::Logic::CredentialChangeSessionRevocation
+
+      def self.name
+        'CredentialChangeHost'
+      end
+
+      attr_reader :auth_logger
+
+      def initialize(auth_logger)
+        @auth_logger = auth_logger
+      end
+
+      def run(customer, except_session_id: nil)
+        revoke_sessions_for_credential_change(customer, except_session_id: except_session_id)
+      end
+    end
+  end
+
+  let(:auth_logger) { double('auth_logger', info: nil, error: nil) }
+  let(:host) { host_class.new(auth_logger) }
+
+  let(:customer) do
+    instance_double(Onetime::Customer, extid: 'ur_cred', last_password_update!: nil)
+  end
+
+  let(:current_sid) { 'a' * 64 }
+
+  let(:revoke_op) { Onetime::Operations::Sessions::RevokeAllForCustomerExceptCurrent }
+
+  let(:op) do
+    instance_double(
+      revoke_op,
+      call: revoke_op::Result.new(
+        revoked: true, blobs_deleted: 2, untracked_deleted: 0, scan_capped: false,
+      ),
+    )
+  end
+
+  before do
+    allow(revoke_op).to receive(:new).and_return(op)
+    allow(Onetime::Jobs::Publisher).to receive(:enqueue_session_revocation_sweep).and_return(true)
+    allow(Onetime::Customer).to receive(:load_by_extid_or_email)
+    allow(Onetime::Customer).to receive(:load)
+    allow(Onetime::Customer).to receive(:find_by_extid)
+    allow(Onetime::Customer).to receive(:find_by_email)
+  end
+
+  it 'hands the inline revoke the record it holds, never a re-resolvable extid' do
+    host.run(customer, except_session_id: current_sid)
+
+    expect(revoke_op).to have_received(:new).once
+    expect(revoke_op).to have_received(:new).with(
+      hash_including(customer: customer, except_session_id: current_sid, scan_untracked: false),
+    )
+    expect(revoke_op).not_to have_received(:new).with(hash_including(:custid))
+    expect(op).to have_received(:call)
+
+    # The mixin itself never goes back to the index for a record it already has.
+    expect(Onetime::Customer).not_to have_received(:load_by_extid_or_email)
+    expect(Onetime::Customer).not_to have_received(:load)
+    expect(Onetime::Customer).not_to have_received(:find_by_extid)
+    expect(Onetime::Customer).not_to have_received(:find_by_email)
+  end
+
+  it 'passes a nil except_session_id through for the reset path (revoke ALL), still by record' do
+    host.run(customer)
+
+    expect(revoke_op).to have_received(:new).with(
+      hash_including(customer: customer, except_session_id: nil, scan_untracked: false),
+    )
+    expect(revoke_op).not_to have_received(:new).with(hash_including(:custid))
+  end
+
+  it 'enqueues the async sweep by extid (the queue API carries an identifier, not a record)' do
+    host.run(customer, except_session_id: current_sid)
+
+    expect(Onetime::Jobs::Publisher).to have_received(:enqueue_session_revocation_sweep)
+      .with('ur_cred', except_session_id: current_sid)
+  end
+
+  it 'still revokes inline (by record) when the sweep enqueue raises' do
+    allow(Onetime::Jobs::Publisher).to receive(:enqueue_session_revocation_sweep)
+      .and_raise(StandardError, 'broker down')
+
+    host.run(customer, except_session_id: current_sid)
+
+    expect(auth_logger).to have_received(:error)
+      .with('[credential-change] sessions_sweep_enqueue_FAILED', hash_including(customer_id: 'ur_cred'))
+    expect(revoke_op).to have_received(:new).with(hash_including(customer: customer))
+    expect(op).to have_received(:call)
+  end
+end

--- a/src/shared/stores/systemSettingsStore.ts
+++ b/src/shared/stores/systemSettingsStore.ts
@@ -9,11 +9,12 @@ import { ref } from 'vue';
 
 /**
  * Type definition for SystemSettingsStore.
+ *
+ * Read-only: the colonel config write path was removed, so this store only
+ * holds the fetched `details` (no `record`, no write/initialized flags).
  */
 export type SystemSettingsStore = {
   // State
-  _initialized: boolean;
-  record: {} | null; // response is empty object
   details: SystemSettingsDetails;
 
   // Actions
@@ -26,9 +27,7 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   const $api = useApi();
 
   // State
-  const record = ref<{} | null>(null);
   const details = ref<SystemSettingsDetails | null>(null);
-  const _initialized = ref(false);
 
   /**
    * Fetch system settings from the API
@@ -54,7 +53,6 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
   }
 
   function dispose() {
-    record.value = null;
     details.value = null;
   }
 
@@ -62,15 +60,12 @@ export const useSystemSettingsStore = defineStore('systemSettings', () => {
    * Reset store state to initial values
    */
   function $reset() {
-    record.value = null;
     details.value = null;
-    _initialized.value = false;
   }
 
   // Expose store interface
   return {
     // State
-    record,
     details,
 
     // Actions

--- a/try/integration/api/colonel/customer_admin_try.rb
+++ b/try/integration/api/colonel/customer_admin_try.rb
@@ -134,12 +134,14 @@ post "/api/colonel/users/#{@verify_target.objid}/unverify", {}.to_json, confirmi
 
 # ---- Purge success + audit --------------------------------------------
 
-## Purge (DELETE) returns 200, destroys the user, audits once
+## Purge (DELETE) returns 200, destroys the user, audits the revoke then the purge
+# Two mutations, two events: sessions are revoked for containment before
+# DeleteCustomer runs, and each owns its own audit event (Customers::Purge).
 AE.events.clear
 delete "/api/colonel/users/#{@purge_target.objid}", {}, confirming(@purge_target, { 'rack.session' => @colonel_session, 'HTTP_ACCEPT' => 'application/json', 'HTTP_X_CSRF_TOKEN' => tryouts_csrf_token(@colonel_session) })
 @purge_resp = JSON.parse(last_response.body)
-[last_response.status, @purge_resp['record']['deleted'], Onetime::Customer.load(@purge_target_objid).nil?, AE.count, AE.recent(1).first['verb']]
-#=> [200, true, true, 1, "customer.purge"]
+[last_response.status, @purge_resp['record']['deleted'], Onetime::Customer.load(@purge_target_objid).nil?, AE.count, AE.recent(2).map { |event| event['verb'] }.sort]
+#=> [200, true, true, 2, ["customer.purge", "session.revoke_all"]]
 
 # ---- Teardown ---------------------------------------------------------
 AE.events.clear

--- a/try/unit/auth/operations/customers_ops_try.rb
+++ b/try/unit/auth/operations/customers_ops_try.rb
@@ -12,7 +12,9 @@
 # - SetRole: success + EXACTLY ONE audit event, idempotent no_change (no audit),
 #   invalid role rejected
 # - SetVerification: success audits once, no_change does not audit
-# - Purge: destroys + audits once; audit target is the (pre-destroy) extid
+# - Purge: destroys + audits once; audit target is the (pre-destroy) extid;
+#   a customer whose extid_lookup entry has DRIFTED still gets its live session
+#   revoked (the op is handed the record, not an extid to re-resolve)
 # - Doctor: healthy customer clean, integrity issue detected, repair audits
 #
 # Run: try --agent try/unit/auth/operations/customers_ops_try.rb
@@ -22,6 +24,8 @@ require_relative '../../../support/test_helpers'
 OT.boot! :test
 
 require 'web/auth/operations/customers'
+require 'securerandom'
+require 'onetime/operations/sessions/track_metadata'
 
 AE = Onetime::ColonelAuditEvent
 
@@ -46,6 +50,24 @@ end
 
 @purge_cust  = mk('purge', @stamp)
 @purge_extid = @purge_cust.extid
+
+# EXTID-INDEX DRIFT purge regression (the gap that motivated `customer:` on
+# RevokeAllForCustomer, #4205/#4217): a customer with one live TRACKED session
+# whose extid_lookup entry is MISSING. Seeded BEFORE the entry is dropped
+# because TrackMetadata resolves the owner via find_by_extid.
+@purge_drift       = mk('purgedrift', @stamp)
+@purge_drift_extid = @purge_drift.extid
+@purge_drift_sid   = SecureRandom.hex(32)
+Onetime::Operations::Sessions::TrackMetadata.new(
+  session_id: @purge_drift_sid,
+  session_data: { 'authenticated' => true, 'external_id' => @purge_drift_extid,
+                  'ip_address' => '203.0.113.7', 'user_agent' => 'UA' },
+).call
+Familia.dbclient.set(
+  "session:#{@purge_drift_sid}",
+  Onetime::SessionCodec.from_config.encode({ 'authenticated' => true, 'external_id' => @purge_drift_extid }),
+)
+Onetime::Customer.extid_lookup.remove_field(@purge_drift_extid)
 
 @doc_healthy = mk('doc', @stamp)
 
@@ -181,6 +203,28 @@ AE.events.clear
 ]
 #=> [:success, true, 2, ["customer.purge", "session.revoke_all"], [@purge_extid, @purge_extid]]
 
+## Purge of a customer whose extid index entry has DRIFTED still revokes the
+## live session: Purge hands the op the record it holds, so the blob is gone,
+## the customer is destroyed, and session.revoke_all records blobs_deleted 1
+## at the extid. (With `custid: extid` the re-resolution misses, the revoke
+## degrades to 0 and the destroy leaves the blob live behind a deleted customer.)
+AE.events.clear
+@pd_pre = [
+  Onetime::Customer.load_by_extid_or_email(@purge_drift_extid).nil?,                       # drift is real
+  Onetime::Operations::Sessions::Store.find_key(Familia.dbclient, @purge_drift_sid).nil?, # blob is live
+]
+@pd        = Auth::Operations::Customers::Purge.new(customer: @purge_drift, actor: 'ur_colonel_pub').call
+@pd_revoke = AE.recent(2).find { |event| event['verb'] == 'session.revoke_all' }
+[
+  @pd_pre,
+  @pd.status,
+  Onetime::Customer.load(@purge_drift.objid).nil?,
+  Onetime::Operations::Sessions::Store.find_key(Familia.dbclient, @purge_drift_sid).nil?,
+  @pd_revoke['target'],
+  @pd_revoke['detail']['blobs_deleted'],
+]
+#=> [[true, false], :success, true, true, @purge_drift_extid, 1]
+
 # ---- Doctor -----------------------------------------------------------
 
 ## Doctor reports no issues for a healthy customer
@@ -207,6 +251,8 @@ AE.count
 
 # Cleanup
 AE.events.clear
-[@list_customers, @show_cust, @role_cust, @ver_cust, @doc_healthy, @doc_bad, @doc_repair].flatten.each do |c|
+Familia.dbclient.del("session:#{@purge_drift_sid}")
+Onetime::SessionMetadata.load(@purge_drift_sid)&.destroy! rescue nil
+[@list_customers, @show_cust, @role_cust, @ver_cust, @doc_healthy, @doc_bad, @doc_repair, @purge_drift].flatten.each do |c|
   c.destroy! rescue nil
 end

--- a/try/unit/operations/sessions/revoke_all_for_customer_except_current_try.rb
+++ b/try/unit/operations/sessions/revoke_all_for_customer_except_current_try.rb
@@ -30,6 +30,12 @@
 #   rejection); stale blobs and blobs with no authenticated_at stamp still die; a
 #   nil watermark degrades to the unguarded revoke; flag off (default) ignores the
 #   watermark entirely
+# - EXTID-INDEX DRIFT (#4205/#4217, the credential-change gap): a customer whose
+#   extid_lookup entry is missing cannot be resolved by `custid:` (silent
+#   zero-count degrade, no audit event), but a caller holding the record passes
+#   it as `customer:` and the op kills every OTHER blob WITHOUT consulting the
+#   index while still preserving the current session; exactly one of
+#   custid:/customer: is required (ArgumentError otherwise)
 #
 # Run: try --agent try/unit/operations/sessions/revoke_all_for_customer_except_current_try.rb
 
@@ -98,6 +104,41 @@ DB.set("sidecar:#{@untracked}:domain_context", 'sidecar-envelope')
 @other_sid = "tryxc_other_#{@nonce}"
 DB.set("session:#{@other_sid}", @codec.encode({ 'authenticated' => true,
                                                'external_id' => @other.extid, 'email' => @other.email }))
+
+# Acting colonel for the DRIFT block at the bottom — the only section of this
+# file that names an actor, because an actor is what makes the op write the one
+# admin ColonelAuditEvent whose target/detail that regression pins. Every other
+# section stays self-service (no actor, no event), as the M-2 hooks call it.
+@actor = "ur1colonelpub_#{@nonce}" # a PUBLIC id (extid-shaped), never an objid
+
+# EXTID-INDEX DRIFT fixture (#4205/#4217): a customer whose `extid_lookup` entry
+# is MISSING while the record and its sessions are live. Two TRACKED sids (one
+# of them the session to KEEP) plus one UNTRACKED blob, all keyed on the drift
+# customer's extid so none of the @cust sweeps above can touch them. Seeded
+# BEFORE the index entry is dropped because TrackMetadata itself resolves the
+# owner via find_by_extid.
+@drift = Onetime::Customer.create!(email: "driftxc_#{@nonce}@example.com")
+@drift.verified = 'true'
+@drift.save
+@drift_extid = @drift.extid
+
+@drift_current = SecureRandom.hex(32)
+@drift_other   = SecureRandom.hex(32)
+[@drift_current, @drift_other].each do |sid|
+  Onetime::Operations::Sessions::TrackMetadata.new(
+    session_id: sid,
+    session_data: { 'authenticated' => true, 'external_id' => @drift_extid,
+                    'ip_address' => '203.0.113.9', 'user_agent' => 'UA' },
+  ).call
+  DB.set("session:#{sid}", @codec.encode({ 'authenticated' => true,
+                                           'external_id' => @drift_extid, 'email' => @drift.email }))
+end
+@drift_untracked = SecureRandom.hex(32)
+DB.set("session:#{@drift_untracked}", @codec.encode({ 'authenticated' => true,
+                                                      'external_id' => @drift_extid, 'email' => @drift.email }))
+
+# The drift itself: the index no longer knows this extid.
+Onetime::Customer.extid_lookup.remove_field(@drift_extid)
 
 # ---- pre-conditions ---------------------------------------------------
 
@@ -297,10 +338,95 @@ DB.set("session:#{@wm_after}", @codec.encode({ 'authenticated' => true, 'externa
 [@res8.blobs_deleted, Store.find_key(DB, @wm_at).nil?, Store.find_key(DB, @wm_after).nil?]
 #=> [1, true, false]
 
+# ---- extid-index drift: `customer:` must not depend on the index ---------
+# The credential-change callers (CredentialChangeSessionRevocation, the colonel
+# self-target path) HOLD the customer record. Re-resolving its extid through
+# the index is not guaranteed to agree with the record in hand — the index has
+# drifted before (#4205/#4217) — and a miss takes the nil-customer branch: a
+# `blobs_deleted: 0` success with every pre-change session still live. So the
+# op takes `customer:` and uses it as given.
+
+## the drift is REAL: by extid (and by objid-load of the extid) the customer
+## resolves to nothing, yet the record and ALL THREE of its session blobs are live
+[
+  Onetime::Customer.load_by_extid_or_email(@drift_extid).nil?,
+  Onetime::Customer.load(@drift_extid).nil?,
+  @drift.exists?,
+  Store.find_key(DB, @drift_current).nil?,
+  Store.find_key(DB, @drift_other).nil?,
+  Store.find_key(DB, @drift_untracked).nil?,
+]
+#=> [true, true, true, false, false, false]
+
+## addressed by `custid:` (the pre-fix caller shape) the revoke DEGRADES: zero
+## counts, every blob survives, and — worse than the sibling op — NO audit
+## event at all, since the nil-customer branch returns before the admin write.
+## This is the gap; it is pinned so the `customer:` block below is proven
+## non-vacuous against the same fixture.
+AE.events.clear
+@drift_by_id = RXC.new(custid: @drift_extid, except_session_id: @drift_current, actor: @actor).call
+[
+  @drift_by_id.blobs_deleted,
+  AE.count,
+  Store.find_key(DB, @drift_other).nil?,
+  Store.find_key(DB, @drift_untracked).nil?,
+]
+#=> [0, 0, false, false]
+
+## handed the record as `customer:` plus the current sid, the same revoke kills
+## the OTHER tracked blob and the untracked blob (2 = 1 tracked + 1 untracked),
+## never the current one, without ever consulting the index
+AE.events.clear
+@drift_res = RXC.new(customer: @drift, except_session_id: @drift_current, actor: @actor).call
+[@drift_res.revoked, @drift_res.blobs_deleted, @drift_res.untracked_deleted, @drift_res.scan_capped]
+#=> [true, 2, 1, false]
+
+## post-state: the current session keeps its blob, sidecar and index entry (the
+## ONLY entry left); the other two blobs are gone and the revoked sid lost its sidecar
+[
+  Store.find_key(DB, @drift_current).nil?,
+  SM.load(@drift_current).nil?,
+  Store.find_key(DB, @drift_other),
+  Store.find_key(DB, @drift_untracked),
+  SM.load(@drift_other).nil?,
+  @drift.active_sessions.revrange(0, -1),
+]
+#=> [false, false, nil, nil, true, ["#{@drift_current}"]]
+
+## exactly ONE session.revoke_all event, target the record's extid, detail
+## flagged except_current and carrying blobs_deleted > 0
+@drift_ev = AE.recent(1).first
+[AE.count, @drift_ev['verb'], @drift_ev['target'],
+ @drift_ev['detail']['except_current'], @drift_ev['detail']['blobs_deleted'] > 0]
+#=> [1, "session.revoke_all", "#{@drift_extid}", true, true]
+
+## the op used the record AS GIVEN: the index was not repopulated as a side effect
+Onetime::Customer.load_by_extid_or_email(@drift_extid).nil?
+#=> true
+
+## neither kwarg is rejected: exactly one of custid:/customer: is required
+begin
+  RXC.new(except_session_id: @drift_current)
+rescue ArgumentError => e
+  e.class
+end
+#=> ArgumentError
+
+## both kwargs is rejected too (no silent precedence between the two)
+begin
+  RXC.new(custid: @drift_extid, customer: @drift, except_session_id: @drift_current)
+rescue ArgumentError => e
+  e.class
+end
+#=> ArgumentError
+
 # Cleanup
 [@current, @revoked, @untracked, @other_sid, @st_tracked, @st_untracked,
  @wm_fresh, @wm_stale, @wm_ufresh, @wm_unstamp, @off_fresh,
  @wm_at, @wm_after].each { |sid| SM.load(sid)&.destroy!; DB.del("session:#{sid}") }
+[@drift_current, @drift_other, @drift_untracked].each { |sid| SM.load(sid)&.destroy!; DB.del("session:#{sid}") }
+@drift.active_sessions.clear
+@drift.destroy!
 DB.del("sidecar:#{@current}:awaiting_mfa")
 DB.del("sidecar:#{@revoked}:awaiting_mfa")
 DB.del("sidecar:#{@untracked}:domain_context")

--- a/try/unit/operations/sessions/revoke_all_for_customer_try.rb
+++ b/try/unit/operations/sessions/revoke_all_for_customer_try.rb
@@ -21,6 +21,11 @@
 #   (docs/architecture/audit-logging.md "Session verbs")
 # - rodauth_rows_deleted is 0 here (simple/test mode: no auth DB)
 # - IDEMPOTENT: a second call returns revoked:true with zero counts
+# - EXTID-INDEX DRIFT (#4205/#4217, the purge gap): a customer whose extid_lookup
+#   entry is missing cannot be resolved by `custid:` (zero-count degrade), but a
+#   caller holding the record passes it as `customer:` and the op kills every
+#   blob WITHOUT consulting the index; exactly one of custid:/customer: is
+#   required (ArgumentError otherwise)
 #
 # Run: try --agent try/unit/operations/sessions/revoke_all_for_customer_try.rb
 
@@ -93,6 +98,29 @@ DB.set("session:#{@mislabeled}", @codec.encode({ 'authenticated' => true,
 @other_sid = "tryall_other_#{@nonce}"
 DB.set("session:#{@other_sid}", @codec.encode({ 'authenticated' => true,
                                                'external_id' => @other.extid, 'email' => @other.email }))
+
+# EXTID-INDEX DRIFT fixture: a customer whose `extid_lookup` entry is MISSING
+# while the record and its sessions are live. Seeded BEFORE the index entry is
+# dropped because TrackMetadata itself resolves the owner via find_by_extid.
+@drift = Onetime::Customer.create!(email: "drift_#{@nonce}@example.com")
+@drift.verified = 'true'
+@drift.save
+@drift_extid = @drift.extid
+
+@drift_tracked = SecureRandom.hex(32)
+Onetime::Operations::Sessions::TrackMetadata.new(
+  session_id: @drift_tracked,
+  session_data: { 'authenticated' => true, 'external_id' => @drift_extid,
+                  'ip_address' => '203.0.113.9', 'user_agent' => 'UA' },
+).call
+DB.set("session:#{@drift_tracked}", @codec.encode({ 'authenticated' => true,
+                                                    'external_id' => @drift_extid, 'email' => @drift.email }))
+@drift_untracked = SecureRandom.hex(32)
+DB.set("session:#{@drift_untracked}", @codec.encode({ 'authenticated' => true,
+                                                      'external_id' => @drift_extid, 'email' => @drift.email }))
+
+# The drift itself: the index no longer knows this extid.
+Onetime::Customer.extid_lookup.remove_field(@drift_extid)
 
 # ---- pre-conditions ---------------------------------------------------
 
@@ -196,8 +224,82 @@ RAFC.new(custid: @ghost, actor: @actor).call.revoked
 [AE.count, AE.recent(1).first['target']]
 #=> [1, "#{@ghost}"]
 
+# ---- extid-index drift: `customer:` must not depend on the index ---------
+
+## the drift is REAL: by extid (and by objid-load of the extid) the customer
+## resolves to nothing, yet the record and BOTH of its session blobs are live
+[
+  Onetime::Customer.load_by_extid_or_email(@drift_extid).nil?,
+  Onetime::Customer.load(@drift_extid).nil?,
+  @drift.exists?,
+  Store.find_key(DB, @drift_tracked).nil?,
+  Store.find_key(DB, @drift_untracked).nil?,
+]
+#=> [true, true, true, false, false]
+
+## addressed by `custid:` (the pre-fix Purge shape) the revoke DEGRADES: zero
+## counts and both blobs survive, while the trail still reads like a normal
+## revoke (target is the extid either way). This is the gap; it is pinned here
+## so the `customer:` block below is proven non-vacuous.
+AE.events.clear
+@res_by_id = RAFC.new(custid: @drift_extid, actor: @actor).call
+[
+  @res_by_id.blobs_deleted,
+  AE.recent(1).first['target'],
+  Store.find_key(DB, @drift_tracked).nil?,
+  Store.find_key(DB, @drift_untracked).nil?,
+]
+#=> [0, "#{@drift_extid}", false, false]
+
+## handed the record as `customer:`, the same revoke kills BOTH blobs
+## (1 tracked + 1 untracked) without ever consulting the index
+AE.events.clear
+@res_drift = RAFC.new(customer: @drift, actor: @actor).call
+[@res_drift.revoked, @res_drift.blobs_deleted, @res_drift.untracked_deleted]
+#=> [true, 2, 1]
+
+## both blobs are gone, the sidecar is destroyed and the index cleared
+[
+  Store.find_key(DB, @drift_tracked),
+  Store.find_key(DB, @drift_untracked),
+  SM.load(@drift_tracked).nil?,
+  @drift.active_sessions.revrange(0, -1),
+]
+#=> [nil, nil, true, []]
+
+## exactly ONE session.revoke_all event, target the record's extid, detail
+## carrying blobs_deleted > 0
+@drift_ev = AE.recent(1).first
+[AE.count, @drift_ev['verb'], @drift_ev['target'], @drift_ev['detail']['blobs_deleted'] > 0]
+#=> [1, "session.revoke_all", "#{@drift_extid}", true]
+
+## the op used the record AS GIVEN: the index was not repopulated as a side effect
+Onetime::Customer.load_by_extid_or_email(@drift_extid).nil?
+#=> true
+
+## neither kwarg is rejected: exactly one of custid:/customer: is required
+begin
+  RAFC.new(actor: @actor)
+rescue ArgumentError => e
+  e.class
+end
+#=> ArgumentError
+
+## both kwargs is rejected too (no silent precedence between the two)
+begin
+  RAFC.new(custid: @drift_extid, customer: @drift, actor: @actor)
+rescue ArgumentError => e
+  e.class
+end
+#=> ArgumentError
+
 # Cleanup
 @tracked.each { |sid| SM.load(sid)&.destroy!; DB.del("session:#{sid}") }
+SM.load(@drift_tracked)&.destroy!
+DB.del("session:#{@drift_tracked}")
+DB.del("session:#{@drift_untracked}")
+@drift.active_sessions.clear
+@drift.destroy!
 DB.del("session:#{@untracked}")
 DB.del("session:#{@mislabeled}")
 DB.del("session:#{@other_sid}")


### PR DESCRIPTION
Stacked on `feature/4325-sprint1-ops-repair` (#4325 sprint-1 ops repair) — merge that first.

## Why
Review of the revoke-all / purge-revocation work found that `Customers::Purge` handed `RevokeAllForCustomer` the extid it already held a record for, and the op re-resolved it through the extid index. On an index miss (drift — #4205/#4217 precedent) the op silently wrote a `session.revoke_all` success with `blobs_deleted: 0` and Purge destroyed the customer anyway, leaving live blobs, sidecars, and the `active_sessions` ZSET behind — the 2.14 gap the parent branch marks resolved.

## What
- `RevokeAllForCustomer#initialize(actor:, custid: nil, customer: nil, ...)` — exactly one of `custid:`/`customer:`; with `customer:` the record is used as given, never re-resolved. Construction rule documented in the class: pass `customer:` whenever you hold the record; `custid:` is for id-only entry points.
- All four production callers that hold the record now pass it: `Customers::Purge`, `Customers::ChangeEmail`, colonel `RevokeAllCustomerSessions` logic, `ots session revoke-all`.
- Second commit applies the identical rule to `RevokeAllForCustomerExceptCurrent`: credential-change revocation mixin and the colonel self-target path pass `customer:`. The four remaining `custid:` sites (publisher inline fallback, sweep worker, two Rodauth password hooks) are genuinely id-only — payload string / Rodauth account row, no `Customer` — and are documented as such.
- CLI: `register 'session', SessionCommand, aliases: ['sessions']` replaces the duplicate top-level `sessions` node (which only held `revoke-all`, so `ots sessions list` fell through to the banner). `revoke-all` error paths `exit 1` so a scripted `--force` typo can't read as success.
- `systemSettingsStore.ts`: drop dead `record` / `_initialized` left over from the write-path removal.
- Stale `obscure_email` comment in Purge corrected (it does not raise for anonymous/nil).

## Not changed, deliberately
- Revoke-before-`deleted` ordering: `DeleteCustomer#call` only returns false for a nil customer, which Purge never passes; reordering would also break the revoke (needs the live ZSET/extid).
- Innermost-frame audit on nested failure: `AuditedFailure`'s documented design, not a Purge bug.
- Synchronous untracked SCAN on the delete path: same class of cost `SetSuspension` already accepts on the colonel suspend path. If it bites, an `untracked: false` option for purge is the mitigation (after destroy, untracked blobs go inert via `[CUSTOMER_NOT_FOUND]` anyway).

## Tests
- `tests/lanes/run unit` on purge / change_email / session_command / operator_reason_audit / revoke_all_customer_sessions specs → 161 examples, 0 failures
- `tests/lanes/run unit` on `customers_ops_try.rb` + `revoke_all_for_customer_try.rb` → 50 testcases, 0 failed
- New drift regressions (op-level and Purge-level, live datastore with the `extid_lookup` entry removed after seeding) verified to fail (4/50) against a mutant that re-resolves through the index.
- Second commit: 225 rspec examples / 0 failures across the touched specs (incl. new `credential_change_session_revocation_spec.rb`); 80 tryouts / 0 failed across both RevokeAll ops + customers ops; except-current drift regression fails 3/30 under a re-resolving mutant.
- rubocop clean; `vue-tsc --noEmit` + eslint clean on the store.