### PR TITLE
Update Redis container; bump container version in README

### DIFF
--- a/.github/workflows/compose-smoke.yml
+++ b/.github/workflows/compose-smoke.yml
@@ -326,7 +326,7 @@ jobs:
       # The README quick start, run verbatim (the two `docker run` commands and
       # the secret-file step from README §Quick start).
       - name: Start Redis (README step 1)
-        run: docker run -p 6379:6379 -d redis:bookworm
+        run: docker run -p 6379:6379 -d redis:trixie
 
       - name: Generate persistent secret key (README step 2)
         run: |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ recipient ever sees the contents.
 
 ```bash
 # 1. Start Redis
-docker run -p 6379:6379 -d redis:bookworm
+docker run -p 6379:6379 -d redis:trixie
 
 # 2. Generate and store a persistent secret key — back this up safely
 openssl rand -hex 32 > .ots_secret && chmod 600 .ots_secret
@@ -26,7 +26,7 @@ docker run -p 3000:3000 -d \
   -e SECRET="$(cat .ots_secret)" \
   -e HOST=localhost:3000 \
   -e SSL=false \
-  onetimesecret/onetimesecret:v0.26.9
+  onetimesecret/onetimesecret:v0.26.10
 ```
 
 Open <http://localhost:3000>, then create an admin ("colonel") account — it

--- a/docker/compose/docker-compose.full.yml
+++ b/docker/compose/docker-compose.full.yml
@@ -56,7 +56,7 @@ services:
   app:
     # Default tag is kept in lockstep with the README quick-start pin.
     # Bump both together at release time (see docker/README.md).
-    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.9}
+    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.10}
     container_name: onetime-app
     depends_on:
       maindb:
@@ -191,7 +191,7 @@ services:
       start_period: 30s
 
   worker-email:
-    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.9}
+    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.10}
     container_name: onetime-worker-email
     depends_on:
       maindb:
@@ -234,7 +234,7 @@ services:
       - app-data:/app/data
 
   scheduler:
-    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.9}
+    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.10}
     container_name: onetime-scheduler
     depends_on:
       maindb:

--- a/docker/compose/docker-compose.simple.yml
+++ b/docker/compose/docker-compose.simple.yml
@@ -19,7 +19,7 @@ services:
   app:
     # Default tag is kept in lockstep with the README quick-start pin.
     # Bump both together at release time (see docker/README.md).
-    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.9}
+    image: onetimesecret/onetimesecret:${OTS_IMAGE_TAG:-v0.26.10}
     container_name: onetime-app
     depends_on:
       maindb:


### PR DESCRIPTION
## Summary

Update Redis container from Bookworm to Trixie base. Bookworm is EOL since 2026-07-12;
Update `onetimesecret` from `v0.26.9` to latest `v0.26.10` in README

## Related Issues

Fixes #4380

## Test Plan

Tested on local instance
- Host: Debian 13 (Trixie) ARM64
- Docker version 29.8.0, build 88096ef