### PR TITLE
Consolidate the #4337 attempt/preview audit envelope behind a shared mixin

### DIFF
--- a/apps/web/auth/operations/customers/change_email.rb
+++ b/apps/web/auth/operations/customers/change_email.rb
@@ -6,6 +6,8 @@
 # autoloader), so every dependency is required explicitly.
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/audit_reason'
+require 'onetime/operations/audit_attempt'
 require 'onetime/jobs/publisher'
 require 'onetime/operations/sessions/revoke_all_for_customer'
 require 'auth/account_statuses'
@@ -145,6 +147,8 @@ module Auth
       class ChangeEmail
         include Onetime::LoggerMethods
         include Onetime::AuditedFailure
+        include Onetime::AuditReason
+        include Onetime::Operations::AuditAttempt
 
         AUDIT_VERB = 'customer.change_email'
 
@@ -263,8 +267,15 @@ module Auth
           @require_verification       = require_verification
           @revoke_sessions            = revoke_sessions
           @notify                     = notify
-          @reason                     = reason
-          @ticket                     = ticket
+          # NORMALIZED, not stored raw (#4338). {Onetime::AuditReason::MAX_LENGTH}
+          # is 255 precisely so a provenance string is never silently clipped by
+          # the audit model's 256-char per-value bound: what the operator typed
+          # is what a reviewer reads. The colonel HTTP adapter sanitizes on the
+          # way in, but `bin/ots customers change-email --reason` passes its flag
+          # straight through, and this is the highest-value verb in the trail —
+          # the one place a truncated reason costs the most.
+          @reason                     = normalize_reason(reason)
+          @ticket                     = normalize_reason(ticket)
           @allow_closed_account_reuse = allow_closed_account_reuse
           @db                         = db
           @warnings                   = []
@@ -921,22 +932,38 @@ module Auth
           extid.empty? ? Onetime::AuditedFailure::UNKNOWN : extid
         end
 
+        # The #4337 envelope's target hook, and `failure_target` rather than a
+        # bare `@customer.extid` because that is what both emitters already
+        # used: it degrades to the UNKNOWN sentinel instead of an empty string.
+        # The `usable_customer?` guard means an extid is present by the time
+        # either fires, so the two agree in practice; the sentinel is the
+        # defensive floor, not a path anything relies on. `record_audit` keeps
+        # `@customer.extid` directly — by then the swap has landed. `audit_verb`
+        # defaults to AUDIT_VERB and `audit_actor` to @actor.
+        def audit_target = failure_target
+
+        # D41 operator provenance, for the events that carry it: the reason (via
+        # {Onetime::AuditReason#with_reason}) plus the support ticket. Both are
+        # OMITTED when absent, so a detail hash without them is byte-for-byte
+        # what it was before D41 existed — a `reason: nil` key would change every
+        # existing event's shape to record nothing. Both were normalized in the
+        # constructor, so neither can arrive blank-but-present or over-length.
+        def with_provenance(detail)
+          detail = with_reason(detail)
+          return detail if @ticket.nil?
+
+          detail.merge(ticket: @ticket)
+        end
+
         # One OBSERVATION per preview (#4337), on the budgeted access trail.
         # Same verb and target as the applied event, and — like every other
         # event this op writes — OBSCURED addresses only; `result: 'preview'`
         # and `dry_run: true` distinguish it from the apply that may follow.
         def record_preview_event(old_email, org_count)
-          Onetime::ColonelAuditEvent.record_access(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: failure_target,
-            result: 'preview',
-            detail: {
-              dry_run: true,
-              from: OT::Utils.obscure_email(old_email.to_s),
-              to: OT::Utils.obscure_email(@new_email.to_s),
-              orgs: org_count,
-            },
+          record_preview_observation(
+            from: OT::Utils.obscure_email(old_email.to_s),
+            to: OT::Utils.obscure_email(@new_email.to_s),
+            orgs: org_count,
           )
         rescue StandardError => ex
           auth_logger.error '[customer.change_email] preview audit failed', exception: ex
@@ -957,32 +984,20 @@ module Auth
         # moved.
         def record_no_change_event(old_email)
           detail = {
-            outcome: 'no_change',
             from: OT::Utils.obscure_email(old_email.to_s),
             to: OT::Utils.obscure_email(@new_email.to_s),
           }
 
+          # The dry-run half keeps BOTH markers: `dry_run: true` from the
+          # envelope says it was a preview, `outcome: 'no_change'` says the
+          # preview found nothing to do. It is the one preview in the cohort
+          # that carries the no-change marker onto the observation trail.
           if @dry_run
-            Onetime::ColonelAuditEvent.record_access(
-              actor: @actor,
-              verb: AUDIT_VERB,
-              target: failure_target,
-              result: 'preview',
-              detail: detail.merge(dry_run: true),
-            )
+            record_preview_observation(detail.merge(outcome: 'no_change'))
             return
           end
 
-          detail[:reason] = @reason.to_s unless @reason.to_s.strip.empty?
-          detail[:ticket] = @ticket.to_s unless @ticket.to_s.strip.empty?
-
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: failure_target,
-            result: :success,
-            detail: detail,
-          )
+          record_no_change_attempt(with_provenance(detail))
         end
 
         # Same verb/target/actor as the success event; obscured addresses only,
@@ -1149,8 +1164,7 @@ module Auth
           # D41: optional operator provenance — this is the highest-value
           # account-takeover primitive an operator has, and without these the
           # trail records only actor='cli'.
-          detail[:reason] = @reason.to_s unless @reason.to_s.strip.empty?
-          detail[:ticket] = @ticket.to_s unless @ticket.to_s.strip.empty?
+          detail          = with_provenance(detail)
 
           Onetime::ColonelAuditEvent.record(
             actor: @actor,

--- a/apps/web/auth/operations/customers/set_plan.rb
+++ b/apps/web/auth/operations/customers/set_plan.rb
@@ -4,6 +4,7 @@
 
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/operations/audit_attempt'
 
 module Auth
   module Operations
@@ -27,6 +28,7 @@ module Auth
       class SetPlan
         include Onetime::LoggerMethods
         include Onetime::AuditedFailure
+        include Onetime::Operations::AuditAttempt
 
         AUDIT_VERB = 'customer.set_plan'
 
@@ -84,18 +86,17 @@ module Auth
 
         private
 
+        # The #4337 envelope's target hook: the customer's PUBLIC extid, the
+        # same target the applied event carries. `audit_verb` defaults to
+        # AUDIT_VERB and `audit_actor` to @actor.
+        def audit_target = @customer.extid
+
         # A no-change attempt (#4337) — the OPERATOR trail, not the observation
         # trail. Same verb and target as the applied event, with
         # `outcome: 'no_change'` marking it. NOT fail-closed: nothing moved, so
         # there is nothing untraceable for a hard failure to surface.
         def record_no_change_event(from)
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @customer.extid,
-            result: :success,
-            detail: { outcome: 'no_change', from: from, to: @planid },
-          )
+          record_no_change_attempt({ from: from, to: @planid })
         end
 
         # Loggable, non-secret actor label (mirrors the audit actor normalization).

--- a/apps/web/auth/operations/customers/set_role.rb
+++ b/apps/web/auth/operations/customers/set_role.rb
@@ -5,6 +5,7 @@
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
 require 'onetime/audit_reason'
+require 'onetime/operations/audit_attempt'
 require 'onetime/operations/customers/role_support'
 
 module Auth
@@ -40,6 +41,7 @@ module Auth
         include Onetime::LoggerMethods
         include Onetime::AuditedFailure
         include Onetime::AuditReason
+        include Onetime::Operations::AuditAttempt
         include Onetime::Operations::Customers::RoleSupport
 
         AUDIT_VERB = 'customer.set_role'
@@ -154,6 +156,11 @@ module Auth
 
         private
 
