### PR TITLE
Gate the sessions security card on AUTH_ACTIVE_SESSIONS_ENABLED

### DIFF
--- a/changelog.d/20260910_011600_delano_active_sessions_settings.rst
+++ b/changelog.d/20260910_011600_delano_active_sessions_settings.rst
@@ -1,0 +1,11 @@
+Changed
+-------
+
+- The active-session inactivity deadline is temporarily extended from 24 to 72
+  hours.
+
+Fixed
+-----
+
+- The Active Sessions card and ``/account/settings/security/sessions`` are now
+  available when ``AUTH_ACTIVE_SESSIONS_ENABLED`` is enabled.

--- a/lib/onetime/session/active_session_gate.rb
+++ b/lib/onetime/session/active_session_gate.rb
@@ -115,7 +115,7 @@ module Onetime
     # Rodauth's session deadlines, in seconds. Owned here and fed to Rodauth
     # (`session_inactivity_deadline`, `session_lifetime_deadline`) so this
     # gate and the sessions page's sweep apply the same two values.
-    INACTIVITY_DEADLINE = 86_400    # 24 hours since `last_use`
+    INACTIVITY_DEADLINE = 86_400*3  # 72 hours since `last_use`
     LIFETIME_DEADLINE   = 2_592_000 # 30 days since `created_at`
 
     TABLE = :account_active_session_keys

--- a/src/apps/workspace/account/ConnectedIdentities.vue
+++ b/src/apps/workspace/account/ConnectedIdentities.vue
@@ -6,6 +6,7 @@
   import OIcon from '@/shared/components/icons/OIcon.vue';
   import ConfirmDialog from '@/shared/components/modals/ConfirmDialog.vue';
   import { useConnectedIdentities } from '@/shared/composables/useConnectedIdentities';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
   import { useCsrfStore } from '@/shared/stores/csrfStore';
   import { submitSsoLogin } from '@/shared/utils/sso';
   // Two label helpers on purpose: linked rows name the provider canonically
@@ -14,6 +15,7 @@
   import {
     configuredProviderLabel,
     getSsoProviders,
+    isActiveSessionsEnabledOf,
     providerLabel,
     type SsoProvider,
   } from '@/utils/features';
@@ -23,6 +25,11 @@
 
   const { t } = useI18n();
   const csrfStore = useCsrfStore();
+  const bootstrapStore = useBootstrapStore();
+
+  // Sessions link is gated on AUTH_ACTIVE_SESSIONS_ENABLED; the route guard
+  // bounces to /account when off, so don't offer a dead-end link.
+  const activeSessionsEnabled = computed(() => isActiveSessionsEnabledOf(bootstrapStore));
   const { identities, isLoading, error, errorCode, fetchIdentities, removeIdentity, clearError } =
     useConnectedIdentities();
 
@@ -287,6 +294,7 @@
           <div class="space-y-2">
             <!-- prettier-ignore-attribute class -->
             <router-link
+              v-if="activeSessionsEnabled"
               to="/account/settings/security/sessions"
               class="
                 flex items-center gap-3 text-sm text-gray-700 hover:text-brand-600

--- a/src/apps/workspace/account/MfaSettings.vue
+++ b/src/apps/workspace/account/MfaSettings.vue
@@ -7,12 +7,19 @@
   import SettingsLayout from '@/apps/workspace/layouts/SettingsLayout.vue';
   import { useAccount } from '@/shared/composables/useAccount';
   import { useMfa } from '@/shared/composables/useMfa';
+  import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
+  import { isActiveSessionsEnabledOf } from '@/utils/features';
   import { formatDisplayDateTime } from '@/utils/format';
-  import { onMounted, ref } from 'vue';
+  import { computed, onMounted, ref } from 'vue';
 
   const { t } = useI18n();
   const { mfaStatus, isLoading, error, fetchMfaStatus, disableMfa, clearError } = useMfa();
   const { fetchAccountInfo } = useAccount();
+  const bootstrapStore = useBootstrapStore();
+
+  // Sessions link is gated on AUTH_ACTIVE_SESSIONS_ENABLED; the route guard
+  // bounces to /account when off, so don't offer a dead-end link.
+  const activeSessionsEnabled = computed(() => isActiveSessionsEnabledOf(bootstrapStore));
 
   const showSetupWizard = ref(false);
   const showDisableConfirm = ref(false);
