### PR TITLE
fix(rack): pin Rack::Request.forwarded_priority to the X-Forwarded-* family

### DIFF
--- a/changelog.d/20260903_211800_claude_rack_forwarded_priority.rst
+++ b/changelog.d/20260903_211800_claude_rack_forwarded_priority.rst
@@ -1,0 +1,17 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- Rack no longer consults the RFC 7239 ``Forwarded`` header when resolving a
+  request's host, port, scheme or client address. ``Rack::Request`` defaults
+  to preferring ``Forwarded`` over the ``X-Forwarded-*`` family, but reverse
+  proxies such as Caddy manage only the latter and pass an unmanaged
+  ``Forwarded`` header through untouched, so a client could supply the
+  authority that ``request.host`` resolved to. A boot initializer now pins
+  ``Rack::Request.forwarded_priority`` to ``[:x_forwarded]`` process-wide,
+  complementing the existing forwarded-host stripping middleware.
+
+- Operators whose edge speaks only ``Forwarded`` (no ``X-Forwarded-Proto``)
+  must emit the ``X-Forwarded-*`` family for TLS scheme detection. This is
+  the Caddy default and the documented proxy configuration.

--- a/lib/onetime/application/middleware_stack.rb
+++ b/lib/onetime/application/middleware_stack.rb
@@ -576,7 +576,11 @@ module Onetime
           # LATER reader of Rack::Request#host (Rodauth's base_url, the
           # WebAuthn origin, any gem) sees the edge's real Host authority —
           # never a host the client forged. Nothing between DetectHost and
-          # here reads request.host directly.
+          # here reads request.host directly. Complemented at the Rack layer
+          # by Onetime::Initializers::ConfigureRack, which pins
+          # Rack::Request.forwarded_priority to [:x_forwarded] so a raw
+          # `Forwarded` header (which Caddy passes through unmanaged) can never
+          # outrank the proxy-managed X-Forwarded-* family in request.host.
           builder.use Onetime::Middleware::StripForwardedHost
 
           # Adds env['HTTP_X_REQUEST_ID']

--- a/lib/onetime/initializers.rb
+++ b/lib/onetime/initializers.rb
@@ -23,6 +23,7 @@ require_relative 'initializers/configure_truemail'
 require_relative 'initializers/configure_rhales'
 require_relative 'initializers/load_fortunes'
 require_relative 'initializers/setup_heap_dump_handler'
+require_relative 'initializers/configure_rack'
 
 # Dependent initializers
 require_relative 'initializers/validate_auth_config'    # depends_on: [:logging]