+        # The #4337 envelope's target hook: the customer's PUBLIC extid, the
+        # same target the applied event carries. `audit_verb` defaults to
+        # AUDIT_VERB and `audit_actor` to @actor.
+        def audit_target = @customer.extid
+
         # Only a DEMOTION of one's own account is refused: a colonel raising
         # their own role is not a lockout risk, and the CLI (actor_objid nil)
         # never self-refuses.
@@ -227,13 +234,7 @@ module Auth
         # action still has a why, and a probe at a privileged account is exactly
         # the row a reviewer wants the operator's own words on.
         def record_no_change_event
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @customer.extid,
-            result: :success,
-            detail: with_reason(outcome: 'no_change', from: @from, to: @role),
-          )
+          record_no_change_attempt(with_reason(from: @from, to: @role))
         end
 
         # Loggable, non-secret actor label (mirrors the audit actor normalization).

--- a/apps/web/auth/operations/customers/set_suspension.rb
+++ b/apps/web/auth/operations/customers/set_suspension.rb
@@ -5,6 +5,7 @@
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
 require 'onetime/audit_reason'
+require 'onetime/operations/audit_attempt'
 require 'onetime/operations/sessions/store'
 
 module Auth
@@ -50,6 +51,7 @@ module Auth
         include Onetime::LoggerMethods
         include Onetime::AuditedFailure
         include Onetime::AuditReason
+        include Onetime::Operations::AuditAttempt
 
         AUDIT_VERB_SUSPEND   = 'customer.suspend'
         AUDIT_VERB_UNSUSPEND = 'customer.unsuspend'
@@ -157,6 +159,17 @@ module Auth
 
         private
 
+        # The #4337 envelope's verb hook. This op has no single AUDIT_VERB: the
+        # verb names the DIRECTION (suspend vs unsuspend), so the envelope's
+        # verb is direction-dependent rather than one constant. The applied
+        # event and the audit_failures declaration pick the same pair by hand.
+        def audit_verb = @suspended ? AUDIT_VERB_SUSPEND : AUDIT_VERB_UNSUSPEND
+
+        # The #4337 envelope's target hook: the customer's PUBLIC extid, the
+        # same target the applied event carries. `audit_actor` defaults to
+        # @actor.
+        def audit_target = @customer.extid
+
         # On SUSPEND the reason key is present unconditionally (including as
         # nil), because it predates #4338 and the existing wire/spec shape
         # depends on it. On UNSUSPEND — a release, whose own why is worth just
@@ -189,13 +202,7 @@ module Auth
         # customer row records nothing on this path for a reviewer to fall back
         # on.
         def record_no_change_event
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: @suspended ? AUDIT_VERB_SUSPEND : AUDIT_VERB_UNSUSPEND,
-            target: @customer.extid,
-            result: :success,
-            detail: with_reason(outcome: 'no_change', suspended: @suspended),
-          )
+          record_no_change_attempt(with_reason(suspended: @suspended))
         end
 
         # Delete every readable session belonging to this customer. Bounded by

--- a/apps/web/auth/operations/customers/set_verification.rb
+++ b/apps/web/auth/operations/customers/set_verification.rb
@@ -6,6 +6,7 @@
 # the auth app's autoloader, so require the dependency explicitly.
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/operations/audit_attempt'
 require 'onetime/operations/customers/role_support'
 require 'auth/operations/set_customer_verification'
 
@@ -53,6 +54,7 @@ module Auth
       # struct, because three adapters already `case` on the returned symbol.
       class SetVerification
         include Onetime::AuditedFailure
+        include Onetime::Operations::AuditAttempt
         include Onetime::Operations::Customers::RoleSupport
 
         AUDIT_VERB = 'customer.set_verification'
@@ -164,6 +166,11 @@ module Auth
 
         private
 
+        # The #4337 envelope's target hook: the customer's PUBLIC extid, the
+        # same target the applied event carries. `audit_verb` defaults to
+        # AUDIT_VERB and `audit_actor` to @actor.
+        def audit_target = @customer.extid
+
         # @return [Symbol, nil] the refusal status, or nil to proceed
         def unverify_refusal
           return nil if @verified
@@ -223,12 +230,12 @@ module Auth
         # destroys nothing.
         def record_audit_event(result)
           detail = { verified: @verified }
-          detail = { outcome: 'no_change' }.merge(detail) unless result == :success
+          return record_no_change_attempt(detail) unless result == :success
 
           Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @customer.extid,
+            actor: audit_actor,
+            verb: audit_verb,
+            target: audit_target,
             result: :success,
             detail: detail,
           )

--- a/docs/architecture/audit-logging.md
+++ b/docs/architecture/audit-logging.md
@@ -418,6 +418,65 @@ refusal path) and is unchanged. `email/ingest_feedback`'s all-rejected-batch
 path also stays unaudited on purpose: a batch that accepts nothing is an honest
 pipeline outcome, not an operator reaching for a named target.
 