@@ -229,6 +236,7 @@
               <span>{{ t('web.auth.recovery_codes.link_title') }}</span>
             </router-link>
             <router-link
+              v-if="activeSessionsEnabled"
               to="/account/settings/security/sessions"
               class="flex items-center gap-3 text-sm text-gray-700 hover:text-brand-600 dark:text-gray-300 dark:hover:text-brand-400">
               <OIcon

--- a/src/apps/workspace/account/settings/SecurityOverview.vue
+++ b/src/apps/workspace/account/settings/SecurityOverview.vue
@@ -8,12 +8,13 @@
   import type { AccountInfo } from '@/types/auth';
   import {
     hasPasswordOf,
+    isActiveSessionsEnabledOf,
     isMfaEnabledOf,
     isPasswordAuthPermittedOf,
     isSsoEnabledOf,
     isWebAuthnEnabledOf,
   } from '@/utils/features';
-  import { computed, onMounted, ref } from 'vue';
+  import { computed, onMounted } from 'vue';
   import { useI18n } from 'vue-i18n';
 
   const { t } = useI18n();
@@ -21,7 +22,7 @@
 
   // Feature toggles — derived from the reactive bootstrap store so they reflect
   // post-login state without re-mounting (e.g. after checkWindowStatus refresh).
-  const showSessionsCard = ref(false);
+  const activeSessionsEnabled = computed(() => isActiveSessionsEnabledOf(bootstrapStore));
   const mfaFeatureEnabled = computed(() => isMfaEnabledOf(bootstrapStore));
   const webAuthnEnabled = computed(() => isWebAuthnEnabledOf(bootstrapStore));
   const ssoEnabled = computed(() => isSsoEnabledOf(bootstrapStore));
@@ -195,7 +196,7 @@
       cards.push(buildConnectionsCard());
     }
 