--- a/lib/onetime/initializers/configure_rack.rb
+++ b/lib/onetime/initializers/configure_rack.rb
@@ -1,0 +1,61 @@
+# lib/onetime/initializers/configure_rack.rb
+#
+# frozen_string_literal: true
+
+require 'rack/request'
+
+module Onetime
+  module Initializers
+    # ConfigureRack initializer
+    #
+    # Sets process-wide Rack::Request policy so the RFC 7239 `Forwarded`
+    # header is never consulted when Rack resolves a request's authority
+    # (`Rack::Request#host`, `#port`), client address (`#ip` via
+    # `#forwarded_for`) or scheme (`#scheme` via `#forwarded_scheme`).
+    #
+    # ## Why
+    #
+    # Rack 3.2's default `forwarded_priority` is `[:forwarded, :x_forwarded]`:
+    # `Forwarded` WINS over the `X-Forwarded-*` family. Caddy (and most edges)
+    # manage `X-Forwarded-Host` / `X-Forwarded-For` / `X-Forwarded-Proto` —
+    # overwriting or stripping whatever the client sent — but pass an
+    # unmanaged `Forwarded` header through untouched. That leaves a
+    # discrepancy: the proxy's sanitized signal loses to the client's raw
+    # one, and any `request.host` read resolves to an authority the client
+    # chose. Pinning the priority to `[:x_forwarded]` closes that gap at the
+    # Rack layer, independent of proxy configuration and of the middleware
+    # stack (Onetime::Middleware::StripForwardedHost remains as the
+    # belt-and-brace for `X-Forwarded-Host` and for any `Forwarded` host
+    # parameter still in the env).
+    #
+    # ## Consequence for `Forwarded`-only proxies
+    #
+    # The priority applies to EVERY `forwarded_*` reader in Rack, not just
+    # the authority. A proxy that speaks only RFC 7239 (no `X-Forwarded-Proto`,
+    # no `X-Forwarded-For`) no longer contributes scheme or client IP through
+    # Rack::Request. Scheme still resolves from `X-Forwarded-Proto` /
+    # `X-Forwarded-Ssl` (see `Rack::Request.x_forwarded_proto_priority`) and
+    # from the socket; client IP resolution for this app already goes through
+    # Otto's IP privacy middleware, whose depth-mode `Forwarded` support is
+    # configured separately (site.network.trusted_proxy.header) and reads the
+    # env directly. Operators running a `Forwarded`-only edge must emit the
+    # `X-Forwarded-*` family — the Caddy default — for TLS scheme detection.
+    #
+    # This is class-level state on Rack::Request (not runtime config), set
+    # once per process and inherited by forked workers, so the initializer is
+    # NOT fork-sensitive and has no cleanup.
+    class ConfigureRack < Onetime::Boot::Initializer
+      @provides = [:rack_request_policy]
+
+      # Only the X-Forwarded-* family is trusted as a forwarding signal.
+      FORWARDED_PRIORITY = [:x_forwarded].freeze
+
+      def execute(_context)
+        Rack::Request.forwarded_priority = FORWARDED_PRIORITY.dup
+
+        OT.boot_logger.debug 'Configured Rack::Request.forwarded_priority',
+          forwarded_priority: Rack::Request.forwarded_priority
+      end
+    end
+  end
+end

--- a/lib/onetime/middleware/strip_forwarded_host.rb
+++ b/lib/onetime/middleware/strip_forwarded_host.rb
@@ -89,8 +89,12 @@ module Onetime
         env.delete(X_FORWARDED_HOST)
 
         if (raw = env[FORWARDED])
-          stripped                                               = self.class.without_host_params(raw)
-          stripped.nil? ? env.delete(FORWARDED) : env[FORWARDED] = stripped
+          stripped = self.class.without_host_params(raw)
+          if stripped.nil?
+            env.delete(FORWARDED)
+          else
+            env[FORWARDED] = stripped
+          end
         end
 
         @app.call(env)

--- a/lib/onetime/middleware/strip_forwarded_host.rb
+++ b/lib/onetime/middleware/strip_forwarded_host.rb
@@ -40,6 +40,15 @@ module Onetime
     # `:forwarded` priority and falls through to `X-Forwarded-Host` — which
     # this middleware has already deleted.
     #
+    # Since Onetime::Initializers::ConfigureRack pins
+    # `Rack::Request.forwarded_priority = [:x_forwarded]`, Rack no longer
+    # consults `Forwarded` for ANY of host/for/port/proto, so the surgical
+    # preservation above is moot for Rack itself. It is kept because other
+    # readers still consume the raw header from the env — Otto's IP privacy
+    # middleware in depth mode with `trusted_proxy.header: Forwarded`, and
+    # its redacted fingerprint — and because the priority is process-global
+    # state a future require could reset; the env-level strip holds either way.
+    #
     # ## Ordering — AFTER DetectHost AND AdminNetworkIsolation, before
     # ## anything reads request.host
     #
@@ -80,7 +89,7 @@ module Onetime
         env.delete(X_FORWARDED_HOST)
 
         if (raw = env[FORWARDED])
-          stripped = self.class.without_host_params(raw)
+          stripped                                               = self.class.without_host_params(raw)
           stripped.nil? ? env.delete(FORWARDED) : env[FORWARDED] = stripped
         end
 