+**One envelope for both families (#4366).** Both row shapes above were
+re-typed by hand in every op, and the correctness of the whole feature rested
+on ~28 hand-written kwarg lists agreeing with one another.
+`Onetime::Operations::AuditAttempt` (`lib/onetime/operations/audit_attempt.rb`)
+now owns the envelope, and an op composes it with `include`.
+`record_no_change_attempt(detail)` writes the operator-trail row
+(`ColonelAuditEvent.record`, `result: :success`);
+`record_preview_observation(detail)` writes the observation-trail row
+(`ColonelAuditEvent.record_access`, `result: 'preview'`).
+
+The three marker fields the feature rests on are structural now rather than
+conventional. `result:` is no longer a kwarg a call site types; it is decided
+by which of the two methods you call. `outcome: 'no_change'` and
+`dry_run: true` are merged into the detail **last**, so a call site cannot
+displace them. And there is no `fail_closed` parameter to pass, so a
+no-change row cannot be fail-closed by construction — a no-change destroyed
+nothing, so there is no irrecoverable fact for a hard failure to protect, and
+hard-failing an idempotent no-op would be a regression rather than a
+safeguard. Ops recording an *applied* effect still call
+`ColonelAuditEvent.record` directly and keep their `fail_closed: true`.
+
+What stays at the call site is the detail hash, and the per-op security
+rationale comment above the branch that decides to emit. Those comments are
+genuinely per-op — why *this* verb's no-change is worth a row, why *these*
+fields and not others — and they are the most valuable text in these files.
+The module replaces none of them; it owns only the parts that must be
+identical everywhere.
+
+It is a **sibling** of `Onetime::AuditReason` rather than part of it. Reason
+policy has real per-op variance the envelope does not:
+`customers/set_suspension` keeps `reason:` present unconditionally on SUSPEND
+but omit-when-absent on UNSUSPEND, so a module that auto-merged the reason
+would break that shape. The two concerns compose at the call site instead —
+`record_no_change_attempt(with_reason(purged: 0))`.
+
+Three hooks carry the per-op parts: `audit_actor` (defaults to `@actor`),
+`audit_verb` (defaults to the class's `AUDIT_VERB`), and `audit_target` (no
+default — it raises `NotImplementedError` rather than let an op record a row
+against nil). `audit_verb` is overridden where the verb is direction- or
+action-dependent: `customers/set_suspension` (suspend vs unsuspend) and both
+`entitlement_override` ops, whose verb is computed from `@action`.
+
+Converted: `customers/change_email`, `customers/set_role`,
+`customers/set_plan`, `customers/set_suspension`,
+`customers/set_verification`, `dlq/purge`, `dlq/replay`, `email/send_test`,
+`memberships/add`, `memberships/set_role`,
+`memberships/entitlement_override`, `org/set_plan`,
+`org/entitlement_override`.
+
+**Still hand-rolled.** Nine pre-#4337 preview-only emitters still build the
+envelope inline, deliberately deferred to a follow-up: they carry arity-heavy
+signatures and their own rescue/logging conventions, so folding them in is
+more than a mechanical change. `domains/remove`, `domains/transfer`,
+`domains/repair`, `domains/ensure_domain_configs`, `org/delete`,
+`org/reconcile`, `org/transfer_ownership`, `email/sync_provider_feedback`,
+and `customers/reconcile_role_index`. Until they adopt the mixin their
+`result:` and `dry_run:` markers rest on review attention rather than on
+construction.
+
 ### What the security-telemetry stream holds (#4339)
 
 `security_events` started as the home for rate-limiter cap-hits — the three
@@ -645,6 +704,15 @@ rules live, so twelve ops cannot drift:
 - **`MAX_LENGTH` is 255**, one under `MAX_DETAIL_VALUE_LENGTH`, so a reason that
   passes validation is never silently clipped on the way into storage.
   `reason` is deliberately *not* matched by `SENSITIVE_KEY_PATTERN`.
+
+`customers/change_email` was the op that had not adopted the module: it did
+not include `Onetime::AuditReason` and stored `@reason` raw, so a long
+`--reason` from the CLI passed unvalidated and landed truncated by the audit
+model's 256-char per-value bound — the silent clip `MAX_LENGTH` exists to
+prevent. It now includes the module, normalizes both `@reason` and `@ticket`
+through `normalize_reason`, and shares one `with_provenance` helper between
+its no-change and applied events so the two rows carry identical provenance
+(#4366).
 
 It rides **inside `detail`**, not as a new top-level field: `ColonelAuditReader`'s
 allowlist, the `colonelAuditEventSchema` Zod shape and the CSV header are one

--- a/lib/onetime/operations/audit_attempt.rb
+++ b/lib/onetime/operations/audit_attempt.rb
@@ -1,0 +1,173 @@
+# lib/onetime/operations/audit_attempt.rb
+#
+# frozen_string_literal: true
+
+require 'onetime/models/colonel_audit_event'
+
+module Onetime
+  module Operations
+    # AuditAttempt — the ENVELOPE for the two #4337 row families, in one place.
+    #
+    # #4337 established that an operator action which changed nothing still
+    # records, and that the two ways of changing nothing go to DIFFERENT trails:
+    #
+    #   * A NO-CHANGE ATTEMPT is a live firing of a mutating verb that found
+    #     nothing to move (suspend on an already-suspended customer, purge on an
+    #     already-empty queue). The operator got past every confirmation gate and
+    #     pulled the trigger; whether the state happened to already match must
+    #     not decide whether the trail shows the attempt. It belongs on the
+    #     OPERATOR trail ({Onetime::ColonelAuditEvent.record}), under the same
+    #     verb and target as the applied event, marked `outcome: 'no_change'`.
+    #
+    #   * A DRY-RUN PREVIEW changed nothing because it was never going to. It is
+    #     reconnaissance — "show me what deleting this org would take out" — and
+    #     it belongs on the budgeted OBSERVATION trail
+    #     ({Onetime::ColonelAuditEvent.record_access}), under the same verb and
+    #     target, with `result: 'preview'` and `dry_run: true`.
+    #
+    # Before this module each op re-typed that envelope by hand, and the
+    # correctness of the whole feature rested on ~28 hand-written kwarg lists
+    # agreeing with one another. The five kwargs were never the problem; three
+    # marker fields enforced only by CONVENTION were:
+    #
+    #   1. `result:` — `:success` on the operator trail vs `'preview'` on the
+    #      observation trail. Get it wrong and a preview reads as an applied
+    #      change, or an attempt disappears from the applied-verb view.
+    #   2. `outcome: 'no_change'` — the marker every verb-filter query and every
+    #      reviewer's mental model depends on to tell an attempt from an effect.
+    #   3. The ABSENCE of `fail_closed:`. A no-change destroyed nothing, so there
+    #      is no irrecoverable fact for a hard failure to protect; hard-failing
+    #      an idempotent no-op would turn a harmless double-click into an
+    #      operator-visible error. See the fail-closed contract in #4333.
+    #
+    # This module makes all three structural rather than remembered. There is no
+    # `fail_closed` parameter to pass, the trail is chosen by which method you
+    # call, and the marker is merged LAST so a call site cannot displace it.
+    #
+    # ## What stays at the call site
+    #
+    # The DETAIL, and the per-op security rationale comment above the branch that
+    # decides to emit. That comment is genuinely per-op — why THIS verb's
+    # no-change is worth a row, why THESE fields and not others — and it is the
+    # most valuable text in the file. Nothing here replaces it. This module owns
+    # only the parts that must be identical across every op.
+    #
+    # ## Sibling of {Onetime::AuditReason}, not an extension of it
+    #
+    # Reason policy has real per-op variance the envelope does not: the
+    # suspension op keeps `reason:` present unconditionally on SUSPEND but
+    # omit-when-absent on UNSUSPEND, so a module that auto-merged the reason
+    # would break that shape. The two concerns compose at the call site instead:
+    #
+    #   record_no_change_attempt(with_reason(purged: 0))
+    #
+    # ## Naming
+    #
+    # Deliberately NOT `record_no_change_event` / `record_preview_event`: many
+    # ops already define methods by those names, with varying arity, and a module
+    # method of the same name would be silently shadowed by the class body. Each
+    # op keeps its own named wrapper (and that wrapper's comment) and delegates.
+    #
+    # ## Usage
+    #
+    #   class Purge
+    #     include Onetime::AuditReason
+    #     include Onetime::Operations::AuditAttempt
+    #
+    #     AUDIT_VERB = 'queue.dlq.purge'
+    #
+    #     private
+    #
+    #     # `audit_verb` defaults to AUDIT_VERB; `audit_actor` to @actor.
+    #     def audit_target = @queue
+    #
+    #     def record_preview_event(count)
+    #       record_preview_observation(with_reason(count: count))
+    #     end
+    #
+    #     def record_no_change_event
+    #       record_no_change_attempt(with_reason(purged: 0))
+    #     end
+    #   end
+    #
+    module AuditAttempt
+      # The `outcome` value that marks an operator-trail row as an attempt that
+      # moved nothing. Verb-filter queries and the audit screen both key off it,
+      # so it lives here rather than being retyped as a literal per op.
+      NO_CHANGE_OUTCOME = 'no_change'
+
+      # The `result` value that marks an observation-trail row as a dry run.
+      # A String, not a Symbol, matching {Onetime::ColonelAuditEvent.record_access}'s
+      # documented `'preview'` and the shape already on the wire.
+      PREVIEW_RESULT = 'preview'
+
+      private
+
+      # Record a mutation ATTEMPT that moved nothing, on the OPERATOR trail.
+      #
+      # There is deliberately NO `fail_closed` parameter. A no-change attempt
+      # destroyed nothing, so there is no irrecoverable fact a hard failure could
+      # surface — all it could do is fail an operation that was already a no-op.
+      # Ops that need fail-closed writes are recording an APPLIED effect and call
+      # {Onetime::ColonelAuditEvent.record} directly, as they did before.
+      #
+      # @param detail [Hash, nil] the op's own context. Merged UNDER the
+      #   `outcome` marker, so a call site cannot displace it.
+      # @return [Hash, nil] the stored event, or nil if the write failed
+      #   (`record` is best-effort by default — see `errors.rb`).
+      def record_no_change_attempt(detail = {})
+        Onetime::ColonelAuditEvent.record(
+          actor: audit_actor,
+          verb: audit_verb,
+          target: audit_target,
+          result: :success,
+          detail: (detail || {}).merge(outcome: NO_CHANGE_OUTCOME),
+        )
+      end
+
+      # Record a dry-run PREVIEW, on the budgeted OBSERVATION trail.
+      #
+      # Never the operator trail: a preview applied nothing, and putting
+      # reconnaissance among applied effects is exactly the conflation #4337
+      # exists to prevent. `record_access` has no `fail_closed` keyword at all —
+      # observing must never break the console.
+      #
+      # @param detail [Hash, nil] the op's own context. Merged UNDER the
+      #   `dry_run` marker, so a call site cannot displace it.
+      # @return [Hash, nil] the stored event, or nil if the write failed.
+      def record_preview_observation(detail = {})
+        Onetime::ColonelAuditEvent.record_access(
+          actor: audit_actor,
+          verb: audit_verb,
+          target: audit_target,
+          result: PREVIEW_RESULT,
+          detail: (detail || {}).merge(dry_run: true),
+        )
+      end
+
+      # The acting colonel's public identity. Every op in the cohort stores it in
+      # `@actor`; override when yours does not.
+      def audit_actor
+        @actor
+      end
+
+      # The verb both rows carry — the SAME verb as the applied event, which is
+      # what lets a preview, an attempt and an effect read as one sequence.
+      #
+      # Defaults to the class's `AUDIT_VERB`. Ops whose verb is direction- or
+      # action-dependent override this; several already define a method by
+      # exactly this name, and a class-body definition wins over an included
+      # module's, so those keep working untouched.
+      def audit_verb
+        self.class::AUDIT_VERB
+      end
+
+      # The public id of the affected resource. No sensible default — an op that
+      # includes this module and forgets it should fail loudly at the first
+      # emit, not record a row against nil.
+      def audit_target
+        raise NotImplementedError, "#{self.class} must define #audit_target"
+      end
+    end
+  end
+end

--- a/lib/onetime/operations/dlq/purge.rb
+++ b/lib/onetime/operations/dlq/purge.rb
@@ -6,6 +6,7 @@ require 'onetime/operations/dlq/store'
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
 require 'onetime/audit_reason'
+require 'onetime/operations/audit_attempt'
 
 module Onetime
   module Operations
@@ -46,6 +47,7 @@ module Onetime
       class Purge
         include Onetime::AuditedFailure
         include Onetime::AuditReason
+        include Onetime::Operations::AuditAttempt
 
         # Audit verb recorded for every purge that removes ≥ 1 message.
         AUDIT_VERB = 'queue.dlq.purge'
@@ -131,6 +133,11 @@ module Onetime
 
         private
 
+        # The #4337 envelope's target hook: the DLQ name, for the preview, the
+        # no-change attempt and the applied event alike. `audit_verb` defaults
+        # to AUDIT_VERB and `audit_actor` to @actor.
+        def audit_target = @queue
+
         # One OBSERVATION per dry run (#4337), on the budgeted access trail.
         # Same verb and target as the applied event, so a preview and the purge
         # that followed it read as one sequence; `result: 'preview'` and
@@ -139,13 +146,7 @@ module Onetime
         # (#4338) carries onto the preview too when one was given, so the two
         # rows still read as one sequence once the console starts sending it.
         def record_preview_event(count)
-          Onetime::ColonelAuditEvent.record_access(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @queue,
-            result: 'preview',
-            detail: with_reason(dry_run: true, count: count),
-          )
+          record_preview_observation(with_reason(count: count))
         end
 
         # A no-change attempt (#4337) — the OPERATOR trail, not the observation
@@ -156,13 +157,7 @@ module Onetime
         # message was destroyed, so there is no irrecoverable fact for a hard
         # failure to protect.
         def record_no_change_event
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @queue,
-            result: :success,
-            detail: with_reason(outcome: 'no_change', purged: 0),
-          )
+          record_no_change_attempt(with_reason(purged: 0))
         end
       end
     end

--- a/lib/onetime/operations/dlq/replay.rb
+++ b/lib/onetime/operations/dlq/replay.rb
@@ -5,6 +5,7 @@
 require 'onetime/operations/dlq/store'
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/operations/audit_attempt'
 
 module Onetime
   module Operations
@@ -47,6 +48,7 @@ module Onetime
       # Stateless, single `#call`, returns an immutable {Result}.
       class Replay
         include Onetime::AuditedFailure
+        include Onetime::Operations::AuditAttempt
 
         # Audit verb recorded for every replay that processes ≥ 1 message.
         AUDIT_VERB = 'queue.dlq.replay'
@@ -157,6 +159,11 @@ module Onetime
 
         private
 
+        # The #4337 envelope's target hook: the DLQ name, the same target the
+        # preview observation, the no-change attempt and the applied event all
+        # carry. `audit_verb` defaults to AUDIT_VERB and `audit_actor` to @actor.
+        def audit_target = @queue
+
         # One OBSERVATION per dry run (#4337), on the budgeted access trail.
         # Same verb and target as the applied event so a preview and the replay
         # that followed read as one sequence; `result: 'preview'` and
@@ -164,16 +171,10 @@ module Onetime
         # counts the preview exists to produce. `outcome` is set (to
         # 'no_change') when the preview found the queue already empty.
         def record_preview_event(would_replay, available, outcome: nil)
-          detail           = { dry_run: true, would_replay: would_replay, available: available }
+          detail           = { would_replay: would_replay, available: available }
           detail[:outcome] = outcome if outcome
 
-          Onetime::ColonelAuditEvent.record_access(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @queue,
-            result: 'preview',
-            detail: detail,
-          )
+          record_preview_observation(detail)
         end
 
         # A no-change attempt (#4337) — the OPERATOR trail, not the observation
@@ -186,13 +187,7 @@ module Onetime
         # fail-closed: nothing was republished or acked, so there is no
         # irrecoverable fact for a hard failure to protect.
         def record_no_change_event
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @queue,
-            result: :success,
-            detail: { outcome: 'no_change', replayed: 0, failed: 0 },
-          )
+          record_no_change_attempt({ replayed: 0, failed: 0 })
         end
 
         def empty_result