-    if (showSessionsCard.value) {
+    if (activeSessionsEnabled.value) {
       cards.push(buildSessionsCard(accountInfo.value));
     }
 

--- a/src/apps/workspace/config/settings-navigation.ts
+++ b/src/apps/workspace/config/settings-navigation.ts
@@ -5,28 +5,38 @@
 //
 // Own = owner, Adm = admin, Mem = member; pw = password account, SSO = SSO-provisioned,
 // inv = invited (has password)
-// ┌──────────────────┬────────────────────┬────────┬────────┬────────┬────────┬────────┬────────┐
-// │ Tab / Section    │ Gate               │ Own pw │ Own SSO│ Adm pw │ Adm SSO│ Mem inv│ Mem SSO│
-// ├──────────────────┼────────────────────┼────────┼────────┼────────┼────────┼────────┼────────┤
-// │ Profile          │ —                  │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
-// │  └ Change Email  │ isOwnerOrAdmin     │ ✓      │ —      │ ✓      │ —      │ —      │ —      │
-// │                  │ + hasPassword      │        │        │        │        │        │        │
-// │ Security section │ isFullAuthMode     │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
-// │  ├ Password      │ hasPassword        │ ✓      │ —      │ ✓      │ —      │ ✓      │ —      │
-// │  ├ MFA           │ hasPassword        │ ✓      │ —      │ ✓      │ —      │ ✓      │ —      │
-// │  ├ Sessions      │ —                  │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
-// │  ├ Recovery      │ hasPassword        │ ✓      │ —      │ ✓      │ —      │ ✓      │ —      │
-// │  ├ Passkeys      │ isWebAuthnEnabled  │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
-// │  └ Connections   │ isSsoEnabled       │ ✓†     │ ✓†     │ ✓†     │ ✓†     │ ✓†     │ ✓†     │
-// │ API              │ —                  │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
-// │ Region           │ isOwnerOrAdmin     │ ✓*     │ ✓*     │ ✓*     │ ✓*     │ —      │ —      │
-// │ Caution          │ isOwnerOrAdmin     │ ✓*     │ ✓*     │ ✓*     │ ✓*     │ —      │ —      │
-// │                  │                    │        │        │        │        │        │        │
-// │ * also requires isFullAuthMode        │        │        │        │        │        │        │
-// │ † only when SSO is enabled (isSsoEnabled)                                    │        │
-// └──────────────────┴────────────────────┴────────┴────────┴────────┴────────┴────────┴────────┘
+/* eslint-disable max-len -- box-drawing table; wrapping would break column alignment */
+// ┌──────────────────┬─────────────────────────┬────────┬────────┬────────┬────────┬────────┬────────┐
+// │ Tab / Section    │ Gate                    │ Own pw │ Own SSO│ Adm pw │ Adm SSO│ Mem inv│ Mem SSO│
+// ├──────────────────┼─────────────────────────┼────────┼────────┼────────┼────────┼────────┼────────┤
+// │ Profile          │ —                       │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
+// │  └ Change Email  │ isOwnerOrAdmin          │ ✓      │ —      │ ✓      │ —      │ —      │ —      │
+// │                  │ + hasPassword           │        │        │        │        │        │        │
+// │ Security section │ isFullAuthMode          │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
+// │  ├ Password      │ hasPassword             │ ✓      │ —      │ ✓      │ —      │ ✓      │ —      │
+// │  ├ MFA           │ hasPassword             │ ✓      │ —      │ ✓      │ —      │ ✓      │ —      │
+// │  ├ Sessions      │ isActiveSessionsEnabled │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
+// │  ├ Recovery      │ hasPassword             │ ✓      │ —      │ ✓      │ —      │ ✓      │ —      │
+// │  ├ Passkeys      │ isWebAuthnEnabled       │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
+// │  └ Connections   │ isSsoEnabled            │ ✓†     │ ✓†     │ ✓†     │ ✓†     │ ✓†     │ ✓†     │
+// │ API              │ —                       │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │ ✓      │
+// │ Region           │ isOwnerOrAdmin          │ ✓*     │ ✓*     │ ✓*     │ ✓*     │ —      │ —      │
+// │ Caution          │ isOwnerOrAdmin          │ ✓*     │ ✓*     │ ✓*     │ ✓*     │ —      │ —      │
+// │                  │                         │        │        │        │        │        │        │
+// │ * also requires isFullAuthMode             │        │        │        │        │        │        │
+// │ † only when SSO is enabled (isSsoEnabled)  │        │        │        │        │        │        │
+// └──────────────────┴─────────────────────────┴────────┴────────┴────────┴────────┴────────┴────────┘
+/* eslint-enable max-len */
 
-import { hasPassword, isFullAuthMode, isSsoEnabled, isSsoOnlyMode, isOwnerOrAdmin, isWebAuthnEnabled } from '@/utils/features';
+import {
+  hasPassword,
+  isActiveSessionsEnabled,
+  isFullAuthMode,
+  isOwnerOrAdmin,
+  isSsoEnabled,
+  isSsoOnlyMode,
+  isWebAuthnEnabled,
+} from '@/utils/features';
 import type { ComposerTranslation } from 'vue-i18n';
 
 /**
@@ -44,6 +54,7 @@ export interface NavigationFeatures {
   isOwnerOrAdmin: boolean;
   isWebAuthnEnabled: boolean;
   isSsoEnabled: boolean;
+  isActiveSessionsEnabled: boolean;
 }
 
 function resolveFeatures(features?: NavigationFeatures): NavigationFeatures {
@@ -55,6 +66,7 @@ function resolveFeatures(features?: NavigationFeatures): NavigationFeatures {
       isOwnerOrAdmin: isOwnerOrAdmin(),
       isWebAuthnEnabled: isWebAuthnEnabled(),
       isSsoEnabled: isSsoEnabled(),
+      isActiveSessionsEnabled: isActiveSessionsEnabled(),
     }
   );
 }
@@ -136,12 +148,9 @@ function getProfileSection(t: ComposerTranslation, f: NavigationFeatures): Setti
  * that regular members can access Sessions. Password-dependent sub-tabs
  * (password, MFA, recovery codes) are gated by hasPassword — visible to
  * any user who set a password (owners, admins, or invited members).
- * Passkeys are gated by the webauthn feature flag independently.
+ * Passkeys and Sessions are gated by their feature flags independently.
  */
-function getSecuritySection(
-  t: ComposerTranslation,
-  f: NavigationFeatures
-): SettingsNavigationItem {
+function getSecuritySection(t: ComposerTranslation, f: NavigationFeatures): SettingsNavigationItem {
   return {
     id: 'security',
     to: '/account/settings/security',
@@ -169,6 +178,9 @@ function getSecuritySection(
         to: '/account/settings/security/sessions',
         icon: { collection: 'heroicons', name: 'computer-desktop-solid' },
         label: t('web.auth.sessions.title'),
+        // Gated on the active_sessions bootstrap flag (AUTH_ACTIVE_SESSIONS_ENABLED),
+        // mirroring the route guard in account.ts; without it the link dead-ends.
+        visible: () => f.isActiveSessionsEnabled,
       },
       {
         id: 'recovery-codes',
@@ -200,10 +212,7 @@ function getSecuritySection(
 }
 
 /** Region section navigation */
-function getRegionSection(
-  t: ComposerTranslation,
-  f: NavigationFeatures
-): SettingsNavigationItem {
+function getRegionSection(t: ComposerTranslation, f: NavigationFeatures): SettingsNavigationItem {
   return {
     id: 'region',
     to: '/account/region',

--- a/src/apps/workspace/layouts/SettingsLayout.vue
+++ b/src/apps/workspace/layouts/SettingsLayout.vue
@@ -14,6 +14,7 @@ import { useBootstrapStore } from '@/shared/stores/bootstrapStore';
 import { debugLog } from '@/utils/debug';
 import {
   hasPasswordOf,
+  isActiveSessionsEnabledOf,
   isFullAuthModeOf,
   isOwnerOrAdminOf,
   isSsoEnabledOf,
@@ -42,6 +43,7 @@ const tabItems = computed(() => {
     isOwnerOrAdmin: isOwnerOrAdminOf(bootstrapStore),
     isWebAuthnEnabled: isWebAuthnEnabledOf(bootstrapStore),
     isSsoEnabled: isSsoEnabledOf(bootstrapStore),
+    isActiveSessionsEnabled: isActiveSessionsEnabledOf(bootstrapStore),
   };
   const sections = getSettingsNavigationSections(t, features);
   const allItems = sections.flatMap((section) => section.items);

--- a/src/apps/workspace/routes/account.ts
+++ b/src/apps/workspace/routes/account.ts
@@ -2,7 +2,13 @@
 
 import WorkspaceLayout from '@/apps/workspace/layouts/WorkspaceLayout.vue';
 import { SCOPE_PRESETS } from '@/types/router';
-import { hasPassword, isFullAuthMode, isOwnerOrAdmin, isPasswordAuthPermitted } from '@/utils/features';
+import {
+  hasPassword,
+  isActiveSessionsEnabled,
+  isFullAuthMode,
+  isOwnerOrAdmin,
+  isPasswordAuthPermitted,
+} from '@/utils/features';
 import type { RouteRecordRaw } from 'vue-router';
 
 /**
@@ -62,6 +68,17 @@ function checkSetPasswordAccess() {
  */
 function checkSecurityAccess() {
   if (!isFullAuthMode()) {
+    return { name: 'Account' };
+  }
+  return true;
+}
+
+/**
+ * Route guard for the Active Sessions page: full auth mode AND the
+ * active_sessions feature flag (AUTH_ACTIVE_SESSIONS_ENABLED).
+ */
+function checkActiveSessionsAccess() {
+  if (!isFullAuthMode() || !isActiveSessionsEnabled()) {
     return { name: 'Account' };
   }
   return true;
@@ -283,7 +300,7 @@ const routes: Array<RouteRecordRaw> = [
   {
     path: '/account/settings/security/sessions',
     name: 'Active Sessions',
-    beforeEnter: checkSecurityAccess,
+    beforeEnter: checkActiveSessionsAccess,
     component: () => import('@/apps/workspace/account/ActiveSessions.vue'),
     meta: {
       title: 'web.TITLES.active_sessions',

--- a/src/apps/workspace/routes/account.ts
+++ b/src/apps/workspace/routes/account.ts
@@ -64,7 +64,7 @@ function checkSetPasswordAccess() {
 
 /**
  * Route guard for security routes accessible to all authenticated
- * users (Security Overview, Active Sessions).
+ * users (Security Overview, Passkeys, Connected Identities).
  */
 function checkSecurityAccess() {
   if (!isFullAuthMode()) {
@@ -74,11 +74,17 @@ function checkSecurityAccess() {
 }
 
 /**
- * Route guard for the Active Sessions page: full auth mode AND the
- * active_sessions feature flag (AUTH_ACTIVE_SESSIONS_ENABLED).
+ * Route guard for the Active Sessions page: everything checkSecurityAccess
+ * requires AND the active_sessions feature flag
+ * (AUTH_ACTIVE_SESSIONS_ENABLED). Delegates so the auth-mode rule lives in
+ * one place.
  */
 function checkActiveSessionsAccess() {
-  if (!isFullAuthMode() || !isActiveSessionsEnabled()) {
+  const securityAccess = checkSecurityAccess();
+  if (securityAccess !== true) {
+    return securityAccess;
+  }
+  if (!isActiveSessionsEnabled()) {
     return { name: 'Account' };
   }
   return true;

--- a/src/schemas/contracts/bootstrap.ts
+++ b/src/schemas/contracts/bootstrap.ts
@@ -359,6 +359,7 @@ export const featuresSchema = z.object({
   password_requirements: z.boolean().optional(),
   email_auth: z.boolean().optional(),
   webauthn: z.boolean().optional(),
+  active_sessions: z.boolean().optional(),
   sso: z.union([z.boolean(), ssoConfigSchema]).optional(),
   // Legacy scalar projection retained for existing consumers.
   restrict_to: restrictToSchema.nullable().optional(),

--- a/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
+++ b/src/tests/apps/workspace/account/ConnectedIdentities.spec.ts
@@ -81,9 +81,12 @@ vi.mock('@/shared/composables/useConnectedIdentities', () => ({
 // them (built-in map vs. operator display_name) is exercised, not stubbed away.
 import type { SsoProvider } from '@/utils/features';
 const mockGetSsoProviders = vi.fn<() => SsoProvider[]>(() => []);
+// Sessions "related settings" link is gated on AUTH_ACTIVE_SESSIONS_ENABLED.
+const mockActiveSessionsEnabled = ref(false);
 vi.mock('@/utils/features', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@/utils/features')>()),
   getSsoProviders: () => mockGetSsoProviders(),
+  isActiveSessionsEnabledOf: () => mockActiveSessionsEnabled.value,
 }));
 
 // SSO connect initiates a form POST (navigates away); assert the call, not nav.
@@ -139,6 +142,7 @@ describe('ConnectedIdentities', () => {
     mockState.removeIdentity.mockResolvedValue(true);
     // clearAllMocks keeps implementations, so reset the provider list explicitly.
     mockGetSsoProviders.mockReturnValue([]);
+    mockActiveSessionsEnabled.value = false;
   });
 
   afterEach(() => {
@@ -394,6 +398,27 @@ describe('ConnectedIdentities', () => {
       expect(wrapper.find('[data-testid="connections-connect-oidc"]').text()).toContain(
         'Connect OpenID Connect'
       );
+    });
+  });
+
+  describe('Related settings', () => {
+    // The component does not import RouterLink, so <router-link> renders as a
+    // bare custom element here; assert on its `to` attribute.
+    const hasLinkTo = (path: string) => wrapper.find(`[to="${path}"]`).exists();
+    const SESSIONS_PATH = '/account/settings/security/sessions';
+
+    it('links to Sessions when the active sessions feature is enabled', () => {
+      mockActiveSessionsEnabled.value = true;
+      wrapper = mountComponent();
+      expect(hasLinkTo(SESSIONS_PATH)).toBe(true);
+    });
+
+    it('omits the Sessions link when the feature is disabled (route guard would dead-end)', () => {
+      mockActiveSessionsEnabled.value = false;
+      wrapper = mountComponent();
+      expect(hasLinkTo(SESSIONS_PATH)).toBe(false);
+      // Sibling passkeys link is unaffected.
+      expect(hasLinkTo('/account/settings/security/passkeys')).toBe(true);
     });
   });
 

--- a/src/tests/apps/workspace/account/settings/SecurityOverview.spec.ts
+++ b/src/tests/apps/workspace/account/settings/SecurityOverview.spec.ts
@@ -38,6 +38,7 @@ vi.mock('@/apps/workspace/layouts/SettingsLayout.vue', () => ({
 // Mock feature flags
 const mockMfaEnabled = ref(true);
 const mockWebAuthnEnabled = ref(true);
+const mockActiveSessionsEnabled = ref(false);
 const mockHasPassword = ref(true);
 const mockSsoEnabled = ref(false);
 const mockPasswordAuthPermitted = ref(true);
@@ -50,6 +51,9 @@ vi.mock('@/utils/features', () => ({
   // exercising the same MFA/WebAuthn on/off matrix.
   isMfaEnabledOf: () => mockMfaEnabled.value,
   isWebAuthnEnabledOf: () => mockWebAuthnEnabled.value,
+  // Sessions card is gated on AUTH_ACTIVE_SESSIONS_ENABLED. Default OFF so
+  // the pre-existing card matrix is unchanged; the dedicated block flips it on.
+  isActiveSessionsEnabledOf: () => mockActiveSessionsEnabled.value,
   hasPasswordOf: () => mockHasPassword.value,
   // Connected identities (#3840) card is gated on SSO enablement. Default OFF
   // so the pre-existing card matrix is unchanged; the dedicated block below
@@ -108,6 +112,7 @@ describe('SecurityOverview', () => {
     // Reset mocks
     mockMfaEnabled.value = true;
     mockWebAuthnEnabled.value = true;
+    mockActiveSessionsEnabled.value = false;
     mockHasPassword.value = true;
     mockSsoEnabled.value = false;
     mockPasswordAuthPermitted.value = true;
@@ -482,6 +487,32 @@ describe('SecurityOverview', () => {
 
       expect(findCardByIcon('key-solid')).toBeDefined();
       expect(findCardByIcon('document-text-solid')).toBeDefined();
+    });
+  });
+
+  describe('Sessions Card (Active Sessions Feature Flag)', () => {
+    it('shows sessions card when active sessions is enabled', () => {
+      mockActiveSessionsEnabled.value = true;
+      wrapper = mountComponent();
+
+      expect(findCardByIcon('computer-desktop-solid')).toBeDefined();
+    });
+
+    it('hides sessions card when active sessions is disabled', () => {
+      mockActiveSessionsEnabled.value = false;
+      wrapper = mountComponent();
+
+      expect(findCardByIcon('computer-desktop-solid')).toBeUndefined();
+    });
+
+    it('links sessions card to the active sessions route', () => {
+      mockActiveSessionsEnabled.value = true;
+      wrapper = mountComponent();
+
+      const link = wrapper
+        .findAll('a')
+        .find((a) => a.attributes('href') === '/account/settings/security/sessions');
+      expect(link).toBeDefined();
     });
   });
 

--- a/src/tests/apps/workspace/config/settings-navigation.spec.ts
+++ b/src/tests/apps/workspace/config/settings-navigation.spec.ts
@@ -10,6 +10,7 @@ vi.mock('@/utils/features', () => ({
   isSsoOnlyMode: vi.fn(() => false),
   isWebAuthnEnabled: vi.fn(() => false),
   isSsoEnabled: vi.fn(() => false),
+  isActiveSessionsEnabled: vi.fn(() => false),
   hasPassword: vi.fn(() => false),
   isOwnerOrAdmin: vi.fn(() => false),
 }));
@@ -39,6 +40,9 @@ function makeFeatures(overrides: Partial<NavigationFeatures> = {}): NavigationFe
     isOwnerOrAdmin: false,
     isWebAuthnEnabled: false,
     isSsoEnabled: false,
+    // Default ON: sessions is a baseline tab in the persona matrix below; the
+    // dedicated flag-off test flips it.
+    isActiveSessionsEnabled: true,
     ...overrides,
   };
 }
@@ -167,13 +171,21 @@ describe('settings-navigation config', () => {
     });
 
     it('sessions child visible regardless of hasPassword', () => {
-      const sections = getSettingsNavigationSections(t, makeFeatures({ hasPassword: false }));
-      const securityItem = sections.flatMap((s) => s.items).find((i) => i.id === 'security');
-      const sessionsChild = securityItem?.children?.find((c) => c.id === 'sessions');
+      // sessions is not password-dependent: SSO-only accounts still manage devices.
+      expect(getVisibleChildIds(makeFeatures({ hasPassword: false }), 'security')).toContain('sessions');
+      expect(getVisibleChildIds(makeFeatures({ hasPassword: true }), 'security')).toContain('sessions');
+    });
 
-      // sessions has no visible callback -- always visible when parent is visible
-      expect(sessionsChild).toBeDefined();
-      expect(sessionsChild?.visible).toBeUndefined();
+    it('sessions child visible only when active sessions feature is enabled', () => {
+      // Mirrors the /account/settings/security/sessions route guard: with
+      // AUTH_ACTIVE_SESSIONS_ENABLED off the link would dead-end at /account.
+      expect(
+        getVisibleChildIds(makeFeatures({ isActiveSessionsEnabled: false }), 'security')
+      ).not.toContain('sessions');
+
+      expect(
+        getVisibleChildIds(makeFeatures({ isActiveSessionsEnabled: true }), 'security')
+      ).toContain('sessions');
     });
 
     it('passkeys child visible only when WebAuthn is enabled', () => {

--- a/src/tests/apps/workspace/routes/account.guards.spec.ts
+++ b/src/tests/apps/workspace/routes/account.guards.spec.ts
@@ -2,8 +2,9 @@
 //
 // Tests for the per-route beforeEnter guards defined in account.ts.
 // The guards (checkOwnerOrAdminAccess, checkPasswordSecurityAccess,
-// checkSetPasswordAccess, checkSecurityAccess) are not exported, so we test
-// them indirectly by invoking beforeEnter on the route records themselves.
+// checkSetPasswordAccess, checkOwnerWithPasswordAccess, checkSecurityAccess,
+// checkActiveSessionsAccess) are not exported, so we test them indirectly by
+// invoking beforeEnter on the route records themselves.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -13,6 +14,7 @@ vi.mock('@/utils/features', () => ({
   hasPassword: vi.fn(() => false),
   isOwnerOrAdmin: vi.fn(() => false),
   isPasswordAuthPermitted: vi.fn(() => false),
+  isActiveSessionsEnabled: vi.fn(() => false),
 }));
 
 import accountRoutes from '@/apps/workspace/routes/account';
@@ -21,6 +23,7 @@ import {
   hasPassword,
   isOwnerOrAdmin,
   isPasswordAuthPermitted,
+  isActiveSessionsEnabled,
 } from '@/utils/features';
 import type { RouteRecordRaw, NavigationGuardWithThis } from 'vue-router';
 
@@ -28,6 +31,7 @@ const mockedIsFullAuthMode = vi.mocked(isFullAuthMode);
 const mockedHasPassword = vi.mocked(hasPassword);
 const mockedIsOwnerOrAdmin = vi.mocked(isOwnerOrAdmin);
 const mockedIsPasswordAuthPermitted = vi.mocked(isPasswordAuthPermitted);
+const mockedIsActiveSessionsEnabled = vi.mocked(isActiveSessionsEnabled);
 
 /**
  * Extract the beforeEnter guard from a route found by path.
@@ -69,6 +73,7 @@ describe('Account route guards', () => {
     mockedHasPassword.mockReturnValue(false);
     mockedIsOwnerOrAdmin.mockReturnValue(false);
     mockedIsPasswordAuthPermitted.mockReturnValue(false);
+    mockedIsActiveSessionsEnabled.mockReturnValue(false);
   });
 
   // ── Guard wiring verification ─────────────────────────────────────
@@ -322,7 +327,6 @@ describe('Account route guards', () => {
   describe('checkSecurityAccess (auth-mode-only routes)', () => {
     const guardedPaths = [
       '/account/settings/security',
-      '/account/settings/security/sessions',
       '/account/settings/security/passkeys',
       // Connected identities is guarded like passkeys — full-auth mode only,
       // NOT password-dependent (SSO-only accounts must be able to reach it).
@@ -354,6 +358,49 @@ describe('Account route guards', () => {
     }
   });
 
+  // ── checkActiveSessionsAccess ─────────────────────────────────────
+
+  describe('checkActiveSessionsAccess (sessions route, feature-flag gated)', () => {
+    const path = '/account/settings/security/sessions';
+
+    it('allows when full auth mode AND active_sessions flag enabled', () => {
+      mockedIsFullAuthMode.mockReturnValue(true);
+      mockedIsActiveSessionsEnabled.mockReturnValue(true);
+
+      expect(invokeGuard(path)).toBe(true);
+    });
+
+    it('redirects to Account when full auth mode but flag disabled', () => {
+      mockedIsFullAuthMode.mockReturnValue(true);
+      mockedIsActiveSessionsEnabled.mockReturnValue(false);
+
+      expect(invokeGuard(path)).toEqual({ name: 'Account' });
+    });
+
+    it('redirects to Account when flag enabled but not full auth mode', () => {
+      mockedIsFullAuthMode.mockReturnValue(false);
+      mockedIsActiveSessionsEnabled.mockReturnValue(true);
+
+      expect(invokeGuard(path)).toEqual({ name: 'Account' });
+    });
+
+    it('redirects to Account when both gates fail', () => {
+      mockedIsFullAuthMode.mockReturnValue(false);
+      mockedIsActiveSessionsEnabled.mockReturnValue(false);
+
+      expect(invokeGuard(path)).toEqual({ name: 'Account' });
+    });
+
+    it('is independent of password and role (SSO member allowed when both gates pass)', () => {
+      mockedIsFullAuthMode.mockReturnValue(true);
+      mockedIsActiveSessionsEnabled.mockReturnValue(true);
+      mockedHasPassword.mockReturnValue(false);
+      mockedIsOwnerOrAdmin.mockReturnValue(false);
+
+      expect(invokeGuard(path)).toBe(true);
+    });
+  });
+
   // ── Cross-cutting persona scenarios ───────────────────────────────
 
   describe('persona scenarios (end-to-end guard behavior)', () => {
@@ -361,6 +408,8 @@ describe('Account route guards', () => {
       mockedIsFullAuthMode.mockReturnValue(true);
       mockedHasPassword.mockReturnValue(true);
       mockedIsOwnerOrAdmin.mockReturnValue(true);
+      // Sessions is additionally gated on the active_sessions feature flag.
+      mockedIsActiveSessionsEnabled.mockReturnValue(true);
 
       const allGuardedPaths = accountRoutes
         .filter((r: RouteRecordRaw) => r.beforeEnter)
@@ -375,6 +424,7 @@ describe('Account route guards', () => {
       mockedIsFullAuthMode.mockReturnValue(true);
       mockedHasPassword.mockReturnValue(false);
       mockedIsOwnerOrAdmin.mockReturnValue(true);
+      mockedIsActiveSessionsEnabled.mockReturnValue(true);
 
       // Should allow
       expect(invokeGuard('/account/region')).toBe(true);
@@ -394,6 +444,7 @@ describe('Account route guards', () => {
       mockedIsFullAuthMode.mockReturnValue(true);
       mockedHasPassword.mockReturnValue(true);
       mockedIsOwnerOrAdmin.mockReturnValue(false);
+      mockedIsActiveSessionsEnabled.mockReturnValue(true);
 
       // Should allow
       expect(invokeGuard('/account/settings/security')).toBe(true);
@@ -410,6 +461,7 @@ describe('Account route guards', () => {
       mockedIsFullAuthMode.mockReturnValue(true);
       mockedHasPassword.mockReturnValue(false);
       mockedIsOwnerOrAdmin.mockReturnValue(false);
+      mockedIsActiveSessionsEnabled.mockReturnValue(true);
 
       // Should allow
       expect(invokeGuard('/account/settings/security')).toBe(true);

--- a/src/utils/features.ts
+++ b/src/utils/features.ts
@@ -114,6 +114,23 @@ export function isWebAuthnEnabled(): boolean {
 }
 
 /**
+ * Pure predicate: active sessions (view + revoke per-device sessions) enabled
+ * in the given state. Mirrors AUTH_ACTIVE_SESSIONS_ENABLED on the backend.
+ */
+export function isActiveSessionsEnabledOf(state: { features?: Features }): boolean {
+  return state.features?.active_sessions === true;
+}
+
+/**
+ * Checks if the active sessions feature is enabled
+ */
+export function isActiveSessionsEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+
+  return isActiveSessionsEnabledOf({ features: getBootstrapValue('features') });
+}
+
+/**
  * Checks if account lockout (after failed login attempts) is enabled
  */
 export function isLockoutEnabled(): boolean {


### PR DESCRIPTION
The Sessions card on the security overview was hidden behind a hardcoded `showSessionsCard = false` ref since 4ab47e726a, so the `features.active_sessions` flag the backend already serialized never reached the UI. This reads that flag through a new `isActiveSessionsEnabledOf` predicate, declares `active_sessions` in the bootstrap features schema, and gives the `/account/settings/security/sessions` route a matching guard so a flag-off install cannot reach the page by URL. Spec coverage added for the card on/off matrix and its link target.

Also bumps `ActiveSessionGate::INACTIVITY_DEADLINE` from 24h to 72h as a temporary measure for the v0.26.12 deploy: the deadline is now enforced but `last_use` had not been kept current, so a 24h window would sign out everyone who had not logged in within a day.