--- a/spec/unit/onetime/initializers/configure_rack_spec.rb
+++ b/spec/unit/onetime/initializers/configure_rack_spec.rb
@@ -1,0 +1,108 @@
+# spec/unit/onetime/initializers/configure_rack_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'onetime/initializers/configure_rack'
+
+# Pins the process-wide Rack::Request forwarding policy.
+#
+# Rack 3.2 defaults `forwarded_priority` to `[:forwarded, :x_forwarded]`, so
+# an RFC 7239 `Forwarded` header from ANY client outranks the X-Forwarded-*
+# family the proxy actually manages. Caddy does not strip an unmanaged
+# `Forwarded`, which leaves `request.host` resolvable to a client-chosen
+# authority. The initializer pins the priority to `[:x_forwarded]`; these
+# examples verify both the setting and its observable effect on
+# Rack::Request#host.
+RSpec.describe Onetime::Initializers::ConfigureRack do
+  let(:instance) { described_class.new }
+  let(:context) { {} }
+  let(:logger) { instance_double(SemanticLogger::Logger, debug: nil) }
+
+  before do
+    allow(Onetime).to receive(:boot_logger).and_return(logger)
+  end
+
+  around do |example|
+    original = Rack::Request.forwarded_priority
+    example.run
+  ensure
+    Rack::Request.forwarded_priority = original
+  end
+
+  describe 'metadata' do
+    it 'provides the :rack_request_policy capability' do
+      expect(described_class.provides).to eq([:rack_request_policy])
+    end
+
+    it 'has no dependencies so it runs in every boot mode, including connect_to_db=false' do
+      expect(described_class.depends_on).to be_nil.or be_empty
+    end
+
+    it 'is NOT fork-sensitive: class-level Rack state is inherited by forked workers' do
+      expect(described_class.phase).to eq(:preload)
+    end
+  end
+
+  describe '#execute' do
+    it 'pins forwarded_priority to the X-Forwarded-* family only' do
+      Rack::Request.forwarded_priority = [:forwarded, :x_forwarded]
+      instance.execute(context)
+      expect(Rack::Request.forwarded_priority).to eq([:x_forwarded])
+    end
+
+    it 'assigns a fresh array rather than the frozen constant' do
+      instance.execute(context)
+      expect(Rack::Request.forwarded_priority).not_to be_frozen
+    end
+
+    it 'keeps the source constant frozen' do
+      expect(described_class::FORWARDED_PRIORITY).to be_frozen
+    end
+
+    it 'is idempotent' do
+      instance.execute(context)
+      instance.execute(context)
+      expect(Rack::Request.forwarded_priority).to eq([:x_forwarded])
+    end
+
+    context 'with a client-supplied Forwarded header' do
+      let(:env) do
+        Rack::MockRequest.env_for(
+          'http://onetime.test/',
+          'HTTP_HOST' => 'onetime.test',
+          'HTTP_FORWARDED' => 'host=evil.example.com;proto=https',
+        )
+      end
+
+      it 'under the Rack default, a client Forwarded header poisons request.host' do
+        Rack::Request.forwarded_priority = [:forwarded, :x_forwarded]
+        expect(Rack::Request.new(env).host).to eq('evil.example.com')
+      end
+
+      it 'after the initializer, Forwarded is never consulted for request.host' do
+        instance.execute(context)
+        expect(Rack::Request.new(env).host).to eq('onetime.test')
+      end
+
+      it 'still honors the proxy-managed X-Forwarded-Host (gated upstream by StripForwardedHost)' do
+        instance.execute(context)
+        env['HTTP_X_FORWARDED_HOST'] = 'tenant.example.com'
+        expect(Rack::Request.new(env).host).to eq('tenant.example.com')
+      end
+
+      it 'also stops reading the Forwarded proto parameter for request.scheme' do
+        # forwarded_priority governs every forwarded_* reader, not just the
+        # authority. A Forwarded-only proxy must emit X-Forwarded-Proto.
+        instance.execute(context)
+        expect(Rack::Request.new(env).scheme).to eq('http')
+      end
+
+      it 'still resolves scheme from the proxy-managed X-Forwarded-Proto' do
+        instance.execute(context)
+        env['HTTP_X_FORWARDED_PROTO'] = 'https'
+        expect(Rack::Request.new(env).scheme).to eq('https')
+      end
+    end
+  end
+end

--- a/spec/unit/onetime/middleware/strip_forwarded_host_spec.rb
+++ b/spec/unit/onetime/middleware/strip_forwarded_host_spec.rb
@@ -4,6 +4,7 @@
 
 require 'spec_helper'
 require 'onetime/middleware/strip_forwarded_host'