--- a/lib/onetime/operations/email/send_test.rb
+++ b/lib/onetime/operations/email/send_test.rb
@@ -12,6 +12,7 @@ require 'socket'
 require 'onetime/mail'
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/operations/audit_attempt'
 
 module Onetime
   module Operations
@@ -43,6 +44,7 @@ module Onetime
       # behave exactly as before.
       class SendTest
         include Onetime::AuditedFailure
+        include Onetime::Operations::AuditAttempt
 
         # Audit verb recorded for every successful real send.
         AUDIT_VERB = 'email.test_send'
@@ -140,18 +142,17 @@ module Onetime
 
         private
 
+        # The #4337 envelope's target hook: the recipient address, the same
+        # target the sent event carries. `audit_verb` defaults to AUDIT_VERB and
+        # `audit_actor` to @actor.
+        def audit_target = @to
+
         # One OBSERVATION per dry run (#4337), on the budgeted access trail.
         # Same verb and target as the sent event; `result: 'preview'` and
         # `dry_run: true` distinguish them. Provider and mode only — never the
         # message content, exactly as on the applied path.
         def record_preview_event(diagnostic)
-          Onetime::ColonelAuditEvent.record_access(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @to,
-            result: 'preview',
-            detail: { dry_run: true, provider: diagnostic.provider, enqueue: @enqueue },
-          )
+          record_preview_observation({ provider: diagnostic.provider, enqueue: @enqueue })
         end
 
         # Direct delivery via the configured backend. Raises on failure (caller's

--- a/lib/onetime/operations/memberships/add.rb
+++ b/lib/onetime/operations/memberships/add.rb
@@ -6,6 +6,7 @@
 # autoloaders — require the audit model explicitly.
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/operations/audit_attempt'
 
 module Onetime
   module Operations
@@ -52,6 +53,7 @@ module Onetime
       # state.
       class Add
         include Onetime::AuditedFailure
+        include Onetime::Operations::AuditAttempt
 
         AUDIT_VERB = 'membership.add'
 
@@ -126,6 +128,11 @@ module Onetime
 
         private
 
+        # The #4337 envelope's target hook: the customer's public extid, the same
+        # target the applied event carries. `audit_verb` defaults to AUDIT_VERB
+        # and `audit_actor` to @actor.
+        def audit_target = @customer.extid
+
         # Single exit point for every non-success status, so the refusal audit
         # cannot be forgotten at an early return.
         def build(status, role)
