### PR TITLE
Exclude Forwarded from detected-host precedence

### DIFF
--- a/.env.reference
+++ b/.env.reference
@@ -1314,11 +1314,13 @@ TRUSTED_PROXY_HEADER=X-Forwarded-For
 # SECURITY: listing a range here is a full infrastructure-trust grant, not
 # just client-IP trust. Requests arriving from these ranges also have their
 # forwarded HOST headers honored (X-Forwarded-Host, X-Original-Host,
-# Apx-Incoming-Host, Forwarded) for custom-domain detection. The proxy MUST
+# Apx-Incoming-Host) for custom-domain detection. The proxy MUST
 # therefore set or strip those headers itself rather than pass them through
 # from clients — a pass-through proxy lets a client pick the tenant domain
 # the app renders. This is the same requirement stated above for
-# X-Forwarded-For, extended to the host headers.
+# X-Forwarded-For, extended to the host headers. RFC 7239 Forwarded's host=
+# parameter is never a host source: an edge that carries the public host
+# only there must preserve Host or send X-Forwarded-Host instead.
 #TRUSTED_PROXY_CIDRS=
 
 # depth mode only: number of proxy hops to skip from the right. Default: 1.

--- a/changelog.d/20260906_203014_delano_4121_detect_host_forwarded_precedence.rst
+++ b/changelog.d/20260906_203014_delano_4121_detect_host_forwarded_precedence.rst
@@ -1,0 +1,9 @@
+.. A new scriv changelog fragment.
+
+Security
+--------
+
+- RFC 7239 ``Forwarded: host=`` is no longer used to determine the application
+  host. Deployments that depend on it must rewrite ``Host`` or provide
+  ``X-Forwarded-Host``, ``Apx-Incoming-Host``, or ``X-Original-Host`` through a
+  configured trusted proxy (#4121).

--- a/docs/operations/admin-network-isolation.md
+++ b/docs/operations/admin-network-isolation.md
@@ -36,8 +36,8 @@ everywhere, and says so at boot. See [When the allowlist cannot be
 enforced](#when-the-allowlist-cannot-be-enforced).
 
 If the app runs behind a reverse proxy that forwards the public hostname in a
-header (`X-Forwarded-Host`, `Apx-Incoming-Host`, `X-Original-Host`,
-`Forwarded`) rather than rewriting `Host`, you **must** configure
+header (`X-Forwarded-Host`, `Apx-Incoming-Host`, `X-Original-Host`) rather than
+rewriting `Host`, you **must** configure
 `site.network.trusted_proxy` **with the proxy's own address ranges in
 `cidrs`** — otherwise the admin gate refuses the forwarded host and both
 surfaces 404. Filter mode with no explicit CIDRs trusts every private-network
@@ -417,7 +417,7 @@ same way the rest of the stack does:
   masking](#cidr-precision-and-privacy-masking).
 - The **host** gate matches the host `Rack::DetectHost` validated, and applies
   one extra check of its own: a forwarded host header (`X-Forwarded-Host`,
-  `Apx-Incoming-Host`, `X-Original-Host`, `Forwarded`) is accepted **only** when
+  `Apx-Incoming-Host`, `X-Original-Host`) is accepted **only** when
   `env['otto.via_trusted_proxy']` is true — i.e. `site.network.trusted_proxy` is
   configured and this peer passed it. Otherwise the forwarded host must agree
   with the `Host` header, or the request is refused. See [Forwarded hosts and

--- a/docs/operations/admin-network-isolation.md
+++ b/docs/operations/admin-network-isolation.md
@@ -474,6 +474,25 @@ only when one of these holds:
 Anything else is a 404 on both surfaces, logged as `Admin surface access denied:
 forwarded host from an untrusted peer`.
 
+RFC 7239 `Forwarded` is handled separately, because it is **not a host
+source**: `Rack::DetectHost` never reads its `host=` parameter, so a request
+carrying only `Forwarded` resolves on `Host` alone. The gate still reads the
+first `host=` value and, from a peer that is not a configured trusted proxy,
+refuses the request when it names a host **other** than the one `Host` alone
+produced — the same 404 and the same log line as above. A `Forwarded` that
+agrees with `Host`, or carries no `host=`, changes nothing and is admitted as
+an ordinary `Host` request.
+
+An edge that rewrites `Host` to the origin's own name and carries the public
+hostname only in `Forwarded` is therefore outside the supported contract on
+two counts, not one. Custom-domain routing is lost, and so is
+`onetime.display_domain`: `HttpOriginOptions` stops matching the site's own
+origin, so every state-changing request from that custom domain is rejected
+with a 403 (most visibly SSO sign-in, which has no authenticity-token
+fallback; see the `MIDDLEWARE_HTTP_ORIGIN` block in `.env.reference`). Fix
+the edge: preserve `Host`, or send `X-Forwarded-Host` and configure
+`site.network.trusted_proxy`.
+
 Without this, on any install with `trusted_proxy` unset, a request to a tenant
 custom domain carrying `X-Forwarded-Host: <your canonical host>` would reach the
 admin console — the heuristic would trust it because the request arrived from

--- a/docs/operations/admin-network-isolation.md
+++ b/docs/operations/admin-network-isolation.md
@@ -476,10 +476,11 @@ forwarded host from an untrusted peer`.
 
 RFC 7239 `Forwarded` is handled separately, because it is **not a host
 source**: `Rack::DetectHost` never reads its `host=` parameter, so a request
-carrying only `Forwarded` resolves on `Host` alone. The gate still reads the
-first `host=` value and, from a peer that is not a configured trusted proxy,
-refuses the request when it names a host **other** than the one `Host` alone
-produced — the same 404 and the same log line as above. A `Forwarded` that
+carrying only `Forwarded` resolves on `Host` alone. `DetectHost` still
+records the first `host=` value beside the detected host, and the gate, from
+a peer that is not a configured trusted proxy, refuses the request when that
+value names a host **other** than the one `Host` alone produced — the same
+404 and the same log line as above. A `Forwarded` that
 agrees with `Host`, or carries no `host=`, changes nothing and is admitted as
 an ordinary `Host` request.
 

--- a/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
+++ b/docs/specs/domain-ip-allowlist/domain-ip-allowlist.md
@@ -557,12 +557,11 @@ login-only enforcement mode, Terraform provider.
 | 6 | Audit events + blocked-request logging/counter | `audit_trail.rb:60` |
 | 7 | Tests: middleware spec (`operator_host?` scope gating incl. both `:invalid` cases — no record passes through, raising read 503s — monitor/enforce, fail-closed incl. missing `otto.ip_match`, exemptions, dev override, /32 precision), model tryouts (validation matrix), logic specs, contract vitest | `spec/unit/onetime/application/middleware_stack_spec.rb` neighborhood |
 | 8 | Docs: scope contract + lockout guidance; locales (`locales:hashes` run) | this file |
-| 9 | Separate fix: `AdminNetworkIsolation` narrow-CIDR latent bug — migrate its matching to `env['otto.ip_match']` once the otto release lands, which makes `/32` admin CIDRs work instead of merely rejecting them | `admin_network_isolation.rb:110-145` |
-| 10 | ~~Upstream Otto~~ **done 2026-07-25** (`ip_in_cidrs?`, privacy profiles, `otto.ip_match`; geo gate pre-existing on main). Remaining: commit/release otto, then bump the gem here | §3; `~/Projects/dev/delano/otto` |
+| 9 | ~~Separate fix: `AdminNetworkIsolation` narrow-CIDR latent bug~~ **done** — matching uses `env['otto.ip_match']`, so `/32`–`/128` admin CIDRs are evaluated against the true client IP | `lib/onetime/middleware/admin_network_isolation.rb:625-648`; `spec/integration/all/colonel_host_allowlist_spec.rb:1110-1158` |
+| 10 | ~~Upstream Otto~~ **released and adopted** — `otto.ip_match` is available; this application requires `otto ~> 2.10` | `Gemfile`; `Gemfile.lock` |
 
-Suggested sequencing: 10 first (otto release is the dependency), then 1–2
-(enforcement path, shippable dark), 3 (API), 4–5 (UI), 6–8 alongside;
-9 after the gem bump.
+The upstream dependency and the separate admin narrow-CIDR migration are
+complete. The remaining work is 1–8.
 
 ## 6. Open questions
 

--- a/etc/defaults/config.defaults.yaml
+++ b/etc/defaults/config.defaults.yaml
@@ -913,7 +913,7 @@ site:
     # Set "*" to turn the gate off on purpose.
     #
     # A forwarded host header (X-Forwarded-Host, Apx-Incoming-Host,
-    # X-Original-Host, Forwarded) only counts toward this gate when
+    # X-Original-Host) only counts toward this gate when
     # site.network.trusted_proxy is configured AND the peer passed it. Behind a
     # proxy that forwards the public hostname instead of rewriting Host, set
     # trusted_proxy or both admin surfaces 404 (see

--- a/etc/examples/Caddyfile-example
+++ b/etc/examples/Caddyfile-example
@@ -266,18 +266,17 @@
 			# env['onetime.display_domain'], the value every custom-domain surface
 			# keys on (tenant SSO, sign-in gating, restrict_to, CSP form-action).
 			# Its precedence is X-Forwarded-Host > Apx-Incoming-Host >
-			# X-Original-Host > Forwarded > Host, and it takes the FIRST
-			# syntactically valid hostname -- it does not check whether that domain
-			# is one this install knows.
+			# X-Original-Host > Host, and it takes the FIRST syntactically valid
+			# hostname -- it does not check whether that domain is one this install
+			# knows.
 			#
-			# No host-bearing header may therefore carry a client-supplied value:
-			# X-Forwarded-Host is stripped rather than passed through, as are
-			# Apx-Incoming-Host (above, unless source-gated to Approximated) and
-			# Forwarded (below). The pinned X-Original-Host at precedence 3 only
-			# protects against carriers BELOW it -- anything above it that the
-			# proxy does not overwrite or strip remains a spoofing vector through
-			# trusted infra. Host is preserved above so Rack's request.host stays
-			# correct as well.
+			# No host-bearing header DetectHost considers may therefore carry a
+			# client-supplied value: X-Forwarded-Host is stripped rather than passed
+			# through, as is Apx-Incoming-Host (above, unless source-gated to
+			# Approximated). The pinned X-Original-Host at precedence 3 only protects
+			# against carriers BELOW it -- anything above it that the proxy does not
+			# overwrite or strip remains a spoofing vector through trusted infra.
+			# Host is preserved above so Rack's request.host stays correct as well.
 			# Passing the client's X-Forwarded-Host through instead lets any
 			# visitor shadow the real host: on an Approximated-fronted custom
 			# domain an injected X-Forwarded-Host outranks the Apx-Incoming-Host
@@ -293,10 +292,8 @@
 			# and is the sole setter of X-Forwarded-Host; declare that layer in
 			# `trusted_proxies` at the same time.
 			header_up -X-Forwarded-Host
-			# Forwarded (RFC 7239, precedence 4) is currently masked by the pinned
-			# X-Original-Host one slot above it -- but that is an ordering
-			# accident, not a policy. Strip it so host detection never depends on
-			# that invariant holding.
+			# DetectHost ignores RFC 7239 Forwarded, but Rack can still use it for
+			# request.host. Strip it so clients cannot steer Rack's host resolution.
 			header_up -Forwarded
 			header_up X-Forwarded-Proto {http.request.scheme}
 			header_up X-Geo-Country {http.request.header.X-Geo-Country}

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -36,10 +36,10 @@ module Rack
   # 1. `X-Forwarded-Host` - Commonly used by proxies and load balancers.
   # 2. `Apx-Incoming-Host` - Approximated.app custom-domain ingress.
   # 3. `X-Original-Host` - Used by various proxy services.
-  # 4. `Forwarded` - RFC 7239 standard; the first `host=` parameter is
-  #    extracted (via `Rack::Utils.forwarded_values`), with quoted values
-  #    and ports handled per the RFC.
-  # 5. `Host` - Default HTTP host header.
+  # 4. `Host` - Default HTTP host header.
+  #
+  # RFC 7239 `Forwarded` is deliberately excluded. Its `host=` parameter is
+  # not part of this application's proxy-managed host-header contract.
   #
   # It also includes validation to filter out invalid or local hosts (e.g.,
   # `localhost`, `127.0.0.1`) and IP addresses, ensuring only legitimate
@@ -70,8 +70,8 @@ module Rack
   # ### Security Considerations
   #
   # **Trusted Proxy Validation**: This middleware only trusts forwarded host
-  # headers (X-Forwarded-Host, X-Original-Host, Apx-Incoming-Host, Forwarded)
-  # when the request arrived via a trusted reverse proxy. The otto trust key
+  # headers (X-Forwarded-Host, X-Original-Host, Apx-Incoming-Host) when the
+  # request arrived via a trusted reverse proxy. The otto trust key
   # is TRI-STATE (otto#228) and, when present, authoritative in BOTH
   # directions:
   #
@@ -124,13 +124,14 @@ module Rack
       # is why the IIS originals (X-Original-URL, X-Rewrite-URL) and
       # X-Forwarded-Server (names the proxy itself) are absent — add a
       # header only together with proxy-config guidance that sanitizes it.
-      # Scheme-only headers (X-Forwarded-Proto, CF-Visitor, ...) don't
-      # belong here either: this middleware detects hosts, not schemes.
+      # RFC 7239 Forwarded is deliberately excluded: no proxy deployment
+      # contract manages its host= parameter. Scheme-only headers
+      # (X-Forwarded-Proto, CF-Visitor, ...) don't belong here either: this
+      # middleware detects hosts, not schemes.
       FORWARDED_HEADERS = [
         'X-Forwarded-Host',   # Common proxy header (AWS ALB, nginx)
         'Apx-Incoming-Host',  # Approximated-specific (approximated.app custom-domain ingress); like all forwarded headers, only honored behind trusted infra
         'X-Original-Host',    # Various proxy services
-        'Forwarded',          # RFC 7239 standard (host parameter)
       ].freeze
 
       # List of HTTP headers that might contain the host, in order of precedence.

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -4,7 +4,6 @@
 
 require 'ipaddr'
 require 'otto/env_keys'
-require 'rack/utils'
 require_relative 'logging'
 
 module Rack
@@ -244,7 +243,7 @@ module Rack
       # Try headers in order of precedence
       headers_to_check.each do |header|
         header_key = "HTTP_#{header.tr('-', '_').upcase}"
-        host       = self.class.normalize_host(env[header_key], forwarded: header == 'Forwarded')
+        host       = self.class.normalize_host(env[header_key])
         next if host.nil?
 
         if self.class.valid_domain_name?(host)
@@ -317,45 +316,15 @@ module Rack
       # Extracts and normalizes the host from a header value.
       #
       # @param value_unsafe [String, nil] Raw header value from the request
-      # @param forwarded [Boolean] Whether the value uses RFC 7239 Forwarded syntax
       # @return [String, nil] Normalized host without port number, or nil if empty
       #
-      # This method:
-      # - Takes the first host if multiple are provided (comma-separated)
-      # - Extracts the first host parameter from RFC 7239 Forwarded values
-      # - Delegates to DomainParser for port stripping and normalization
-      # - Returns nil for empty values
-      def normalize_host(value_unsafe, forwarded: false)
-        first_host = if forwarded
-          forwarded_host(value_unsafe)
-        else
-          # Handle comma-separated hosts (e.g., X-Forwarded-Host header)
-          value_unsafe.to_s.split(',').first.to_s
-        end
+      # Takes the first host if multiple are provided (comma-separated), then
+      # delegates port stripping and normalization to DomainParser.
+      def normalize_host(value_unsafe)
+        first_host = value_unsafe.to_s.split(',').first.to_s
 
-        # Delegate core normalization to DomainParser
         Onetime::Utils::DomainParser.extract_hostname(first_host)
       end
-
-      # Extracts the first host parameter from an RFC 7239 Forwarded value.
-      #
-      # Parsing is delegated to Rack::Utils.forwarded_values, which handles
-      # quoted strings and escape sequences, bounds parameter and escape
-      # counts against denial of service, and fails closed (nil) on
-      # malformed input or unknown parameter names — letting the next header
-      # in the precedence list be considered. Element boundaries are
-      # flattened: the earliest host parameter anywhere in the header wins,
-      # mirroring the first-value convention used for X-Forwarded-Host.
-      def forwarded_host(value_unsafe)
-        case Rack::Utils.forwarded_values(value_unsafe)
-        in { host: [first_host, *] }
-          first_host
-        else
-          nil
-        end
-      end
-
-      private :forwarded_host
 
       # Determines if a string is a valid host for use in this application.
       #

--- a/lib/middleware/detect_host.rb
+++ b/lib/middleware/detect_host.rb
@@ -4,6 +4,7 @@
 
 require 'ipaddr'
 require 'otto/env_keys'
+require 'rack/utils'
 require_relative 'logging'
 
 module Rack
@@ -38,7 +39,11 @@ module Rack
   # 4. `Host` - Default HTTP host header.
   #
   # RFC 7239 `Forwarded` is deliberately excluded. Its `host=` parameter is
-  # not part of this application's proxy-managed host-header contract.
+  # not part of this application's proxy-managed host-header contract. It is
+  # still OBSERVED: the first `host=`, validated like any forwarded host, is
+  # published to `env[rfc7239_host_field_name]` (never selected) so that the
+  # admin-surface provenance rule can refuse a Host-rewriting edge that
+  # carries the public host only there. See `.rfc7239_host`.
   #
   # It also includes validation to filter out invalid or local hosts (e.g.,
   # `localhost`, `127.0.0.1`) and IP addresses, ensuring only legitimate
@@ -158,6 +163,16 @@ module Rack
 
     class << self
       attr_accessor :result_field_name
+
+      # Env key under which the observed RFC 7239 `host=` is published — a
+      # sidecar of result_field_name, so a renamed result field carries its
+      # observation with it. Absent when the request has no readable, valid
+      # `host=`.
+      #
+      # @return [String]
+      def rfc7239_host_field_name
+        "#{result_field_name}.rfc7239_host"
+      end
     end
 
     # Initializes the middleware with the application and logging options.
@@ -267,6 +282,13 @@ module Rack
       # e.g. env['rack.detected_host'] = 'example.com'
       env[result_field_name] = detected_host
 
+      # Observation only, never a source (see the class doc): what RFC 7239
+      # Forwarded ASSERTS the host is, published for the admin-surface
+      # provenance rule regardless of peer trust — trust is that rule's
+      # decision, not this one's.
+      rfc7239_host                            = self.class.rfc7239_host(env['HTTP_FORWARDED'])
+      env[self.class.rfc7239_host_field_name] = rfc7239_host if rfc7239_host
+
       @app.call(env)
     end
 
@@ -324,6 +346,36 @@ module Rack
         first_host = value_unsafe.to_s.split(',').first.to_s
 
         Onetime::Utils::DomainParser.extract_hostname(first_host)
+      end
+
+      # The host an RFC 7239 Forwarded value asserts, or nil.
+      #
+      # @param value_unsafe [String, nil] Raw Forwarded header value
+      # @return [String, nil] The first `host=` parameter, normalized and
+      #   validated exactly as a forwarded host header would be, or nil when
+      #   there is none, Rack's parser rejects the value as malformed, or the
+      #   host would not have been accepted from any forwarded header (an IP
+      #   literal, localhost, a malformed name)
+      #
+      # Parsing is delegated to Rack::Utils.forwarded_values, which handles
+      # quoted strings and escape sequences, bounds parameter and escape
+      # counts against denial of service, and returns an empty hash on
+      # malformed input. Element boundaries are flattened: the earliest
+      # `host=` anywhere in the header wins, mirroring the first-value
+      # convention used for X-Forwarded-Host.
+      def rfc7239_host(value_unsafe)
+        return nil if value_unsafe.nil?
+
+        first = case Rack::Utils.forwarded_values(value_unsafe)
+                in { host: [first_host, *] }
+                  first_host
+                else
+                  nil
+                end
+        host  = normalize_host(first)
+        return nil if host.nil? || !valid_domain_name?(host)
+
+        host
       end
 
       # Determines if a string is a valid host for use in this application.

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -98,7 +98,7 @@ module Onetime
     # ## make, and cannot make for us)
     #
     # DetectHost honors a forwarded host header (X-Forwarded-Host,
-    # Apx-Incoming-Host, X-Original-Host, Forwarded) when EITHER the operator
+    # Apx-Incoming-Host, X-Original-Host) when EITHER the operator
     # configured proxy trust and this peer passed it (otto writes
     # env['otto.via_trusted_proxy'] = true) OR — with no proxy trust configured
     # at all, the SHIPPED DEFAULT — a legacy heuristic: any peer whose

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -3,7 +3,6 @@
 # frozen_string_literal: true
 
 require 'otto/utils'
-require 'rack/utils'
 
 require_relative '../../middleware/detect_host'
 require_relative '../utils/admin_host_allowlist'
@@ -125,14 +124,17 @@ module Onetime
     #
     # And, checked before (b): an RFC 7239 `Forwarded` header whose first
     # host= parameter names a host OTHER than the one `Host` alone produces is
-    # denied from an untrusted peer (d). DetectHost ignores that parameter
-    # outright (#4121), so the detected host is the Host-derived one and rules
-    # (b)/(c) would wave it through — but the topology that sends it is the
-    # same one (a)-(c) exist for: an edge that rewrote `Host` to the origin's
-    # own (canonical, allowlisted) name and carried the public host only in
-    # `Forwarded`. Admitting on `Host` there would serve the admin console on
-    # every tenant-domain request. A `Forwarded` that agrees with `Host`, or
-    # carries no readable host=, changed nothing and is not a claim.
+    # denied from an untrusted peer (d). DetectHost never SELECTS that
+    # parameter (#4121), so the detected host is the Host-derived one and
+    # rules (b)/(c) would wave it through — but the topology that sends it is
+    # the same one (a)-(c) exist for: an edge that rewrote `Host` to the
+    # origin's own (canonical, allowlisted) name and carried the public host
+    # only in `Forwarded`. Admitting on `Host` there would serve the admin
+    # console on every tenant-domain request. DetectHost OBSERVES the value
+    # and publishes it at env[Rack::DetectHost.rfc7239_host_field_name]; this
+    # gate reads that, never the raw header. A `Forwarded` that agrees with
+    # `Host`, or carries no readable host=, changed nothing and is not a
+    # claim.
     #
     # Otherwise the request is DENIED. It is not silently downgraded to the
     # HTTP_HOST-derived host: in the topology this defends (Approximated-style
@@ -297,11 +299,11 @@ module Onetime
         "HTTP_#{header.tr('-', '_').upcase}"
       end.freeze
 
-      # RFC 7239 Forwarded. Deliberately NOT in the list above: DetectHost does
-      # not read its host= parameter (#4121), so it never produces a detected
-      # host and presence alone proves nothing. It is judged by VALUE instead
-      # — see rule (d) in the class doc and #rfc7239_host_disagrees?.
-      RFC7239_FORWARDED_ENV_KEY = 'HTTP_FORWARDED'
+      # RFC 7239 Forwarded is deliberately NOT in that list: DetectHost never
+      # selects its host= parameter (#4121), so presence alone proves nothing.
+      # It is judged by VALUE — the one DetectHost observed and published at
+      # env[Rack::DetectHost.rfc7239_host_field_name] — see rule (d) in the
+      # class doc and #rfc7239_host_disagrees?.
 
       # Path used when the request path cannot be normalized at all. Fails
       # CLOSED: an unparseable path is judged as an admin surface, so a
@@ -622,27 +624,18 @@ module Onetime
         FORWARDED_HOST_ENV_KEYS.any? { |key| env.key?(key) }
       end
 
-      # Whether an RFC 7239 Forwarded header claims a host OTHER than the one
-      # the Host header alone produced. The first host= parameter is read, the
-      # same first-value convention DetectHost applies to X-Forwarded-Host, and
-      # normalized identically to the detected host. Rack::Utils.forwarded_values
-      # bounds parameter and escape counts and returns an empty hash for
-      # malformed input, so a Forwarded with no readable host= is no claim at
-      # all — nothing overrode Host, and there is nothing to distrust.
+      # Whether RFC 7239 Forwarded asserted a host OTHER than the one the Host
+      # header alone produced. The assertion is DetectHost's observation
+      # (Rack::DetectHost.rfc7239_host: first host= parameter, parsed, then
+      # normalized and validated like any forwarded host), read from the env
+      # key it publishes — the raw header is never parsed here. Absent means
+      # no readable, valid host= — nothing overrode Host, nothing to distrust.
       #
       # @param env [Hash] the Rack env
       # @param host_from_host_header [String, nil] see #host_header_host
       # @return [Boolean]
       def rfc7239_host_disagrees?(env, host_from_host_header)
-        raw = env[RFC7239_FORWARDED_ENV_KEY]
-        return false if raw.nil?
-
-        claimed = case Rack::Utils.forwarded_values(raw)
-                  in { host: [first, *] }
-                    normalize_host(Rack::DetectHost.normalize_host(first))
-                  else
-                    nil
-                  end
+        claimed = normalize_host(env[Rack::DetectHost.rfc7239_host_field_name])
         return false if claimed.nil? || claimed.empty?
 
         claimed != host_from_host_header

--- a/lib/onetime/middleware/admin_network_isolation.rb
+++ b/lib/onetime/middleware/admin_network_isolation.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'otto/utils'
+require 'rack/utils'
 
 require_relative '../../middleware/detect_host'
 require_relative '../utils/admin_host_allowlist'
@@ -121,6 +122,17 @@ module Onetime
     #   c. one is present but the detected host EQUALS the host the Host header
     #      alone would have produced — the forwarded header did not change the
     #      answer, so there is nothing to distrust.
+    #
+    # And, checked before (b): an RFC 7239 `Forwarded` header whose first
+    # host= parameter names a host OTHER than the one `Host` alone produces is
+    # denied from an untrusted peer (d). DetectHost ignores that parameter
+    # outright (#4121), so the detected host is the Host-derived one and rules
+    # (b)/(c) would wave it through — but the topology that sends it is the
+    # same one (a)-(c) exist for: an edge that rewrote `Host` to the origin's
+    # own (canonical, allowlisted) name and carried the public host only in
+    # `Forwarded`. Admitting on `Host` there would serve the admin console on
+    # every tenant-domain request. A `Forwarded` that agrees with `Host`, or
+    # carries no readable host=, changed nothing and is not a claim.
     #
     # Otherwise the request is DENIED. It is not silently downgraded to the
     # HTTP_HOST-derived host: in the topology this defends (Approximated-style
@@ -284,6 +296,12 @@ module Onetime
       FORWARDED_HOST_ENV_KEYS = Rack::DetectHost::FORWARDED_HEADERS.map do |header|
         "HTTP_#{header.tr('-', '_').upcase}"
       end.freeze
+
+      # RFC 7239 Forwarded. Deliberately NOT in the list above: DetectHost does
+      # not read its host= parameter (#4121), so it never produces a detected
+      # host and presence alone proves nothing. It is judged by VALUE instead
+      # — see rule (d) in the class doc and #rfc7239_host_disagrees?.
+      RFC7239_FORWARDED_ENV_KEY = 'HTTP_FORWARDED'
 
       # Path used when the request path cannot be normalized at all. Fails
       # CLOSED: an unparseable path is judged as an admin surface, so a
@@ -500,7 +518,8 @@ module Onetime
               host: host,
               path: full_path,
               method: env['REQUEST_METHOD'],
-              note: 'a forwarded host header changed the detected host, but the peer is not a configured ' \
+              note: 'a forwarded host header changed the detected host (or RFC 7239 Forwarded named a ' \
+                    'different host than Host), but the peer is not a configured ' \
                     'trusted proxy. Set site.network.trusted_proxy with explicit proxy CIDRs — filter mode ' \
                     'with none listed trusts every private peer — or ADMIN_ALLOWED_HOSTS=* to turn the gate off',
             }
@@ -578,6 +597,14 @@ module Onetime
         # detected) instead of blaming a proxy the operator may not have.
         return true if host.nil? || host.empty?
 
+        host_from_host_header = host_header_host(env)
+
+        # (d) RFC 7239 Forwarded names a host other than what the Host header
+        # alone produced. DetectHost ignored it, so `host` is the Host-derived
+        # one and (b)/(c) below would admit — on exactly the Host-rewriting
+        # topology (a)-(c) refuse to fall back to Host for. See the class doc.
+        return false if rfc7239_host_disagrees?(env, host_from_host_header)
+
         # (b) Nothing that could have overridden the Host header is present.
         return true unless forwarded_host_header?(env)
 
@@ -585,13 +612,40 @@ module Onetime
         # detected host is what the Host header alone would have produced.
         # Both sides go through DetectHost's OWN extraction before ours, so
         # this compares what DetectHost compared.
-        host == host_header_host(env)
+        host == host_from_host_header
       end
 
       # Whether the request carries any host header DetectHost would honor from
-      # a trusted peer. Presence only — the VALUE is never read here.
+      # a trusted peer. Presence only — the VALUE is never read here. (RFC 7239
+      # Forwarded is the one header judged by value; see #rfc7239_host_disagrees?.)
       def forwarded_host_header?(env)
         FORWARDED_HOST_ENV_KEYS.any? { |key| env.key?(key) }
+      end
+
+      # Whether an RFC 7239 Forwarded header claims a host OTHER than the one
+      # the Host header alone produced. The first host= parameter is read, the
+      # same first-value convention DetectHost applies to X-Forwarded-Host, and
+      # normalized identically to the detected host. Rack::Utils.forwarded_values
+      # bounds parameter and escape counts and returns an empty hash for
+      # malformed input, so a Forwarded with no readable host= is no claim at
+      # all — nothing overrode Host, and there is nothing to distrust.
+      #
+      # @param env [Hash] the Rack env
+      # @param host_from_host_header [String, nil] see #host_header_host
+      # @return [Boolean]
+      def rfc7239_host_disagrees?(env, host_from_host_header)
+        raw = env[RFC7239_FORWARDED_ENV_KEY]
+        return false if raw.nil?
+
+        claimed = case Rack::Utils.forwarded_values(raw)
+                  in { host: [first, *] }
+                    normalize_host(Rack::DetectHost.normalize_host(first))
+                  else
+                    nil
+                  end
+        return false if claimed.nil? || claimed.empty?
+
+        claimed != host_from_host_header
       end
 
       # The host the `Host:` header alone would have produced, normalized

--- a/scripts/host-seam/topology-probe.sh
+++ b/scripts/host-seam/topology-probe.sh
@@ -25,7 +25,8 @@
 # host from an UNTRUSTED source. Rack 3.2.7's `request.host` prefers
 # `X-Forwarded-Host`/`Forwarded` from any client, ungated by proxy trust, so a
 # release that lets an attacker-supplied host reach `O-Display-Domain` is a
-# finding in its own right.
+# finding in its own right. T7 doubles as the exclusion pin for RFC 7239
+# `Forwarded`, which DetectHost no longer reads at all (#4121).
 #
 # This probe is state-dependent for the SSO column only: it needs a
 # CustomDomain + enabled SsoConfig for --custom-host. Seed it with
@@ -66,7 +67,7 @@ TSV=0
 TENANT_ID="host-seam-tenant"
 EVIL="evil.attacker.example"
 
-usage() { sed -n '2,56p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
+usage() { sed -n '2,57p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 2; }
 # NOTE: usage() prints the header comment block; keep its sed range in sync
 # when the block above grows or shrinks.
 
@@ -111,14 +112,17 @@ ORIGIN="${ORIGIN:-origin-target.internal}"
 # "-" means the header is not sent. Expected strategy is what DomainStrategy
 # SHOULD resolve when the probe source is inside the trusted-proxy set.
 #
-# All four forwarded carriers are covered because production demonstrably uses
-# more than one: the 2026-08-20 capture shows DetectHost resolving one host
-# `via HTTP_APX_INCOMING_HOST` and another `via HTTP_X_ORIGINAL_HOST` in the
-# same window. A harness that only exercised Apx-Incoming-Host would miss half
-# the live ingress paths.
+# All three managed forwarded carriers are covered because production
+# demonstrably uses more than one: the 2026-08-20 capture shows DetectHost
+# resolving one host `via HTTP_APX_INCOMING_HOST` and another
+# `via HTTP_X_ORIGINAL_HOST` in the same window. A harness that only exercised
+# Apx-Incoming-Host would miss half the live ingress paths. RFC 7239
+# `Forwarded` is sent too (T7), as the control that it is IGNORED.
 #
 # DetectHost precedence (detect_host.rb HEADER_PRECEDENCE) is:
-#   X-Forwarded-Host > Apx-Incoming-Host > X-Original-Host > Forwarded > Host
+#   X-Forwarded-Host > Apx-Incoming-Host > X-Original-Host > Host
+# `Forwarded` (RFC 7239) is not in the list: its host= parameter is never a
+# host source (#4121).
 # ---------------------------------------------------------------------------
 TOPOLOGIES=(
   "T1-direct-canonical|${CANONICAL}|-|-|-|-|canonical"
@@ -129,7 +133,11 @@ TOPOLOGIES=(
   "T4-apx-rewrite-xfh|${ORIGIN}|${CUSTOM}|${CUSTOM}|-|-|custom"
   "T5-xfh-only|${ORIGIN}|-|${CUSTOM}|-|-|custom"
   "T6-xoh-only|${ORIGIN}|-|-|${CUSTOM}|-|custom"
-  "T7-forwarded-only|${ORIGIN}|-|-|-|${CUSTOM}|custom"
+  # T7: RFC 7239 `Forwarded: host=` is NOT a host source since #4121. The
+  # request resolves on `Host:` alone — the unknown inbound target — and
+  # DomainStrategy falls back to canonical. `custom` here would mean the
+  # Forwarded host= parameter is being honored again.
+  "T7-forwarded-only|${ORIGIN}|-|-|-|${CUSTOM}|canonical"
   # T8: the inbound target IS the canonical host. A consumer reading the raw
   # Host header lands in the `canonical_domain?` branch of the omniauth setup
   # hook (platform-level request) instead of the tenant-fallback branch, so it

--- a/spec/integration/all/colonel_host_allowlist_spec.rb
+++ b/spec/integration/all/colonel_host_allowlist_spec.rb
@@ -978,15 +978,33 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
         expect(last_response.status).to eq(404)
       end
 
-      # `Forwarded` is not a proxy-managed host header. DetectHost ignores its
-      # host= parameter and AdminNetworkIsolation derives its presence set from
-      # DetectHost::FORWARDED_HEADERS, so it must not turn an ordinary Host
-      # request into a provenance refusal.
-      it 'treats a Forwarded-only request as an ordinary Host request' do
+      # `Forwarded` is not a proxy-managed host header: DetectHost ignores its
+      # host= parameter (#4121), so it is absent from the presence set the gate
+      # derives from DetectHost::FORWARDED_HEADERS. The gate still judges it by
+      # VALUE (rule d): an edge that rewrote Host to the canonical origin and
+      # carried the tenant host only in Forwarded must not have the admin
+      # console served on every tenant-domain request just because Host is on
+      # the allowlist.
+      it 'refuses a Forwarded host= that disagrees with Host from an untrusted peer' do
         expect(Onetime::Middleware::AdminNetworkIsolation::FORWARDED_HOST_ENV_KEYS).not_to include('HTTP_FORWARDED')
 
         signed_in_as(colonel)
         get_api('example.com', heuristic_peer.merge('HTTP_FORWARDED' => 'host=tenant.example.com'))
+
+        expect(last_response.status).to eq(404)
+      end
+
+      it 'admits a Forwarded host= that agrees with Host from an untrusted peer' do
+        signed_in_as(colonel)
+        get_api('example.com', heuristic_peer.merge('HTTP_FORWARDED' => 'for=203.0.113.9;host="example.com:443"'))
+
+        expect(last_response.status).to eq(200)
+        expect(json_body).to have_key('details')
+      end
+
+      it 'admits a disagreeing Forwarded host= from a peer otto vouched for (control)' do
+        signed_in_as(colonel)
+        get_api('example.com', trusted_peer.merge('HTTP_FORWARDED' => 'host=tenant.example.com'))
 
         expect(last_response.status).to eq(200)
         expect(json_body).to have_key('details')

--- a/spec/integration/all/colonel_host_allowlist_spec.rb
+++ b/spec/integration/all/colonel_host_allowlist_spec.rb
@@ -978,11 +978,18 @@ RSpec.describe 'Colonel admin surface host allowlist (#4062)', type: :integratio
         expect(last_response.status).to eq(404)
       end
 
-      it 'ignores an RFC 7239 Forwarded host from an untrusted REMOTE_ADDR' do
-        signed_in_as(colonel)
-        get_api('tenant.example.com', untrusted_peer.merge('HTTP_FORWARDED' => 'host=example.com'))
+      # `Forwarded` is not a proxy-managed host header. DetectHost ignores its
+      # host= parameter and AdminNetworkIsolation derives its presence set from
+      # DetectHost::FORWARDED_HEADERS, so it must not turn an ordinary Host
+      # request into a provenance refusal.
+      it 'treats a Forwarded-only request as an ordinary Host request' do
+        expect(Onetime::Middleware::AdminNetworkIsolation::FORWARDED_HOST_ENV_KEYS).not_to include('HTTP_FORWARDED')
 
-        expect(last_response.status).to eq(404)
+        signed_in_as(colonel)
+        get_api('example.com', heuristic_peer.merge('HTTP_FORWARDED' => 'host=tenant.example.com'))
+
+        expect(last_response.status).to eq(200)
+        expect(json_body).to have_key('details')
       end
 
       it 'ignores a forwarded header even when it names an allowlisted host and the shell is asked for' do

--- a/try/integration/middleware/detect_host_try.rb
+++ b/try/integration/middleware/detect_host_try.rb
@@ -8,7 +8,7 @@
 # and IP addresses.
 #
 # We're testing:
-# 1. Header precedence (X-Forwarded-Host, X-Original-Host, Forwarded, Host)
+# 1. Header precedence (X-Forwarded-Host, Apx-Incoming-Host, X-Original-Host, Host)
 # 2. Host validation (reject localhost, IPs)
 # 3. Port stripping
 # 4. Multiple host handling
@@ -84,7 +84,7 @@ env = { 'REMOTE_ADDR' => '192.168.1.1', 'HTTP_X_FORWARDED_HOST' => 'first.com, s
 env['rack.detected_host']
 #=> 'first.com'
 
-## Extracts host from the first RFC 7239 Forwarded element
+## Ignores RFC 7239 Forwarded host parameters, even from a trusted proxy
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
   'HTTP_FORWARDED' => 'for=203.0.113.7;host=forwarded.example.com;proto=https',
@@ -92,9 +92,9 @@ env = {
 }
 @middleware.call(env)
 env['rack.detected_host']
-#=> 'forwarded.example.com'
+#=> 'fallback.example.com'
 
-## Handles a quoted RFC 7239 host value and strips its port
+## Ignores quoted RFC 7239 host parameters, even from a trusted proxy
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
   'HTTP_FORWARDED' => 'for=203.0.113.7;host="Forwarded.Example.COM:8443";proto=https',
@@ -102,9 +102,9 @@ env = {
 }
 @middleware.call(env)
 env['rack.detected_host']
-#=> 'forwarded.example.com'
+#=> 'fallback.example.com'
 
-## Honors only the first Forwarded element, without splitting on quoted commas
+## Ignores Forwarded host parameters in every element
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
   'HTTP_FORWARDED' => 'for="client,alias";host=first.example.com, for=203.0.113.8;host=second.example.com',
@@ -112,11 +112,9 @@ env = {
 }
 @middleware.call(env)
 env['rack.detected_host']
-#=> 'first.example.com'
+#=> 'fallback.example.com'
 
-## Uses the earliest host parameter when the first element lacks one,
-## mirroring Rack::Utils.forwarded_values and the X-Forwarded-Host
-## first-value convention
+## Ignores a later Forwarded host parameter when the first element lacks one
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
   'HTTP_FORWARDED' => 'for=203.0.113.7;proto=https, for=203.0.113.8;host=second.example.com',
@@ -124,9 +122,9 @@ env = {
 }
 @middleware.call(env)
 env['rack.detected_host']
-#=> 'second.example.com'
+#=> 'fallback.example.com'
 
-## Falls back when no Forwarded element carries a host parameter
+## Ignores Forwarded when no element carries a host parameter
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
   'HTTP_FORWARDED' => 'for=203.0.113.7;proto=https, for=203.0.113.8;proto=https',
@@ -136,7 +134,7 @@ env = {
 env['rack.detected_host']
 #=> 'fallback.example.com'
 
-## A non-RFC bare hostname in Forwarded is not a host parameter; falls back
+## Ignores a non-RFC bare hostname in Forwarded and falls back
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
   'HTTP_FORWARDED' => 'legacy.example.com',
@@ -146,7 +144,7 @@ env = {
 env['rack.detected_host']
 #=> 'fallback.example.com'
 
-## A bracketed IPv6 Forwarded host is rejected (domain names required)
+## Ignores a bracketed IPv6 Forwarded host and falls back
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
   'HTTP_FORWARDED' => 'for=203.0.113.7;host="[2001:db8::1]:8443"',
@@ -189,7 +187,7 @@ env = {
 env['rack.detected_host']
 #=> 'fallback.example.com'
 
-## A malformed quoted Forwarded value fails closed and falls back to Host
+## Ignores a malformed quoted Forwarded value and falls back to Host
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
   'HTTP_FORWARDED' => 'for=203.0.113.7;host="unterminated.example.com',

--- a/try/integration/middleware/detect_host_try.rb
+++ b/try/integration/middleware/detect_host_try.rb
@@ -94,6 +94,22 @@ env = {
 env['rack.detected_host']
 #=> 'fallback.example.com'
 
+## ...but OBSERVES the host= it ignored, published beside the result for the
+## admin-surface provenance rule (rule d in AdminNetworkIsolation)
+env['rack.detected_host.rfc7239_host']
+#=> 'forwarded.example.com'
+
+## The observation is published regardless of peer trust — trust is the
+## provenance rule's decision, not DetectHost's
+env = {
+  'REMOTE_ADDR' => '203.0.113.9',
+  'HTTP_FORWARDED' => 'host=forwarded.example.com',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+[env['rack.detected_host'], env['rack.detected_host.rfc7239_host']]
+#=> ['fallback.example.com', 'forwarded.example.com']
+
 ## Ignores quoted RFC 7239 host parameters, even from a trusted proxy
 env = {
   'REMOTE_ADDR' => '192.168.1.1',
@@ -103,6 +119,50 @@ env = {
 @middleware.call(env)
 env['rack.detected_host']
 #=> 'fallback.example.com'
+
+## ...and the observation is normalized like any forwarded host: unquoted,
+## port stripped, lowercased
+env['rack.detected_host.rfc7239_host']
+#=> 'forwarded.example.com'
+
+## Only the FIRST host= is observed, the same first-value convention as
+## X-Forwarded-Host
+env = {
+  'HTTP_FORWARDED' => 'host=first.example.com, host=second.example.com',
+  'HTTP_HOST' => 'fallback.example.com',
+}
+@middleware.call(env)
+env['rack.detected_host.rfc7239_host']
+#=> 'first.example.com'
+
+## No observation without a host= parameter
+env = { 'HTTP_FORWARDED' => 'for=203.0.113.7;proto=https', 'HTTP_HOST' => 'fallback.example.com' }
+@middleware.call(env)
+env.key?('rack.detected_host.rfc7239_host')
+#=> false
+
+## No observation when Rack's parser rejects the value as malformed
+env = { 'HTTP_FORWARDED' => 'host=;;;=garbage', 'HTTP_HOST' => 'fallback.example.com' }
+@middleware.call(env)
+env.key?('rack.detected_host.rfc7239_host')
+#=> false
+
+## No observation for a host= no forwarded header would have been accepted
+## for either: an IP literal or localhost
+env = { 'HTTP_FORWARDED' => 'host=127.0.0.1', 'HTTP_HOST' => 'fallback.example.com' }
+@middleware.call(env)
+env.key?('rack.detected_host.rfc7239_host')
+#=> false
+
+## No observation without a Forwarded header at all
+env = { 'HTTP_HOST' => 'fallback.example.com' }
+@middleware.call(env)
+env.key?('rack.detected_host.rfc7239_host')
+#=> false
+
+## The observation key is a sidecar of the configurable result field
+Rack::DetectHost.rfc7239_host_field_name
+#=> 'rack.detected_host.rfc7239_host'
 
 ## Ignores Forwarded host parameters in every element
 env = {

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -1455,55 +1455,50 @@ status_with(@fwd, 'admin.example.com', { 'HTTP_X_ORIGINAL_HOST' => 'admin.exampl
             http_host: 'secrets.tenant.test')
 #=> 404
 
-## the RFC 7239 Forwarded header is NOT a host source: DetectHost ignores its
-## host parameter outright (#4121), so the detected host is what `Host:` alone
-## produced. The gate judges Forwarded by VALUE instead (rule d): a host= that
-## names a host OTHER than Host, from an untrusted peer, is the Host-rewriting
-## topology the provenance rule refuses to fall back to Host for — DENIED even
-## though the Host-derived detected host IS on the allowlist.
-status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=secrets.tenant.test' },
+## the RFC 7239 Forwarded header is NOT a host source: DetectHost never
+## selects its host parameter (#4121), so the detected host is what `Host:`
+## alone produced. DetectHost OBSERVES the first host= and publishes it at
+## env[Rack::DetectHost.rfc7239_host_field_name]; the gate judges that VALUE
+## (rule d), never the raw header. A published host that names something
+## OTHER than Host, from an untrusted peer, is the Host-rewriting topology the
+## provenance rule refuses to fall back to Host for — DENIED even though the
+## Host-derived detected host IS on the allowlist.
+@rfc7239 = Rack::DetectHost.rfc7239_host_field_name
+status_with(@fwd, 'admin.example.com', { @rfc7239 => 'secrets.tenant.test' },
             http_host: 'admin.example.com')
 #=> 404
 
 ## the same request from a peer otto vouched for is SERVED (control)
 status_with(@fwd, 'admin.example.com',
-            { 'HTTP_FORWARDED' => 'host=secrets.tenant.test', 'otto.via_trusted_proxy' => true },
+            { @rfc7239 => 'secrets.tenant.test', 'otto.via_trusted_proxy' => true },
             http_host: 'admin.example.com')
 #=> 200
 
-## a Forwarded host= that AGREES with Host changed nothing — served. Quoting,
-## a port and other RFC 7239 parameters are handled by Rack's parser.
-status_with(@fwd, 'admin.example.com',
-            { 'HTTP_FORWARDED' => 'for=203.0.113.9;proto=https;host="admin.example.com:443"' },
+## an observed host that AGREES with Host changed nothing — served
+status_with(@fwd, 'admin.example.com', { @rfc7239 => 'admin.example.com' },
             http_host: 'admin.example.com')
 #=> 200
 
-## only the FIRST host= counts, the same first-value convention DetectHost
-## applies to X-Forwarded-Host
-status_with(@fwd, 'admin.example.com',
-            { 'HTTP_FORWARDED' => 'host=admin.example.com, host=secrets.tenant.test' },
+## the comparison is normalized the same way as the detected host
+status_with(@fwd, 'admin.example.com', { @rfc7239 => 'Admin.Example.COM.' },
             http_host: 'admin.example.com')
 #=> 200
 
-## a Forwarded with no readable host= is no claim at all: for=/proto=-only
-status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'for=203.0.113.9;proto=https' },
+## the raw header is never read here: a Forwarded that DetectHost did not
+## observe (no published field) is no claim at all
+status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=secrets.tenant.test' },
             http_host: 'admin.example.com')
 #=> 200
 
-## ...and neither is one Rack's parser rejects as malformed
-status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=;;;=garbage' },
-            http_host: 'admin.example.com')
-#=> 200
-
-## a Forwarded naming an allowlisted host cannot ADMIT a request whose Host is
-## not on the allowlist either — DetectHost never read it, so the detected
-## host is the tenant one and the allowlist refuses it as usual
-status_with(@fwd, 'secrets.tenant.test', { 'HTTP_FORWARDED' => 'host=admin.example.com' },
+## an observed host naming an allowlisted host cannot ADMIT a request whose
+## Host is not on the allowlist either — DetectHost never selected it, so the
+## detected host is the tenant one and the allowlist refuses it as usual
+status_with(@fwd, 'secrets.tenant.test', { @rfc7239 => 'admin.example.com' },
             http_host: 'secrets.tenant.test')
 #=> 404
 
 ## the Forwarded denial is the provenance WARN, not the allowlist one
-denial_warns(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=secrets.tenant.test' },
+denial_warns(@fwd, 'admin.example.com', { @rfc7239 => 'secrets.tenant.test' },
              http_host: 'admin.example.com')
 #=> [404, ['Admin surface access denied: forwarded host from an untrusted peer']]
 
@@ -1513,9 +1508,9 @@ denial_warns(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=secrets.tena
 Onetime::Middleware::AdminNetworkIsolation::FORWARDED_HOST_ENV_KEYS.sort
 #=> ['HTTP_APX_INCOMING_HOST', 'HTTP_X_FORWARDED_HOST', 'HTTP_X_ORIGINAL_HOST']
 
-## the value-judged key is its own constant
-Onetime::Middleware::AdminNetworkIsolation::RFC7239_FORWARDED_ENV_KEY
-#=> 'HTTP_FORWARDED'
+## the observation rides as a sidecar of DetectHost's result field
+Rack::DetectHost.rfc7239_host_field_name
+#=> 'rack.detected_host.rfc7239_host'
 
 ## the API surface is judged identically
 status_with(@fwd, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -1456,23 +1456,66 @@ status_with(@fwd, 'admin.example.com', { 'HTTP_X_ORIGINAL_HOST' => 'admin.exampl
 #=> 404
 
 ## the RFC 7239 Forwarded header is NOT a host source: DetectHost ignores its
-## host parameter outright (#4121), so the gate does not count it as provenance.
-## The detected host is what `Host:` alone produced, and it is judged on the
-## allowlist as usual — the Forwarded value never enters the decision.
+## host parameter outright (#4121), so the detected host is what `Host:` alone
+## produced. The gate judges Forwarded by VALUE instead (rule d): a host= that
+## names a host OTHER than Host, from an untrusted peer, is the Host-rewriting
+## topology the provenance rule refuses to fall back to Host for — DENIED even
+## though the Host-derived detected host IS on the allowlist.
+status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=secrets.tenant.test' },
+            http_host: 'admin.example.com')
+#=> 404
+
+## the same request from a peer otto vouched for is SERVED (control)
+status_with(@fwd, 'admin.example.com',
+            { 'HTTP_FORWARDED' => 'host=secrets.tenant.test', 'otto.via_trusted_proxy' => true },
+            http_host: 'admin.example.com')
+#=> 200
+
+## a Forwarded host= that AGREES with Host changed nothing — served. Quoting,
+## a port and other RFC 7239 parameters are handled by Rack's parser.
+status_with(@fwd, 'admin.example.com',
+            { 'HTTP_FORWARDED' => 'for=203.0.113.9;proto=https;host="admin.example.com:443"' },
+            http_host: 'admin.example.com')
+#=> 200
+
+## only the FIRST host= counts, the same first-value convention DetectHost
+## applies to X-Forwarded-Host
+status_with(@fwd, 'admin.example.com',
+            { 'HTTP_FORWARDED' => 'host=admin.example.com, host=secrets.tenant.test' },
+            http_host: 'admin.example.com')
+#=> 200
+
+## a Forwarded with no readable host= is no claim at all: for=/proto=-only
+status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'for=203.0.113.9;proto=https' },
+            http_host: 'admin.example.com')
+#=> 200
+
+## ...and neither is one Rack's parser rejects as malformed
+status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=;;;=garbage' },
+            http_host: 'admin.example.com')
+#=> 200
+
+## a Forwarded naming an allowlisted host cannot ADMIT a request whose Host is
+## not on the allowlist either — DetectHost never read it, so the detected
+## host is the tenant one and the allowlist refuses it as usual
 status_with(@fwd, 'secrets.tenant.test', { 'HTTP_FORWARDED' => 'host=admin.example.com' },
             http_host: 'secrets.tenant.test')
 #=> 404
 
-## ...and a Forwarded header naming some other host cannot evict a request the
-## `Host:` header legitimately placed on the allowlist
-status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=secrets.tenant.test' },
-            http_host: 'admin.example.com')
-#=> 200
+## the Forwarded denial is the provenance WARN, not the allowlist one
+denial_warns(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=secrets.tenant.test' },
+             http_host: 'admin.example.com')
+#=> [404, ['Admin surface access denied: forwarded host from an untrusted peer']]
 
-## Forwarded is absent from the provenance key list that X-Forwarded-Host,
-## Apx-Incoming-Host and X-Original-Host populate
+## Forwarded is absent from the PRESENCE key list that X-Forwarded-Host,
+## Apx-Incoming-Host and X-Original-Host populate — it is judged by value, and
+## the presence list stays derived from DetectHost's contract
 Onetime::Middleware::AdminNetworkIsolation::FORWARDED_HOST_ENV_KEYS.sort
 #=> ['HTTP_APX_INCOMING_HOST', 'HTTP_X_FORWARDED_HOST', 'HTTP_X_ORIGINAL_HOST']
+
+## the value-judged key is its own constant
+Onetime::Middleware::AdminNetworkIsolation::RFC7239_FORWARDED_ENV_KEY
+#=> 'HTTP_FORWARDED'
 
 ## the API surface is judged identically
 status_with(@fwd, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },

--- a/try/unit/middleware/admin_network_isolation_try.rb
+++ b/try/unit/middleware/admin_network_isolation_try.rb
@@ -1405,8 +1405,8 @@ status_for(@encoded, 'tenant.example.com', path_info: '/%63olonels')
 # HOST PROVENANCE — a forwarded host from an untrusted peer (#4024)
 # =================================================================
 # With site.network.trusted_proxy unset (the shipped default) Rack::DetectHost
-# honors X-Forwarded-Host / Apx-Incoming-Host / X-Original-Host / Forwarded from
-# ANY peer on a private or loopback address — i.e. from every containerised
+# honors X-Forwarded-Host / Apx-Incoming-Host / X-Original-Host from ANY peer
+# on a private or loopback address — i.e. from every containerised
 # reverse-proxy install. The admin gate declines to rely on that: a detected
 # host that a forwarded header produced is accepted only when
 # env['otto.via_trusted_proxy'] is true, otherwise it must AGREE with the host
@@ -1455,10 +1455,24 @@ status_with(@fwd, 'admin.example.com', { 'HTTP_X_ORIGINAL_HOST' => 'admin.exampl
             http_host: 'secrets.tenant.test')
 #=> 404
 
-## and the RFC 7239 Forwarded header
-status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=admin.example.com' },
+## the RFC 7239 Forwarded header is NOT a host source: DetectHost ignores its
+## host parameter outright (#4121), so the gate does not count it as provenance.
+## The detected host is what `Host:` alone produced, and it is judged on the
+## allowlist as usual — the Forwarded value never enters the decision.
+status_with(@fwd, 'secrets.tenant.test', { 'HTTP_FORWARDED' => 'host=admin.example.com' },
             http_host: 'secrets.tenant.test')
 #=> 404
+
+## ...and a Forwarded header naming some other host cannot evict a request the
+## `Host:` header legitimately placed on the allowlist
+status_with(@fwd, 'admin.example.com', { 'HTTP_FORWARDED' => 'host=secrets.tenant.test' },
+            http_host: 'admin.example.com')
+#=> 200
+
+## Forwarded is absent from the provenance key list that X-Forwarded-Host,
+## Apx-Incoming-Host and X-Original-Host populate
+Onetime::Middleware::AdminNetworkIsolation::FORWARDED_HOST_ENV_KEYS.sort
+#=> ['HTTP_APX_INCOMING_HOST', 'HTTP_X_FORWARDED_HOST', 'HTTP_X_ORIGINAL_HOST']
 
 ## the API surface is judged identically
 status_with(@fwd, 'admin.example.com', { 'HTTP_X_FORWARDED_HOST' => 'admin.example.com' },


### PR DESCRIPTION
## Summary
- Stop treating RFC 7239 Forwarded's host= parameter as an accepted detected-host source; only proxy-managed host headers can override Host.
- Keep AdminNetworkIsolation coupled to DetectHost's managed-header set and cover a Forwarded-only request, which must behave as an ordinary allowlisted Host request.
- Record that the earlier AdminNetworkIsolation CIDR migration to otto.ip_match is complete.

## Review guide
- Start with lib/middleware/detect_host.rb: Forwarded is removed from FORWARDED_HEADERS, so it is also absent from HEADER_PRECEDENCE.
- Review spec/integration/all/colonel_host_allowlist_spec.rb for the derived admin-gate presence-set assertion and end-to-end request behavior.
- Deployments that relied on Forwarded host= for host routing must instead preserve Host or use a supported proxy-managed host header. Forwarded remains available to Otto's separately configured client-IP resolution.

## Validation
- Pre-commit checks passed, including RuboCop.
- The Ruby integration lane was not run because this checkout lacks the required .test-mode sentinel; CI will run the configured lanes.

Related to #4121