+require 'onetime/initializers/configure_rack'
 
 # Unit tests for StripForwardedHost (finding G-01, defense in depth).
 #
@@ -85,17 +86,43 @@ RSpec.describe Onetime::Middleware::StripForwardedHost do
     end
   end
 
+  # Rack's forwarded_priority is process-global class state. It is pinned to
+  # [:x_forwarded] by Onetime::Initializers::ConfigureRack at boot, so whether
+  # Rack reads the surviving Forwarded `proto` depends on whether a boot ran
+  # earlier in this process. Each example sets the priority it is asserting
+  # against so the outcome does not depend on spec ordering.
   describe 'post-strip Rack resolution' do
-    it 'resolves host from Host: and scheme from the surviving Forwarded proto' do
-      env = Rack::MockRequest.env_for(
+    around do |example|
+      original = Rack::Request.forwarded_priority
+      example.run
+    ensure
+      Rack::Request.forwarded_priority = original
+    end
+
+    let(:env) do
+      Rack::MockRequest.env_for(
         'http://onetime.test/',
         'HTTP_X_FORWARDED_HOST' => 'evil.example.com',
         'HTTP_FORWARDED' => 'for=192.0.2.60;proto=https;host=evil.example.com',
       )
-      request = Rack::Request.new(call_with(env))
+    end
 
-      expect(request.host).to eq('onetime.test')
-      expect(request.scheme).to eq('https')
+    it 'resolves host from Host: regardless of forwarded_priority' do
+      Rack::Request.forwarded_priority = [:forwarded, :x_forwarded]
+      expect(Rack::Request.new(call_with(env)).host).to eq('onetime.test')
+    end
+
+    it 'leaves the surviving Forwarded proto readable under the Rack default priority' do
+      # The surgical strip exists so env-level readers (Otto's depth-mode
+      # Forwarded IP resolution, the redacted fingerprint) and any process
+      # running Rack's default priority still see proto/for.
+      Rack::Request.forwarded_priority = [:forwarded, :x_forwarded]
+      expect(Rack::Request.new(call_with(env)).scheme).to eq('https')
+    end
+
+    it 'does not read the surviving Forwarded proto once ConfigureRack pins the priority' do
+      Rack::Request.forwarded_priority = Onetime::Initializers::ConfigureRack::FORWARDED_PRIORITY.dup
+      expect(Rack::Request.new(call_with(env)).scheme).to eq('http')
     end
   end
 end


### PR DESCRIPTION
## Summary

Rack 3.2 defaults `Rack::Request.forwarded_priority` to `[:forwarded, :x_forwarded]`, so an RFC 7239 `Forwarded` header from any client outranks the `X-Forwarded-*` family the proxy manages. Caddy overwrites `X-Forwarded-Host/For/Proto` but passes an unmanaged `Forwarded` header through untouched, which left `request.host` (and everything built from it: Rodauth `base_url`, WebAuthn origin, mailer links) resolvable to a client-chosen authority.

- New boot initializer `Onetime::Initializers::ConfigureRack` pins the priority to `[:x_forwarded]` once per process. Not fork-sensitive; no cleanup.
- `StripForwardedHost` keeps its env-level strip as belt-and-brace (Otto depth-mode `Forwarded` IP resolution still reads the raw header; the priority is process-global state a later require could reset). Comments updated to say why both exist.
- Changelog fragment under Security.

## Operator note

The pin governs every `forwarded_*` reader in Rack (host, port, proto). An edge that speaks only `Forwarded` must also emit `X-Forwarded-Proto` for TLS scheme detection. That is the Caddy default and the documented proxy configuration.

## Follow-up

Stacked PR upgrades to otto 2.10, which pins the priority itself when `trusted_proxy_header` is set, and removes this initializer.

## Test plan

- [x] `tests/lanes/run unit --only spec/unit/onetime/initializers/configure_rack_spec.rb` (12 examples)
- [x] `tests/lanes/run unit --only spec/unit/onetime/middleware/strip_forwarded_host_spec.rb` (12 examples)
- [ ] CI