@@ -147,13 +154,7 @@ module Onetime
         # the `outcome: 'no_change'` marker. NOT fail-closed: nothing moved.
         # No local rescue — `record` is best-effort and swallows its own errors.
         def record_no_change_event(role)
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @customer.extid,
-            result: :success,
-            detail: { outcome: 'no_change', role: role, org_id: @org.extid },
-          )
+          record_no_change_attempt({ role: role, org_id: @org.extid })
         end
 
         # Same verb/target/actor as the success event. Best-effort: never break

--- a/lib/onetime/operations/memberships/entitlement_override.rb
+++ b/lib/onetime/operations/memberships/entitlement_override.rb
@@ -9,6 +9,7 @@
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
 require 'onetime/operations/org/entitlement_override'
+require 'onetime/operations/audit_attempt'
 
 module Onetime
   module Operations
@@ -73,6 +74,7 @@ module Onetime
       # stay symmetric.
       class EntitlementOverride
         include Onetime::AuditedFailure
+        include Onetime::Operations::AuditAttempt
 
         ACTIONS = Org::EntitlementOverride::ACTIONS
 
@@ -241,6 +243,11 @@ module Onetime
 
         private
 
+        # The #4337 envelope's target hook: the CUSTOMER's extid, the key every
+        # row on this op has always carried — preview, no-change attempt and
+        # applied event alike. This class's own `audit_verb` supplies the verb.
+        def audit_target = @customer.extid
+
         # "membership.entitlement.<action>" — BYTE-IDENTICAL to what the success
         # path has always emitted for a valid action (a frontend filter
         # prefix-matches these). An INVALID action falls back to the bare prefix
@@ -260,20 +267,13 @@ module Onetime
         # on D15.
         def record_preview_event(outcome: nil)
           detail           = {
-            dry_run: true,
             org_id: @org.extid,
             action: @action,
             entitlement: @entitlement,
           }
           detail[:outcome] = outcome if outcome
 
-          Onetime::ColonelAuditEvent.record_access(
-            actor: @actor,
-            verb: audit_verb,
-            target: @customer.extid,
-            result: 'preview',
-            detail: detail,
-          )
+          record_preview_observation(detail)
         end
 
         # A LIVE no-change attempt (#4337) — the OPERATOR trail, mirroring the
@@ -282,13 +282,7 @@ module Onetime
         # verb carries the action) plus the `outcome: 'no_change'` marker. NOT
         # fail-closed: nothing moved.
         def record_no_change_event
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: audit_verb,
-            target: @customer.extid,
-            result: :success,
-            detail: { outcome: 'no_change', org_id: @org.extid, entitlement: @entitlement },
-          )
+          record_no_change_attempt({ org_id: @org.extid, entitlement: @entitlement })
         end
 
         # Same verb/target/actor as the success event. Best-effort: never break

--- a/lib/onetime/operations/memberships/set_role.rb
+++ b/lib/onetime/operations/memberships/set_role.rb
@@ -7,6 +7,7 @@
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
 require 'onetime/audit_reason'
+require 'onetime/operations/audit_attempt'
 require_relative 'support'
 
 module Onetime
@@ -51,6 +52,7 @@ module Onetime
         include Memberships::Support
         include Onetime::AuditedFailure
         include Onetime::AuditReason
+        include Onetime::Operations::AuditAttempt
 
         AUDIT_VERB = 'membership.set_role'
 
@@ -140,6 +142,11 @@ module Onetime
 
         private
 
+        # The #4337 envelope's target hook: the customer's public extid, the same
+        # target the applied event carries. `audit_verb` defaults to AUDIT_VERB
+        # and `audit_actor` to @actor.
+        def audit_target = @customer.extid
+
         # A no-change attempt (#4337) — the OPERATOR trail, not the observation
         # trail. Same verb, target and detail keys as the applied event, with
         # `outcome: 'no_change'` marking it, so a filter on
@@ -149,13 +156,7 @@ module Onetime
         # operator's `reason` (#4338) rides here too — an attempted-but-no-op
         # reach for `owner` still has a why.
         def record_no_change_event(from)
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @customer.extid,
-            result: :success,
-            detail: with_reason(outcome: 'no_change', from: from, to: @new_role, org_id: @org.extid),
-          )
+          record_no_change_attempt(with_reason(from: from, to: @new_role, org_id: @org.extid))
         end
 
         # Single exit point for every non-success status, so the refusal audit

--- a/lib/onetime/operations/org/entitlement_override.rb
+++ b/lib/onetime/operations/org/entitlement_override.rb
@@ -6,6 +6,7 @@
 # autoloaders — require the audit model explicitly.
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/operations/audit_attempt'
 
 module Onetime
   module Operations
@@ -90,6 +91,7 @@ module Onetime
       #   is shape-compatible.
       class EntitlementOverride
         include Onetime::AuditedFailure
+        include Onetime::Operations::AuditAttempt
 
         ACTIONS = %w[grant revoke clear].freeze
 
@@ -273,6 +275,11 @@ module Onetime
 
         private
 
+        # The #4337 envelope's target hook: the org's extid, the key every row
+        # on this op has always carried — preview, no-change attempt and
+        # applied event alike. This class's own `audit_verb` supplies the verb.
+        def audit_target = @org.extid
+
         # "organization.entitlement.<action>" — BYTE-IDENTICAL to the
         # pre-extraction value for a valid action (the existing trail and the
         # colonel tryout gate match those exact strings). An INVALID action falls
@@ -291,16 +298,10 @@ module Onetime
         # same reason the applied event's detail is {} for clear). `outcome`
         # is set (to 'no_change') when the preview short-circuited on D15.
         def record_preview_event(outcome: nil)
-          detail           = { dry_run: true, action: @action, entitlement: @entitlement }
+          detail           = { action: @action, entitlement: @entitlement }
           detail[:outcome] = outcome if outcome
 
-          Onetime::ColonelAuditEvent.record_access(
-            actor: @actor,
-            verb: audit_verb,
-            target: @org.extid,
-            result: 'preview',
-            detail: detail,
-          )
+          record_preview_observation(detail)
         end
 
         # A LIVE no-change attempt (#4337) — the OPERATOR trail. Re-granting an
@@ -311,13 +312,7 @@ module Onetime
         # carries the action) plus the `outcome: 'no_change'` marker. NOT
         # fail-closed: nothing moved.
         def record_no_change_event
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: audit_verb,
-            target: @org.extid,
-            result: :success,
-            detail: { outcome: 'no_change', entitlement: @entitlement },
-          )
+          record_no_change_attempt({ entitlement: @entitlement })
         end
 
         # Same verb/target/actor as the success event. Best-effort: never break

--- a/lib/onetime/operations/org/set_plan.rb
+++ b/lib/onetime/operations/org/set_plan.rb
@@ -11,6 +11,7 @@
 # (Gemfile pins it require: false).
 require 'onetime/models/colonel_audit_event'
 require 'onetime/audited_failure'
+require 'onetime/operations/audit_attempt'
 require_relative '../../../../apps/web/billing/operations/apply_subscription_to_org'
 
 module Onetime
@@ -72,6 +73,7 @@ module Onetime
       # via audit_failures and re-raises.
       class SetPlan
         include Onetime::AuditedFailure
+        include Onetime::Operations::AuditAttempt
 
         AUDIT_VERB = 'organization.set_plan'
 
@@ -146,19 +148,18 @@ module Onetime
 
         private
 
+        # The #4337 envelope's target hook: the ORGANIZATION's public extid — the
+        # plan belongs to the org, not to the acting colonel. `audit_verb` defaults
+        # to AUDIT_VERB and `audit_actor` to @actor.
+        def audit_target = @org.extid
+
         # A no-change attempt (#4337) — the OPERATOR trail, not the observation
         # trail. Same verb and target as the applied event, with
         # `outcome: 'no_change'` marking it. `materialization` is omitted
         # rather than sent as nil: no engine ran, so there is no status to
         # report. NOT fail-closed — nothing moved.
         def record_no_change_event(from)
-          Onetime::ColonelAuditEvent.record(
-            actor: @actor,
-            verb: AUDIT_VERB,
-            target: @org.extid,
-            result: :success,
-            detail: { outcome: 'no_change', from: from, to: @planid },
-          )
+          record_no_change_attempt({ from: from, to: @planid })
         end
 
         # Re-materialize entitlements from the new plan. DEGRADABLE: the

--- a/spec/unit/onetime/operations/preview_and_no_change_audit_spec.rb
+++ b/spec/unit/onetime/operations/preview_and_no_change_audit_spec.rb
@@ -21,16 +21,26 @@
 #
 # Run: pnpm run test:rspec spec/unit/onetime/operations/preview_and_no_change_audit_spec.rb
 
+# Every op in the cohort is required here, not just the ones with behavioural
+# examples below: the membership assertions at the bottom walk the whole list,
+# and loading all 13 is itself the check that the shared envelope resolves from
+# `lib/` and from `apps/web/auth/` alike.
 require 'spec_helper'
 require 'onetime/models/colonel_audit_event'
+require 'onetime/operations/audit_attempt'
 require 'onetime/operations/dlq/purge'
 require 'onetime/operations/dlq/replay'
 require 'onetime/operations/email/send_test'
 require 'onetime/operations/memberships/add'
+require 'onetime/operations/memberships/entitlement_override'
+require 'onetime/operations/memberships/set_role'
 require 'onetime/operations/org/entitlement_override'
+require 'onetime/operations/org/set_plan'
+require 'auth/operations/customers/change_email'
 require 'auth/operations/customers/set_plan'
 require 'auth/operations/customers/set_role'
 require 'auth/operations/customers/set_suspension'
+require 'auth/operations/customers/set_verification'
 
 RSpec.describe 'preview and no-change auditing' do
   let(:actor) { 'ur_colonel_public' } # PUBLIC identity (extid/email)
@@ -225,6 +235,41 @@ RSpec.describe 'preview and no-change auditing' do
       end
     end
 
+    # The one op in the cohort whose applied row and whose no-change row come
+    # out of the SAME method (`record_audit_event`), so nothing structural
+    # keeps them apart — only the marker does. And this admin wrapper exists
+    # precisely to separate an OPERATOR verification from the self-service
+    # Rodauth one, so a dropped no-op would let an operator poke repeatedly at
+    # a named account's verification state behind a silent trail.
+    describe Auth::Operations::Customers::SetVerification do
+      let(:customer) do
+        double('Customer', extid: 'ur_target_public', objid: 'cust-obj-1', role: 'customer')
+      end
+
+      before do
+        allow(Auth::Operations::SetCustomerVerification).to receive(:new)
+          .and_return(double('SetCustomerVerification', call: :no_change))
+      end
+
+      it 'records the attempt even though one emitter serves both paths' do
+        result = described_class.new(
+          customer: customer, verified: true, actor: actor, verified_by: 'colonel_admin',
+        ).call
+
+        expect(result).to eq(:no_change)
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            actor: actor,
+            verb: described_class::AUDIT_VERB,
+            target: 'ur_target_public',
+            result: :success,
+            detail: hash_including(outcome: 'no_change'),
+          ),
+        )
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record_access)
+      end
+    end
+
     describe Onetime::Operations::Memberships::Add do
       let(:org) { double('Organization', objid: 'org-obj-1', extid: 'on_org_ext') }
       let(:customer) { double('Customer', objid: 'cust-obj-1', extid: 'ur_member') }
@@ -247,6 +292,75 @@ RSpec.describe 'preview and no-change auditing' do
           target: 'ur_member',
           result: :success,
           detail: { outcome: 'no_change', role: 'admin', org_id: 'on_org_ext' },
+        )
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record_access)
+      end
+    end
+
+    # The org-scoped twin of the customer role change above, and the reason the
+    # envelope is shared rather than retyped: reaching for `owner` on a
+    # membership that already holds it is the same reach for the same
+    # privilege, so whether the state happened to already match must not decide
+    # whether the trail shows the reach.
+    describe Onetime::Operations::Memberships::SetRole do
+      let(:org) { double('Organization', objid: 'org-obj-1', extid: 'on_org_ext') }
+      let(:customer) { double('Customer', objid: 'cust-obj-1', extid: 'ur_member') }
+
+      before do
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org-obj-1', 'cust-obj-1')
+          .and_return(double('OrganizationMembership', role: 'owner', active?: true))
+      end
+
+      def no_change
+        described_class.new(org: org, customer: customer, new_role: 'owner', actor: actor).call
+      end
+
+      it 'records the attempt under the normal verb, marked outcome: no_change' do
+        result = no_change
+
+        expect(result.status).to eq(:no_change)
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            actor: actor,
+            verb: described_class::AUDIT_VERB,
+            target: 'ur_member',
+            result: :success,
+            detail: hash_including(outcome: 'no_change'),
+          ),
+        )
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record_access)
+      end
+
+      # Here the absence is the DISTINCTION, not an omission: this op's applied
+      # event is fail-closed (#4333) because the membership stores only the role
+      # it now holds. A no-change moved no privilege, so there is no untraceable
+      # grant for a hard failure to protect — only an idempotent no-op to break.
+      it 'is NOT fail-closed, unlike the applied membership role change' do
+        no_change
+
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).with(hash_excluding(:fail_closed))
+      end
+    end
+
+    # A billing verb, and the target is the ORG rather than the acting colonel:
+    # moving a paying org onto a plan is money-adjacent, so an operator
+    # re-applying the plan the org already holds must not read as silence.
+    describe Onetime::Operations::Org::SetPlan do
+      let(:org) { double('Organization', extid: 'on_org_ext', planid: 'identity_plus_v1') }
+
+      it 'records a re-application of the plan the org already holds' do
+        result = described_class.new(org: org, planid: 'identity_plus_v1', actor: actor).call
+
+        expect(result.status).to eq(:no_change)
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            actor: actor,
+            verb: described_class::AUDIT_VERB,
+            target: 'on_org_ext',
+            result: :success,
+            detail: hash_including(outcome: 'no_change'),
+          ),
         )
         expect(Onetime::ColonelAuditEvent).not_to have_received(:record_access)
       end
@@ -335,6 +449,125 @@ RSpec.describe 'preview and no-change auditing' do
       end
     end
 
+    # The membership-scoped sibling of the org op above, on the same D15
+    # short-circuit. It earns its own row because a membership grant is NOT
+    # bounded by the org plan or the role template — the grants set is unioned
+    # on top with no intersection, so it reaches `can?` directly. "An operator
+    # asked for that reach" is the fact, whether or not the set moved.
+    describe Onetime::Operations::Memberships::EntitlementOverride do
+      let(:org) do
+        double('Organization', objid: 'org-obj-1', extid: 'on_org_ext', billing_enabled?: true)
+      end
+      let(:customer) { double('Customer', objid: 'cust-obj-1', extid: 'ur_member') }
+
+      # A literal, not a constant read: this op has AUDIT_VERB_PREFIX and
+      # computes the emitted verb from @action, so the string IS the assertion.
+      let(:verb) { 'membership.entitlement.grant' }
+
+      before do
+        allow(Onetime::OrganizationMembership).to receive(:find_by_org_customer)
+          .with('org-obj-1', 'cust-obj-1')
+          .and_return(
+            double(
+              'OrganizationMembership',
+              active?: true,
+              entitlements_grants: double('GrantsSet', to_a: ['custom_branding']),
+              entitlements_revokes: double('RevokesSet', to_a: []),
+              materialized_entitlements: double('MaterializedSet', to_a: ['custom_branding']),
+            ),
+          )
+      end
+
+      def run(dry_run:)
+        described_class.new(
+          org: org, customer: customer, action: 'grant', actor: actor,
+          entitlement: 'custom_branding', dry_run: dry_run,
+        ).call
+      end
+
+      it 'stays on the observation trail as a preview when discovered dry' do
+        result = run(dry_run: true)
+
+        expect(result.status).to eq(:no_change)
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+        expect(Onetime::ColonelAuditEvent).to have_received(:record_access).once.with(
+          hash_including(
+            actor: actor,
+            verb: verb,
+            target: 'ur_member',
+            result: 'preview',
+            detail: hash_including(dry_run: true, outcome: 'no_change'),
+          ),
+        )
+      end
+
+      it 'lands on the operator trail when the same grant is live' do
+        result = run(dry_run: false)
+
+        expect(result.status).to eq(:no_change)
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record_access)
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            actor: actor,
+            verb: verb,
+            target: 'ur_member',
+            result: :success,
+            detail: hash_including(outcome: 'no_change'),
+          ),
+        )
+      end
+    end
+
+    # The highest-value account-takeover primitive an operator has, which is
+    # why verb-filter completeness matters MOST here: a :no_change answer also
+    # CONFIRMS the account currently holds the address that was asked for, so a
+    # repeated same-address probe is exactly the pattern the trail must not go
+    # quiet on. Its dry-run half is the one preview in the cohort that carries
+    # the no-change marker onto the observation trail — both markers at once.
+    describe Auth::Operations::Customers::ChangeEmail do
+      let(:customer) do
+        double('Customer', extid: 'ur_target_public', email: 'old@example.com', anonymous?: false)
+      end
+
+      def run(dry_run:)
+        described_class.new(
+          customer: customer, new_email: 'OLD@Example.com', actor: actor, dry_run: dry_run,
+        ).call
+      end
+
+      it 'records a LIVE same-address request as a no-change attempt' do
+        result = run(dry_run: false)
+
+        expect(result.status).to eq(:no_change)
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record_access)
+        expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+          hash_including(
+            actor: actor,
+            verb: described_class::AUDIT_VERB,
+            target: 'ur_target_public',
+            result: :success,
+            detail: hash_including(outcome: 'no_change'),
+          ),
+        )
+      end
+
+      it 'keeps the dry-run half on the observation trail, marked BOTH ways' do
+        result = run(dry_run: true)
+
+        expect(result.status).to eq(:no_change)
+        expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+        expect(Onetime::ColonelAuditEvent).to have_received(:record_access).once.with(
+          hash_including(
+            actor: actor,
+            verb: described_class::AUDIT_VERB,
+            target: 'ur_target_public',
+            result: 'preview',
+            detail: hash_including(dry_run: true, outcome: 'no_change'),
+          ),
+        )
+      end
+    end
+
     describe Onetime::Operations::Dlq::Replay do
       let(:channel) { double('Channel', close: true, open?: false) }
       let(:connection) { double('Connection', create_channel: channel) }
@@ -377,6 +610,201 @@ RSpec.describe 'preview and no-change auditing' do
           detail: { dry_run: true, would_replay: 0, available: 0, outcome: 'no_change' },
         )
       end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # The envelope itself (#4366)
+  # ---------------------------------------------------------------------------
+  # Everything above asserts the envelope one op at a time, which is how the
+  # feature was built: 28 hand-written kwarg lists that had to agree with each
+  # other, and CI would happily accept the tenth op getting one of them wrong.
+  # These examples assert it ONCE, against the module that now produces it, so
+  # the three fields the whole feature rests on hold by construction:
+  #
+  #   1. WHICH TRAIL — chosen by which method you call, not by a kwarg.
+  #   2. THE MARKER — merged last, so a call site cannot displace it.
+  #   3. NO `fail_closed` — there is no parameter for it to pass.
+  #
+  describe Onetime::Operations::AuditAttempt do
+    # A minimal host: the module plus the hooks an op supplies. Deliberately not
+    # a real op — the point here is the envelope, and every op's own detail is
+    # already pinned above or in its own spec.
+    let(:host_class) do
+      Class.new do
+        include Onetime::Operations::AuditAttempt
+
+        def initialize(actor:, target:)
+          @actor  = actor
+          @target = target
+        end
+
+        def audit_target = @target
+
+        # The module's methods are private, exactly as an op's callers see them,
+        # so the examples reach them through shims rather than `send`.
+        def no_change(detail = {}) = record_no_change_attempt(detail)
+        def preview(detail = {})   = record_preview_observation(detail)
+      end.tap { |klass| klass.const_set(:AUDIT_VERB, 'test.envelope') }
+    end
+
+    let(:host) { host_class.new(actor: actor, target: 'tg_public') }
+
+    it 'puts a no-change attempt on the OPERATOR trail under the op verb' do
+      host.no_change(purged: 0)
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record).once.with(
+        actor: actor,
+        verb: 'test.envelope',
+        target: 'tg_public',
+        result: :success,
+        detail: { purged: 0, outcome: 'no_change' },
+      )
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record_access)
+    end
+
+    it 'puts a preview on the OBSERVATION trail under the same op verb' do
+      host.preview(count: 42)
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record_access).once.with(
+        actor: actor,
+        verb: 'test.envelope',
+        target: 'tg_public',
+        result: 'preview',
+        detail: { count: 42, dry_run: true },
+      )
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+
+    # The invariant #4333 leaves to this module: a no-change destroyed nothing,
+    # so there is no irrecoverable fact for a hard failure to surface. All
+    # fail-closing an idempotent no-op could do is fail an operation that had
+    # already succeeded by doing nothing. Asserted against the method's ARITY
+    # rather than the emitted kwargs, because the guarantee is that no op can
+    # opt in even by accident.
+    it 'exposes no fail_closed parameter, so a no-change row cannot be fail-closed' do
+      expect(described_class.instance_method(:record_no_change_attempt).parameters)
+        .to eq([[:opt, :detail]])
+
+      host.no_change(purged: 0)
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record).with(hash_excluding(:fail_closed))
+    end
+
+    # The marker is what every verb-filter query keys off to tell an ATTEMPT
+    # from an EFFECT, so a call site does not get to overwrite it — the merge
+    # order in the module puts the marker last on purpose.
+    it 'will not let a call site displace the no_change marker' do
+      host.no_change(outcome: 'applied')
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record)
+        .with(hash_including(detail: { outcome: 'no_change' }))
+    end
+
+    it 'will not let a call site displace the dry_run marker' do
+      host.preview(dry_run: false)
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record_access)
+        .with(hash_including(detail: { dry_run: true }))
+    end
+
+    # `AuditReason#with_reason` returns nil for a nil detail when no reason was
+    # given, so the two modules have to compose without the envelope blowing up.
+    it 'tolerates a nil detail, so with_reason composes with it' do
+      host.no_change(nil)
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record)
+        .with(hash_including(detail: { outcome: 'no_change' }))
+    end
+
+    # Three ops compute their verb rather than reading a constant
+    # (`customers/set_suspension` by direction, both `entitlement_override`s
+    # from `@action`). A class-body definition wins over an included module's,
+    # which is why the hook is named for what those ops already called it.
+    it 'lets an op whose verb is computed override the AUDIT_VERB default' do
+      computed = Class.new(host_class) do
+        def audit_verb = 'test.computed'
+      end
+
+      computed.new(actor: actor, target: 'tg_public').no_change
+
+      expect(Onetime::ColonelAuditEvent).to have_received(:record)
+        .with(hash_including(verb: 'test.computed'))
+    end
+
+    # No default target, on purpose: an op that forgets the hook should fail
+    # loudly on its first emit rather than record a row against nil.
+    it 'raises rather than recording a row against a nil target' do
+      forgetful = Class.new do
+        include Onetime::Operations::AuditAttempt
+
+        def go = record_no_change_attempt({})
+      end
+      forgetful.const_set(:AUDIT_VERB, 'test.forgetful')
+
+      expect { forgetful.new.go }.to raise_error(NotImplementedError, /audit_target/)
+      expect(Onetime::ColonelAuditEvent).not_to have_received(:record)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Cohort membership (#4366)
+  # ---------------------------------------------------------------------------
+  # The gap the per-op examples above cannot close: they pin the ops they know
+  # about, and say nothing about the fourteenth op someone adds next quarter.
+  # These two walk the whole cohort, so an op that hand-rolls the envelope
+  # again is a CI failure rather than a review miss.
+  describe 'the #4337 cohort' do
+    let(:cohort) do
+      [
+        Auth::Operations::Customers::ChangeEmail,
+        Auth::Operations::Customers::SetPlan,
+        Auth::Operations::Customers::SetRole,
+        Auth::Operations::Customers::SetSuspension,
+        Auth::Operations::Customers::SetVerification,
+        Onetime::Operations::Dlq::Purge,
+        Onetime::Operations::Dlq::Replay,
+        Onetime::Operations::Email::SendTest,
+        Onetime::Operations::Memberships::Add,
+        Onetime::Operations::Memberships::EntitlementOverride,
+        Onetime::Operations::Memberships::SetRole,
+        Onetime::Operations::Org::EntitlementOverride,
+        Onetime::Operations::Org::SetPlan,
+      ]
+    end
+
+    it 'composes the shared envelope in every op' do
+      missing = cohort.reject { |op| op.include?(Onetime::Operations::AuditAttempt) }
+
+      expect(missing).to be_empty
+    end
+
+    # The module has no default target, so every op owes one. Checked
+    # structurally rather than by calling it, since building 13 ops here would
+    # duplicate 13 specs' worth of fixtures to learn nothing extra.
+    it 'supplies the target hook in every op, since the module has no default' do
+      missing = cohort.reject do |op|
+        (op.private_instance_methods(false) + op.instance_methods(false)).include?(:audit_target)
+      end
+
+      expect(missing).to be_empty
+    end
+
+    # The three whose verb is not a single constant must say so themselves.
+    it 'overrides the verb hook wherever the verb is not a bare AUDIT_VERB' do
+      computed = [
+        Auth::Operations::Customers::SetSuspension,
+        Onetime::Operations::Memberships::EntitlementOverride,
+        Onetime::Operations::Org::EntitlementOverride,
+      ]
+      missing = computed.reject { |op| op.private_instance_methods(false).include?(:audit_verb) }
+
+      expect(missing).to be_empty
+
+      # And the other ten must carry the constant the default hook reads.
+      constant_verb = (cohort - computed).reject { |op| op.const_defined?(:AUDIT_VERB, false) }
+
+      expect(constant_verb).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Summary

[#4366](https://github.com/onetimesecret/onetimesecret/issues/4366)

The #4337 attempt/preview audit envelope was hand-rolled per op: every emitter re-typed the same five kwargs, and the correctness of the whole feature rested on ~28 hand-written kwarg lists agreeing with one another.

This adds `Onetime::Operations::AuditAttempt` (`lib/onetime/operations/audit_attempt.rb`) and converts all 13 ops in the #4337 cohort to it.

The point is not DRY — the kwarg lines are dwarfed by the 10–20 line security rationale comment above each one, and those comments stay exactly where they are. The point is that **three marker fields were enforced only by convention**, and each is now structural:

- **`result:`** is no longer a kwarg a call site types. It is decided by which method you call: `record_no_change_attempt` writes the operator trail (`ColonelAuditEvent.record`, `result: :success`), `record_preview_observation` writes the observation trail (`record_access`, `result: 'preview'`).
- **`outcome: 'no_change'` and `dry_run: true`** are merged into the detail *last*, so a call site cannot displace the marker every verb-filter query depends on.
- **`fail_closed:`** has no parameter at all, so a no-change row cannot be fail-closed by construction. A no-change destroyed nothing, so there is no irrecoverable fact for a hard failure to protect; all it could do is fail an operation that had already succeeded by doing nothing (#4333).

> Note: this deviates from the issue's sketch in one deliberate way. The sketch merged the marker *first* (`{ outcome: 'no_change' }.merge(detail)`), which leaves it displaceable by a caller-supplied key. Merging it last makes the marker unforgeable while keeping every emitted payload equal (`Hash#==` ignores insertion order), which is what the stated problem asks for.

`AuditAttempt` is a **sibling** of `Onetime::AuditReason`, not part of it: reason policy has per-op variance the envelope does not (`set_suspension` keeps `reason:` present unconditionally on SUSPEND but omit-when-absent on UNSUSPEND, so a module that auto-merged the reason would break that shape). The two compose at the call site: `record_no_change_attempt(with_reason(purged: 0))`.

Three hooks carry the per-op parts: `audit_actor` (defaults to `@actor`), `audit_verb` (defaults to the class's `AUDIT_VERB`), and `audit_target` (no default; it raises rather than let an op record a row against nil). Both `entitlement_override` ops already defined `audit_verb` under exactly that name, so they satisfy the hook untouched; `set_suspension` overrides it for the suspend/unsuspend direction.

### Also fixed: the divergence hand-rolling had already produced

`Auth::Operations::Customers::ChangeEmail` did not include `Onetime::AuditReason` and stored `@reason` raw. `AuditReason::MAX_LENGTH` is 255 specifically so a reason is never silently clipped by `ColonelAuditEvent`'s 256-char per-value bound; the colonel HTTP adapter sanitizes, but the CLI passes `--reason` straight through, so a long reason on the highest-value verb in the trail landed truncated. It now includes the module, normalizes both `@reason` and `@ticket`, and shares one `with_provenance` helper between its no-change and applied events.

This is the one intentional behaviour change in the PR, and the carve-out the issue's acceptance criteria allow for.

## Related Issues

Refs #4366, #4337, #4338, #4333

## Test Plan

Verified against a **pre-change baseline on the same working tree**, not just "tests pass":

| | baseline | with this PR |
|---|---|---|
| `spec/unit` + `apps/web/auth/spec/operations` | 5569 examples, 1 failure, 29 pending | 5588 examples, 1 failure, 29 pending |
| `pnpm run test:tryouts` | 10 failed, 9959 passed | 10 failed, 9959 passed |

The single rspec failure (`spec/unit/onetime/mail/mailer_spec.rb`) and the 10 tryout failures (config/brand fixtures) are pre-existing and identical before and after; none touch audit code.

- **No existing spec or tryout needed an edit.** Per the issue's acceptance criteria, a spec that needed a kwarg change would mean the refactor moved an emitted payload. None did. The only spec file touched is the shared cross-op contract spec, which the issue asks to be extended.
- `try/unit/operations/dlq_try.rb` 29/29, and all 28 files under `try/integration/api/colonel/` pass.
- **RuboCop** clean on the new module and all 13 converted ops.

Invariants checked explicitly:

- `grep -rn "fail_closed: true" lib apps` is byte-identical before and after apart from line-number shifts. All 13 production call sites are applied-destructive and untouched.
- Every converted no-change still calls `record`; every converted preview still calls `record_access`. No emitter switched trails.
- Per-op `rescue StandardError` / logger wrappers are preserved verbatim; the module neither adds nor removes rescue behaviour, since `record` and `record_access` are already fail-open by default.

`spec/unit/onetime/operations/preview_and_no_change_audit_spec.rb` goes from 8 to **all 13** cohort ops (19 → 36 examples, 0 deletions), plus two sections that close the gap the per-op examples cannot: the envelope's own invariants (markers cannot be displaced, no `fail_closed` parameter, target hook has no default) and a cohort-membership walk, so a fourteenth op that hand-rolls the envelope is a CI failure rather than a review miss.

## Deliberately out of scope

The 9 pre-#4337 preview-only emitters (`domains/remove`, `domains/transfer`, `domains/repair`, `domains/ensure_domain_configs`, `org/delete`, `org/reconcile`, `org/transfer_ownership`, `email/sync_provider_feedback`, `customers/reconcile_role_index`) still build the envelope inline. The issue splits them into a second PR on purpose: they carry arity-heavy signatures and their own rescue/logging conventions, and folding them into the same diff makes a security refactor un-reviewable. They are now **named in `audit-logging.md`** so the gap is visible rather than silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzmmWfaKd6eqVMXeCa3aFv